### PR TITLE
Suggest follow-up actions after a Copilot turn

### DIFF
--- a/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { LoginMethod } from "../../state-machine-types";
+import { LoginMethod, FollowupSuggestion } from "../../state-machine-types";
 import {
     TestGenerationMentions,
     RequirementSpecification,
@@ -147,6 +147,7 @@ export interface AIPanelAPI {
     getActiveTempDir: () => Promise<string>;
     hasPendingReview: (params: HasPendingReviewRequest) => Promise<boolean>;
     getRunStatus: (params: GetRunStatusRequest) => Promise<GetRunStatusResponse>;
+    getLatestFollowupSuggestions: () => Promise<FollowupSuggestion[]>;
     getUsage: () => Promise<UsageResponse | undefined>;
     requestQuota: (params: QuotaRequestParams) => Promise<QuotaRequestResult>;
     openFileDiff: (params: OpenFileDiffRequest) => void;

--- a/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -17,7 +17,7 @@
  * 
  * THIS FILE INCLUDES AUTO GENERATED CODE
  */
-import { LoginMethod } from "../../state-machine-types";
+import { LoginMethod, FollowupSuggestion } from "../../state-machine-types";
 import {
     TestGenerationMentions,
     RequirementSpecification,
@@ -135,6 +135,7 @@ export const updateChatMessage: RequestType<UpdateChatMessageRequest, void> = { 
 export const getActiveTempDir: RequestType<void, string> = { method: `${_preFix}/getActiveTempDir` };
 export const hasPendingReview: RequestType<HasPendingReviewRequest, boolean> = { method: `${_preFix}/hasPendingReview` };
 export const getRunStatus: RequestType<GetRunStatusRequest, GetRunStatusResponse> = { method: `${_preFix}/getRunStatus` };
+export const getLatestFollowupSuggestions: RequestType<void, FollowupSuggestion[]> = { method: `${_preFix}/getLatestFollowupSuggestions` };
 export const getUsage: RequestType<void, UsageResponse | undefined> = { method: `${_preFix}/getUsage` };
 export const requestQuota: RequestType<QuotaRequestParams, QuotaRequestResult> = { method: `${_preFix}/requestQuota` };
 export const openFileDiff: NotificationType<OpenFileDiffRequest> = { method: `${_preFix}/openFileDiff` };

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -881,6 +881,8 @@ export interface Generation {
     fileAttachments?: FileAttatchment[];
     /** Code context for this generation */
     codeContext?: CodeContext;
+    /** Post-turn follow-up suggestions; runtime-only, not persisted across a restart */
+    followupSuggestions?: FollowupSuggestion[];
     /** Generation metadata */
     metadata: GenerationMetadata;
 }

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -374,7 +374,24 @@ export type ChatNotify = (
     | CompactionDisabledEvent
     | ConfigChangeEvent
     | MigrationProgressEvent
+    | FollowupSuggestionsEvent
 ) & ChatNotifyMeta;
+
+/** A single clickable follow-up suggestion shown after a completed turn. */
+export interface FollowupSuggestion {
+    /** Short imperative chip text (what the user sees). */
+    label: string;
+    /** The message sent to Copilot when the chip is clicked. */
+    prompt: string;
+}
+
+/** Post-turn follow-up suggestions for a specific assistant message. */
+export interface FollowupSuggestionsEvent {
+    type: "followup_suggestions";
+    /** The assistant message these suggestions belong to. */
+    messageId: string;
+    suggestions: FollowupSuggestion[];
+}
 
 /** Structured progress event emitted by the migration orchestrator at each stage boundary. */
 export interface MigrationProgressEvent {

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -377,9 +377,6 @@ export type ChatNotify = (
     | FollowupSuggestionsEvent
 ) & ChatNotifyMeta;
 
-/** How the turn these suggestions belong to ended. */
-export type FollowupSituation = "completed" | "aborted";
-
 /** A single clickable follow-up suggestion shown after a completed turn. */
 export interface FollowupSuggestion {
     /** Short imperative chip text (what the user sees). */
@@ -394,8 +391,6 @@ export interface FollowupSuggestionsEvent {
     /** The assistant message these suggestions belong to. */
     messageId: string;
     suggestions: FollowupSuggestion[];
-    /** Lets the webview merge rather than replace chips it already showed (e.g. Continue on abort). */
-    reason?: FollowupSituation;
 }
 
 /** Structured progress event emitted by the migration orchestrator at each stage boundary. */

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -377,6 +377,9 @@ export type ChatNotify = (
     | FollowupSuggestionsEvent
 ) & ChatNotifyMeta;
 
+/** How the turn these suggestions belong to ended. */
+export type FollowupSituation = "completed" | "aborted";
+
 /** A single clickable follow-up suggestion shown after a completed turn. */
 export interface FollowupSuggestion {
     /** Short imperative chip text (what the user sees). */
@@ -391,6 +394,8 @@ export interface FollowupSuggestionsEvent {
     /** The assistant message these suggestions belong to. */
     messageId: string;
     suggestions: FollowupSuggestion[];
+    /** Lets the webview merge rather than replace chips it already showed (e.g. Continue on abort). */
+    reason?: FollowupSituation;
 }
 
 /** Structured progress event emitted by the migration orchestrator at each stage boundary. */

--- a/packages/ballerina-extension/package.json
+++ b/packages/ballerina-extension/package.json
@@ -339,6 +339,12 @@
                     "default": false,
                     "scope": "resource",
                     "description": "Show context usage indicator in the AI chat input footer."
+                },
+                "ballerina.copilot.followupSuggestions": {
+                    "type": "boolean",
+                    "default": true,
+                    "scope": "resource",
+                    "description": "Suggest follow-up actions after Copilot responds in the AI chat."
                 }
             }
         },

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -975,6 +975,9 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                     abortSignal: this.config.abortController.signal,
                 });
                 if (suggestions.length > 0 && !this.config.abortController.signal.aborted) {
+                    const projectRootPath = context.ctx.workspacePath || context.ctx.projectPath || '';
+                    const threadId = this.config.chatStorage?.threadId ?? 'default';
+                    chatStateStorage.updateGeneration(projectRootPath, threadId, context.messageId, { followupSuggestions: suggestions });
                     this.config.eventHandler({
                         type: 'followup_suggestions',
                         messageId: context.messageId,

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -24,6 +24,7 @@ import { getAnthropicClient, getProviderCacheControl, addCacheControlToMessages,
 import { populateHistoryForAgent, getErrorMessage, buildChatError } from '../utils/ai-utils';
 import { sendAgentDidOpenForFreshProjects } from '../utils/project/ls-schema-notifications';
 import { getSystemPrompt, getUserPrompt } from './prompts';
+import { generateFollowupSuggestions } from './followups';
 import { prepareAgentsMdForTurn } from './agents-md';
 // TODO(auto-memory): temporarily disabled for this release.
 // import { executeAutoDream, isMemoryEnabled } from '../memory/autoDream';
@@ -144,6 +145,26 @@ function computeTokenBreakdown(
     const toolResults = Math.round(inputTokens * toolChars / totalChars);
     const toolDefinitions = Math.max(0, inputTokens - systemInstructions - files - messages - toolResults);
     return { systemInstructions, toolDefinitions, reservedOutput: RESERVED_OUTPUT_TOKENS, files, messages, toolResults };
+}
+
+/** Concatenates the assistant's text output from a set of model messages. */
+function extractAssistantText(messages: any[]): string {
+    const parts: string[] = [];
+    for (const message of messages ?? []) {
+        if (message?.role !== 'assistant') {
+            continue;
+        }
+        if (typeof message.content === 'string') {
+            parts.push(message.content);
+        } else if (Array.isArray(message.content)) {
+            for (const item of message.content) {
+                if (item?.type === 'text' && typeof item.text === 'string') {
+                    parts.push(item.text);
+                }
+            }
+        }
+    }
+    return parts.join('\n').trim();
 }
 
 /**
@@ -915,12 +936,55 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
         // Emit UI events
         await this.emitReviewActions(context);
 
+        // Follow-up suggestions — best-effort, non-blocking. Only reached on a normally
+        // completed turn (abort/error paths return earlier and never call this).
+        this.maybeEmitFollowupSuggestions(context, assistantMessages);
+
         // TODO(auto-memory): auto-dream consolidation temporarily disabled for this release.
         // // autoDream consolidation — skipped on compaction turns (no real user activity)
         // const workspacePath = context.ctx.workspacePath || context.ctx.projectPath || '';
         // if (workspacePath && !context.wasCompactionTurn) {
         //     executeAutoDream({ workspacePath });
         // }
+    }
+
+    /**
+     * Generates post-turn follow-up suggestions and pushes them to the webview.
+     *
+     * Fire-and-forget: never blocks turn completion, and any failure (disabled, empty
+     * response, model error, abort) simply results in no chips. Honors the turn's abort
+     * signal so a superseded turn does not emit stale suggestions.
+     */
+    private maybeEmitFollowupSuggestions(context: StreamContext, assistantMessages: any[]): void {
+        const enabled = workspace.getConfiguration('ballerina.copilot').get<boolean>('followupSuggestions', true);
+        if (!enabled || this.config.abortController.signal.aborted) {
+            return;
+        }
+
+        const assistantText = extractAssistantText(assistantMessages);
+        if (!assistantText) {
+            return;
+        }
+
+        void (async () => {
+            try {
+                const suggestions = await generateFollowupSuggestions({
+                    userQuery: this.config.params.usecase ?? '',
+                    assistantResponse: assistantText,
+                    mode: this.config.params.isPlanMode ? 'Plan' : 'Edit',
+                    abortSignal: this.config.abortController.signal,
+                });
+                if (suggestions.length > 0 && !this.config.abortController.signal.aborted) {
+                    this.config.eventHandler({
+                        type: 'followup_suggestions',
+                        messageId: context.messageId,
+                        suggestions,
+                    });
+                }
+            } catch (error) {
+                console.warn('[AgentExecutor] Follow-up suggestion generation failed:', error);
+            }
+        })();
     }
 
     /**

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -21,7 +21,7 @@ import { Command, GenerateAgentCodeRequest, ProjectSource, ExecutionContext, Sem
 import { StateMachine } from '../../../stateMachine';
 import { ModelMessage, stepCountIs, streamText, TextStreamPart } from 'ai';
 import { getAnthropicClient, getProviderCacheControl, addCacheControlToMessages, ANTHROPIC_SONNET_4 } from '../utils/ai-client';
-import { populateHistoryForAgent, getErrorMessage, buildChatError } from '../utils/ai-utils';
+import { populateHistoryForAgent, getErrorMessage, getErrorCode, buildChatError } from '../utils/ai-utils';
 import { sendAgentDidOpenForFreshProjects } from '../utils/project/ls-schema-notifications';
 import { getSystemPrompt, getUserPrompt } from './prompts';
 import { FollowupSituation, startFollowupSuggestions } from './followups';
@@ -828,6 +828,11 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
             });
             updateAndSaveChat(context.messageId, Command.Agent, context.eventHandler);
         }
+
+        // The quota banner owns that failure, and retrying under an exhausted quota just fails again.
+        if (getErrorCode(error) !== 'usage_limit') {
+            this.maybeScheduleFollowups(context, messagesToSave, 'error', getErrorMessage(error));
+        }
     }
 
     /**
@@ -936,7 +941,12 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
     }
 
     /** Hands the finished turn to the follow-up suggestion flow; at most once per turn. */
-    private maybeScheduleFollowups(context: StreamContext, assistantMessages: any[], situation: FollowupSituation): void {
+    private maybeScheduleFollowups(
+        context: StreamContext,
+        assistantMessages: any[],
+        situation: FollowupSituation,
+        errorMessage?: string
+    ): void {
         // Migration and evals drive this executor with their own handlers and no chat storage —
         // suggestions there would burn a call and leak chips into the wrong panel.
         if (this._followupsScheduled || !this.config.chatStorage?.enabled) {
@@ -951,6 +961,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
             userQuery: this.config.params.usecase ?? '',
             isPlanMode: this.config.params.isPlanMode,
             abortSignal: this.config.abortController.signal,
+            errorMessage,
             eventHandler: this.config.eventHandler,
         });
     }

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -829,10 +829,10 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
             updateAndSaveChat(context.messageId, Command.Agent, context.eventHandler);
         }
 
-        // The quota banner owns that failure, and retrying under an exhausted quota just fails again.
-        if (getErrorCode(error) !== 'usage_limit') {
-            this.maybeScheduleFollowups(context, messagesToSave, 'error', getErrorMessage(error));
-        }
+        // A quota failure gets a Continue chip with no model call — the webview keeps it hidden
+        // until the limit resets, so the user can pick the work back up then.
+        const situation: FollowupSituation = getErrorCode(error) === 'usage_limit' ? 'usage_limit' : 'error';
+        this.maybeScheduleFollowups(context, messagesToSave, situation, getErrorMessage(error));
     }
 
     /**

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -17,7 +17,7 @@
  */
 
 import { AICommandExecutor, AICommandConfig, AIExecutionResult } from '../executors/base/AICommandExecutor';
-import { Command, GenerateAgentCodeRequest, ProjectSource, ExecutionContext, SemanticDiff, ReviewModeData, PROJECT_KIND, LoginMethod } from '@wso2/ballerina-core';
+import { Command, GenerateAgentCodeRequest, ProjectSource, ExecutionContext, SemanticDiff, ReviewModeData, PROJECT_KIND, LoginMethod, FollowupSituation, FollowupSuggestion } from '@wso2/ballerina-core';
 import { StateMachine } from '../../../stateMachine';
 import { ModelMessage, stepCountIs, streamText, TextStreamPart } from 'ai';
 import { getAnthropicClient, getProviderCacheControl, addCacheControlToMessages, ANTHROPIC_SONNET_4 } from '../utils/ai-client';
@@ -68,6 +68,14 @@ import { runningServicesManager } from './tools/running-service-manager';
 
 
 const RESERVED_OUTPUT_TOKENS = 8_192;
+
+/** Below this much partial output an aborted turn gets the Continue chip only, with no model call. */
+const MIN_CHARS_FOR_ABORT_FOLLOWUPS = 200;
+
+const CONTINUE_SUGGESTION: FollowupSuggestion = {
+    label: 'Continue',
+    prompt: 'Redo the step you were interrupted on and carry on.',
+};
 
 /**
  * Tracks threads that have already received a compaction_disabled warning this session.
@@ -239,6 +247,9 @@ async function determineAffectedPackages(
 export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
     /** Tracks in-flight tool-call start times keyed by toolCallId for duration logging. */
     private readonly _pendingToolCalls = new Map<string, number>();
+
+    /** A turn can reach both the finish and abort paths; suggestions must be scheduled once. */
+    private _followupsScheduled = false;
 
     constructor(config: AICommandConfig<GenerateAgentCodeRequest>) {
         super(config);
@@ -653,6 +664,11 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                         );
                     }
 
+                    // Only meaningful once the turn produced something to pivot away from.
+                    if (partialLLMMessages.length > 0) {
+                        this.scheduleFollowups(streamContext, partialLLMMessages, 'aborted');
+                    }
+
                     // Note: Abort event is sent by base class handleExecutionError()
                 }
 
@@ -936,9 +952,8 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
         // Emit UI events
         await this.emitReviewActions(context);
 
-        // Follow-up suggestions — best-effort, non-blocking. Only reached on a normally
-        // completed turn (abort/error paths return earlier and never call this).
-        this.maybeEmitFollowupSuggestions(context, assistantMessages);
+        // Follow-up suggestions — best-effort, non-blocking.
+        this.scheduleFollowups(context, assistantMessages, 'completed');
 
         // TODO(auto-memory): auto-dream consolidation temporarily disabled for this release.
         // // autoDream consolidation — skipped on compaction turns (no real user activity)
@@ -955,39 +970,93 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
      * response, model error, abort) simply results in no chips. Honors the turn's abort
      * signal so a superseded turn does not emit stale suggestions.
      */
-    private maybeEmitFollowupSuggestions(context: StreamContext, assistantMessages: any[]): void {
-        const enabled = workspace.getConfiguration('ballerina.copilot').get<boolean>('followupSuggestions', true);
-        if (!enabled || this.config.abortController.signal.aborted) {
+    private scheduleFollowups(context: StreamContext, assistantMessages: any[], situation: FollowupSituation): void {
+        if (this._followupsScheduled || process.env.AI_TEST_ENV) {
+            return;
+        }
+        // Migration and evals drive this executor with their own handlers and no chat storage —
+        // suggestions there would burn a call and leak chips into the wrong panel.
+        if (!this.config.chatStorage?.enabled) {
+            return;
+        }
+        if (!workspace.getConfiguration('ballerina.copilot').get<boolean>('followupSuggestions', true)) {
+            return;
+        }
+
+        const aborted = situation === 'aborted';
+        // On the aborted path the turn's signal is already tripped, so it can neither gate nor be reused.
+        if (!aborted && this.config.abortController.signal.aborted) {
             return;
         }
 
         const assistantText = extractAssistantText(assistantMessages);
-        if (!assistantText) {
+        if (!aborted && !assistantText) {
             return;
         }
 
+        this._followupsScheduled = true;
+
+        const projectRootPath = context.ctx.workspacePath || context.ctx.projectPath || '';
+        const threadId = this.config.chatStorage.threadId;
+        // Users abort constantly; only pay for a model call when there is enough to pivot from.
+        const worthGenerating = assistantText.length >= MIN_CHARS_FOR_ABORT_FOLLOWUPS || !aborted;
+        console.log(`[Followups] Scheduling for ${context.messageId} (situation=${situation})`);
+
         void (async () => {
             try {
-                const suggestions = await generateFollowupSuggestions({
-                    userQuery: this.config.params.usecase ?? '',
-                    assistantResponse: assistantText,
-                    mode: this.config.params.isPlanMode ? 'Plan' : 'Edit',
-                    abortSignal: this.config.abortController.signal,
-                });
-                if (suggestions.length > 0 && !this.config.abortController.signal.aborted) {
-                    const projectRootPath = context.ctx.workspacePath || context.ctx.projectPath || '';
-                    const threadId = this.config.chatStorage?.threadId ?? 'default';
-                    chatStateStorage.updateGeneration(projectRootPath, threadId, context.messageId, { followupSuggestions: suggestions });
-                    this.config.eventHandler({
-                        type: 'followup_suggestions',
-                        messageId: context.messageId,
-                        suggestions,
-                    });
+                const generated = worthGenerating
+                    ? await generateFollowupSuggestions({
+                        userQuery: this.config.params.usecase ?? '',
+                        assistantResponse: assistantText,
+                        mode: this.config.params.isPlanMode ? 'Plan' : 'Edit',
+                        situation,
+                        maxSuggestions: aborted ? 2 : 3,
+                        abortSignal: aborted ? undefined : this.config.abortController.signal,
+                    })
+                    : [];
+
+                const suggestions = aborted ? [CONTINUE_SUGGESTION, ...generated] : generated;
+                if (suggestions.length === 0) {
+                    return;
                 }
+                if (!aborted && this.config.abortController.signal.aborted) {
+                    return;
+                }
+                if (!this.isTurnStillCurrent(projectRootPath, threadId, context.messageId)) {
+                    console.log(`[Followups] Dropped for ${context.messageId} — no longer the latest turn`);
+                    return;
+                }
+
+                chatStateStorage.updateGeneration(projectRootPath, threadId, context.messageId, { followupSuggestions: suggestions });
+                this.config.eventHandler({
+                    type: 'followup_suggestions',
+                    messageId: context.messageId,
+                    suggestions,
+                    reason: situation,
+                });
+                console.log(`[Followups] Emitted for ${context.messageId}: ${suggestions.map(s => s.label).join(', ')}`);
             } catch (error) {
-                console.warn('[AgentExecutor] Follow-up suggestion generation failed:', error);
+                console.warn(`[Followups] Generation failed for ${context.messageId}:`, error);
             }
         })();
+    }
+
+    /**
+     * Whether the turn is still the one the user is looking at, checked after the model call.
+     * The webview cannot tell stale suggestions apart, so a thread switch or a newer prompt
+     * during the call must suppress them.
+     */
+    private isTurnStillCurrent(projectRootPath: string, threadId: string, messageId: string): boolean {
+        // Checked first: getGenerations would otherwise recreate a thread that was just cleared.
+        if (chatStateStorage.getActiveThread(projectRootPath)?.id !== threadId) {
+            return false;
+        }
+        const active = chatStateStorage.getActiveExecution(projectRootPath, threadId);
+        if (active && active.generationId !== messageId) {
+            return false;
+        }
+        const generations = chatStateStorage.getGenerations(projectRootPath, threadId);
+        return generations[generations.length - 1]?.id === messageId;
     }
 
     /**

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -17,14 +17,14 @@
  */
 
 import { AICommandExecutor, AICommandConfig, AIExecutionResult } from '../executors/base/AICommandExecutor';
-import { Command, GenerateAgentCodeRequest, ProjectSource, ExecutionContext, SemanticDiff, ReviewModeData, PROJECT_KIND, LoginMethod, FollowupSituation, FollowupSuggestion } from '@wso2/ballerina-core';
+import { Command, GenerateAgentCodeRequest, ProjectSource, ExecutionContext, SemanticDiff, ReviewModeData, PROJECT_KIND, LoginMethod } from '@wso2/ballerina-core';
 import { StateMachine } from '../../../stateMachine';
 import { ModelMessage, stepCountIs, streamText, TextStreamPart } from 'ai';
 import { getAnthropicClient, getProviderCacheControl, addCacheControlToMessages, ANTHROPIC_SONNET_4 } from '../utils/ai-client';
 import { populateHistoryForAgent, getErrorMessage, buildChatError } from '../utils/ai-utils';
 import { sendAgentDidOpenForFreshProjects } from '../utils/project/ls-schema-notifications';
 import { getSystemPrompt, getUserPrompt } from './prompts';
-import { generateFollowupSuggestions } from './followups';
+import { FollowupSituation, startFollowupSuggestions } from './followups';
 import { prepareAgentsMdForTurn } from './agents-md';
 // TODO(auto-memory): temporarily disabled for this release.
 // import { executeAutoDream, isMemoryEnabled } from '../memory/autoDream';
@@ -68,14 +68,6 @@ import { runningServicesManager } from './tools/running-service-manager';
 
 
 const RESERVED_OUTPUT_TOKENS = 8_192;
-
-/** Below this much partial output an aborted turn gets the Continue chip only, with no model call. */
-const MIN_CHARS_FOR_ABORT_FOLLOWUPS = 200;
-
-const CONTINUE_SUGGESTION: FollowupSuggestion = {
-    label: 'Continue',
-    prompt: 'Redo the step you were interrupted on and carry on.',
-};
 
 /**
  * Tracks threads that have already received a compaction_disabled warning this session.
@@ -153,26 +145,6 @@ function computeTokenBreakdown(
     const toolResults = Math.round(inputTokens * toolChars / totalChars);
     const toolDefinitions = Math.max(0, inputTokens - systemInstructions - files - messages - toolResults);
     return { systemInstructions, toolDefinitions, reservedOutput: RESERVED_OUTPUT_TOKENS, files, messages, toolResults };
-}
-
-/** Concatenates the assistant's text output from a set of model messages. */
-function extractAssistantText(messages: any[]): string {
-    const parts: string[] = [];
-    for (const message of messages ?? []) {
-        if (message?.role !== 'assistant') {
-            continue;
-        }
-        if (typeof message.content === 'string') {
-            parts.push(message.content);
-        } else if (Array.isArray(message.content)) {
-            for (const item of message.content) {
-                if (item?.type === 'text' && typeof item.text === 'string') {
-                    parts.push(item.text);
-                }
-            }
-        }
-    }
-    return parts.join('\n').trim();
 }
 
 /**
@@ -666,7 +638,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
 
                     // Only meaningful once the turn produced something to pivot away from.
                     if (partialLLMMessages.length > 0) {
-                        this.scheduleFollowups(streamContext, partialLLMMessages, 'aborted');
+                        this.maybeScheduleFollowups(streamContext, partialLLMMessages, 'aborted');
                     }
 
                     // Note: Abort event is sent by base class handleExecutionError()
@@ -953,7 +925,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
         await this.emitReviewActions(context);
 
         // Follow-up suggestions — best-effort, non-blocking.
-        this.scheduleFollowups(context, assistantMessages, 'completed');
+        this.maybeScheduleFollowups(context, assistantMessages, 'completed');
 
         // TODO(auto-memory): auto-dream consolidation temporarily disabled for this release.
         // // autoDream consolidation — skipped on compaction turns (no real user activity)
@@ -963,100 +935,24 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
         // }
     }
 
-    /**
-     * Generates post-turn follow-up suggestions and pushes them to the webview.
-     *
-     * Fire-and-forget: never blocks turn completion, and any failure (disabled, empty
-     * response, model error, abort) simply results in no chips. Honors the turn's abort
-     * signal so a superseded turn does not emit stale suggestions.
-     */
-    private scheduleFollowups(context: StreamContext, assistantMessages: any[], situation: FollowupSituation): void {
-        if (this._followupsScheduled || process.env.AI_TEST_ENV) {
-            return;
-        }
+    /** Hands the finished turn to the follow-up suggestion flow; at most once per turn. */
+    private maybeScheduleFollowups(context: StreamContext, assistantMessages: any[], situation: FollowupSituation): void {
         // Migration and evals drive this executor with their own handlers and no chat storage —
         // suggestions there would burn a call and leak chips into the wrong panel.
-        if (!this.config.chatStorage?.enabled) {
+        if (this._followupsScheduled || !this.config.chatStorage?.enabled) {
             return;
         }
-        if (!workspace.getConfiguration('ballerina.copilot').get<boolean>('followupSuggestions', true)) {
-            return;
-        }
-
-        const aborted = situation === 'aborted';
-        // On the aborted path the turn's signal is already tripped, so it can neither gate nor be reused.
-        if (!aborted && this.config.abortController.signal.aborted) {
-            return;
-        }
-
-        const assistantText = extractAssistantText(assistantMessages);
-        if (!aborted && !assistantText) {
-            return;
-        }
-
-        this._followupsScheduled = true;
-
-        const projectRootPath = context.ctx.workspacePath || context.ctx.projectPath || '';
-        const threadId = this.config.chatStorage.threadId;
-        // Users abort constantly; only pay for a model call when there is enough to pivot from.
-        const worthGenerating = assistantText.length >= MIN_CHARS_FOR_ABORT_FOLLOWUPS || !aborted;
-        console.log(`[Followups] Scheduling for ${context.messageId} (situation=${situation})`);
-
-        void (async () => {
-            try {
-                const generated = worthGenerating
-                    ? await generateFollowupSuggestions({
-                        userQuery: this.config.params.usecase ?? '',
-                        assistantResponse: assistantText,
-                        mode: this.config.params.isPlanMode ? 'Plan' : 'Edit',
-                        situation,
-                        maxSuggestions: aborted ? 2 : 3,
-                        abortSignal: aborted ? undefined : this.config.abortController.signal,
-                    })
-                    : [];
-
-                const suggestions = aborted ? [CONTINUE_SUGGESTION, ...generated] : generated;
-                if (suggestions.length === 0) {
-                    return;
-                }
-                if (!aborted && this.config.abortController.signal.aborted) {
-                    return;
-                }
-                if (!this.isTurnStillCurrent(projectRootPath, threadId, context.messageId)) {
-                    console.log(`[Followups] Dropped for ${context.messageId} — no longer the latest turn`);
-                    return;
-                }
-
-                chatStateStorage.updateGeneration(projectRootPath, threadId, context.messageId, { followupSuggestions: suggestions });
-                this.config.eventHandler({
-                    type: 'followup_suggestions',
-                    messageId: context.messageId,
-                    suggestions,
-                    reason: situation,
-                });
-                console.log(`[Followups] Emitted for ${context.messageId}: ${suggestions.map(s => s.label).join(', ')}`);
-            } catch (error) {
-                console.warn(`[Followups] Generation failed for ${context.messageId}:`, error);
-            }
-        })();
-    }
-
-    /**
-     * Whether the turn is still the one the user is looking at, checked after the model call.
-     * The webview cannot tell stale suggestions apart, so a thread switch or a newer prompt
-     * during the call must suppress them.
-     */
-    private isTurnStillCurrent(projectRootPath: string, threadId: string, messageId: string): boolean {
-        // Checked first: getGenerations would otherwise recreate a thread that was just cleared.
-        if (chatStateStorage.getActiveThread(projectRootPath)?.id !== threadId) {
-            return false;
-        }
-        const active = chatStateStorage.getActiveExecution(projectRootPath, threadId);
-        if (active && active.generationId !== messageId) {
-            return false;
-        }
-        const generations = chatStateStorage.getGenerations(projectRootPath, threadId);
-        return generations[generations.length - 1]?.id === messageId;
+        this._followupsScheduled = startFollowupSuggestions({
+            situation,
+            messageId: context.messageId,
+            projectRootPath: context.ctx.workspacePath || context.ctx.projectPath || '',
+            threadId: this.config.chatStorage.threadId,
+            assistantMessages,
+            userQuery: this.config.params.usecase ?? '',
+            isPlanMode: this.config.params.isPlanMode,
+            abortSignal: this.config.abortController.signal,
+            eventHandler: this.config.eventHandler,
+        });
     }
 
     /**

--- a/packages/ballerina-extension/src/features/ai/agent/followups/anchors.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/anchors.ts
@@ -31,13 +31,12 @@ export interface AnchorAction {
 }
 
 export const ANCHOR_ACTIONS: AnchorAction[] = [
-    { label: "Add tests", description: "generate unit or integration tests for the code just written" },
-    { label: "Try it out", description: "run or invoke the service/function to see it working" },
-    { label: "Add error handling", description: "handle errors, timeouts, and edge cases in the code" },
-    { label: "Add authentication", description: "secure the service (auth/authz, API keys, OAuth2)" },
-    { label: "Add logging", description: "add logging or observability for debugging and monitoring" },
-    { label: "Validate input", description: "validate and sanitize incoming request payloads or parameters" },
-    { label: "Explain the code", description: "walk through how the generated code works" },
-    { label: "Add a connector", description: "integrate an external service using a Ballerina connector" },
-    { label: "Deploy", description: "deploy or containerize the integration" },
+    { label: "Add tests", description: "add tests that check the integration behaves as expected" },
+    { label: "Try it out", description: "run the integration and see it working" },
+    { label: "Handle errors", description: "handle failures, timeouts, and unexpected input gracefully" },
+    { label: "Add authentication", description: "secure the service so only authorized callers can use it" },
+    { label: "Add logging", description: "record activity so the integration can be monitored and debugged" },
+    { label: "Validate input", description: "check incoming requests so bad data is rejected safely" },
+    { label: "Explain how it works", description: "walk through what the integration does" },
+    { label: "Add a connector", description: "connect to another system or service, such as a database, API, or SaaS app" },
 ];

--- a/packages/ballerina-extension/src/features/ai/agent/followups/anchors.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/anchors.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * High-value follow-up actions a Ballerina developer commonly wants next.
+ *
+ * These are NOT rigid templates. They steer the model (hybrid strategy): when one of
+ * these is relevant to the last exchange, the model is told to prefer it and phrase it
+ * for the current context; otherwise it generates a contextual suggestion of its own.
+ */
+export interface AnchorAction {
+    /** Short chip text, imperative (what the user sees). */
+    label: string;
+    /** When this action is worth suggesting — guidance for the model, not shown to the user. */
+    description: string;
+}
+
+export const ANCHOR_ACTIONS: AnchorAction[] = [
+    { label: "Add tests", description: "generate unit or integration tests for the code just written" },
+    { label: "Try it out", description: "run or invoke the service/function to see it working" },
+    { label: "Add error handling", description: "handle errors, timeouts, and edge cases in the code" },
+    { label: "Add authentication", description: "secure the service (auth/authz, API keys, OAuth2)" },
+    { label: "Add logging", description: "add logging or observability for debugging and monitoring" },
+    { label: "Validate input", description: "validate and sanitize incoming request payloads or parameters" },
+    { label: "Explain the code", description: "walk through how the generated code works" },
+    { label: "Add a connector", description: "integrate an external service using a Ballerina connector" },
+    { label: "Deploy", description: "deploy or containerize the integration" },
+];

--- a/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { generateObject } from "ai";
+import { ANTHROPIC_HAIKU, getAnthropicClient } from "../../utils/ai-client";
+import { buildFollowupMessages, FollowupPromptInput } from "./prompt";
+import { followupSuggestionsSchema, GeneratedFollowupSuggestion } from "./schema";
+
+const MAX_SUGGESTIONS = 3;
+
+export interface GenerateFollowupsOptions extends FollowupPromptInput {
+    /** Aborts the call when the turn is superseded or the panel closes. */
+    abortSignal?: AbortSignal;
+}
+
+/**
+ * Generates a small set of follow-up suggestions for a completed turn.
+ *
+ * Best-effort: any failure (model error, timeout, abort, or output that fails schema
+ * validation) resolves to an empty array so the caller can simply show no chips.
+ */
+export async function generateFollowupSuggestions(
+    options: GenerateFollowupsOptions
+): Promise<GeneratedFollowupSuggestion[]> {
+    const { abortSignal, ...promptInput } = options;
+
+    // Nothing to build suggestions from.
+    if (!promptInput.assistantResponse?.trim()) {
+        return [];
+    }
+
+    try {
+        const { object } = await generateObject({
+            model: await getAnthropicClient(ANTHROPIC_HAIKU),
+            maxOutputTokens: 1024,
+            temperature: 0.3,
+            messages: buildFollowupMessages(promptInput),
+            schema: followupSuggestionsSchema,
+            abortSignal: abortSignal ?? new AbortController().signal,
+        });
+        return sanitize(object.suggestions);
+    } catch (error) {
+        console.warn("[Followups] Suggestion generation failed:", error);
+        return [];
+    }
+}
+
+/** Trims, drops blanks/duplicates, and caps the list. */
+function sanitize(raw: GeneratedFollowupSuggestion[]): GeneratedFollowupSuggestion[] {
+    const seen = new Set<string>();
+    const out: GeneratedFollowupSuggestion[] = [];
+    for (const s of raw ?? []) {
+        const label = s?.label?.trim();
+        const prompt = s?.prompt?.trim();
+        if (!label || !prompt) {
+            continue;
+        }
+        const key = label.toLowerCase();
+        if (seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+        out.push({ label, prompt });
+        if (out.length >= MAX_SUGGESTIONS) {
+            break;
+        }
+    }
+    return out;
+}

--- a/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
@@ -98,7 +98,8 @@ export function startFollowupSuggestions(turn: FollowupTurn): boolean {
 
     // Nothing produced means nothing to pivot on — a failure that early is almost always
     // infrastructure, where the fixed chip is the only honest suggestion.
-    const worthGenerating = !interrupted || assistantText.length >= MIN_CHARS_FOR_INTERRUPTED;
+    const worthGenerating = situation !== "usage_limit"
+        && (!interrupted || assistantText.length >= MIN_CHARS_FOR_INTERRUPTED);
     console.log(`[Followups] Scheduling for ${messageId} (situation=${situation})`);
 
     void (async () => {
@@ -114,7 +115,9 @@ export function startFollowupSuggestions(turn: FollowupTurn): boolean {
                 }, abortSignal)
                 : [];
 
-            const fixed = aborted ? [CONTINUE_SUGGESTION] : situation === "error" ? [RETRY_SUGGESTION] : [];
+            const fixed = aborted || situation === "usage_limit" ? [CONTINUE_SUGGESTION]
+                : situation === "error" ? [RETRY_SUGGESTION]
+                : [];
             const suggestions = [...fixed, ...generated];
             if (suggestions.length === 0 || (!interrupted && abortSignal.aborted)) {
                 return;

--- a/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
@@ -17,15 +17,20 @@
  */
 
 import { generateObject } from "ai";
+import { FollowupSituation } from "@wso2/ballerina-core";
 import { ANTHROPIC_HAIKU, getAnthropicClient } from "../../utils/ai-client";
 import { buildFollowupMessages, FollowupPromptInput } from "./prompt";
 import { followupSuggestionsSchema, GeneratedFollowupSuggestion } from "./schema";
 
-const MAX_SUGGESTIONS = 3;
+const DEFAULT_TIMEOUT_MS = 8_000;
 
 export interface GenerateFollowupsOptions extends FollowupPromptInput {
     /** Aborts the call when the turn is superseded or the panel closes. */
     abortSignal?: AbortSignal;
+    /** Caps the call so a hung request cannot linger for the session. */
+    timeoutMs?: number;
+    /** Upper bound on returned suggestions. */
+    maxSuggestions?: number;
 }
 
 /**
@@ -37,7 +42,7 @@ export interface GenerateFollowupsOptions extends FollowupPromptInput {
 export async function generateFollowupSuggestions(
     options: GenerateFollowupsOptions
 ): Promise<GeneratedFollowupSuggestion[]> {
-    const { abortSignal, ...promptInput } = options;
+    const { abortSignal, timeoutMs = DEFAULT_TIMEOUT_MS, maxSuggestions = 3, ...promptInput } = options;
 
     // Nothing to build suggestions from.
     if (!promptInput.assistantResponse?.trim()) {
@@ -51,9 +56,9 @@ export async function generateFollowupSuggestions(
             temperature: 0.3,
             messages: buildFollowupMessages(promptInput),
             schema: followupSuggestionsSchema,
-            abortSignal: abortSignal ?? new AbortController().signal,
+            abortSignal: abortSignal ?? AbortSignal.timeout(timeoutMs),
         });
-        return sanitize(object.suggestions);
+        return sanitize(object.suggestions, maxSuggestions, promptInput.situation);
     } catch (error) {
         console.warn("[Followups] Suggestion generation failed:", error);
         return [];
@@ -61,7 +66,11 @@ export async function generateFollowupSuggestions(
 }
 
 /** Trims, drops blanks/duplicates, and caps the list. */
-function sanitize(raw: GeneratedFollowupSuggestion[]): GeneratedFollowupSuggestion[] {
+function sanitize(
+    raw: GeneratedFollowupSuggestion[],
+    max: number,
+    situation?: FollowupSituation
+): GeneratedFollowupSuggestion[] {
     const seen = new Set<string>();
     const out: GeneratedFollowupSuggestion[] = [];
     for (const s of raw ?? []) {
@@ -70,13 +79,17 @@ function sanitize(raw: GeneratedFollowupSuggestion[]): GeneratedFollowupSuggesti
         if (!label || !prompt) {
             continue;
         }
+        // The aborted flow offers its own Continue chip, so drop model-generated near-duplicates.
+        if (situation === "aborted" && /^(continue|resume|finish|complete)\b/i.test(label)) {
+            continue;
+        }
         const key = label.toLowerCase();
         if (seen.has(key)) {
             continue;
         }
         seen.add(key);
         out.push({ label, prompt });
-        if (out.length >= MAX_SUGGESTIONS) {
+        if (out.length >= max) {
             break;
         }
     }

--- a/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
@@ -17,48 +17,126 @@
  */
 
 import { generateObject } from "ai";
-import { FollowupSituation } from "@wso2/ballerina-core";
+import { FollowupSuggestion } from "@wso2/ballerina-core";
+import { workspace } from "vscode";
+import { chatStateStorage } from "../../../../views/ai-panel/chatStateStorage";
+import { CopilotEventHandler } from "../../utils/events";
 import { ANTHROPIC_HAIKU, getAnthropicClient } from "../../utils/ai-client";
-import { buildFollowupMessages, FollowupPromptInput } from "./prompt";
+import { buildFollowupMessages, FollowupPromptInput, FollowupSituation } from "./prompt";
 import { followupSuggestionsSchema, GeneratedFollowupSuggestion } from "./schema";
 
-const DEFAULT_TIMEOUT_MS = 8_000;
+export { FollowupSituation } from "./prompt";
 
-export interface GenerateFollowupsOptions extends FollowupPromptInput {
-    /** Aborts the call when the turn is superseded or the panel closes. */
-    abortSignal?: AbortSignal;
-    /** Caps the call so a hung request cannot linger for the session. */
-    timeoutMs?: number;
-    /** Upper bound on returned suggestions. */
-    maxSuggestions?: number;
+const TIMEOUT_MS = 8_000;
+
+/** Below this much partial output an aborted turn gets the Continue chip only, with no model call. */
+const MIN_CHARS_FOR_ABORT = 200;
+
+/** Offered whenever a turn is stopped part-way. */
+const CONTINUE_SUGGESTION: FollowupSuggestion = {
+    label: "Continue",
+    prompt: "Redo the step you were interrupted on and carry on.",
+};
+
+export interface FollowupTurn {
+    situation: FollowupSituation;
+    /** Generation this turn belongs to. */
+    messageId: string;
+    projectRootPath: string;
+    threadId: string;
+    /** Model messages for the turn; the assistant text is taken from these. */
+    assistantMessages: any[];
+    userQuery: string;
+    isPlanMode: boolean;
+    /** The turn's signal — already tripped on the aborted path. */
+    abortSignal: AbortSignal;
+    eventHandler: CopilotEventHandler;
 }
 
 /**
- * Generates a small set of follow-up suggestions for a completed turn.
+ * Produces follow-up suggestions for a finished turn and pushes them to the webview.
  *
- * Best-effort: any failure (model error, timeout, abort, or output that fails schema
- * validation) resolves to an empty array so the caller can simply show no chips.
+ * Fire-and-forget: never blocks turn completion, and any failure (disabled, empty response,
+ * model error, abort) simply results in no chips.
+ *
+ * @returns whether generation started, so the caller can avoid running twice for one turn.
  */
-export async function generateFollowupSuggestions(
-    options: GenerateFollowupsOptions
-): Promise<GeneratedFollowupSuggestion[]> {
-    const { abortSignal, timeoutMs = DEFAULT_TIMEOUT_MS, maxSuggestions = 3, ...promptInput } = options;
+export function startFollowupSuggestions(turn: FollowupTurn): boolean {
+    const { situation, messageId, projectRootPath, threadId, assistantMessages, userQuery, isPlanMode, abortSignal, eventHandler } = turn;
 
-    // Nothing to build suggestions from.
-    if (!promptInput.assistantResponse?.trim()) {
-        return [];
+    if (process.env.AI_TEST_ENV) {
+        return false;
+    }
+    if (!workspace.getConfiguration("ballerina.copilot").get<boolean>("followupSuggestions", true)) {
+        return false;
     }
 
+    const aborted = situation === "aborted";
+    // On the aborted path the turn's signal is already tripped, so it can neither gate nor be reused.
+    if (!aborted && abortSignal.aborted) {
+        return false;
+    }
+
+    const assistantText = extractAssistantText(assistantMessages);
+    if (!aborted && !assistantText) {
+        return false;
+    }
+
+    // Users abort constantly; only pay for a model call when there is enough to pivot from.
+    const worthGenerating = !aborted || assistantText.length >= MIN_CHARS_FOR_ABORT;
+    console.log(`[Followups] Scheduling for ${messageId} (situation=${situation})`);
+
+    void (async () => {
+        try {
+            const generated = worthGenerating
+                ? await generateSuggestions({
+                    userQuery,
+                    assistantResponse: assistantText,
+                    mode: isPlanMode ? "Plan" : "Edit",
+                    situation,
+                }, abortSignal)
+                : [];
+
+            const suggestions = aborted ? [CONTINUE_SUGGESTION, ...generated] : generated;
+            if (suggestions.length === 0 || (!aborted && abortSignal.aborted)) {
+                return;
+            }
+
+            chatStateStorage.updateGeneration(projectRootPath, threadId, messageId, { followupSuggestions: suggestions });
+            eventHandler({ type: "followup_suggestions", messageId, suggestions });
+            console.log(`[Followups] Emitted for ${messageId}: ${suggestions.map(s => s.label).join(", ")}`);
+        } catch (error) {
+            console.warn(`[Followups] Generation failed for ${messageId}:`, error);
+        }
+    })();
+
+    return true;
+}
+
+/**
+ * Best-effort: any failure (model error, timeout, abort, or output that fails schema validation)
+ * resolves to an empty array so the caller simply shows no chips.
+ */
+async function generateSuggestions(
+    input: FollowupPromptInput,
+    turnSignal: AbortSignal
+): Promise<GeneratedFollowupSuggestion[]> {
+    if (!input.assistantResponse?.trim()) {
+        return [];
+    }
+    const aborted = input.situation === "aborted";
     try {
         const { object } = await generateObject({
             model: await getAnthropicClient(ANTHROPIC_HAIKU),
             maxOutputTokens: 1024,
             temperature: 0.3,
-            messages: buildFollowupMessages(promptInput),
+            messages: buildFollowupMessages(input),
             schema: followupSuggestionsSchema,
-            abortSignal: abortSignal ?? AbortSignal.timeout(timeoutMs),
+            // A stopped turn's signal is already tripped, so fall back to a plain timeout.
+            abortSignal: aborted ? AbortSignal.timeout(TIMEOUT_MS) : turnSignal,
         });
-        return sanitize(object.suggestions, maxSuggestions, promptInput.situation);
+        // Leave room for the Continue chip that an aborted turn prepends.
+        return sanitize(object.suggestions, aborted ? 2 : 3, input.situation);
     } catch (error) {
         console.warn("[Followups] Suggestion generation failed:", error);
         return [];
@@ -94,4 +172,24 @@ function sanitize(
         }
     }
     return out;
+}
+
+/** Concatenates the assistant's text output from a set of model messages. */
+function extractAssistantText(messages: any[]): string {
+    const parts: string[] = [];
+    for (const message of messages ?? []) {
+        if (message?.role !== "assistant") {
+            continue;
+        }
+        if (typeof message.content === "string") {
+            parts.push(message.content);
+        } else if (Array.isArray(message.content)) {
+            for (const item of message.content) {
+                if (item?.type === "text" && typeof item.text === "string") {
+                    parts.push(item.text);
+                }
+            }
+        }
+    }
+    return parts.join("\n").trim();
 }

--- a/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
@@ -22,7 +22,7 @@ import { workspace } from "vscode";
 import { chatStateStorage } from "../../../../views/ai-panel/chatStateStorage";
 import { CopilotEventHandler } from "../../utils/events";
 import { ANTHROPIC_HAIKU, getAnthropicClient } from "../../utils/ai-client";
-import { buildFollowupMessages, FollowupPromptInput, FollowupSituation } from "./prompt";
+import { buildFollowupMessages, FollowupPromptInput, FollowupSituation, RecentExchange } from "./prompt";
 import { followupSuggestionsSchema, GeneratedFollowupSuggestion } from "./schema";
 
 export { FollowupSituation } from "./prompt";
@@ -31,6 +31,10 @@ const TIMEOUT_MS = 8_000;
 
 /** Below this much partial output an aborted turn gets the Continue chip only, with no model call. */
 const MIN_CHARS_FOR_ABORT = 200;
+
+/** How many earlier turns are passed as context, and how much of each message. */
+const HISTORY_TURNS = 3;
+const MAX_HISTORY_TEXT_CHARS = 1_500;
 
 /** Offered whenever a turn is stopped part-way. */
 const CONTINUE_SUGGESTION: FollowupSuggestion = {
@@ -92,6 +96,7 @@ export function startFollowupSuggestions(turn: FollowupTurn): boolean {
                 ? await generateSuggestions({
                     userQuery,
                     assistantResponse: assistantText,
+                    earlierExchanges: getRecentExchanges(projectRootPath, threadId, messageId),
                     mode: isPlanMode ? "Plan" : "Edit",
                     situation,
                 }, abortSignal)
@@ -192,4 +197,27 @@ function extractAssistantText(messages: any[]): string {
         }
     }
     return parts.join("\n").trim();
+}
+
+/**
+ * Trimmed transcript of the turns before this one, oldest first. Read from the stored generations
+ * rather than the LLM history: `userPrompt` is the bare question, so the codebase block that the
+ * LLM copy carries never has to be stripped back out. Tool calls and results are skipped —
+ * suggestions only need the narrative, and tool payloads would dwarf it.
+ */
+function getRecentExchanges(projectRootPath: string, threadId: string, currentGenerationId: string): RecentExchange[] {
+    // Read the thread directly: getGenerations() would create and persist an empty thread if this
+    // one is no longer in memory, which has cost real chat history before.
+    const generations = chatStateStorage.getWorkspaceState(projectRootPath)?.threads.get(threadId)?.generations ?? [];
+    const transcript: RecentExchange[] = [];
+    for (const generation of generations.filter(g => g.id !== currentGenerationId).slice(-HISTORY_TURNS)) {
+        if (generation.userPrompt) {
+            transcript.push({ role: "user", text: generation.userPrompt.slice(0, MAX_HISTORY_TEXT_CHARS) });
+        }
+        const assistantText = extractAssistantText(generation.modelMessages);
+        if (assistantText) {
+            transcript.push({ role: "assistant", text: assistantText.slice(0, MAX_HISTORY_TEXT_CHARS) });
+        }
+    }
+    return transcript;
 }

--- a/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
@@ -106,6 +106,12 @@ export function startFollowupSuggestions(turn: FollowupTurn): boolean {
             if (suggestions.length === 0 || (!aborted && abortSignal.aborted)) {
                 return;
             }
+            // The webview shows whatever arrives, and it cannot tell that the user switched
+            // threads while this was generating — so these chips would land on the wrong thread.
+            if (chatStateStorage.getActiveThread(projectRootPath)?.id !== threadId) {
+                console.log(`[Followups] Dropped for ${messageId} — thread is no longer active`);
+                return;
+            }
 
             chatStateStorage.updateGeneration(projectRootPath, threadId, messageId, { followupSuggestions: suggestions });
             eventHandler({ type: "followup_suggestions", messageId, suggestions });

--- a/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
@@ -29,8 +29,8 @@ export { FollowupSituation } from "./prompt";
 
 const TIMEOUT_MS = 8_000;
 
-/** Below this much partial output an aborted turn gets the Continue chip only, with no model call. */
-const MIN_CHARS_FOR_ABORT = 200;
+/** Below this much partial output an interrupted turn gets its fixed chip only, with no model call. */
+const MIN_CHARS_FOR_INTERRUPTED = 200;
 
 /** How many earlier turns are passed as context, and how much of each message. */
 const HISTORY_TURNS = 3;
@@ -40,6 +40,12 @@ const MAX_HISTORY_TEXT_CHARS = 1_500;
 const CONTINUE_SUGGESTION: FollowupSuggestion = {
     label: "Continue",
     prompt: "Redo the step you were interrupted on and carry on.",
+};
+
+/** Offered on failure, so there is something to act on even when generation fails too. */
+const RETRY_SUGGESTION: FollowupSuggestion = {
+    label: "Try again",
+    prompt: "Try that again.",
 };
 
 export interface FollowupTurn {
@@ -52,8 +58,10 @@ export interface FollowupTurn {
     assistantMessages: any[];
     userQuery: string;
     isPlanMode: boolean;
-    /** The turn's signal — already tripped on the aborted path. */
+    /** The turn's signal — already tripped on the interrupted paths. */
     abortSignal: AbortSignal;
+    /** What went wrong, when the turn failed. */
+    errorMessage?: string;
     eventHandler: CopilotEventHandler;
 }
 
@@ -66,7 +74,7 @@ export interface FollowupTurn {
  * @returns whether generation started, so the caller can avoid running twice for one turn.
  */
 export function startFollowupSuggestions(turn: FollowupTurn): boolean {
-    const { situation, messageId, projectRootPath, threadId, assistantMessages, userQuery, isPlanMode, abortSignal, eventHandler } = turn;
+    const { situation, messageId, projectRootPath, threadId, assistantMessages, userQuery, isPlanMode, abortSignal, errorMessage, eventHandler } = turn;
 
     if (process.env.AI_TEST_ENV) {
         return false;
@@ -76,18 +84,21 @@ export function startFollowupSuggestions(turn: FollowupTurn): boolean {
     }
 
     const aborted = situation === "aborted";
-    // On the aborted path the turn's signal is already tripped, so it can neither gate nor be reused.
-    if (!aborted && abortSignal.aborted) {
+    // The turn's signal is tripped on stop, and moments after a failure — so on those paths it
+    // can neither gate the work nor be reused for the call.
+    const interrupted = situation !== "completed";
+    if (!interrupted && abortSignal.aborted) {
         return false;
     }
 
     const assistantText = extractAssistantText(assistantMessages);
-    if (!aborted && !assistantText) {
+    if (!assistantText && !interrupted) {
         return false;
     }
 
-    // Users abort constantly; only pay for a model call when there is enough to pivot from.
-    const worthGenerating = !aborted || assistantText.length >= MIN_CHARS_FOR_ABORT;
+    // Nothing produced means nothing to pivot on — a failure that early is almost always
+    // infrastructure, where the fixed chip is the only honest suggestion.
+    const worthGenerating = !interrupted || assistantText.length >= MIN_CHARS_FOR_INTERRUPTED;
     console.log(`[Followups] Scheduling for ${messageId} (situation=${situation})`);
 
     void (async () => {
@@ -99,11 +110,13 @@ export function startFollowupSuggestions(turn: FollowupTurn): boolean {
                     earlierExchanges: getRecentExchanges(projectRootPath, threadId, messageId),
                     mode: isPlanMode ? "Plan" : "Edit",
                     situation,
+                    errorMessage,
                 }, abortSignal)
                 : [];
 
-            const suggestions = aborted ? [CONTINUE_SUGGESTION, ...generated] : generated;
-            if (suggestions.length === 0 || (!aborted && abortSignal.aborted)) {
+            const fixed = aborted ? [CONTINUE_SUGGESTION] : situation === "error" ? [RETRY_SUGGESTION] : [];
+            const suggestions = [...fixed, ...generated];
+            if (suggestions.length === 0 || (!interrupted && abortSignal.aborted)) {
                 return;
             }
             // The webview shows whatever arrives, and it cannot tell that the user switched
@@ -135,7 +148,7 @@ async function generateSuggestions(
     if (!input.assistantResponse?.trim()) {
         return [];
     }
-    const aborted = input.situation === "aborted";
+    const interrupted = input.situation !== "completed";
     try {
         const { object } = await generateObject({
             model: await getAnthropicClient(ANTHROPIC_HAIKU),
@@ -143,11 +156,11 @@ async function generateSuggestions(
             temperature: 0.3,
             messages: buildFollowupMessages(input),
             schema: followupSuggestionsSchema,
-            // A stopped turn's signal is already tripped, so fall back to a plain timeout.
-            abortSignal: aborted ? AbortSignal.timeout(TIMEOUT_MS) : turnSignal,
+            // The turn's signal is tripped on the interrupted paths, so fall back to a timeout.
+            abortSignal: interrupted ? AbortSignal.timeout(TIMEOUT_MS) : turnSignal,
         });
-        // Leave room for the Continue chip that an aborted turn prepends.
-        return sanitize(object.suggestions, aborted ? 2 : 3, input.situation);
+        // Leave room for the fixed chip that an interrupted turn prepends.
+        return sanitize(object.suggestions, interrupted ? 2 : 3, input.situation);
     } catch (error) {
         console.warn("[Followups] Suggestion generation failed:", error);
         return [];
@@ -168,8 +181,11 @@ function sanitize(
         if (!label || !prompt) {
             continue;
         }
-        // The aborted flow offers its own Continue chip, so drop model-generated near-duplicates.
+        // Both interrupted flows prepend their own chip, so drop model-generated near-duplicates.
         if (situation === "aborted" && /^(continue|resume|finish|complete)\b/i.test(label)) {
+            continue;
+        }
+        if (situation === "error" && /^(retry|try again)\b/i.test(label)) {
             continue;
         }
         const key = label.toLowerCase();

--- a/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
@@ -20,7 +20,7 @@ import { ModelMessage } from "ai";
 import { ANCHOR_ACTIONS } from "./anchors";
 
 /** How the turn these suggestions belong to ended. */
-export type FollowupSituation = "completed" | "aborted" | "error";
+export type FollowupSituation = "completed" | "aborted" | "error" | "usage_limit";
 
 /** One message from an earlier turn, as context for the suggestions. */
 export interface RecentExchange {

--- a/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
@@ -30,21 +30,25 @@ export interface FollowupPromptInput {
 
 const anchorGuidance = ANCHOR_ACTIONS.map((a) => `- ${a.label}: ${a.description}`).join("\n");
 
-const SYSTEM_PROMPT = `You suggest the next things a Ballerina developer is most likely to want to do, based on their last exchange with the WSO2 Integrator Copilot.
+const SYSTEM_PROMPT = `You help users of the WSO2 Integrator Copilot decide what to do next.
 
-Given the user's last message and the assistant's response, propose 2-3 short, specific follow-up actions the developer would realistically take next. These are shown as clickable chips; clicking one sends its prompt to Copilot as the user's next message.
+The Copilot builds integrations for the user. Given the user's last message and the Copilot's response, propose 2-3 short, specific follow-up actions the user is most likely to want next. Each is shown as a clickable chip; clicking one sends its prompt to the Copilot as the user's next message.
 
-Prefer these high-value actions when one is relevant to what just happened, and phrase it for the current context:
+Prefer these high-value actions when one fits what just happened, and phrase it for the current context:
 ${anchorGuidance}
 
-If none of the above fit, generate a contextual suggestion that clearly follows from the last exchange.
+If none fit, suggest a next step that clearly follows from the last exchange.
 
-Rules:
-- Each suggestion has a "label" (imperative chip text, at most ~4 words, e.g. "Add tests") and a "prompt" (a natural first-person message the user would send, e.g. "Add unit tests for the order service").
-- Make suggestions specific to the code and context of this exchange, not generic filler.
-- No duplicates; each should offer a distinct next step.
-- Only suggest actions that genuinely make sense. Fewer good suggestions is better than padding to three.
-- Do not suggest actions the assistant already completed in its response.`;
+Scope — only suggest things the Copilot can actually do: build, change, explain, run, or test the user's integration, or connect it to other systems or services. Never suggest anything else, because it will be refused — in particular, no deploying to a container or cloud platform, and no infrastructure, CI/CD, or cloud-provider setup.
+
+Audience — the user builds integrations in a friendly, low-code product and may not be a programmer. Write every label and prompt in plain, outcome-focused language: say what the user gets, not how it is built. Never expose implementation details — no programming-language or Ballerina specifics, no command-line commands, no code, annotation, or configuration syntax, no file, module, or library names, and no technical keywords or type names.
+
+Output:
+- Each suggestion has a "label" (imperative chip text, max ~4 words, e.g. "Add tests") and a "prompt" (a natural first-person message the user would send, e.g. "Add tests for the order service").
+- Base every suggestion on what actually happened in this exchange — be specific, never generic filler.
+- No duplicates; each must offer a distinct next step.
+- Only include actions that genuinely make sense; one or two strong suggestions beat three padded ones.
+- Never suggest something the Copilot already did in its response.`;
 
 export function buildFollowupMessages(input: FollowupPromptInput): ModelMessage[] {
     const { userQuery, assistantResponse, mode } = input;
@@ -56,7 +60,7 @@ ${userQuery}
 ${assistantResponse}
 </assistant_response>
 
-Suggest the developer's likely next actions.`;
+Suggest the user's likely next actions.`;
 
     return [
         { role: "system", content: SYSTEM_PROMPT },

--- a/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
@@ -50,6 +50,7 @@ Audience — the user builds integrations in a friendly, low-code product and ma
 
 Output:
 - Each suggestion has a "label" (imperative chip text, max ~4 words, e.g. "Add tests") and a "prompt" (a natural first-person message the user would send, e.g. "Add tests for the order service").
+- The "prompt" is spoken by the user, so it is always an instruction and never a question. Never ask the user anything in it, and never carry over a question the Copilot asked.
 - Base every suggestion on what actually happened in this exchange — be specific, never generic filler.
 - No duplicates; each must offer a distinct next step.
 - Only include actions that genuinely make sense; one or two strong suggestions beat three padded ones.`;

--- a/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
@@ -22,11 +22,19 @@ import { ANCHOR_ACTIONS } from "./anchors";
 /** How the turn these suggestions belong to ended. */
 export type FollowupSituation = "completed" | "aborted";
 
+/** One message from an earlier turn, as context for the suggestions. */
+export interface RecentExchange {
+    role: "user" | "assistant";
+    text: string;
+}
+
 export interface FollowupPromptInput {
     /** The user's last message that produced the response. */
     userQuery: string;
     /** The assistant's final response text for the completed turn. */
     assistantResponse: string;
+    /** Trimmed transcript of the preceding turns, oldest first, for conversation context. */
+    earlierExchanges?: RecentExchange[];
     /** The generation mode the turn ran in. */
     mode?: string;
     /** How the turn ended; defaults to a normally completed turn. */
@@ -54,6 +62,7 @@ Output:
 - Each suggestion has a "label" (imperative chip text, max ~4 words, e.g. "Add tests") and a "prompt" (a natural first-person message the user would send, e.g. "Add tests for the order service").
 - The "prompt" is spoken by the user, so it is always an instruction and never a question. Never ask the user anything in it, and never carry over a question the Copilot asked.
 - Base every suggestion on what actually happened in this exchange — be specific, never generic filler.
+- Earlier turns, when provided, are background only: use them to understand what has already been built and to avoid repeating it. Suggest next steps for the latest exchange, not for the earlier ones.
 - No duplicates; each must offer a distinct next step.
 - Only include actions that genuinely make sense; one or two strong suggestions beat three padded ones.`;
 
@@ -70,9 +79,16 @@ ${SHARED_RULES}${aborted ? "" : COMPLETED_ONLY_RULE}`;
 }
 
 export function buildFollowupMessages(input: FollowupPromptInput): ModelMessage[] {
-    const { userQuery, assistantResponse, mode, situation = "completed" } = input;
+    const { userQuery, assistantResponse, earlierExchanges, mode, situation = "completed" } = input;
     const responseTag = situation === "aborted" ? "assistant_response_interrupted" : "assistant_response";
-    const userContent = `${mode ? `Mode: ${mode}\n\n` : ""}<user_message>
+    const historyBlock = earlierExchanges?.length
+        ? `<earlier_in_this_conversation>
+${earlierExchanges.map((m) => `${m.role === "user" ? "User message" : "Assistant response"}: ${m.text}`).join("\n\n")}
+</earlier_in_this_conversation>
+
+`
+        : "";
+    const userContent = `${mode ? `Mode: ${mode}\n\n` : ""}${historyBlock}<user_message>
 ${userQuery}
 </user_message>
 

--- a/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ModelMessage } from "ai";
+import { ANCHOR_ACTIONS } from "./anchors";
+
+export interface FollowupPromptInput {
+    /** The user's last message that produced the response. */
+    userQuery: string;
+    /** The assistant's final response text for the completed turn. */
+    assistantResponse: string;
+    /** The generation mode the turn ran in. */
+    mode?: string;
+}
+
+const anchorGuidance = ANCHOR_ACTIONS.map((a) => `- ${a.label}: ${a.description}`).join("\n");
+
+const SYSTEM_PROMPT = `You suggest the next things a Ballerina developer is most likely to want to do, based on their last exchange with the WSO2 Integrator Copilot.
+
+Given the user's last message and the assistant's response, propose 2-3 short, specific follow-up actions the developer would realistically take next. These are shown as clickable chips; clicking one sends its prompt to Copilot as the user's next message.
+
+Prefer these high-value actions when one is relevant to what just happened, and phrase it for the current context:
+${anchorGuidance}
+
+If none of the above fit, generate a contextual suggestion that clearly follows from the last exchange.
+
+Rules:
+- Each suggestion has a "label" (imperative chip text, at most ~4 words, e.g. "Add tests") and a "prompt" (a natural first-person message the user would send, e.g. "Add unit tests for the order service").
+- Make suggestions specific to the code and context of this exchange, not generic filler.
+- No duplicates; each should offer a distinct next step.
+- Only suggest actions that genuinely make sense. Fewer good suggestions is better than padding to three.
+- Do not suggest actions the assistant already completed in its response.`;
+
+export function buildFollowupMessages(input: FollowupPromptInput): ModelMessage[] {
+    const { userQuery, assistantResponse, mode } = input;
+    const userContent = `${mode ? `Mode: ${mode}\n\n` : ""}<user_message>
+${userQuery}
+</user_message>
+
+<assistant_response>
+${assistantResponse}
+</assistant_response>
+
+Suggest the developer's likely next actions.`;
+
+    return [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: userContent },
+    ];
+}

--- a/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
@@ -17,6 +17,7 @@
  */
 
 import { ModelMessage } from "ai";
+import { FollowupSituation } from "@wso2/ballerina-core";
 import { ANCHOR_ACTIONS } from "./anchors";
 
 export interface FollowupPromptInput {
@@ -26,20 +27,24 @@ export interface FollowupPromptInput {
     assistantResponse: string;
     /** The generation mode the turn ran in. */
     mode?: string;
+    /** How the turn ended; defaults to a normally completed turn. */
+    situation?: FollowupSituation;
 }
 
 const anchorGuidance = ANCHOR_ACTIONS.map((a) => `- ${a.label}: ${a.description}`).join("\n");
 
-const SYSTEM_PROMPT = `You help users of the WSO2 Integrator Copilot decide what to do next.
-
-The Copilot builds integrations for the user. Given the user's last message and the Copilot's response, propose 2-3 short, specific follow-up actions the user is most likely to want next. Each is shown as a clickable chip; clicking one sends its prompt to the Copilot as the user's next message.
+const COMPLETED_FRAMING = `The Copilot builds integrations for the user. Given the user's last message and the Copilot's response, propose 2-3 short, specific follow-up actions the user is most likely to want next. Each is shown as a clickable chip; clicking one sends its prompt to the Copilot as the user's next message.
 
 Prefer these high-value actions when one fits what just happened, and phrase it for the current context:
 ${anchorGuidance}
 
-If none fit, suggest a next step that clearly follows from the last exchange.
+If none fit, suggest a next step that clearly follows from the last exchange.`;
 
-Scope — only suggest things the Copilot can actually do: build, change, explain, run, or test the user's integration, or connect it to other systems or services. Never suggest anything else, because it will be refused — in particular, no deploying to a container or cloud platform, and no infrastructure, CI/CD, or cloud-provider setup.
+const ABORTED_FRAMING = `The Copilot builds integrations for the user. The user stopped it part-way, so the response below is cut short and the work is unfinished. Propose up to 2 short, specific ways the user might take the work in a DIFFERENT direction from where it stopped. Each is shown as a clickable chip; clicking one sends its prompt to the Copilot as the user's next message.
+
+A separate "Continue" action is already offered to the user, so never suggest continuing, resuming, finishing, or completing the interrupted work — that is covered. People usually stop the Copilot because it was heading somewhere they did not want, so suggest plausible course corrections based on what it had started doing.`;
+
+const SHARED_RULES = `Scope — only suggest things the Copilot can actually do: build, change, explain, run, or test the user's integration, or connect it to other systems or services. Never suggest anything else, because it will be refused — in particular, no deploying to a container or cloud platform, and no infrastructure, CI/CD, or cloud-provider setup.
 
 Audience — the user builds integrations in a friendly, low-code product and may not be a programmer. Write every label and prompt in plain, outcome-focused language: say what the user gets, not how it is built. Never expose implementation details — no programming-language or Ballerina specifics, no command-line commands, no code, annotation, or configuration syntax, no file, module, or library names, and no technical keywords or type names.
 
@@ -47,23 +52,35 @@ Output:
 - Each suggestion has a "label" (imperative chip text, max ~4 words, e.g. "Add tests") and a "prompt" (a natural first-person message the user would send, e.g. "Add tests for the order service").
 - Base every suggestion on what actually happened in this exchange — be specific, never generic filler.
 - No duplicates; each must offer a distinct next step.
-- Only include actions that genuinely make sense; one or two strong suggestions beat three padded ones.
+- Only include actions that genuinely make sense; one or two strong suggestions beat three padded ones.`;
+
+const COMPLETED_ONLY_RULE = `
 - Never suggest something the Copilot already did in its response.`;
 
+function buildSystemPrompt(situation: FollowupSituation): string {
+    const aborted = situation === "aborted";
+    return `You help users of the WSO2 Integrator Copilot decide what to do next.
+
+${aborted ? ABORTED_FRAMING : COMPLETED_FRAMING}
+
+${SHARED_RULES}${aborted ? "" : COMPLETED_ONLY_RULE}`;
+}
+
 export function buildFollowupMessages(input: FollowupPromptInput): ModelMessage[] {
-    const { userQuery, assistantResponse, mode } = input;
+    const { userQuery, assistantResponse, mode, situation = "completed" } = input;
+    const responseTag = situation === "aborted" ? "assistant_response_interrupted" : "assistant_response";
     const userContent = `${mode ? `Mode: ${mode}\n\n` : ""}<user_message>
 ${userQuery}
 </user_message>
 
-<assistant_response>
+<${responseTag}>
 ${assistantResponse}
-</assistant_response>
+</${responseTag}>
 
 Suggest the user's likely next actions.`;
 
     return [
-        { role: "system", content: SYSTEM_PROMPT },
+        { role: "system", content: buildSystemPrompt(situation) },
         { role: "user", content: userContent },
     ];
 }

--- a/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
@@ -17,8 +17,10 @@
  */
 
 import { ModelMessage } from "ai";
-import { FollowupSituation } from "@wso2/ballerina-core";
 import { ANCHOR_ACTIONS } from "./anchors";
+
+/** How the turn these suggestions belong to ended. */
+export type FollowupSituation = "completed" | "aborted";
 
 export interface FollowupPromptInput {
     /** The user's last message that produced the response. */

--- a/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
@@ -20,7 +20,7 @@ import { ModelMessage } from "ai";
 import { ANCHOR_ACTIONS } from "./anchors";
 
 /** How the turn these suggestions belong to ended. */
-export type FollowupSituation = "completed" | "aborted";
+export type FollowupSituation = "completed" | "aborted" | "error";
 
 /** One message from an earlier turn, as context for the suggestions. */
 export interface RecentExchange {
@@ -39,6 +39,8 @@ export interface FollowupPromptInput {
     mode?: string;
     /** How the turn ended; defaults to a normally completed turn. */
     situation?: FollowupSituation;
+    /** What went wrong, when the turn failed. */
+    errorMessage?: string;
 }
 
 const anchorGuidance = ANCHOR_ACTIONS.map((a) => `- ${a.label}: ${a.description}`).join("\n");
@@ -53,6 +55,10 @@ If none fit, suggest a next step that clearly follows from the last exchange.`;
 const ABORTED_FRAMING = `The Copilot builds integrations for the user. The user stopped it part-way, so the response below is cut short and the work is unfinished. Propose up to 2 short, specific ways the user might take the work in a DIFFERENT direction from where it stopped. Each is shown as a clickable chip; clicking one sends its prompt to the Copilot as the user's next message.
 
 A separate "Continue" action is already offered to the user, so never suggest continuing, resuming, finishing, or completing the interrupted work — that is covered. People usually stop the Copilot because it was heading somewhere they did not want, so suggest plausible course corrections based on what it had started doing.`;
+
+const ERROR_FRAMING = `The Copilot builds integrations for the user. This turn FAILED part-way, so the work is unfinished and whatever it was doing did not complete. The failure reason is given below. Propose up to 2 short, specific things the user can do about it.
+
+Base the suggestions on the failure: if it looks like something the user can resolve or work around, suggest that; if the work was simply interrupted, suggest getting it finished. Never pretend the work succeeded, and never ask the user to debug the product itself.`;
 
 const SHARED_RULES = `Scope — only suggest things the Copilot can actually do: build, change, explain, run, or test the user's integration, or connect it to other systems or services. Never suggest anything else, because it will be refused — in particular, no deploying to a container or cloud platform, and no infrastructure, CI/CD, or cloud-provider setup.
 
@@ -70,17 +76,22 @@ const COMPLETED_ONLY_RULE = `
 - Never suggest something the Copilot already did in its response.`;
 
 function buildSystemPrompt(situation: FollowupSituation): string {
-    const aborted = situation === "aborted";
+    const framing = situation === "aborted" ? ABORTED_FRAMING
+        : situation === "error" ? ERROR_FRAMING
+        : COMPLETED_FRAMING;
     return `You help users of the WSO2 Integrator Copilot decide what to do next.
 
-${aborted ? ABORTED_FRAMING : COMPLETED_FRAMING}
+${framing}
 
-${SHARED_RULES}${aborted ? "" : COMPLETED_ONLY_RULE}`;
+${SHARED_RULES}${situation === "completed" ? COMPLETED_ONLY_RULE : ""}`;
 }
 
 export function buildFollowupMessages(input: FollowupPromptInput): ModelMessage[] {
-    const { userQuery, assistantResponse, earlierExchanges, mode, situation = "completed" } = input;
-    const responseTag = situation === "aborted" ? "assistant_response_interrupted" : "assistant_response";
+    const { userQuery, assistantResponse, earlierExchanges, mode, situation = "completed", errorMessage } = input;
+    const responseTag = situation === "completed" ? "assistant_response" : "assistant_response_interrupted";
+    const errorBlock = situation === "error" && errorMessage
+        ? `\n<failure_reason>\n${errorMessage}\n</failure_reason>\n`
+        : "";
     const historyBlock = earlierExchanges?.length
         ? `<earlier_in_this_conversation>
 ${earlierExchanges.map((m) => `${m.role === "user" ? "User message" : "Assistant response"}: ${m.text}`).join("\n\n")}
@@ -95,7 +106,7 @@ ${userQuery}
 <${responseTag}>
 ${assistantResponse}
 </${responseTag}>
-
+${errorBlock}
 Suggest the user's likely next actions.`;
 
     return [

--- a/packages/ballerina-extension/src/features/ai/agent/followups/schema.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/schema.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { z } from "zod";
+
+export const followupSuggestionsSchema = z.object({
+    suggestions: z
+        .array(
+            z.object({
+                label: z.string().describe("Short imperative chip text, at most ~4 words (e.g. \"Add tests\")."),
+                prompt: z.string().describe("The first-person message sent to Copilot when the chip is clicked."),
+            })
+        )
+        .describe("2-3 follow-up suggestions; fewer is fine when only one or two make sense."),
+});
+
+export type FollowupSuggestionsObject = z.infer<typeof followupSuggestionsSchema>;
+export type GeneratedFollowupSuggestion = FollowupSuggestionsObject["suggestions"][number];

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -50,6 +50,7 @@ import {
     getActiveTempDir,
     hasPendingReview,
     getRunStatus,
+    getLatestFollowupSuggestions,
     getAIMachineSnapshot,
     getChatMessages,
     getCheckpoints,
@@ -204,6 +205,7 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(getActiveTempDir, () => rpcManger.getActiveTempDir());
     messenger.onRequest(hasPendingReview, (args: HasPendingReviewRequest) => rpcManger.hasPendingReview(args));
     messenger.onRequest(getRunStatus, (args) => rpcManger.getRunStatus(args));
+    messenger.onRequest(getLatestFollowupSuggestions, () => rpcManger.getLatestFollowupSuggestions());
     messenger.onRequest(getUsage, () => rpcManger.getUsage());
     messenger.onRequest(requestQuota, (args: QuotaRequestParams) => rpcManger.requestQuota(args));
     messenger.onNotification(openFileDiff, (args: OpenFileDiffRequest) => rpcManger.openFileDiff(args));

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -49,6 +49,7 @@ import {
     UsageResponse,
     QuotaRequestParams,
     QuotaRequestResult,
+    FollowupSuggestion,
     WebToolApprovalRequest,
     CompactConversationRequest,
     CompactConversationResponse,
@@ -868,6 +869,12 @@ User reverted the last made changes. The files have been restored to the state b
             // re-surface only still-pending prompts during replay and skip resolved ones.
             pendingRequestIds: approvalManager.getPendingRequestIds(),
         };
+    }
+
+    async getLatestFollowupSuggestions(): Promise<FollowupSuggestion[]> {
+        const projectRootPath = resolveProjectRootPath();
+        const generations = chatStateStorage.getGenerations(projectRootPath, getActiveThreadId(projectRootPath));
+        return generations[generations.length - 1]?.followupSuggestions ?? [];
     }
 
     async compactConversation(_params: CompactConversationRequest): Promise<CompactConversationResponse> {

--- a/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -83,6 +83,8 @@ import {
     GetRunStatusRequest,
     GetRunStatusResponse,
     HasPendingReviewRequest,
+    getLatestFollowupSuggestions,
+    FollowupSuggestion,
     getCheckpoints,
     getDefaultPrompt,
     isScaffoldEnvActive,
@@ -361,6 +363,10 @@ export class AiPanelRpcClient implements AIPanelAPI {
 
     getRunStatus(params: GetRunStatusRequest): Promise<GetRunStatusResponse> {
         return this._messenger.sendRequest(getRunStatus, HOST_EXTENSION, params);
+    }
+
+    getLatestFollowupSuggestions(): Promise<FollowupSuggestion[]> {
+        return this._messenger.sendRequest(getLatestFollowupSuggestions, HOST_EXTENSION);
     }
 
     getUsage(): Promise<UsageResponse | undefined> {

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/MiniChat.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/MiniChat.tsx
@@ -140,7 +140,8 @@ type UnmodelledNotifyType =
     | "compaction_start"
     | "compaction_end"
     | "config_change"
-    | "migration_progress";
+    | "migration_progress"
+    | "followup_suggestions";
 
 /** Friendly one-line label for a tool call (mirrors the status-bar phrasing). */
 function describeTool(toolName: string, toolInput: any): string {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -112,6 +112,17 @@ const DRIFT_CHECK_ERROR = "Failed to check drift between the code and the docume
 const USAGE_EXCEEDED_THRESHOLD_PERCENT = 3;
 const QUOTA_CONTACT_EMAIL = "support@wso2.com";
 
+/** Shown the moment a turn is stopped, before the generated pivot chips arrive. */
+const CONTINUE_SUGGESTION: FollowupSuggestion = {
+    label: "Continue",
+    prompt: "Redo the step you were interrupted on and carry on.",
+};
+
+const mergeSuggestions = (existing: FollowupSuggestion[], incoming: FollowupSuggestion[]): FollowupSuggestion[] => {
+    const seen = new Set(existing.map((s) => s.label.toLowerCase()));
+    return [...existing, ...incoming.filter((s) => !seen.has(s.label.toLowerCase()))];
+};
+
 //TODO: Add better error handling from backend. stream error type and non 200 status codes
 
 const MessageBody = styled.div<{ isUserMessage: boolean }>(({ isUserMessage }: { isUserMessage: boolean }) => ({
@@ -330,6 +341,12 @@ const AIChat: React.FC = () => {
     };
 
     const [isLoading, setIsLoading] = useState(false);
+    // onChatNotify is re-registered each render, so stale closures fire too — suggestion
+    // staleness has to be judged against a ref, not the captured isLoading value.
+    const isLoadingRef = useRef(false);
+    isLoadingRef.current = isLoading;
+    /** Whether the current turn streamed anything — "continue" is meaningless if it didn't. */
+    const turnProducedOutputRef = useRef(false);
     const [followupSuggestions, setFollowupSuggestions] = useState<FollowupSuggestion[]>([]);
     const [isCompacting, setIsCompacting] = useState(false);
     // Tools currently in flight, oldest first, for the composer's loading
@@ -659,6 +676,17 @@ const AIChat: React.FC = () => {
         rpcClient.getAiPanelRpcClient().getMcpToolsEnabled().then(setMcpToolsEnabled).catch(() => {});
     }, []);
 
+    /** Re-derives chips for whichever turn is now last (after a restore or a thread change). */
+    const refreshFollowupSuggestions = async () => {
+        try {
+            const suggestions = await rpcClient.getAiPanelRpcClient().getLatestFollowupSuggestions();
+            setFollowupSuggestions(suggestions ?? []);
+        } catch (error) {
+            console.error('[AIChat] Failed to refresh follow-up suggestions:', error);
+            setFollowupSuggestions([]);
+        }
+    };
+
     const handleCheckpointRestore = async (checkpointId: string) => {
         // Guard against concurrent restores — the separator UI also disables
         // itself, but this is defensive in case the handler is called directly.
@@ -697,13 +725,7 @@ const AIChat: React.FC = () => {
             setContextUsage(null);
             setHasActiveReview(false);
             // History is trimmed to the checkpoint — re-derive so the reverted turn's chips drop.
-            try {
-                const suggestions = await rpcClient.getAiPanelRpcClient().getLatestFollowupSuggestions();
-                setFollowupSuggestions(suggestions ?? []);
-            } catch (error) {
-                console.error('[AIChat] Failed to refresh follow-up suggestions after restore:', error);
-                setFollowupSuggestions([]);
-            }
+            await refreshFollowupSuggestions();
         } catch (error) {
             console.error("Failed to restore checkpoint:", error);
         } finally {
@@ -1233,6 +1255,7 @@ const AIChat: React.FC = () => {
             // An empty append is a no-op; an empty *replace* is meaningful (it clears
             // the trailing text), so only the append path short-circuits.
             if (type === "content_block" && content === "") return;
+            turnProducedOutputRef.current = true;
             setMessages(prevMessages => {
                 const msgs = [...prevMessages];
                 const targetIndex = ensureAssistantMessage(msgs);
@@ -1528,6 +1551,11 @@ const AIChat: React.FC = () => {
             setIsCodeLoading(false);
             setIsLoading(false);
             setBackendRequestTriggered(false);
+            // Offer Continue straight away; the generated pivot chips merge in a moment later.
+            if (turnProducedOutputRef.current) {
+                console.log('[Followups] Showing Continue immediately after abort');
+                setFollowupSuggestions([CONTINUE_SUGGESTION]);
+            }
             if (isMigrationEnhancementRunning) {
                 setIsMigrationEnhancementRunning(false);
                 // Re-fetch session so the Resume card appears
@@ -1573,7 +1601,14 @@ const AIChat: React.FC = () => {
             }
 
         } else if (type === "followup_suggestions") {
-            setFollowupSuggestions(response.suggestions);
+            console.log(`[Followups] Received: ${response.suggestions.map(s => s.label).join(', ')}`);
+            // Chips only ever describe a finished turn, so anything arriving mid-turn is stale.
+            if (isLoadingRef.current) {
+                return;
+            }
+            setFollowupSuggestions((prev) =>
+                response.reason === "aborted" ? mergeSuggestions(prev, response.suggestions) : response.suggestions
+            );
 
         } else if (type === "error") {
             console.log("Received error signal");
@@ -1830,6 +1865,7 @@ const AIChat: React.FC = () => {
         setIsPromptExecutedInCurrentWindow(true);
         setFeedbackGiven(null);
         setFollowupSuggestions([]);
+        turnProducedOutputRef.current = false;
 
         if (content.input.length === 0) {
             return;
@@ -2176,6 +2212,7 @@ const AIChat: React.FC = () => {
         setMessages([]);
         setApprovalRequest(null);
         setContextUsage(null);
+        setFollowupSuggestions([]);
         await rpcClient.getAiPanelRpcClient().clearChat();
         loadThreads();
     }
@@ -2210,6 +2247,7 @@ const AIChat: React.FC = () => {
         setRestoringCheckpointId(null);
         setApprovalRequest(null);
         setContextUsage(null);
+        await refreshFollowupSuggestions();
         loadThreads();
     }
 
@@ -2227,6 +2265,7 @@ const AIChat: React.FC = () => {
         setRestoringCheckpointId(null);
         setApprovalRequest(null);
         setContextUsage(null);
+        await refreshFollowupSuggestions();
         loadThreads();
     }
 

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -26,6 +26,7 @@ import {
     Command,
     TemplateId,
     ChatNotify,
+    FollowupSuggestion,
     DocumentationGeneratorIntermediaryState,
     OperationType,
     DocGenerationRequest,
@@ -53,6 +54,7 @@ import { getToolCallDisplay } from "../AgentStreamView/toolDisplay";
 import { ConnectorGeneratorSegment } from "../ConnectorGeneratorSegment";
 import { ConfigurationCollectorSegment } from "../ConfigurationCollectorSegment";
 import CheckpointSeparator from "../CheckpointSeparator";
+import FollowupSuggestions from "../FollowupSuggestions";
 import { Attachment, AttachmentStatus, SkillEnableStage, SkillEntry, TaskApprovalRequest } from "@wso2/ballerina-core";
 import type { ClarifyEvent, ConfigurationCollectionEvent, ConnectorGenerationNotification } from "@wso2/ballerina-core";
 
@@ -328,6 +330,7 @@ const AIChat: React.FC = () => {
     };
 
     const [isLoading, setIsLoading] = useState(false);
+    const [followupSuggestions, setFollowupSuggestions] = useState<FollowupSuggestion[]>([]);
     const [isCompacting, setIsCompacting] = useState(false);
     // Tools currently in flight, oldest first, for the composer's loading
     // indicator. This is a list rather than a single slot because a step can run
@@ -1551,6 +1554,9 @@ const AIChat: React.FC = () => {
                 }
             }
 
+        } else if (type === "followup_suggestions") {
+            setFollowupSuggestions(response.suggestions);
+
         } else if (type === "error") {
             console.log("Received error signal");
             const errorContent = response.content;
@@ -1805,6 +1811,7 @@ const AIChat: React.FC = () => {
         setCurrentGeneratingPromptIndex(otherMessages.length);
         setIsPromptExecutedInCurrentWindow(true);
         setFeedbackGiven(null);
+        setFollowupSuggestions([]);
 
         if (content.input.length === 0) {
             return;
@@ -2816,6 +2823,19 @@ const AIChat: React.FC = () => {
                                             messageIndex={index}
                                             onFeedback={handleFeedback}
                                             currentFeedback={feedbackGiven}
+                                        />
+                                    )}
+                                    {isAssistantMessage && isLatestAssistantMessage && !isLoading && !isCodeLoading && followupSuggestions.length > 0 && (
+                                        <FollowupSuggestions
+                                            suggestions={followupSuggestions}
+                                            onPick={(suggestion) => {
+                                                aiChatInputRef.current?.setInputContent({
+                                                    type: "text",
+                                                    text: suggestion.prompt,
+                                                    planMode: agentMode === AgentMode.Plan,
+                                                });
+                                                setFollowupSuggestions([]);
+                                            }}
                                         />
                                     )}
                                 </ChatMessage>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -696,6 +696,14 @@ const AIChat: React.FC = () => {
             // Widget will reappear with accurate data on the next agent turn.
             setContextUsage(null);
             setHasActiveReview(false);
+            // History is trimmed to the checkpoint — re-derive so the reverted turn's chips drop.
+            try {
+                const suggestions = await rpcClient.getAiPanelRpcClient().getLatestFollowupSuggestions();
+                setFollowupSuggestions(suggestions ?? []);
+            } catch (error) {
+                console.error('[AIChat] Failed to refresh follow-up suggestions after restore:', error);
+                setFollowupSuggestions([]);
+            }
         } catch (error) {
             console.error("Failed to restore checkpoint:", error);
         } finally {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -112,17 +112,6 @@ const DRIFT_CHECK_ERROR = "Failed to check drift between the code and the docume
 const USAGE_EXCEEDED_THRESHOLD_PERCENT = 3;
 const QUOTA_CONTACT_EMAIL = "support@wso2.com";
 
-/** Shown the moment a turn is stopped, before the generated pivot chips arrive. */
-const CONTINUE_SUGGESTION: FollowupSuggestion = {
-    label: "Continue",
-    prompt: "Redo the step you were interrupted on and carry on.",
-};
-
-const mergeSuggestions = (existing: FollowupSuggestion[], incoming: FollowupSuggestion[]): FollowupSuggestion[] => {
-    const seen = new Set(existing.map((s) => s.label.toLowerCase()));
-    return [...existing, ...incoming.filter((s) => !seen.has(s.label.toLowerCase()))];
-};
-
 //TODO: Add better error handling from backend. stream error type and non 200 status codes
 
 const MessageBody = styled.div<{ isUserMessage: boolean }>(({ isUserMessage }: { isUserMessage: boolean }) => ({
@@ -345,8 +334,6 @@ const AIChat: React.FC = () => {
     // staleness has to be judged against a ref, not the captured isLoading value.
     const isLoadingRef = useRef(false);
     isLoadingRef.current = isLoading;
-    /** Whether the current turn streamed anything — "continue" is meaningless if it didn't. */
-    const turnProducedOutputRef = useRef(false);
     const [followupSuggestions, setFollowupSuggestions] = useState<FollowupSuggestion[]>([]);
     const [isCompacting, setIsCompacting] = useState(false);
     // Tools currently in flight, oldest first, for the composer's loading
@@ -1255,7 +1242,6 @@ const AIChat: React.FC = () => {
             // An empty append is a no-op; an empty *replace* is meaningful (it clears
             // the trailing text), so only the append path short-circuits.
             if (type === "content_block" && content === "") return;
-            turnProducedOutputRef.current = true;
             setMessages(prevMessages => {
                 const msgs = [...prevMessages];
                 const targetIndex = ensureAssistantMessage(msgs);
@@ -1551,11 +1537,6 @@ const AIChat: React.FC = () => {
             setIsCodeLoading(false);
             setIsLoading(false);
             setBackendRequestTriggered(false);
-            // Offer Continue straight away; the generated pivot chips merge in a moment later.
-            if (turnProducedOutputRef.current) {
-                console.log('[Followups] Showing Continue immediately after abort');
-                setFollowupSuggestions([CONTINUE_SUGGESTION]);
-            }
             if (isMigrationEnhancementRunning) {
                 setIsMigrationEnhancementRunning(false);
                 // Re-fetch session so the Resume card appears
@@ -1606,9 +1587,7 @@ const AIChat: React.FC = () => {
             if (isLoadingRef.current) {
                 return;
             }
-            setFollowupSuggestions((prev) =>
-                response.reason === "aborted" ? mergeSuggestions(prev, response.suggestions) : response.suggestions
-            );
+            setFollowupSuggestions(response.suggestions);
 
         } else if (type === "error") {
             console.log("Received error signal");
@@ -1865,7 +1844,6 @@ const AIChat: React.FC = () => {
         setIsPromptExecutedInCurrentWindow(true);
         setFeedbackGiven(null);
         setFollowupSuggestions([]);
-        turnProducedOutputRef.current = false;
 
         if (content.input.length === 0) {
             return;

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2859,7 +2859,8 @@ const AIChat: React.FC = () => {
                                             currentFeedback={feedbackGiven}
                                         />
                                     )}
-                                    {isAssistantMessage && isLatestAssistantMessage && !isLoading && !isCodeLoading && followupSuggestions.length > 0 && (
+                                    {/* Hidden while over quota: the input is disabled, so a chip would prefill something unsendable. */}
+                                    {isAssistantMessage && isLatestAssistantMessage && !isLoading && !isCodeLoading && !isUsageExceeded && followupSuggestions.length > 0 && (
                                         <FollowupSuggestions
                                             suggestions={followupSuggestions}
                                             onPick={(suggestion) => {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -980,6 +980,16 @@ const AIChat: React.FC = () => {
                 liveGateClosedRef.current = false;
                 reconnectSettledResolveRef.current?.();
             }
+            // Follow-up chips arrive via a live notification, so a webview reload would
+            // otherwise lose them — re-derive from the latest generation, like review state.
+            try {
+                const suggestions = await rpcClient.getAiPanelRpcClient().getLatestFollowupSuggestions();
+                if (suggestions?.length > 0) {
+                    setFollowupSuggestions(suggestions);
+                }
+            } catch (error) {
+                console.error('[AIChat] Failed to restore follow-up suggestions:', error);
+            }
         };
 
         loadHistory();

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -1707,7 +1707,7 @@ const AIChat: React.FC = () => {
             const t = setTimeout(() => scrollToEnd("auto"), 120);
             return () => clearTimeout(t);
         }
-    }, [messages, hasActiveReview, isLoading, isCodeLoading]);
+    }, [messages, hasActiveReview, isLoading, isCodeLoading, followupSuggestions]);
 
     async function handleSendQuery(content: {
         input: Input[];
@@ -2540,7 +2540,6 @@ const AIChat: React.FC = () => {
                             // Note: Cannot use useMemo here as it's inside map() callback
                             // The stateless regex implementation in splitContent() ensures no corruption during streaming
                             const segmentedContent = splitContent(message.content);
-                            const hasReviewActions = isLatestAssistantMessage && hasActiveReview;
                             return (
                                 <ChatMessage key={index}>
                                     {/* Checkpoint separator before user messages */}
@@ -2817,8 +2816,8 @@ const AIChat: React.FC = () => {
                                             }
                                         })}
                                     </MessageBody>
-                                    {/* Show feedback bar only for the latest assistant message and when loading is complete, but not if review actions are present */}
-                                    {isAssistantMessage && isLatestAssistantMessage && !isLoading && !isCodeLoading && !hasReviewActions && (
+                                    {/* Show feedback bar for the latest assistant message once loading is complete */}
+                                    {isAssistantMessage && isLatestAssistantMessage && !isLoading && !isCodeLoading && (
                                         <FeedbackBar
                                             messageIndex={index}
                                             onFeedback={handleFeedback}
@@ -2834,7 +2833,6 @@ const AIChat: React.FC = () => {
                                                     text: suggestion.prompt,
                                                     planMode: agentMode === AgentMode.Plan,
                                                 });
-                                                setFollowupSuggestions([]);
                                             }}
                                         />
                                     )}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/FollowupSuggestions/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/FollowupSuggestions/index.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import styled from "@emotion/styled";
+import { FollowupSuggestion } from "@wso2/ballerina-core";
+
+const Container = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 8px;
+`;
+
+const Chip = styled.button`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-family: var(--vscode-font-family);
+    background: var(--vscode-editor-background);
+    color: var(--vscode-descriptionForeground);
+    border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+    border-radius: 8px;
+    cursor: pointer !important;
+    transition: all 0.15s ease;
+    text-align: left;
+
+    &:hover {
+        background: var(--vscode-list-hoverBackground);
+        border-color: var(--vscode-focusBorder, var(--vscode-widget-border));
+        color: var(--vscode-foreground);
+    }
+`;
+
+interface FollowupSuggestionsProps {
+    suggestions: FollowupSuggestion[];
+    onPick: (suggestion: FollowupSuggestion) => void;
+}
+
+const FollowupSuggestions: React.FC<FollowupSuggestionsProps> = ({ suggestions, onPick }) => {
+    if (!suggestions?.length) {
+        return null;
+    }
+    return (
+        <Container role="list" aria-label="Follow-up suggestions">
+            {suggestions.map((suggestion, index) => (
+                <Chip
+                    key={`followup-${index}`}
+                    role="listitem"
+                    type="button"
+                    title={suggestion.prompt}
+                    onClick={() => onPick(suggestion)}
+                >
+                    <span className="codicon codicon-sparkle" aria-hidden="true" />
+                    {suggestion.label}
+                </Chip>
+            ))}
+        </Container>
+    );
+};
+
+export default FollowupSuggestions;


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1934

After a turn ends, Copilot now offers a few short follow-up actions as clickable chips. Clicking one fills it into the chat input so it can be edited before sending. Suggestions are generated from the last exchange plus the recent conversation, so they follow what was actually built rather than being generic starters.

- Suggest follow-up actions after a completed turn, generated from the turn and the last few exchanges
- Offer a Continue action plus contextual alternatives when a turn is stopped part-way
- Offer a retry plus failure-aware suggestions when a turn fails, based on what went wrong
- Offer a Continue action when a turn is cut short by the usage limit, shown once the limit resets
- Keep suggestions in scope and free of technical jargon, and never phrased as questions to the user
- Show the feedback bar on responses that include code changes, which previously hid it
- Add `ballerina.copilot.followupSuggestions` to turn the feature off


<img width="753" height="536" alt="Screenshot 2026-07-28 at 1 47 48 PM" src="https://github.com/user-attachments/assets/b5e4abf4-92c8-4bf3-8418-5343781d2736" />

