### PR TITLE
Add a usage re-check to the header when the limit is reached

### DIFF
--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -581,7 +581,7 @@ const AIChat: React.FC = () => {
         return parts.length > 0 ? parts.join(' ') : 'less than a minute';
     };
 
-    const fetchUsage = async () => {
+    const fetchUsage = async (clearOnError = true) => {
         try {
             const result = await rpcClient.getAiPanelRpcClient().getUsage();
             if (result) {
@@ -593,9 +593,23 @@ const AIChat: React.FC = () => {
             }
         } catch (e) {
             console.error("Failed to fetch usage:", e);
-            // Reset on error to avoid permanently blocking the user on transient failures
-            setUsage(null);
-            setIsUsageExceeded(false);
+            // Clear only on the automatic path, so a transient failure can't block the user.
+            if (clearOnError) {
+                setUsage(null);
+                setIsUsageExceeded(false);
+            }
+        }
+    };
+
+    const [recheckingUsage, setRecheckingUsage] = useState(false);
+
+    /** Nothing else re-checks while the limit is up — the input is disabled, so no turn runs. */
+    const handleRecheckUsage = async (): Promise<void> => {
+        setRecheckingUsage(true);
+        try {
+            await fetchUsage(false);
+        } finally {
+            setRecheckingUsage(false);
         }
     };
 
@@ -2434,6 +2448,16 @@ const AIChat: React.FC = () => {
                                     <Tooltip content={`Resets in ${formatResetsInExact(usage.resetsIn)}`}>
                                         <UsageBadge>{isUsageExceeded ? "100%" : `${Math.round(100 - usage.remainingUsagePercentage)}%`}</UsageBadge>
                                     </Tooltip>
+                                )}
+                                {isUsageExceeded && (
+                                    <Button
+                                        appearance="icon"
+                                        onClick={() => { void handleRecheckUsage(); }}
+                                        tooltip="Check usage again"
+                                        disabled={recheckingUsage}
+                                    >
+                                        <span className={`codicon codicon-refresh${recheckingUsage ? " codicon-modifier-spin" : ""}`} style={{ fontSize: 12 }} />
+                                    </Button>
                                 )}
                             </AuthProviderChip>
                         )}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -56,7 +56,7 @@ import CheckpointSeparator from "../CheckpointSeparator";
 import { Attachment, AttachmentStatus, SkillEnableStage, SkillEntry, TaskApprovalRequest } from "@wso2/ballerina-core";
 import type { ClarifyEvent, ConfigurationCollectionEvent, ConnectorGenerationNotification } from "@wso2/ballerina-core";
 
-import { AIChatView, Header, HeaderButtons, ChatMessage, TurnGroup, AuthProviderChip, UsageBadge, ApprovalOverlay, OverlayMessage, OverlayCloseButton } from "../../styles";
+import { AIChatView, Header, HeaderButtons, ChatMessage, TurnGroup, AuthProviderChip, UsageBadge, UsageRefreshButton, ApprovalOverlay, OverlayMessage, OverlayCloseButton } from "../../styles";
 import { SessionHistoryDropdown } from "../SessionHistory";
 import ReferenceDropdown from "../ReferenceDropdown";
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
@@ -2450,14 +2450,16 @@ const AIChat: React.FC = () => {
                                     </Tooltip>
                                 )}
                                 {isUsageExceeded && (
-                                    <Button
-                                        appearance="icon"
-                                        onClick={() => { void handleRecheckUsage(); }}
-                                        tooltip="Check usage again"
-                                        disabled={recheckingUsage}
-                                    >
-                                        <span className={`codicon codicon-refresh${recheckingUsage ? " codicon-modifier-spin" : ""}`} style={{ fontSize: 12 }} />
-                                    </Button>
+                                    <Tooltip content="Check usage again">
+                                        <UsageRefreshButton
+                                            type="button"
+                                            onClick={() => { void handleRecheckUsage(); }}
+                                            disabled={recheckingUsage}
+                                            aria-label="Check usage again"
+                                        >
+                                            <span className={`codicon codicon-refresh${recheckingUsage ? " codicon-modifier-spin" : ""}`} style={{ fontSize: 12 }} />
+                                        </UsageRefreshButton>
+                                    </Tooltip>
                                 )}
                             </AuthProviderChip>
                         )}

--- a/packages/ballerina-visualizer/src/views/AIPanel/styles.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/styles.tsx
@@ -93,6 +93,34 @@ export const UsageBadge = styled.span`
     white-space: nowrap;
 `;
 
+/** Sized to match UsageBadge so the glyph centres against it instead of riding high. */
+export const UsageRefreshButton = styled.button`
+    width: 20px;
+    height: 20px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 3px;
+    color: var(--vscode-icon-foreground);
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+        background: var(--vscode-toolbar-hoverBackground);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+
+    .codicon-modifier-spin {
+        animation: codicon-spin 1.2s steps(30) infinite;
+    }
+`;
+
 export const ApprovalOverlay = styled.div`
     position: absolute;
     top: 0;


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1936

Once the usage limit was reached, the chat input stayed disabled for the rest of the session even after the quota reset. Nothing re-checked usage in the meantime — the input is disabled, so no turn ran and no completion event fired — so the only way to recover was to close and reopen the window.

- Show a refresh action in the usage header while the limit is reached, so usage can be re-checked on demand
- Keep the previous usage state when a manual re-check fails, instead of reporting that the quota is back and sending the next request into another rejection

<img width="227" height="111" alt="image" src="https://github.com/user-attachments/assets/3711d85e-db85-4136-b4b2-cac3c1822395" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a refresh control to the usage header when the Copilot quota is reached, enabling users to re-check availability without reopening the chat.
- Preserved the existing usage state when a manual re-check fails, keeping the chat disabled until quota status is confirmed.
- Added loading and alignment styles for the new refresh control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->