### PR TITLE
Provide library annotations to Copilot from the Semantic Model

### DIFF
--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
@@ -488,6 +488,7 @@ function selectClients(originalClients: Client[], funcResponse: GetFunctionRespo
             name: originalClient.name,
             description: originalClient.description,
             functions: [],
+            annotations: originalClient.annotations,
         };
 
         const output: (RemoteFunction | ResourceFunction)[] = [];

--- a/packages/ballerina-extension/src/features/ai/utils/libs/library-types.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/library-types.ts
@@ -29,11 +29,18 @@ export interface Link {
 
 export type Category = "internal" | "external";
 
+export interface AnnotationAttachment {
+    name: string;
+    module?: string;
+    value?: string;
+}
+
 export interface Parameter {
     name: string;
     description: string;
     type: Type;
     default?: string;
+    annotations?: AnnotationAttachment[];
 }
 
 export interface ParameterDef {
@@ -59,6 +66,7 @@ export interface Field {
     type: Type;
     default?: string;
     isDeprecated?: boolean;
+    annotations?: AnnotationAttachment[];
 }
 
 export interface UnionValue {
@@ -76,6 +84,7 @@ export interface TypeDefinitionBase {
     description: string;
     type: string;
     isDeprecated?: boolean;
+    annotations?: AnnotationAttachment[];
 }
 
 export interface ConstantTypeDefinition extends TypeDefinitionBase {
@@ -113,6 +122,7 @@ export interface AbstractFunction {
     parameters: Parameter[];
     return: Return;
     isDeprecated?: boolean;
+    annotations?: AnnotationAttachment[];
 }
 
 export interface ResourceFunction extends AbstractFunction {
@@ -139,6 +149,7 @@ export interface Client {
     description: string;
     functions: (RemoteFunction | ResourceFunction)[];
     isDeprecated?: boolean;
+    annotations?: AnnotationAttachment[];
 }
 
 export interface Listener {

--- a/packages/ballerina-extension/src/features/ai/utils/libs/to-syntax-string.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/to-syntax-string.ts
@@ -35,11 +35,30 @@ import {
     ParameterDef,
     PathParameter,
     Annotation,
+    AnnotationAttachment,
 } from "./library-types";
 
 const ATTACHMENT_POINT_LABELS: Record<string, string> = {
+    // Curated service-index points (kept verbatim for backward compatibility).
     SERVICE: "service",
     OBJECT_METHOD: "service_function",
+    // Points supplemented from the Semantic Model, mapped to their Ballerina `on`-clause tokens.
+    TYPE: "type",
+    OBJECT: "object",
+    FUNCTION: "function",
+    RESOURCE: "resource function",
+    PARAMETER: "parameter",
+    RETURN: "return",
+    CLASS: "class",
+    FIELD: "field",
+    OBJECT_FIELD: "object field",
+    RECORD_FIELD: "record field",
+    LISTENER: "listener",
+    ANNOTATION: "annotation",
+    EXTERNAL: "external",
+    VAR: "var",
+    CONST: "const",
+    WORKER: "worker",
 };
 
 /**
@@ -118,6 +137,47 @@ function buildSpecialAgentNote(externalLinks: ExternalLinkInfo[]): string {
 }
 
 /**
+ * Renders a single annotation attachment as `@[prefix:]Name [value]`.
+ * The module prefix is derived from the attachment's `module` (e.g. "ballerina/http" -> "http");
+ * when absent, the annotation belongs to the current library and is rendered bare.
+ */
+function renderAttachmentName(annotation: AnnotationAttachment): string {
+    const prefix = annotation.module ? deriveModulePrefix(annotation.module) : "";
+    const qualifiedName = prefix ? `${prefix}:${annotation.name}` : annotation.name;
+    return annotation.value ? `@${qualifiedName} ${annotation.value}` : `@${qualifiedName}`;
+}
+
+/**
+ * Renders annotation attachments as one line each, prefixed with `indent`.
+ */
+function renderAttachmentLines(annotations: AnnotationAttachment[] | undefined, indent: string): string[] {
+    if (!annotations || annotations.length === 0) {
+        return [];
+    }
+    return annotations.map((annotation) => `${indent}${renderAttachmentName(annotation)}`);
+}
+
+/**
+ * Renders annotation attachments as a block (lines + trailing newline) for string-concatenation
+ * renderers. Returns "" when there are none.
+ */
+function renderAttachmentBlock(annotations: AnnotationAttachment[] | undefined, indent: string): string {
+    const lines = renderAttachmentLines(annotations, indent);
+    return lines.length > 0 ? lines.join("\n") + "\n" : "";
+}
+
+/**
+ * Renders annotation attachments inline (space-separated, trailing space) for a parameter
+ * declaration. Returns "" when there are none.
+ */
+function renderInlineAttachments(annotations: AnnotationAttachment[] | undefined): string {
+    if (!annotations || annotations.length === 0) {
+        return "";
+    }
+    return annotations.map(renderAttachmentName).join(" ") + " ";
+}
+
+/**
  * Renders a description as `#` comment lines.
  */
 function renderDescription(description: string | undefined): string {
@@ -139,6 +199,7 @@ function renderRecord(typeDef: RecordTypeDefinition): string {
     if (typeDef.isDeprecated) {
         lines.push("@deprecated");
     }
+    lines.push(...renderAttachmentLines(typeDef.annotations, ""));
     lines.push(`type ${typeDef.name} record {`);
 
     for (const field of typeDef.fields) {
@@ -148,8 +209,9 @@ function renderRecord(typeDef: RecordTypeDefinition): string {
         const defaultVal = field.default !== undefined ? ` = ${field.default}` : "";
         const fieldDesc = field.description ? `    # ${field.description}\n` : "";
         const fieldDeprecated = field.isDeprecated ? "    @deprecated\n" : "";
+        const fieldAnnotations = renderAttachmentBlock(field.annotations, "    ");
         const agentNote = buildSpecialAgentNote(externalLinks);
-        lines.push(`${fieldDesc}${fieldDeprecated}    ${typeName} ${field.name}${optional}${defaultVal};${agentNote}`);
+        lines.push(`${fieldDesc}${fieldDeprecated}${fieldAnnotations}    ${typeName} ${field.name}${optional}${defaultVal};${agentNote}`);
     }
 
     lines.push("};");
@@ -169,6 +231,7 @@ function renderEnum(typeDef: EnumTypeDefinition): string {
     if (typeDef.isDeprecated) {
         lines.push("@deprecated\n");
     }
+    lines.push(renderAttachmentBlock(typeDef.annotations, ""));
     const members = typeDef.members.map((m) => m.name).join(",\n    ");
     lines.push(`enum ${typeDef.name} {\n    ${members}\n}`);
     return lines.join("");
@@ -180,11 +243,12 @@ function renderEnum(typeDef: EnumTypeDefinition): string {
 function renderUnion(typeDef: UnionTypeDefinition): string {
     const desc = renderDescription(typeDef.description);
     const dep = renderDeprecation(typeDef.isDeprecated);
+    const ann = renderAttachmentBlock(typeDef.annotations, "");
     if (!typeDef.members || typeDef.members.length === 0) {
-        return `${desc}${dep}type ${typeDef.name};`;
+        return `${desc}${dep}${ann}type ${typeDef.name};`;
     }
     const members = typeDef.members.map((m) => m.name).join("|");
-    return `${desc}${dep}type ${typeDef.name} ${members};`;
+    return `${desc}${dep}${ann}type ${typeDef.name} ${members};`;
 }
 
 /**
@@ -193,8 +257,9 @@ function renderUnion(typeDef: UnionTypeDefinition): string {
 function renderConstant(typeDef: ConstantTypeDefinition): string {
     const desc = renderDescription(typeDef.description);
     const dep = renderDeprecation(typeDef.isDeprecated);
+    const ann = renderAttachmentBlock(typeDef.annotations, "");
     const value = typeDef.varType.name === "string" ? `"${typeDef.value}"` : typeDef.value;
-    return `${desc}${dep}const ${typeDef.varType.name} ${typeDef.name} = ${value};`;
+    return `${desc}${dep}${ann}const ${typeDef.varType.name} ${typeDef.name} = ${value};`;
 }
 
 /**
@@ -203,7 +268,8 @@ function renderConstant(typeDef: ConstantTypeDefinition): string {
 function renderClass(typeDef: ClassTypeDefinition): string {
     const desc = renderDescription(typeDef.description);
     const dep = renderDeprecation(typeDef.isDeprecated);
-    return `${desc}${dep}class ${typeDef.name} {\n}`;
+    const ann = renderAttachmentBlock(typeDef.annotations, "");
+    return `${desc}${dep}${ann}class ${typeDef.name} {\n}`;
 }
 
 /**
@@ -257,7 +323,8 @@ function renderParam(param: Parameter): string {
     const typeName = applyPrefixToTypeName(param.type.name, externalLinks);
     const optional = (param as any).optional;
     const defaultVal = (param as any).default !== undefined ? ` = ${(param as any).default}` : "";
-    return `${typeName} ${param.name}${defaultVal}`;
+    const annotations = renderInlineAttachments(param.annotations);
+    return `${annotations}${typeName} ${param.name}${defaultVal}`;
 }
 
 /**
@@ -268,7 +335,8 @@ function renderConstructor(func: RemoteFunction): string {
     const params = func.parameters.map(renderParam).join(", ");
     const returnStr = func.return?.type ? ` returns ${applyPrefixToTypeName(func.return.type.name, allExternalLinks)}` : "";
     const agentNote = buildSpecialAgentNote(allExternalLinks);
-    return `    function init(${params})${returnStr};${agentNote}`;
+    const anns = renderAttachmentBlock(func.annotations, "    ");
+    return `${anns}    function init(${params})${returnStr};${agentNote}`;
 }
 
 /**
@@ -278,10 +346,11 @@ function renderRemoteFunction(func: RemoteFunction, indent: string = "    "): st
     const allExternalLinks = collectFunctionExternalLinks(func.parameters, func.return?.type);
     const desc = func.description ? `${indent}# ${func.description.split("\n").join(`\n${indent}# `)}\n` : "";
     const dep = func.isDeprecated ? `${indent}@deprecated\n` : "";
+    const anns = renderAttachmentBlock(func.annotations, indent);
     const params = func.parameters.map(renderParam).join(", ");
     const returnStr = func.return?.type ? ` returns ${applyPrefixToTypeName(func.return.type.name, allExternalLinks)}` : "";
     const agentNote = buildSpecialAgentNote(allExternalLinks);
-    return `${desc}${dep}${indent}remote function ${func.name}(${params})${returnStr};${agentNote}`;
+    return `${desc}${dep}${anns}${indent}remote function ${func.name}(${params})${returnStr};${agentNote}`;
 }
 
 /**
@@ -291,6 +360,7 @@ function renderResourceFunction(func: ResourceFunction, indent: string = "    ")
     const allExternalLinks = collectFunctionExternalLinks(func.parameters, func.return?.type);
     const desc = func.description ? `${indent}# ${func.description.split("\n").join(`\n${indent}# `)}\n` : "";
     const dep = func.isDeprecated ? `${indent}@deprecated\n` : "";
+    const anns = renderAttachmentBlock(func.annotations, indent);
 
     // Build path string
     const pathSegments = func.paths.map((p) => {
@@ -312,7 +382,7 @@ function renderResourceFunction(func: ResourceFunction, indent: string = "    ")
 
     const returnStr = func.return?.type ? ` returns ${applyPrefixToTypeName(func.return.type.name, allExternalLinks)}` : "";
     const agentNote = buildSpecialAgentNote(allExternalLinks);
-    return `${desc}${dep}${indent}resource function ${func.accessor} ${pathStr}(${params})${returnStr};${agentNote}`;
+    return `${desc}${dep}${anns}${indent}resource function ${func.accessor} ${pathStr}(${params})${returnStr};${agentNote}`;
 }
 
 /**
@@ -322,7 +392,8 @@ function renderClient(client: Client): string {
     const lines: string[] = [];
     const desc = client.description ? renderDescription(client.description) : "";
     const dep = client.isDeprecated ? "@deprecated\n" : "";
-    lines.push(`${desc}${dep}client class ${client.name} {`);
+    const anns = renderAttachmentBlock(client.annotations, "");
+    lines.push(`${desc}${dep}${anns}client class ${client.name} {`);
 
     for (const func of client.functions) {
         if ("type" in func && func.type === "Constructor") {
@@ -369,6 +440,8 @@ function renderStandaloneFunction(func: RemoteFunction): string {
     if (func.isDeprecated) {
         lines.push("@deprecated");
     }
+
+    lines.push(...renderAttachmentLines(func.annotations, ""));
 
     const params = func.parameters.map(renderParam).join(", ");
     const returnStr = func.return?.type ? ` returns ${applyPrefixToTypeName(func.return.type.name, allExternalLinks)}` : "";

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/CopilotLibraryManager.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/CopilotLibraryManager.java
@@ -48,6 +48,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,10 @@ public class CopilotLibraryManager {
     private static final Gson GSON = new Gson();
     private static final String EXCLUSION_JSON_PATH = "/copilot/exclusion.json";
     private static final String TYPE_GENERIC = "generic";
+    // Attachment points owned by the curated service-index catalog (kept as-is; not supplemented
+    // from the Semantic Model).
+    private static final String SERVICE_ATTACH_POINT = "SERVICE";
+    private static final String OBJECT_METHOD_ATTACH_POINT = "OBJECT_METHOD";
 
     // Libraries for which README content should be included in the filtered response.
     private static final Set<String> README_WHITELIST = Set.of(
@@ -169,8 +174,24 @@ public class CopilotLibraryManager {
 
             JsonArray annotationsJson = AnnotationLoader.loadFromServiceIndex(libraryName);
             List<Annotation> annotations = new ArrayList<>();
+            Set<String> seenAnnotations = new HashSet<>();
             for (JsonElement annotationElement : annotationsJson) {
-                annotations.add(GSON.fromJson(annotationElement, Annotation.class));
+                Annotation annotation = GSON.fromJson(annotationElement, Annotation.class);
+                annotations.add(annotation);
+                seenAnnotations.add(annotation.getName() + "::" + annotation.getAttachmentPoint());
+            }
+            // Supplement the curated service-index catalog with Semantic-Model annotation
+            // definitions for the remaining attachment points. The service-index owns the
+            // SERVICE and OBJECT_METHOD points, so those are left untouched here.
+            for (Annotation annotation : symbolResult.getAnnotations()) {
+                String attachmentPoint = annotation.getAttachmentPoint();
+                if (SERVICE_ATTACH_POINT.equals(attachmentPoint)
+                        || OBJECT_METHOD_ATTACH_POINT.equals(attachmentPoint)) {
+                    continue;
+                }
+                if (seenAnnotations.add(annotation.getName() + "::" + attachmentPoint)) {
+                    annotations.add(annotation);
+                }
             }
             library.setAnnotations(annotations);
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/AnnotationAttachment.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/AnnotationAttachment.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.copilot.model;
+
+/**
+ * Represents an annotation actually attached to an API element (function, type definition,
+ * record field, parameter, etc.), as extracted from the compiler Semantic Model.
+ *
+ * <p>Unlike {@link Annotation}, which describes an annotation <em>declaration</em> (the catalog),
+ * this describes a concrete <em>attachment</em> with its supplied value.</p>
+ *
+ * @since 1.7.0
+ */
+public class AnnotationAttachment {
+    private String name;
+    private String module;
+    private String value;
+
+    public AnnotationAttachment() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getModule() {
+        return module;
+    }
+
+    public void setModule(String module) {
+        this.module = module;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/Client.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/Client.java
@@ -34,6 +34,7 @@ public class Client {
     private List<LibraryFunction> functions;
     @SerializedName("isDeprecated")
     private Boolean deprecated;
+    private List<AnnotationAttachment> annotations;
 
     public Client(String name, String description) {
         this.name = name;
@@ -71,5 +72,13 @@ public class Client {
 
     public void setDeprecated(Boolean deprecated) {
         this.deprecated = deprecated;
+    }
+
+    public List<AnnotationAttachment> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(List<AnnotationAttachment> annotations) {
+        this.annotations = annotations;
     }
 }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/Field.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/Field.java
@@ -20,6 +20,8 @@ package io.ballerina.flowmodelgenerator.core.copilot.model;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
+
 /**
  * Represents a record field or enum member.
  *
@@ -34,6 +36,7 @@ public class Field {
     private Boolean optional;
     @SerializedName("isDeprecated")
     private Boolean deprecated;
+    private List<AnnotationAttachment> annotations;
 
     public Field() {
     }
@@ -84,5 +87,13 @@ public class Field {
 
     public void setDeprecated(Boolean deprecated) {
         this.deprecated = deprecated;
+    }
+
+    public List<AnnotationAttachment> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(List<AnnotationAttachment> annotations) {
+        this.annotations = annotations;
     }
 }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/LibraryFunction.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/LibraryFunction.java
@@ -39,6 +39,7 @@ public class LibraryFunction {
     private Return returnInfo;
     @SerializedName("isDeprecated")
     private Boolean deprecated;
+    private List<AnnotationAttachment> annotations;
 
     public LibraryFunction() {
         this.parameters = new ArrayList<>();
@@ -106,5 +107,13 @@ public class LibraryFunction {
 
     public void setDeprecated(Boolean deprecated) {
         this.deprecated = deprecated;
+    }
+
+    public List<AnnotationAttachment> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(List<AnnotationAttachment> annotations) {
+        this.annotations = annotations;
     }
 }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/Parameter.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/Parameter.java
@@ -20,6 +20,8 @@ package io.ballerina.flowmodelgenerator.core.copilot.model;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
+
 /**
  * Represents a function or method parameter.
  *
@@ -32,6 +34,7 @@ public class Parameter {
     private Boolean optional;
     @SerializedName("default")
     private String defaultValue;
+    private List<AnnotationAttachment> annotations;
 
     public Parameter() {
     }
@@ -74,5 +77,13 @@ public class Parameter {
 
     public void setDefaultValue(String defaultValue) {
         this.defaultValue = defaultValue;
+    }
+
+    public List<AnnotationAttachment> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(List<AnnotationAttachment> annotations) {
+        this.annotations = annotations;
     }
 }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/TypeDef.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/TypeDef.java
@@ -38,6 +38,7 @@ public class TypeDef {
     private Type varType;
     @SerializedName("isDeprecated")
     private Boolean deprecated;
+    private List<AnnotationAttachment> annotations;
 
     public TypeDef() {
     }
@@ -112,5 +113,13 @@ public class TypeDef {
 
     public void setDeprecated(Boolean deprecated) {
         this.deprecated = deprecated;
+    }
+
+    public List<AnnotationAttachment> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(List<AnnotationAttachment> annotations) {
+        this.annotations = annotations;
     }
 }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/util/AnnotationAttachmentExtractor.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/util/AnnotationAttachmentExtractor.java
@@ -1,0 +1,164 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.copilot.util;
+
+import io.ballerina.compiler.api.symbols.Annotatable;
+import io.ballerina.compiler.api.symbols.AnnotationAttachmentSymbol;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.values.ConstantValue;
+import io.ballerina.flowmodelgenerator.core.copilot.model.AnnotationAttachment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * Extracts concrete annotation attachments (with their supplied values) from any
+ * {@link Annotatable} compiler symbol (functions, type definitions, record fields,
+ * parameters, classes, constants, etc.) for delivery to Copilot.
+ *
+ * <p>Compiler-internal {@code ballerina/lang.annotations} annotations (e.g. {@code @deprecated},
+ * {@code @strand}, {@code @typeParam}) are skipped as noise &mdash; {@code @deprecated} is already
+ * surfaced separately via the {@code isDeprecated} flags. User-facing annotations from that module,
+ * notably {@code @display}, are retained.</p>
+ *
+ * @since 1.7.0
+ */
+public final class AnnotationAttachmentExtractor {
+
+    private static final String BALLERINA_ORG = "ballerina";
+    private static final String LANG_MODULE_PREFIX = "lang.";
+    // Compiler-internal annotations from ballerina/lang.* that are noise for code generation.
+    // Note: {@code display} is intentionally NOT here - it is a meaningful design-time annotation.
+    private static final Set<String> INTERNAL_LANG_ANNOTATIONS = Set.of(
+            "deprecated", "strand", "typeParam", "builtinSubtype", "isolatedParam",
+            "tainted", "untainted", "DefaultableArgs", "IntrospectionDocConfig");
+
+    private AnnotationAttachmentExtractor() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Extracts the annotation attachments present on the given symbol.
+     *
+     * @param annotatable    the annotatable symbol (may be {@code null})
+     * @param currentOrg     the organization of the library being processed
+     * @param currentPackage the package name of the library being processed
+     * @return the list of attachments (never {@code null}; empty when none apply)
+     */
+    public static List<AnnotationAttachment> extract(Annotatable annotatable, String currentOrg,
+                                                     String currentPackage) {
+        List<AnnotationAttachment> attachments = new ArrayList<>();
+        if (annotatable == null) {
+            return attachments;
+        }
+
+        for (AnnotationAttachmentSymbol attachmentSymbol : annotatable.annotAttachments()) {
+            AnnotationSymbol annotationSymbol = attachmentSymbol.typeDescriptor();
+            Optional<String> optName = annotationSymbol.getName();
+            if (optName.isEmpty()) {
+                continue;
+            }
+            if (isInternalAnnotation(annotationSymbol, optName.get())) {
+                continue;
+            }
+
+            AnnotationAttachment attachment = new AnnotationAttachment();
+            attachment.setName(optName.get());
+            attachment.setModule(resolveModule(annotationSymbol, currentOrg, currentPackage));
+            attachmentSymbol.attachmentValue()
+                    .map(ConstantValue::value)
+                    .map(AnnotationAttachmentExtractor::renderValue)
+                    .ifPresent(attachment::setValue);
+            attachments.add(attachment);
+        }
+        return attachments;
+    }
+
+    /**
+     * Returns the {@code org/module} identifier of the annotation, or {@code null} when it belongs
+     * to the library currently being processed (so it renders without a module prefix).
+     */
+    private static String resolveModule(AnnotationSymbol annotationSymbol, String currentOrg,
+                                        String currentPackage) {
+        Optional<ModuleSymbol> optModule = annotationSymbol.getModule();
+        if (optModule.isEmpty()) {
+            return null;
+        }
+        String org = optModule.get().id().orgName();
+        String moduleName = optModule.get().id().moduleName();
+        // Same-library annotations render bare (no prefix).
+        if (org != null && org.equals(currentOrg) && moduleName != null && moduleName.equals(currentPackage)) {
+            return null;
+        }
+        // Langlib annotations (e.g. @display) are auto-imported and written without a module prefix.
+        if (BALLERINA_ORG.equals(org) && moduleName != null && moduleName.startsWith(LANG_MODULE_PREFIX)) {
+            return null;
+        }
+        return org + "/" + moduleName;
+    }
+
+    private static boolean isInternalAnnotation(AnnotationSymbol annotationSymbol, String name) {
+        Optional<ModuleSymbol> optModule = annotationSymbol.getModule();
+        if (optModule.isEmpty()) {
+            return false;
+        }
+        String org = optModule.get().id().orgName();
+        String moduleName = optModule.get().id().moduleName();
+        boolean isLangModule = BALLERINA_ORG.equals(org) && moduleName != null
+                && moduleName.startsWith(LANG_MODULE_PREFIX);
+        return isLangModule && INTERNAL_LANG_ANNOTATIONS.contains(name);
+    }
+
+    /**
+     * Renders an annotation attachment value into a compact Ballerina-like snippet.
+     * Handles scalars, strings, record/mapping values, and arrays; recurses through nested
+     * {@link ConstantValue} wrappers.
+     */
+    private static String renderValue(Object value) {
+        if (value == null) {
+            return "()";
+        }
+        if (value instanceof ConstantValue constantValue) {
+            return renderValue(constantValue.value());
+        }
+        if (value instanceof Map<?, ?> map) {
+            StringJoiner joiner = new StringJoiner(", ", "{", "}");
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                joiner.add(entry.getKey() + ": " + renderValue(entry.getValue()));
+            }
+            return joiner.toString();
+        }
+        if (value instanceof List<?> list) {
+            StringJoiner joiner = new StringJoiner(", ", "[", "]");
+            for (Object element : list) {
+                joiner.add(renderValue(element));
+            }
+            return joiner.toString();
+        }
+        if (value instanceof String str) {
+            return "\"" + str + "\"";
+        }
+        return value.toString();
+    }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/util/LibraryModelConverter.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/util/LibraryModelConverter.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.flowmodelgenerator.core.copilot.builder.TypeLinkBuilder;
 import io.ballerina.flowmodelgenerator.core.copilot.model.EnumValue;
 import io.ballerina.flowmodelgenerator.core.copilot.model.Field;
@@ -390,6 +391,47 @@ public class LibraryModelConverter {
             }
         }
         return parameter;
+    }
+
+    /**
+     * Converts a {@link TypeSymbol} to a {@link Type} POJO with internal/external type links.
+     * Used for annotation constraint types in the definition catalog; mirrors the return-type
+     * handling in {@link #functionDataToModel}.
+     *
+     * @param typeSymbol     the type symbol to convert
+     * @param currentOrg     the current package organization
+     * @param currentPackage the current package name
+     * @return the Type POJO, or {@code null} when the symbol is {@code null}
+     */
+    public static Type typeSymbolToModel(TypeSymbol typeSymbol, String currentOrg, String currentPackage) {
+        if (typeSymbol == null) {
+            return null;
+        }
+
+        String typeName = typeSymbol.signature();
+        String simpleTypeName = typeName;
+        if (typeName != null && typeName.contains(":")) {
+            simpleTypeName = typeName.substring(typeName.lastIndexOf(':') + 1);
+        }
+
+        boolean isGenericType = simpleTypeName != null && simpleTypeName.contains("<");
+        boolean isPrimitiveType = isPrimitiveOrDefaultType(simpleTypeName);
+
+        String nameToUse = simpleTypeName;
+        List<TypeLink> links = null;
+        if (!isGenericType && !isPrimitiveType && currentOrg != null && currentPackage != null) {
+            links = extractTypeLinksFromSymbol(typeSymbol, currentOrg, currentPackage);
+            links = TypeLinkBuilder.filterInternalExternal(links);
+            if (links != null && !links.isEmpty()) {
+                nameToUse = extractRecordName(typeSymbol);
+            }
+        }
+
+        Type type = new Type(nameToUse);
+        if (links != null && !links.isEmpty()) {
+            type.setLinks(links);
+        }
+        return type;
     }
 
     /**

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/util/SymbolProcessor.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/util/SymbolProcessor.java
@@ -19,11 +19,16 @@
 package io.ballerina.flowmodelgenerator.core.copilot.util;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Annotatable;
+import io.ballerina.compiler.api.symbols.AnnotationAttachPoint;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
@@ -32,9 +37,12 @@ import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.values.ConstantValue;
 import io.ballerina.flowmodelgenerator.core.copilot.builder.TypeDefDataBuilder;
+import io.ballerina.flowmodelgenerator.core.copilot.model.Annotation;
+import io.ballerina.flowmodelgenerator.core.copilot.model.AnnotationAttachment;
 import io.ballerina.flowmodelgenerator.core.copilot.model.Client;
 import io.ballerina.flowmodelgenerator.core.copilot.model.Field;
 import io.ballerina.flowmodelgenerator.core.copilot.model.LibraryFunction;
+import io.ballerina.flowmodelgenerator.core.copilot.model.Parameter;
 import io.ballerina.flowmodelgenerator.core.copilot.model.Type;
 import io.ballerina.flowmodelgenerator.core.copilot.model.TypeDef;
 import io.ballerina.modelgenerator.commons.CommonUtils;
@@ -44,14 +52,17 @@ import io.ballerina.modelgenerator.commons.ModuleInfo;
 import io.ballerina.modelgenerator.commons.TypeDefData;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static io.ballerina.flowmodelgenerator.core.copilot.util.LibraryModelConverter.functionDataToModel;
 import static io.ballerina.flowmodelgenerator.core.copilot.util.LibraryModelConverter.initMethodToModel;
 import static io.ballerina.flowmodelgenerator.core.copilot.util.LibraryModelConverter.typeDefDataToModel;
+import static io.ballerina.flowmodelgenerator.core.copilot.util.LibraryModelConverter.typeSymbolToModel;
 
 /**
  * Processes module symbols and extracts structured data (clients, functions, typedefs).
@@ -71,11 +82,13 @@ public class SymbolProcessor {
         private final List<Client> clients;
         private final List<LibraryFunction> functions;
         private final List<TypeDef> typeDefs;
+        private final List<Annotation> annotations;
 
         public SymbolProcessingResult() {
             this.clients = new ArrayList<>();
             this.functions = new ArrayList<>();
             this.typeDefs = new ArrayList<>();
+            this.annotations = new ArrayList<>();
         }
 
         public List<Client> getClients() {
@@ -88,6 +101,10 @@ public class SymbolProcessor {
 
         public List<TypeDef> getTypeDefs() {
             return typeDefs;
+        }
+
+        public List<Annotation> getAnnotations() {
+            return annotations;
         }
     }
 
@@ -115,6 +132,8 @@ public class SymbolProcessor {
                 processTypeDefSymbol(typeDefSymbol, org, packageName, result);
             } else if (symbol instanceof ConstantSymbol constantSymbol) {
                 processConstantSymbol(constantSymbol, org, packageName, result);
+            } else if (symbol instanceof AnnotationSymbol annotationSymbol) {
+                processAnnotationSymbol(annotationSymbol, org, packageName, result);
             }
         }
         return result;
@@ -151,6 +170,8 @@ public class SymbolProcessor {
 
         // Add the constructor/init function first
         LibraryFunction constructor = functionDataToModel(classData, org, packageName);
+        classSymbol.initMethod().ifPresent(
+                initMethod -> applyFunctionAnnotations(initMethod, constructor, org, packageName));
         functions.add(initMethodToModel(classSymbol, constructor));
 
         // Then add all other methods (remote functions, resource functions, etc.)
@@ -177,17 +198,23 @@ public class SymbolProcessor {
                 if (methodSymbol.deprecated()) {
                     methodFunc.setDeprecated(true);
                 }
+                applyFunctionAnnotations(methodSymbol, methodFunc, org, packageName);
             }
 
             functions.add(methodFunc);
         }
 
         boolean classDeprecated = classSymbol.deprecated();
+        List<AnnotationAttachment> classAnnotations =
+                AnnotationAttachmentExtractor.extract(classSymbol, org, packageName);
         if (isClient) {
             Client client = new Client(className, classData.description());
             client.setFunctions(functions);
             if (classDeprecated) {
                 client.setDeprecated(true);
+            }
+            if (!classAnnotations.isEmpty()) {
+                client.setAnnotations(classAnnotations);
             }
             result.getClients().add(client);
         } else {
@@ -197,6 +224,9 @@ public class SymbolProcessor {
             typeDef.setFunctions(functions);
             if (classDeprecated) {
                 typeDef.setDeprecated(true);
+            }
+            if (!classAnnotations.isEmpty()) {
+                typeDef.setAnnotations(classAnnotations);
             }
             result.getTypeDefs().add(typeDef);
         }
@@ -236,6 +266,8 @@ public class SymbolProcessor {
             function.setDeprecated(true);
         }
 
+        applyFunctionAnnotations(functionSymbol, function, org, packageName);
+
         result.getFunctions().add(function);
     }
 
@@ -256,6 +288,14 @@ public class SymbolProcessor {
             typeDef.setDeprecated(true);
         }
         markDeprecatedFields(typeDefSymbol, typeDef);
+
+        List<AnnotationAttachment> typeAnnotations =
+                AnnotationAttachmentExtractor.extract(typeDefSymbol, org, packageName);
+        if (!typeAnnotations.isEmpty()) {
+            typeDef.setAnnotations(typeAnnotations);
+        }
+        applyFieldAnnotations(typeDefSymbol, typeDef, org, packageName);
+
         result.getTypeDefs().add(typeDef);
     }
 
@@ -325,6 +365,129 @@ public class SymbolProcessor {
         Type varType = new Type(varTypeName);
         typeDef.setVarType(varType);
 
+        List<AnnotationAttachment> constAnnotations =
+                AnnotationAttachmentExtractor.extract(constantSymbol, org, packageName);
+        if (!constAnnotations.isEmpty()) {
+            typeDef.setAnnotations(constAnnotations);
+        }
+
         result.getTypeDefs().add(typeDef);
+    }
+
+    /**
+     * Processes an ANNOTATION declaration symbol into the definition catalog.
+     * Emits one {@link Annotation} entry per declared attachment point.
+     */
+    private static void processAnnotationSymbol(AnnotationSymbol annotationSymbol,
+                                                String org,
+                                                String packageName,
+                                                SymbolProcessingResult result) {
+        if (!annotationSymbol.qualifiers().contains(Qualifier.PUBLIC)) {
+            return;
+        }
+
+        Optional<String> optName = annotationSymbol.getName();
+        if (optName.isEmpty()) {
+            return;
+        }
+        String name = optName.get();
+
+        Type constraintType = annotationSymbol.typeDescriptor()
+                .map(typeSymbol -> typeSymbolToModel(typeSymbol, org, packageName))
+                .orElse(null);
+        String description = annotationSymbol.documentation()
+                .flatMap(Documentation::description)
+                .orElse(null);
+
+        for (AnnotationAttachPoint attachPoint : annotationSymbol.attachPoints()) {
+            Annotation annotation = new Annotation();
+            annotation.setName(name);
+            annotation.setAttachmentPoint(attachPoint.name());
+            annotation.setDescription(description);
+            annotation.setTypeConstraint(constraintType);
+            result.getAnnotations().add(annotation);
+        }
+    }
+
+    /**
+     * Applies the annotation attachments present on a function/method symbol to its model,
+     * including per-parameter attachments (matched by name).
+     */
+    private static void applyFunctionAnnotations(FunctionSymbol functionSymbol,
+                                                 LibraryFunction function,
+                                                 String org,
+                                                 String packageName) {
+        List<AnnotationAttachment> fnAnnotations =
+                AnnotationAttachmentExtractor.extract(functionSymbol, org, packageName);
+        if (!fnAnnotations.isEmpty()) {
+            function.setAnnotations(fnAnnotations);
+        }
+
+        List<Parameter> parameters = function.getParameters();
+        if (parameters == null || parameters.isEmpty()) {
+            return;
+        }
+
+        FunctionTypeSymbol functionTypeSymbol = functionSymbol.typeDescriptor();
+        Optional<List<ParameterSymbol>> optParams = functionTypeSymbol.params();
+        if (optParams.isEmpty()) {
+            return;
+        }
+
+        Map<String, ParameterSymbol> paramsByName = new HashMap<>();
+        for (ParameterSymbol paramSymbol : optParams.get()) {
+            paramSymbol.getName().ifPresent(paramName -> paramsByName.put(paramName, paramSymbol));
+        }
+        functionTypeSymbol.restParam()
+                .ifPresent(restParam -> restParam.getName().ifPresent(n -> paramsByName.put(n, restParam)));
+
+        for (Parameter parameter : parameters) {
+            ParameterSymbol paramSymbol = paramsByName.get(parameter.getName());
+            if (paramSymbol == null) {
+                continue;
+            }
+            List<AnnotationAttachment> paramAnnotations =
+                    AnnotationAttachmentExtractor.extract(paramSymbol, org, packageName);
+            if (!paramAnnotations.isEmpty()) {
+                parameter.setAnnotations(paramAnnotations);
+            }
+        }
+    }
+
+    /**
+     * Applies record-field annotation attachments to the {@link TypeDef} fields (matched by name).
+     * The {@code TypeDef#getFields} list is only populated for record types.
+     */
+    private static void applyFieldAnnotations(TypeDefinitionSymbol typeDefSymbol,
+                                              TypeDef typeDef,
+                                              String org,
+                                              String packageName) {
+        List<Field> fields = typeDef.getFields();
+        if (fields == null || fields.isEmpty()) {
+            return;
+        }
+
+        TypeSymbol rawType = CommonUtils.getRawType(typeDefSymbol.typeDescriptor());
+        if (!(rawType instanceof RecordTypeSymbol recordType)) {
+            return;
+        }
+
+        Map<String, RecordFieldSymbol> fieldSymbolsByName = new HashMap<>();
+        for (Map.Entry<String, RecordFieldSymbol> entry : recordType.fieldDescriptors().entrySet()) {
+            RecordFieldSymbol fieldSymbol = entry.getValue();
+            fieldSymbolsByName.put(fieldSymbol.getName().orElse(entry.getKey()), fieldSymbol);
+        }
+
+        for (Field field : fields) {
+            RecordFieldSymbol fieldSymbol = fieldSymbolsByName.get(field.getName());
+            if (fieldSymbol == null) {
+                continue;
+            }
+            List<AnnotationAttachment> fieldAnnotations =
+                    AnnotationAttachmentExtractor.extract(fieldSymbol, org, packageName);
+            if (!fieldAnnotations.isEmpty()) {
+                field.setAnnotations(fieldAnnotations);
+            }
+        }
     }
 }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/CopilotAnnotationTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/CopilotAnnotationTest.java
@@ -1,0 +1,146 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.extension;
+
+import com.google.gson.GsonBuilder;
+import io.ballerina.flowmodelgenerator.core.copilot.CopilotLibraryManager;
+import io.ballerina.flowmodelgenerator.core.copilot.model.Annotation;
+import io.ballerina.flowmodelgenerator.core.copilot.model.AnnotationAttachment;
+import io.ballerina.flowmodelgenerator.core.copilot.model.Client;
+import io.ballerina.flowmodelgenerator.core.copilot.model.Field;
+import io.ballerina.flowmodelgenerator.core.copilot.model.Library;
+import io.ballerina.flowmodelgenerator.core.copilot.model.LibraryFunction;
+import io.ballerina.flowmodelgenerator.core.copilot.model.ModelToJsonConverter;
+import io.ballerina.flowmodelgenerator.core.copilot.model.Parameter;
+import io.ballerina.flowmodelgenerator.core.copilot.model.TypeDef;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Verifies the annotation data now delivered to Copilot from the Semantic Model:
+ *   (A) the annotation DEFINITION catalog now covers non-service attach points, and
+ *   (B) per-symbol annotation ATTACHMENTS surface on functions/params/fields/clients/types.
+ *
+ * <p>These tests resolve real packages from Ballerina Central (like the other Copilot tests),
+ * so they require the packages to be resolvable (local bala cache or network).</p>
+ */
+public class CopilotAnnotationTest {
+
+    private static final Set<String> SERVICE_POINTS = Set.of("SERVICE", "OBJECT_METHOD");
+
+    /**
+     * (A) Definition catalog — ballerina/http declares many annotations on non-service points
+     * (e.g. Payload on PARAMETER, Header on PARAMETER, CallerInfo on PARAMETER, Query, etc.).
+     * Before this change the catalog only ever contained SERVICE / OBJECT_METHOD entries.
+     */
+    @Test
+    public void testHttpAnnotationCatalogHasNonServicePoints() {
+        Library http = loadOne("ballerina/http");
+
+        List<Annotation> annotations = http.getAnnotations();
+        Assert.assertNotNull(annotations, "http should expose an annotation catalog");
+
+        System.out.println("\n===== ballerina/http annotation CATALOG (name -> attachmentPoint) =====");
+        annotations.forEach(a -> System.out.println("  @" + a.getName() + "  on  " + a.getAttachmentPoint()
+                + (a.getTypeConstraint() != null ? "   [constraint: " + a.getTypeConstraint().getName() + "]" : "")));
+
+        long nonServicePoints = annotations.stream()
+                .filter(a -> !SERVICE_POINTS.contains(a.getAttachmentPoint()))
+                .count();
+        Assert.assertTrue(nonServicePoints > 0,
+                "Expected http catalog to now include non-service attach points (FUNCTION/PARAMETER/etc.)");
+    }
+
+    /**
+     * (B) Per-symbol attachments — connector APIs commonly carry @display on the client / params.
+     * Dumps every attachment found so you can eyeball exactly what Copilot receives.
+     */
+    @Test
+    public void testConnectorPerSymbolAttachments() {
+        Library lib = loadOne("ballerinax/salesforce");
+
+        int[] count = {0};
+        if (lib.getClients() != null) {
+            for (Client client : lib.getClients()) {
+                dumpAttachments("client " + client.getName(), client.getAnnotations(), count);
+                if (client.getFunctions() != null) {
+                    for (LibraryFunction fn : client.getFunctions()) {
+                        dumpAttachments("  fn " + fn.getName(), fn.getAnnotations(), count);
+                        if (fn.getParameters() != null) {
+                            for (Parameter p : fn.getParameters()) {
+                                dumpAttachments("    param " + p.getName(), p.getAnnotations(), count);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (lib.getTypeDefs() != null) {
+            for (TypeDef td : lib.getTypeDefs()) {
+                dumpAttachments("type " + td.getName(), td.getAnnotations(), count);
+                if (td.getFields() != null) {
+                    for (Field f : td.getFields()) {
+                        dumpAttachments("  field " + f.getName(), f.getAnnotations(), count);
+                    }
+                }
+            }
+        }
+        System.out.println("\n===== total per-symbol attachments found on ballerinax/salesforce: " + count[0]);
+        // Soft assertion: connectors are generated with @display, so we expect at least one.
+        Assert.assertTrue(count[0] > 0,
+                "Expected at least one per-symbol annotation attachment on the salesforce connector");
+    }
+
+    /**
+     * Prints the FULL Copilot JSON for a library so you can see end-to-end exactly what is sent.
+     * Never fails — it is a visibility aid. Change the library name to inspect any package.
+     */
+    @Test
+    public void dumpCopilotJsonForHttp() {
+        Library http = loadOne("ballerina/http");
+        String json = new GsonBuilder().setPrettyPrinting().create()
+                .toJson(ModelToJsonConverter.libraryToJson(http));
+        System.out.println("\n===== FULL Copilot JSON for ballerina/http =====\n" + json);
+    }
+
+    private static void dumpAttachments(String owner, List<AnnotationAttachment> annotations, int[] count) {
+        if (annotations == null || annotations.isEmpty()) {
+            return;
+        }
+        count[0] += annotations.size();
+        StringBuilder sb = new StringBuilder();
+        for (AnnotationAttachment a : annotations) {
+            String prefix = a.getModule() != null ? a.getModule() + ":" : "";
+            sb.append(" @").append(prefix).append(a.getName());
+            if (a.getValue() != null) {
+                sb.append(" ").append(a.getValue());
+            }
+        }
+        System.out.println(owner + "  ->  " + sb);
+    }
+
+    private static Library loadOne(String name) {
+        List<Library> libs = new CopilotLibraryManager().loadFilteredLibraries(new String[]{name});
+        Assert.assertFalse(libs.isEmpty(), "Expected " + name + " to resolve");
+        return libs.get(0);
+    }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/testng.xml
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/testng.xml
@@ -127,6 +127,7 @@ under the License.
             <class name="io.ballerina.flowmodelgenerator.extension.CopilotLibraryServicesParityTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.CopilotLibraryAnnotationsTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.CopilotDeprecationTest"/>
+            <class name="io.ballerina.flowmodelgenerator.extension.CopilotAnnotationTest"/>
         </classes>
 
         <packages>


### PR DESCRIPTION
### Purpose

Adds annotation details to the Copilot's library context, sourced dynamically from the compiler Semantic Model. Previously the Copilot only received `SERVICE`/`OBJECT_METHOD` annotation definitions from the static service-index and no per-symbol annotation usage at all.

### What this does

- **Definition catalog — all attachment points.** The annotation catalog now covers every attach point (`function`, `type`, `record field`, `parameter`, `return`, `listener`, etc.), extracted from the Semantic Model. It **supplements** the existing service-index catalog (which keeps owning `SERVICE`/`OBJECT_METHOD`) and de-duplicates, so existing output is unchanged.
- **Per-symbol attachments.** Annotations actually attached to API elements (e.g. `@display`, `@constraint`) are now surfaced on functions, parameters, record fields, type definitions, and clients.
- **Frontend rendering.** These are rendered into the Ballerina-syntax library context fed to the LLM (`to-syntax-string.ts`), with attach-point labels broadened and per-symbol attachments emitted inline.

### Testing

- Added `CopilotAnnotationTest` verifying the catalog now includes non-service attach points (e.g. `ballerina/http` `Payload`/`Header`/`Query` on `PARAMETER`/`RECORD_FIELD`) and that per-symbol attachments (e.g. `@display`) are extracted.
- Verified end-to-end in the Copilot: prompts that require recently-added annotations (e.g. `@log:Sensitive {strategy: {replacement}}`) are now produced correctly, whereas they were not before this change.

Fixes https://github.com/wso2/product-integrator/issues/1929