### PR TITLE
Fix workflow node deletion and workflow form remount

### DIFF
--- a/packages/ballerina-visualizer/src/MainPanel.tsx
+++ b/packages/ballerina-visualizer/src/MainPanel.tsx
@@ -722,6 +722,7 @@ const MainPanel = () => {
                             if (isStaleNavigation()) return;
                             setViewComponent(
                                 <FunctionForm
+                                    key={remountKey}
                                     projectPath={value.projectPath}
                                     filePath={defaultFunctionsFile}
                                     functionName={value?.identifier}

--- a/packages/component-diagram/src/components/nodes/EntryNode/components/GeneralWidget.tsx
+++ b/packages/component-diagram/src/components/nodes/EntryNode/components/GeneralWidget.tsx
@@ -231,9 +231,7 @@ export function GeneralServiceWidget({ model, engine }: BaseNodeWidgetProps) {
 
     const menuItems: Item[] = [
         { id: "edit", label: "Edit", onClick: () => handleOnClick() },
-        ...(model.type !== "workflow"
-            ? [{ id: "delete", label: "Delete", onClick: () => onDeleteComponent(model.node) }]
-            : []),
+        { id: "delete", label: "Delete", onClick: () => onDeleteComponent(model.node) },
     ];
 
     const serviceFunctions = [];


### PR DESCRIPTION
Two workflow UX bugs in the component diagram / visualizer (both in code merged via #639).

## 1. Workflow nodes can't be deleted
`GeneralWidget`'s entry-node menu gated the **Delete** action on `model.type !== "workflow"`, so workflow nodes had no Delete option — even though `onDeleteComponent` already accepts `CDWorkflow`. Delete is now always included (Edit behavior unchanged).

## 2. Workflow form retains stale state
The `BIWorkflowForm` case in `MainPanel` rendered `FunctionForm` without the `key={remountKey}` that every other `FunctionForm` case uses, so reopening the workflow form could keep stale internal state across navigation. Added the remount key so it forces a fresh mount when `projectPath`/`filePath` change.

## Verification
`tsc` passes for both `component-diagram` and `ballerina-visualizer`. UI-only change; no test baselines affected.