### PR TITLE
Fix workflow node UX issues: Run Workflow input typing, flow-node diagnostics, and duplicate variable validation

### DIFF
--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -131,6 +131,7 @@ import io.ballerina.compiler.syntax.tree.WhileStatementNode;
 import io.ballerina.flowmodelgenerator.core.model.Branch;
 import io.ballerina.flowmodelgenerator.core.model.Codedata;
 import io.ballerina.flowmodelgenerator.core.model.CommentProperty;
+import io.ballerina.flowmodelgenerator.core.model.Diagnostics;
 import io.ballerina.flowmodelgenerator.core.model.FlowNode;
 import io.ballerina.flowmodelgenerator.core.model.FormBuilder;
 import io.ballerina.flowmodelgenerator.core.model.ItemOption;
@@ -3363,13 +3364,7 @@ public class CodeAnalyzer extends NodeVisitor {
         }
 
         // The workflow's input parameter is the first parameter that is a subtype of anydata.
-        TypeSymbol inputType = null;
-        for (ParameterSymbol param : workflowFuncSymbol.typeDescriptor().params().orElse(List.of())) {
-            if (param.typeDescriptor().subtypeOf(semanticModel.types().ANYDATA)) {
-                inputType = param.typeDescriptor();
-                break;
-            }
-        }
+        TypeSymbol inputType = WorkflowRunBuilder.findWorkflowInputType(workflowFuncSymbol, semanticModel);
         if (inputType == null) {
             // The workflow function declares no input; drop the library-derived input property.
             currentProps.remove(WorkflowRunBuilder.INPUT_KEY);
@@ -3387,10 +3382,16 @@ public class CodeAnalyzer extends NodeVisitor {
                 valueNode = namedArg.expression();
             }
         }
+        // The input property built by processFunctionSymbol already consumed the diagnostic-handler
+        // cursor for this value node, so its diagnostics are correct — only its type is wrong
+        // (library map<anydata>? vs the workflow's declared type). Capture those diagnostics and
+        // re-apply them, and rebuild the type WITHOUT the handler so the single-pass cursor is not
+        // advanced a second time for the same node (which would drop or misattribute diagnostics).
         Property existingInputProp = currentProps.get(WorkflowRunBuilder.INPUT_KEY);
         String value = valueNode != null ? valueNode.toSourceCode().strip()
                 : (existingInputProp != null && existingInputProp.value() != null
                         ? existingInputProp.value().toString() : "");
+        Diagnostics existingDiagnostics = existingInputProp != null ? existingInputProp.diagnostics() : null;
 
         // Re-adding at the same key preserves the property's position in the form.
         Property.Builder<FormBuilder<NodeBuilder>> customPropBuilder = nodeBuilder.properties().custom();
@@ -3403,8 +3404,13 @@ public class CodeAnalyzer extends NodeVisitor {
                 .placeholder("")
                 .editable()
                 .stepOut();
-        customPropBuilder.typeWithExpression(inputType, moduleInfo, valueNode, semanticModel,
-                customPropBuilder, diagnosticHandler);
+        customPropBuilder.typeWithExpression(inputType, moduleInfo, valueNode, semanticModel, customPropBuilder);
+        if (existingDiagnostics != null && existingDiagnostics.hasDiagnostics()) {
+            customPropBuilder.diagnostics().hasDiagnostics();
+            if (existingDiagnostics.diagnostics() != null) {
+                customPropBuilder.diagnostics().diagnostics(existingDiagnostics.diagnostics());
+            }
+        }
         formBuilder.addProperty(WorkflowRunBuilder.INPUT_KEY, valueNode);
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -172,6 +172,7 @@ import io.ballerina.flowmodelgenerator.core.model.node.VariableBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.VectorStoreBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.WaitBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.WaitDataBuilder;
+import io.ballerina.flowmodelgenerator.core.model.node.WorkflowRunBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.XmlPayloadBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.builtin.BuiltinActivityStrategy;
 import io.ballerina.flowmodelgenerator.core.model.node.builtin.EmailActivityStrategy;
@@ -232,6 +233,7 @@ import static io.ballerina.flowmodelgenerator.core.Constants.Workflow.SLEEP_METH
 import static io.ballerina.flowmodelgenerator.core.Constants.Workflow.WORKFLOW_MODULE;
 import static io.ballerina.flowmodelgenerator.core.Constants.Workflow.WORKFLOW_ORG;
 import static io.ballerina.flowmodelgenerator.core.Constants.Workflow.RUN_METHOD_NAME;
+import static io.ballerina.flowmodelgenerator.core.Constants.Workflow.RUN_PROCESS_FUNCTION_PARAM;
 import static io.ballerina.flowmodelgenerator.core.Constants.Workflow.SEND_DATA_METHOD_NAME;
 import static io.ballerina.flowmodelgenerator.core.model.node.ActivityCallBuilder.EXCLUDED_CALL_ACTIVITY_PARAMS;
 import static io.ballerina.flowmodelgenerator.core.model.node.WaitDataBuilder.EXCLUDED_KEYS;
@@ -3331,7 +3333,79 @@ public class CodeAnalyzer extends NodeVisitor {
                                               FunctionSymbol functionSymbol) {
         if (isWorkflowOperation(functionSymbol, RUN_METHOD_NAME)) {
             overrideSymbolFromFirstArg(functionCallExpressionNode.arguments());
+            populateWorkflowRunProperties(functionCallExpressionNode);
         }
+    }
+
+    /**
+     * Fixes properties after {@code processFunctionSymbol} runs on a {@code workflow:run(...)} call.
+     * The generic path types the {@code input} property from the library signature of
+     * {@code workflow:run} ({@code anydata input}), which loses the specific input type of the
+     * target workflow function. This re-derives the {@code input} property type from the workflow
+     * function's declared input parameter (the first parameter that is a subtype of {@code anydata};
+     * {@code workflow:Context} and the events record are not anydata), matching the template path in
+     * {@link WorkflowRunBuilder}. The raw {@code processFunction} property is dropped because the
+     * function reference is carried in {@code codedata.symbol}.
+     *
+     * @param callNode the {@code workflow:run(...)} call node
+     */
+    private void populateWorkflowRunProperties(FunctionCallExpressionNode callNode) {
+        SeparatedNodeList<FunctionArgumentNode> args = callNode.arguments();
+        Map<String, Property> currentProps = nodeBuilder.properties().build();
+        currentProps.remove(RUN_PROCESS_FUNCTION_PARAM);
+
+        if (args.isEmpty() || !(args.get(0) instanceof PositionalArgumentNode firstArg)) {
+            return;
+        }
+        Optional<Symbol> resolvedSymbol = semanticModel.symbol(firstArg.expression());
+        if (resolvedSymbol.isEmpty() || !(resolvedSymbol.get() instanceof FunctionSymbol workflowFuncSymbol)) {
+            return;
+        }
+
+        // The workflow's input parameter is the first parameter that is a subtype of anydata.
+        TypeSymbol inputType = null;
+        for (ParameterSymbol param : workflowFuncSymbol.typeDescriptor().params().orElse(List.of())) {
+            if (param.typeDescriptor().subtypeOf(semanticModel.types().ANYDATA)) {
+                inputType = param.typeDescriptor();
+                break;
+            }
+        }
+        if (inputType == null) {
+            // The workflow function declares no input; drop the library-derived input property.
+            currentProps.remove(WorkflowRunBuilder.INPUT_KEY);
+            return;
+        }
+
+        // Resolve the current input value from the call source (second positional or named arg).
+        Node valueNode = null;
+        if (args.size() > 1 && args.get(1) instanceof PositionalArgumentNode secondArg) {
+            valueNode = secondArg.expression();
+        }
+        for (FunctionArgumentNode arg : args) {
+            if (arg instanceof NamedArgumentNode namedArg
+                    && WorkflowRunBuilder.INPUT_KEY.equals(namedArg.argumentName().name().text())) {
+                valueNode = namedArg.expression();
+            }
+        }
+        Property existingInputProp = currentProps.get(WorkflowRunBuilder.INPUT_KEY);
+        String value = valueNode != null ? valueNode.toSourceCode().strip()
+                : (existingInputProp != null && existingInputProp.value() != null
+                        ? existingInputProp.value().toString() : "");
+
+        // Re-adding at the same key preserves the property's position in the form.
+        Property.Builder<FormBuilder<NodeBuilder>> customPropBuilder = nodeBuilder.properties().custom();
+        FormBuilder<NodeBuilder> formBuilder = customPropBuilder
+                .metadata()
+                    .label(WorkflowRunBuilder.INPUT_LABEL)
+                    .description(WorkflowRunBuilder.INPUT_DOC)
+                    .stepOut()
+                .value(value)
+                .placeholder("")
+                .editable()
+                .stepOut();
+        customPropBuilder.typeWithExpression(inputType, moduleInfo, valueNode, semanticModel,
+                customPropBuilder, diagnosticHandler);
+        formBuilder.addProperty(WorkflowRunBuilder.INPUT_KEY, valueNode);
     }
 
     private void processFunctionSymbol(NonTerminalNode callNode, SeparatedNodeList<FunctionArgumentNode> arguments,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/Constants.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/Constants.java
@@ -106,6 +106,7 @@ public class Constants {
         public static final String ACTIVITY_MODULE = "workflow.activity";
         public static final String CONTEXT_CLASS_NAME = "Context";
         public static final String RUN_METHOD_NAME = "run";
+        public static final String RUN_PROCESS_FUNCTION_PARAM = "processFunction";
         public static final String RUN_LABEL = "Run Workflow";
         public static final String RUN_DESCRIPTION = "Run a new workflow instance";
         public static final String SEND_DATA_METHOD_NAME = "sendData";

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DiagnosticHandler.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DiagnosticHandler.java
@@ -27,6 +27,7 @@ import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 
 /**
@@ -48,8 +49,18 @@ public class DiagnosticHandler {
     }
 
     public DiagnosticHandler(Collection<Diagnostic> diagnostics) {
+        // The handler advances a single cursor while nodes are visited in source order, so the
+        // diagnostics must be sorted by file and position. Package compilation diagnostics append
+        // compiler-plugin diagnostics (e.g., the workflow plugin's WORKFLOW_1xx codes) after the
+        // semantic-phase ones, which breaks the within-file position order and would cause
+        // plugin diagnostics to be skipped and never attached to flow nodes.
         iterator = diagnostics.stream()
-                .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR).iterator();
+                .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR)
+                .sorted(Comparator
+                        .comparing((Diagnostic diagnostic) -> diagnostic.location().lineRange().fileName())
+                        .thenComparingInt(diagnostic -> diagnostic.location().lineRange().startLine().line())
+                        .thenComparingInt(diagnostic -> diagnostic.location().lineRange().startLine().offset()))
+                .iterator();
         hasNodeAnnotated = false;
         if (iterator.hasNext()) {
             currentDiagnostic = iterator.next();

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DiagnosticHandler.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DiagnosticHandler.java
@@ -57,7 +57,8 @@ public class DiagnosticHandler {
         iterator = diagnostics.stream()
                 .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR)
                 .sorted(Comparator
-                        .comparing((Diagnostic diagnostic) -> diagnostic.location().lineRange().fileName())
+                        .comparing((Diagnostic diagnostic) -> diagnostic.location().lineRange().fileName(),
+                                Comparator.nullsFirst(Comparator.naturalOrder()))
                         .thenComparingInt(diagnostic -> diagnostic.location().lineRange().startLine().line())
                         .thenComparingInt(diagnostic -> diagnostic.location().lineRange().startLine().offset()))
                 .iterator();

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/ExpressionEditorContext.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/ExpressionEditorContext.java
@@ -365,6 +365,8 @@ public class ExpressionEditorContext {
         private static final String ORG_KEY = "org";
         private static final String MODULE_KEY = "module";
         private static final String NODE_KEY = "node";
+        private static final String PROPERTY_CODEDATA_KEY = "codedata";
+        private static final String LINE_RANGE_KEY = "lineRange";
 
         public Property(JsonObject property, JsonObject codedata) {
             this.property = property;
@@ -456,6 +458,20 @@ public class ExpressionEditorContext {
         public NodeKind nodeKind() {
             initialize();
             return nodeKind;
+        }
+
+        /**
+         * Returns {@code true} when the property carries a codedata line range, i.e., it is bound
+         * to an existing declaration in the source (edit/rename flow) rather than a new-node
+         * template whose declaration has not been written yet.
+         *
+         * @return whether the property is backed by an existing source declaration
+         */
+        public boolean hasExistingDeclaration() {
+            return property != null
+                    && property.has(PROPERTY_CODEDATA_KEY)
+                    && property.get(PROPERTY_CODEDATA_KEY).isJsonObject()
+                    && property.getAsJsonObject(PROPERTY_CODEDATA_KEY).has(LINE_RANGE_KEY);
         }
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/IdentifierDiagnosticsRequest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/IdentifierDiagnosticsRequest.java
@@ -106,11 +106,16 @@ public class IdentifierDiagnosticsRequest extends DiagnosticsRequest {
                             || symbol.kind() == SymbolKind.WORKER);
         }
 
-        // Check for redeclared symbols
+        // Check for redeclared symbols. The property's original value is only excluded when the
+        // property is bound to an existing declaration (edit/rename flow) — there, the matching
+        // symbol is the node's own variable. For a new node no declaration exists yet, so any
+        // visible symbol with the same name (including one matching the generated default) is a
+        // genuine duplicate and must be reported.
         Set<Diagnostic> diagnostics = new HashSet<>();
         String inputValue = context.info().expression();
-        boolean redeclaredSymbol =
-                symbolStream.anyMatch(symbol -> symbol.nameEquals(inputValue) && !symbol.nameEquals(value));
+        boolean existingDeclaration = property.hasExistingDeclaration();
+        boolean redeclaredSymbol = symbolStream.anyMatch(symbol -> symbol.nameEquals(inputValue)
+                && !(existingDeclaration && symbol.nameEquals(value)));
         if (redeclaredSymbol) {
             String message = String.format(REDECLARED_SYMBOL, inputValue);
             diagnostics.add(CommonUtils.createDiagnostic(message, context.getExpressionLineRange(),

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WorkflowRunBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WorkflowRunBuilder.java
@@ -20,7 +20,6 @@ package io.ballerina.flowmodelgenerator.core.model.node;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
-import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
@@ -194,19 +193,29 @@ public class WorkflowRunBuilder extends NodeBuilder {
 
         Symbol sym = targetSymbol.get();
         if (sym.kind() == SymbolKind.FUNCTION) {
-            FunctionTypeSymbol functionType = ((FunctionSymbol) sym).typeDescriptor();
-            Optional<List<ParameterSymbol>> params = functionType.params();
-
-            if (params.isPresent()) {
-                // Find the parameter whose type is a subtype of anydata
-                for (ParameterSymbol param : params.get()) {
-                    if (param.typeDescriptor().subtypeOf(semanticModel.types().ANYDATA)) {
-                        return param.typeDescriptor();
-                    }
-                }
-            }
+            return findWorkflowInputType((FunctionSymbol) sym, semanticModel);
         }
 
+        return null;
+    }
+
+    /**
+     * Returns the type of a workflow function's input parameter: the first parameter whose type is
+     * a subtype of {@code anydata} (the {@code workflow:Context} and events-record parameters are
+     * not subtypes of {@code anydata}, so they are skipped). Returns {@code null} when the function
+     * declares no input parameter.
+     *
+     * @param functionSymbol the workflow function symbol
+     * @param semanticModel  the semantic model
+     * @return the input parameter type, or {@code null} if the function takes no input
+     */
+    public static TypeSymbol findWorkflowInputType(FunctionSymbol functionSymbol, SemanticModel semanticModel) {
+        List<ParameterSymbol> params = functionSymbol.typeDescriptor().params().orElse(List.of());
+        for (ParameterSymbol param : params) {
+            if (param.typeDescriptor().subtypeOf(semanticModel.types().ANYDATA)) {
+                return param.typeDescriptor();
+            }
+        }
         return null;
     }
 }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WorkflowRunBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WorkflowRunBuilder.java
@@ -33,6 +33,7 @@ import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 import io.ballerina.flowmodelgenerator.core.model.Property;
 import io.ballerina.flowmodelgenerator.core.model.SourceBuilder;
 import io.ballerina.flowmodelgenerator.core.utils.FileSystemUtils;
+import org.ballerinalang.langserver.common.utils.NameUtil;
 import org.eclipse.lsp4j.TextEdit;
 
 import java.nio.file.Path;
@@ -100,14 +101,16 @@ public class WorkflowRunBuilder extends NodeBuilder {
                     .addProperty(INPUT_KEY);
         }
 
-        // Variable property for result
+        // Variable property for result. Generate a unique default name so that adding
+        // multiple Run Workflow nodes does not produce duplicate variable declarations.
+        String workflowIdVarName = NameUtil.generateTypeName("workflowId", context.getAllVisibleSymbolNames());
         properties().custom()
                 .metadata()
                     .label("Workflow ID Variable Name")
                     .description("Variable name to receive the started workflow ID.")
                     .stepOut()
                 .type(Property.ValueType.IDENTIFIER)
-                .value("workflowId")
+                .value(workflowIdVarName)
                 .editable(true)
                 .stepOut()
                 .addProperty(Property.VARIABLE_KEY);

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/DiagnosticHandlerTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/DiagnosticHandlerTest.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import io.ballerina.flowmodelgenerator.core.model.Diagnostics;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextRange;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Tests for {@link DiagnosticHandler}.
+ * <p>
+ * The handler advances a single cursor while flow nodes are visited in source order, so it must
+ * sort the incoming diagnostics by position. Package compilation appends compiler-plugin
+ * diagnostics (e.g., the workflow plugin's WORKFLOW_1xx codes) after the semantic-phase ones,
+ * which breaks the within-file position order.
+ *
+ * @since 1.5.0
+ */
+public class DiagnosticHandlerTest {
+
+    private static final String FILE_NAME = "main.bal";
+
+    @Test(description = "Out-of-order diagnostics (plugin diagnostics appended after semantic ones) "
+            + "must be attached to their respective nodes")
+    public void testOutOfOrderDiagnosticsAttachToNodes() {
+        LineRange earlyNodeRange = range(5, 0, 6, 1);
+        LineRange lateNodeRange = range(10, 0, 11, 1);
+
+        // The semantic diagnostic (line 10) is emitted before the plugin diagnostic (line 5),
+        // mirroring PackageCompilation.diagnosticResult() ordering.
+        Diagnostic semanticDiagnostic = diagnostic(lateNodeRange, "semantic error on the late node");
+        Diagnostic pluginDiagnostic = diagnostic(earlyNodeRange, "plugin error on the early node");
+        DiagnosticHandler handler = new DiagnosticHandler(List.of(semanticDiagnostic, pluginDiagnostic));
+
+        TestDiagnosticsBuilder earlyNode = new TestDiagnosticsBuilder();
+        TestDiagnosticsBuilder lateNode = new TestDiagnosticsBuilder();
+
+        // Nodes are visited in source order.
+        handler.handle(earlyNode, earlyNodeRange, true);
+        handler.handle(lateNode, lateNodeRange, true);
+
+        Diagnostics earlyDiagnostics = earlyNode.diagnostics().build();
+        Assert.assertTrue(earlyDiagnostics.hasDiagnostics(),
+                "Expected the plugin diagnostic to be attached to the early node");
+        Assert.assertEquals(earlyDiagnostics.diagnostics().getFirst().message(),
+                "plugin error on the early node");
+
+        Diagnostics lateDiagnostics = lateNode.diagnostics().build();
+        Assert.assertTrue(lateDiagnostics.hasDiagnostics(),
+                "Expected the semantic diagnostic to be attached to the late node");
+        Assert.assertEquals(lateDiagnostics.diagnostics().getFirst().message(),
+                "semantic error on the late node");
+    }
+
+    @Test(description = "Non-error diagnostics are filtered out")
+    public void testNonErrorDiagnosticsFiltered() {
+        LineRange nodeRange = range(3, 0, 3, 20);
+        Diagnostic warning = diagnostic(nodeRange, "a warning", DiagnosticSeverity.WARNING);
+        DiagnosticHandler handler = new DiagnosticHandler(List.of(warning));
+
+        TestDiagnosticsBuilder node = new TestDiagnosticsBuilder();
+        handler.handle(node, nodeRange, true);
+        Assert.assertFalse(node.diagnostics().build().hasDiagnostics(),
+                "Warnings should not be attached to flow nodes");
+    }
+
+    private static LineRange range(int startLine, int startOffset, int endLine, int endOffset) {
+        return LineRange.from(FILE_NAME, LinePosition.from(startLine, startOffset),
+                LinePosition.from(endLine, endOffset));
+    }
+
+    private static Diagnostic diagnostic(LineRange lineRange, String message) {
+        return diagnostic(lineRange, message, DiagnosticSeverity.ERROR);
+    }
+
+    private static Diagnostic diagnostic(LineRange lineRange, String message, DiagnosticSeverity severity) {
+        Location location = new Location() {
+            @Override
+            public LineRange lineRange() {
+                return lineRange;
+            }
+
+            @Override
+            public TextRange textRange() {
+                return TextRange.from(0, 0);
+            }
+        };
+        DiagnosticInfo info = new DiagnosticInfo("TEST_001", message, severity);
+        return DiagnosticFactory.createDiagnostic(info, location);
+    }
+
+    /**
+     * Minimal {@link DiagnosticHandler.DiagnosticCapable} that records the attached diagnostics.
+     */
+    private static class TestDiagnosticsBuilder implements DiagnosticHandler.DiagnosticCapable {
+
+        private final Diagnostics.Builder<TestDiagnosticsBuilder> builder = new Builder<>(this);
+
+        @Override
+        public Diagnostics.Builder<TestDiagnosticsBuilder> diagnostics() {
+            return builder;
+        }
+
+        private static class Builder<T> extends Diagnostics.Builder<T> {
+
+            Builder(T parent) {
+                super(parent);
+            }
+        }
+    }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
@@ -5,6 +5,7 @@
         <classes>
             <class name="io.ballerina.flowmodelgenerator.core.AiComponentDiskCacheTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.ConnectionActionProviderTest"/>
+            <class name="io.ballerina.flowmodelgenerator.core.DiagnosticHandlerTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.copilot.service.ServiceIndexLoaderTest"/>
         </classes>
     </test>

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier10.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier10.json
@@ -22,7 +22,20 @@
       "value": "moduleVar",
       "optional": false,
       "editable": true,
-      "advanced": false
+      "advanced": false,
+      "codedata": {
+        "lineRange": {
+          "fileName": "source.bal",
+          "startLine": {
+            "line": 3,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 3,
+            "offset": 13
+          }
+        }
+      }
     }
   },
   "diagnostics": []

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_activity_and_wait.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_activity_and_wait.json
@@ -44,6 +44,9 @@
           "sourceCode": "# Process an order workflow with events\n@workflow:Workflow\nfunction orderWorkflow(workflow:Context ctx, OrderInput input, OrderWorkflowEvents events) returns error? {\n    // Activity call - should be ACTIVITY_CALL\n    int intResult = check ctx->callActivity(calculateDiscount, {amount: 100.0});\n    io:println(\"Discount calculated: \" + intResult.toString());\n\n    // Wait for data - should be WAIT_DATA\n    ApprovalData approval = check wait events.approve;\n    io:println(\"Approved by: \" + approval.approverName);\n}"
         },
         "returning": false,
+        "diagnostics": {
+          "hasDiagnostics": true
+        },
         "flags": 0
       },
       {
@@ -406,6 +409,9 @@
             "hidden": false,
             "codedata": {}
           }
+        },
+        "diagnostics": {
+          "hasDiagnostics": true
         },
         "flags": 1
       },

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_run.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_run.json
@@ -116,52 +116,38 @@
         },
         "returning": false,
         "properties": {
-          "processFunction": {
-            "metadata": {
-              "label": "Process Function",
-              "description": "The workflow function (must have `@Workflow`)"
-            },
-            "types": [
-              {
-                "fieldType": "EXPRESSION",
-                "ballerinaType": "function",
-                "selected": true
-              }
-            ],
-            "value": "orderWorkflow",
-            "placeholder": "",
-            "optional": false,
-            "editable": true,
-            "advanced": false,
-            "hidden": false,
-            "codedata": {
-              "kind": "REQUIRED",
-              "originalName": "processFunction"
-            }
-          },
           "input": {
             "metadata": {
               "label": "Input",
-              "description": "Optional input data for the workflow. Must match the workflow\nfunction's declared input parameter type (any `anydata` subtype)"
+              "description": "Input data for the workflow"
             },
             "types": [
               {
+                "fieldType": "RECORD_MAP_EXPRESSION",
+                "ballerinaType": "OrderInput",
+                "typeMembers": [
+                  {
+                    "type": "OrderInput",
+                    "packageInfo": "$anon:.:0.0.0",
+                    "packageName": ".",
+                    "kind": "RECORD_TYPE",
+                    "selected": false
+                  }
+                ],
+                "selected": false
+              },
+              {
                 "fieldType": "EXPRESSION",
-                "ballerinaType": "anydata",
+                "ballerinaType": "OrderInput",
                 "selected": false
               }
             ],
             "value": "{orderId: \"123\", customerName: \"John\"}",
-            "placeholder": "{}",
-            "optional": true,
+            "placeholder": "",
+            "optional": false,
             "editable": true,
-            "advanced": true,
-            "hidden": false,
-            "codedata": {
-              "kind": "DEFAULTABLE",
-              "originalName": "input"
-            },
-            "defaultValue": "()"
+            "advanced": false,
+            "hidden": false
           },
           "checkError": {
             "metadata": {

--- a/packages/bi-diagram/src/utils/node.ts
+++ b/packages/bi-diagram/src/utils/node.ts
@@ -18,7 +18,7 @@
 
 import { Branch, FlowNode } from "./types";
 
-const WORKFLOW_NODE_KINDS = new Set(["WORKFLOW_RUN", "ACTIVITY_CALL", "SEND_DATA", "WAIT_DATA"]);
+const WORKFLOW_NODE_KINDS = new Set(["WORKFLOW_RUN", "ACTIVITY_CALL", "SEND_DATA", "WAIT_DATA", "HUMAN_TASK"]);
 
 export function getNodeIdFromModel(node: FlowNode, prefix?: string) {
     if (!node) {


### PR DESCRIPTION
## Purpose

Fix three workflow (BI designer) UX defects around the Run Workflow node form, flow-node diagnostics, and variable-name validation.

Resolves wso2/product-integrator#1879, wso2/product-integrator#1880, wso2/product-integrator#1881

## Changes

### 1. Run Workflow node: derive the `input` type from the workflow function on the source-read path (wso2/product-integrator#1879)
A freshly added Run Workflow node types its **Input** field from the selected workflow function's declared input parameter, but once the `workflow:run(...)` call is written to source and re-read, `CodeAnalyzer` rebuilt the form properties from the `workflow:run` library signature (`map<anydata>? input`), losing the specific type and leaking an internal `processFunction` field into the form. The new `CodeAnalyzer.populateWorkflowRunProperties(...)` re-derives the `input` property type from the workflow function symbol (matching the template path in `WorkflowRunBuilder`), keeps the current argument value, drops the `processFunction` property, and removes `input` when the workflow declares no input.

### 2. Sort diagnostics by position so compiler-plugin diagnostics attach to flow nodes (wso2/product-integrator#1880)
`DiagnosticHandler` advances a single cursor while nodes are visited in source order, so it requires position-sorted diagnostics. Package compilation appends compiler-plugin diagnostics (e.g. the workflow plugin's `WORKFLOW_1xx` codes) after the semantic-phase ones, breaking the within-file order — plugin diagnostics were silently skipped and never attached to Run Workflow / Call Activity / Send Data / Wait Data / Human Task nodes. The handler now sorts diagnostics by (file, start line, start offset) before iterating. `HUMAN_TASK` is also added to `WORKFLOW_NODE_KINDS` in `bi-diagram`.

### 3. Report duplicate variable names for new flow nodes (wso2/product-integrator#1881)
The identifier duplicate check excluded any visible symbol matching the property's original value. That exclusion is only correct for the edit/rename flow (where the match is the node's own variable); for **new** nodes it masked genuine duplicates whenever the default or typed name collided with an existing variable, so forms such as Call Activity accepted duplicate result variable names without any error. The exclusion now applies only when the property is bound to an existing declaration (property codedata carries a `lineRange`). `WorkflowRunBuilder` also generates a unique default (`workflowId`, `workflowId1`, ...) instead of a hardcoded name.

## Automation tests

- New `DiagnosticHandlerTest` covering the out-of-order diagnostics case (plugin diagnostics appended after semantic ones).
- `ModelGeneratorTest` expected configs updated for the behavior changes: `workflow_run.json` (input typed from the workflow function, `processFunction` property removed) and `workflow_activity_and_wait.json` (nodes now correctly carry `hasDiagnostics: true`).

## Related PRs

- ballerina-platform/module-ballerina-workflow#63 — module-side counterpart: `workflow:run()` accepts any `anydata` input, and new compile-time validations (`WORKFLOW_130`–`WORKFLOW_136`) produce the diagnostics that change (2) surfaces on the flow nodes.
