### PR TITLE
Improve follow-up suggestions

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
@@ -122,7 +122,11 @@ export function startFollowupSuggestions(turn: FollowupTurn): boolean {
             if (suggestions.length === 0 || (!interrupted && abortSignal.aborted)) {
                 return;
             }
-            chatStateStorage.updateGeneration(projectRootPath, threadId, messageId, { followupSuggestions: suggestions });
+            const stored = chatStateStorage.updateGeneration(projectRootPath, threadId, messageId, { followupSuggestions: suggestions });
+            if (!stored) {
+                console.warn(`[Followups] Not showing for ${messageId} — could not store them on the generation`);
+                return;
+            }
 
             // The webview shows whatever arrives and cannot tell the thread has since changed, so
             // skip the emit and let the switch back read these off the generation instead.

--- a/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/index.ts
@@ -122,14 +122,16 @@ export function startFollowupSuggestions(turn: FollowupTurn): boolean {
             if (suggestions.length === 0 || (!interrupted && abortSignal.aborted)) {
                 return;
             }
-            // The webview shows whatever arrives, and it cannot tell that the user switched
-            // threads while this was generating — so these chips would land on the wrong thread.
-            if (chatStateStorage.getActiveThread(projectRootPath)?.id !== threadId) {
-                console.log(`[Followups] Dropped for ${messageId} — thread is no longer active`);
+            chatStateStorage.updateGeneration(projectRootPath, threadId, messageId, { followupSuggestions: suggestions });
+
+            // The webview shows whatever arrives and cannot tell the thread has since changed, so
+            // skip the emit and let the switch back read these off the generation instead.
+            const activeThreadId = chatStateStorage.getActiveThread(projectRootPath)?.id;
+            if (activeThreadId !== threadId) {
+                console.log(`[Followups] Stored for ${messageId} without showing — thread ${threadId} is not active (now ${activeThreadId ?? "none"})`);
                 return;
             }
 
-            chatStateStorage.updateGeneration(projectRootPath, threadId, messageId, { followupSuggestions: suggestions });
             eventHandler({ type: "followup_suggestions", messageId, suggestions });
             console.log(`[Followups] Emitted for ${messageId}: ${suggestions.map(s => s.label).join(", ")}`);
         } catch (error) {

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -873,8 +873,10 @@ User reverted the last made changes. The files have been restored to the state b
 
     async getLatestFollowupSuggestions(): Promise<FollowupSuggestion[]> {
         const projectRootPath = resolveProjectRootPath();
-        const generations = chatStateStorage.getGenerations(projectRootPath, getActiveThreadId(projectRootPath));
-        return generations[generations.length - 1]?.followupSuggestions ?? [];
+        // Read the thread directly: getGenerations() would create and persist an empty thread if
+        // this one is no longer in memory.
+        const thread = chatStateStorage.getWorkspaceState(projectRootPath)?.threads.get(getActiveThreadId(projectRootPath));
+        return thread?.generations[thread.generations.length - 1]?.followupSuggestions ?? [];
     }
 
     async compactConversation(_params: CompactConversationRequest): Promise<CompactConversationResponse> {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/FollowupSuggestions/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/FollowupSuggestions/index.tsx
@@ -23,14 +23,21 @@ import { FollowupSuggestion } from "@wso2/ballerina-core";
 const Container = styled.div`
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 6px;
-    margin-top: 8px;
+    /* Deliberately asymmetric: the chips belong to the input below, not the message above. */
+    margin: 20px 0 -22px;
+`;
+
+const AiHint = styled.span`
+    display: inline-flex;
+    color: var(--vscode-descriptionForeground);
+    opacity: 0.8;
 `;
 
 const Chip = styled.button`
     display: flex;
     align-items: center;
-    gap: 6px;
     padding: 4px 10px;
     font-size: 12px;
     font-family: var(--vscode-font-family);
@@ -60,6 +67,7 @@ const FollowupSuggestions: React.FC<FollowupSuggestionsProps> = ({ suggestions, 
     }
     return (
         <Container role="list" aria-label="Follow-up suggestions">
+            <AiHint className="codicon codicon-sparkle" aria-hidden="true" />
             {suggestions.map((suggestion, index) => (
                 <Chip
                     key={`followup-${index}`}
@@ -68,7 +76,6 @@ const FollowupSuggestions: React.FC<FollowupSuggestionsProps> = ({ suggestions, 
                     title={suggestion.prompt}
                     onClick={() => onPick(suggestion)}
                 >
-                    <span className="codicon codicon-sparkle" aria-hidden="true" />
                     {suggestion.label}
                 </Chip>
             ))}


### PR DESCRIPTION
- Keep generated suggestions on the generation when the active session has changed while they were being generated. They were being discarded, so the work was wasted and nothing appeared on returning to that session; now they are stored and shown on switching back.
- Fetch the latest suggestions with a plain thread lookup. The previous call went through `getGenerations()`, which creates and persists an empty thread when that thread is not in memory — so reading suggestions could overwrite a session's history.
- Sit the chips closer to the chat input and further from the feedback bar, and use a single leading icon for the row instead of one per chip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Preserve follow-up suggestions generated while a session is inactive and display them when the session becomes active again.
- Retrieve suggestions from existing in-memory thread state to avoid creating empty threads or altering session history.
- Reposition follow-up chips closer to the chat input and simplify the row to use one leading icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->