### PR TITLE
Fix Workflow Management not auto-enabling when ICP is enabled

### DIFF
--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ICPEnablerService.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ICPEnablerService.java
@@ -247,23 +247,31 @@ public class ICPEnablerService implements ExtendedLanguageServerService {
      * @param pkg the package to inspect
      * @return {@code true} if ICP is enabled, {@code false} otherwise
      */
-    public static boolean isIcpEnabled(Package pkg) {
+    /**
+     * Checks whether the default module imports {@code ballerinax/wso2.controlplane as _}. Unlike
+     * {@link #isIcpEnabled(Package)}, this does not consult Ballerina.toml, so it reflects an import
+     * added in-session (e.g. via a text edit) even before the toml build-option write is visible to
+     * the loaded project.
+     *
+     * @param pkg the package to inspect
+     * @return {@code true} if the control-plane import is present
+     */
+    public static boolean hasControlPlaneImport(Package pkg) {
         Module defaultModule = pkg.getDefaultModule();
-        boolean hasCorrectImport = false;
         for (DocumentId documentId : defaultModule.documentIds()) {
             Document document = defaultModule.document(documentId);
             ModulePartNode root = document.syntaxTree().rootNode();
             for (ImportDeclarationNode importNode : root.imports()) {
                 if (validOrg(importNode) && validModuleName(importNode) && validPrefix(importNode)) {
-                    hasCorrectImport = true;
-                    break;
+                    return true;
                 }
             }
-            if (hasCorrectImport) {
-                break;
-            }
         }
-        if (!hasCorrectImport) {
+        return false;
+    }
+
+    public static boolean isIcpEnabled(Package pkg) {
+        if (!hasControlPlaneImport(pkg)) {
             return false;
         }
         Optional<BallerinaToml> ballerinaToml = pkg.ballerinaToml();

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/WorkflowManagementService.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/WorkflowManagementService.java
@@ -112,8 +112,12 @@ public class WorkflowManagementService implements ExtendedLanguageServerService 
             try {
                 Project project = this.workspaceManager.loadProject(Path.of(request.projectPath()));
                 Package pkg = project.currentPackage();
+                // Use the control-plane import (not the full isIcpEnabled) as the ICP signal: this
+                // runs during ICP enablement, right after the import is added via a text edit but
+                // before the Ballerina.toml remoteManagement write is reflected in the loaded
+                // project, so an isIcpEnabled() toml check would spuriously fail here.
                 boolean shouldEnable = !hasManagementImport(pkg)
-                        && ICPEnablerService.isIcpEnabled(pkg)
+                        && ICPEnablerService.hasControlPlaneImport(pkg)
                         && hasWorkflowFunction(pkg);
                 response.setEnabled(shouldEnable);
             } catch (Throwable e) {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_management_default_enable/config/config5.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_management_default_enable/config/config5.json
@@ -1,0 +1,7 @@
+{
+  "projectPath": "proj5",
+  "description": "Control-plane import present but remoteManagement not yet in Ballerina.toml (mid ICP-enable) + workflow function -> enable by default",
+  "response": {
+    "enabled": true
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_management_default_enable/source/proj5/Ballerina.toml
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_management_default_enable/source/proj5/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "org"
+name = "proj5"
+version = "0.1.0"
+distribution = "2201.11.0"
+
+[build-options]
+observabilityIncluded = true

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_management_default_enable/source/proj5/main.bal
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_management_default_enable/source/proj5/main.bal
@@ -1,0 +1,14 @@
+import ballerina/workflow;
+import ballerinax/wso2.controlplane as _;
+
+type OrderInput record {
+    readonly string orderId;
+};
+
+@workflow:Workflow
+function orderWorkflow(workflow:Context ctx, OrderInput input) returns json|error {
+    return {};
+}
+
+public function main() {
+}


### PR DESCRIPTION
## Problem
When enabling **ICP monitoring** on a workflow integration, the **Enable Workflow Management** checkbox stayed unchecked — the auto-enable never fired.

## Root cause
`WorkflowManagementService.shouldEnableWorkflowManagementByDefault` runs inside `addICP` and gated on `ICPEnablerService.isIcpEnabled(pkg)`, which requires `remoteManagement = true` in `Ballerina.toml`. But `addICP` writes that toml via a raw `fs.writeFileSync`, so the language server's in-session loaded project doesn't reflect it during the same call — the toml check fails and the auto-enable is skipped. (The control-plane *import*, by contrast, is added via a text edit and is visible immediately.)

## Fix
Gate the auto-enable on the **control-plane import** rather than the full `isIcpEnabled` (which reads the not-yet-visible toml):
- Extract `ICPEnablerService.hasControlPlaneImport(Package)` and reuse it from `isIcpEnabled(Package)`.
- `shouldEnableWorkflowManagementByDefault` now checks `!hasManagementImport && hasControlPlaneImport && hasWorkflowFunction`.

This is safe because the predicate is only invoked during ICP enablement, where the import has just been added.

## Tests
- Existing `WorkflowManagementDefaultEnableTests` (proj1–4) still pass (import presence correlates with ICP-enabled in those fixtures).
- Added **proj5**: control-plane import present but `remoteManagement` not yet in `Ballerina.toml` (the mid-enable state) + a workflow function → expects `enabled: true`. This fails with the old `isIcpEnabled` check and passes with the fix.
- `ICPEnablerTests` / `AddICPTest` unchanged and green (`isIcpEnabled` behavior preserved).