### PR TITLE
Improve file trigger form descriptions

### DIFF
--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
@@ -1290,7 +1290,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Content Schema",
+                      "label": "Row Schema",
                       "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
                     "value": "string[][]",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
@@ -1290,7 +1290,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Row Schema",
+                      "label": "Content Schema",
                       "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
                     "value": "string[][]",
@@ -1348,7 +1348,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "File properties: path, name, size, eTag and last-modified time."
+                "description": "File properties such as path, name, size, eTag and last-modified time."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -1373,7 +1373,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "File properties: path, name, size, eTag and last-modified time."
+                  "description": "File properties such as path, name, size, eTag and last-modified time."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -1469,8 +1469,8 @@
           "properties": {
             "afterFileProcessing": {
               "metadata": {
-                "label": "After File Processing",
-                "description": "@files:FunctionConfig - routing and auto-consume actions applied to the file after this handler runs."
+                "label": "File Handling Options",
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -1885,7 +1885,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "File properties: path, name, size, eTag and last-modified time."
+                "description": "File properties such as path, name, size, eTag and last-modified time."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -1910,7 +1910,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "File properties: path, name, size, eTag and last-modified time."
+                  "description": "File properties such as path, name, size, eTag and last-modified time."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -2006,8 +2006,8 @@
           "properties": {
             "afterFileProcessing": {
               "metadata": {
-                "label": "After File Processing",
-                "description": "@files:FunctionConfig - routing and auto-consume actions applied to the file after this handler runs."
+                "label": "File Handling Options",
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -2412,7 +2412,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "File properties: path, name, size, eTag and last-modified time."
+                "description": "File properties such as path, name, size, eTag and last-modified time."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -2437,7 +2437,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "File properties: path, name, size, eTag and last-modified time."
+                  "description": "File properties such as path, name, size, eTag and last-modified time."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -2533,8 +2533,8 @@
           "properties": {
             "afterFileProcessing": {
               "metadata": {
-                "label": "After File Processing",
-                "description": "@files:FunctionConfig - routing and auto-consume actions applied to the file after this handler runs."
+                "label": "File Handling Options",
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -2935,7 +2935,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "File properties: path, name, size, eTag and last-modified time."
+                "description": "File properties such as path, name, size, eTag and last-modified time."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -2960,7 +2960,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "File properties: path, name, size, eTag and last-modified time."
+                  "description": "File properties such as path, name, size, eTag and last-modified time."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -3056,8 +3056,8 @@
           "properties": {
             "afterFileProcessing": {
               "metadata": {
-                "label": "After File Processing",
-                "description": "@files:FunctionConfig - routing and auto-consume actions applied to the file after this handler runs."
+                "label": "File Handling Options",
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -3458,7 +3458,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "File properties: path, name, size, eTag and last-modified time."
+                "description": "File properties such as path, name, size, eTag and last-modified time."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -3483,7 +3483,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "File properties: path, name, size, eTag and last-modified time."
+                  "description": "File properties such as path, name, size, eTag and last-modified time."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -3579,8 +3579,8 @@
           "properties": {
             "afterFileProcessing": {
               "metadata": {
-                "label": "After File Processing",
-                "description": "@files:FunctionConfig - routing and auto-consume actions applied to the file after this handler runs."
+                "label": "File Handling Options",
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
@@ -1076,8 +1076,8 @@
     },
     "path": {
       "metadata": {
-        "label": "Monitoring Path",
-        "description": "The folder on the share to monitor for file actions (e.g., /uploads or /incoming); / watches the share root"
+        "label": "Monitored Path",
+        "description": "The folder on the share to monitor for file actions (e.g., /uploads or /incoming)"
       },
       "types": [
         {
@@ -1239,7 +1239,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Handles a file whose extension routes to the CSV format (.csv), binding its content as string[][] or as rows of a record type (T[]).",
+            "description": "Invoked when a .csv file is created in the monitored directory. Define a row schema below to receive the rows as custom types (e.g., User[], Student[]).",
             "addLabel": "Add On Create Handler (CSV)",
             "badge": "onCreate"
           },
@@ -1257,7 +1257,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "ONE_EACH_PER_GROUP",
-          "documentation": "Handles a file whose extension routes to the CSV format (.csv), binding its content as string[][] or as rows of a record type (T[]).",
+          "documentation": "Handles a newly created CSV file.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onFileCsv",
@@ -1268,13 +1268,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Handles a file whose extension routes to the CSV format (.csv), binding its content as string[][] or as rows of a record type (T[])."
+                "description": "Define a row schema below to receive the rows as custom types (e.g., User[], Student[])."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "Content",
-                  "description": "Handles a file whose extension routes to the CSV format (.csv), binding its content as string[][] or as rows of a record type (T[])."
+                  "description": "Define a row schema below to receive the rows as custom types (e.g., User[], Student[])."
                 },
                 "types": [
                   {
@@ -1291,7 +1291,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Row Schema",
-                      "description": "Define or select the bound row type (T); content is delivered as T[]. Defaults to string[] rows."
+                      "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
                     "value": "string[][]",
                     "enabled": false,
@@ -1321,7 +1321,7 @@
               "name": {
                 "metadata": {
                   "label": "content",
-                  "description": "Handles a file whose extension routes to the CSV format (.csv), binding its content as string[][] or as rows of a record type (T[])."
+                  "description": "Define a row schema below to receive the rows as custom types (e.g., User[], Student[])."
                 },
                 "placeholder": "content",
                 "value": "content",
@@ -1766,7 +1766,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Handles a file whose extension routes to the JSON format (.json), binding its content as map<json> or a record type.",
+            "description": "Invoked when a .json file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (JSON)",
             "badge": "onCreate"
           },
@@ -1784,7 +1784,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "ONE_EACH_PER_GROUP",
-          "documentation": "Handles a file whose extension routes to the JSON format (.json), binding its content as map<json> or a record type.",
+          "documentation": "Handles a newly created JSON file.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onFileJson",
@@ -1795,13 +1795,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Handles a file whose extension routes to the JSON format (.json), binding its content as map<json> or a record type."
+                "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "Content",
-                  "description": "Handles a file whose extension routes to the JSON format (.json), binding its content as map<json> or a record type."
+                  "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
                 },
                 "types": [
                   {
@@ -1818,7 +1818,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content Schema",
-                      "description": "Bound content type (defaults to map<json>). Bind a record type for schema-checked access; bare json is not supported."
+                      "description": "Create a record type describing the file content. Defaults to map<json>; bare json is not supported."
                     },
                     "value": "map<json>",
                     "enabled": true,
@@ -1858,7 +1858,7 @@
               "name": {
                 "metadata": {
                   "label": "content",
-                  "description": "Handles a file whose extension routes to the JSON format (.json), binding its content as map<json> or a record type."
+                  "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
                 },
                 "placeholder": "content",
                 "value": "content",
@@ -2303,7 +2303,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Handles a file whose extension routes to the XML format (.xml), binding its content as xml or a record type.",
+            "description": "Invoked when a .xml file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (XML)",
             "badge": "onCreate"
           },
@@ -2321,7 +2321,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "ONE_EACH_PER_GROUP",
-          "documentation": "Handles a file whose extension routes to the XML format (.xml), binding its content as xml or a record type.",
+          "documentation": "Handles a newly created XML file.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onFileXml",
@@ -2332,13 +2332,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Handles a file whose extension routes to the XML format (.xml), binding its content as xml or a record type."
+                "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "Content",
-                  "description": "Handles a file whose extension routes to the XML format (.xml), binding its content as xml or a record type."
+                  "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
                 },
                 "types": [
                   {
@@ -2355,7 +2355,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content Schema",
-                      "description": "Bound content type (defaults to xml). Bind a record type for schema-checked access."
+                      "description": "Create a record type describing the file content. Defaults to xml."
                     },
                     "value": "xml",
                     "enabled": false,
@@ -2385,7 +2385,7 @@
               "name": {
                 "metadata": {
                   "label": "content",
-                  "description": "Handles a file whose extension routes to the XML format (.xml), binding its content as xml or a record type."
+                  "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
                 },
                 "placeholder": "content",
                 "value": "content",
@@ -2830,7 +2830,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Handles a file whose extension routes to the Text format (.txt).",
+            "description": "Invoked when a .txt file is created in the monitored directory. The content arrives as plain text.",
             "addLabel": "Add On Create Handler (Text)",
             "badge": "onCreate"
           },
@@ -2848,7 +2848,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "ONE_EACH_PER_GROUP",
-          "documentation": "Handles a file whose extension routes to the Text format (.txt).",
+          "documentation": "Handles a newly created text file.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onFileText",
@@ -2859,13 +2859,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Handles a file whose extension routes to the Text format (.txt)."
+                "description": "The content arrives as plain text."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "Content",
-                  "description": "Handles a file whose extension routes to the Text format (.txt)."
+                  "description": "The content arrives as plain text."
                 },
                 "types": [
                   {
@@ -2882,7 +2882,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content",
-                      "description": "The text file content as a plain string."
+                      "description": "The file content as plain text."
                     },
                     "value": "string",
                     "enabled": false,
@@ -2908,7 +2908,7 @@
               "name": {
                 "metadata": {
                   "label": "content",
-                  "description": "Handles a file whose extension routes to the Text format (.txt)."
+                  "description": "The content arrives as plain text."
                 },
                 "placeholder": "content",
                 "value": "content",
@@ -3353,7 +3353,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Handles any present file as raw bytes; also the fallback for extensions without a typed handler.",
+            "description": "Invoked when a file is created in the monitored directory. Handles any extension without a typed handler; the content arrives as raw, unparsed bytes.",
             "addLabel": "Add On Create Handler (Raw Bytes)",
             "badge": "onCreate"
           },
@@ -3371,7 +3371,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "ONE_EACH_PER_GROUP",
-          "documentation": "Handles any present file as raw bytes; also the fallback for extensions without a typed handler.",
+          "documentation": "Handles a newly created file as raw bytes.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onFile",
@@ -3382,13 +3382,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Handles any present file as raw bytes; also the fallback for extensions without a typed handler."
+                "description": "The content arrives as raw, unparsed bytes."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "Content",
-                  "description": "Handles any present file as raw bytes; also the fallback for extensions without a typed handler."
+                  "description": "The content arrives as raw, unparsed bytes."
                 },
                 "types": [
                   {
@@ -3431,7 +3431,7 @@
               "name": {
                 "metadata": {
                   "label": "content",
-                  "description": "Handles any present file as raw bytes; also the fallback for extensions without a typed handler."
+                  "description": "The content arrives as raw, unparsed bytes."
                 },
                 "placeholder": "content",
                 "value": "content",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
@@ -3876,7 +3876,7 @@
         {
           "metadata": {
             "label": "On Error",
-            "description": "Invoked when a poll or file-processing error occurs.",
+            "description": "Invoked when an error occurs while processing a file in the monitored directory.",
             "addLabel": "Add On Error Handler",
             "badge": "onError"
           },
@@ -3901,7 +3901,7 @@
             {
               "metadata": {
                 "label": "Azure Files Error",
-                "description": "The error raised by the poll or the file processing."
+                "description": "The error that occurred while processing the file."
               },
               "kind": "REQUIRED",
               "type": {
@@ -3925,7 +3925,7 @@
               "name": {
                 "metadata": {
                   "label": "err",
-                  "description": "The error that occurred during file processing."
+                  "description": "The error that occurred while processing the file."
                 },
                 "placeholder": "err",
                 "value": "err",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/ftp.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/ftp.json
@@ -796,7 +796,7 @@
     },
     "path": {
       "metadata": {
-        "label": "Monitoring Path",
+        "label": "Monitored Path",
         "description": "The folder on the remote server to monitor for file actions (e.g., /uploads or /incoming)"
       },
       "types": [
@@ -880,7 +880,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Invoked when a file is created in the monitored directory. Comma-separated rows \u2014 binds each row to T, emits T[] (or stream<T, error?> for large files).",
+            "description": "Invoked when a file is created in the monitored directory. Define a row schema below to receive the rows as custom types (e.g., User[], Student[]).",
             "addLabel": "Add On Create Handler (CSV)",
             "badge": "onCreate"
           },
@@ -909,13 +909,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Comma-separated rows \u2014 binds each row to T, emits T[] (or stream<T, error?> for large files)."
+                "description": "Define a row schema below to receive the rows as custom types (e.g., User[], Student[])."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "CSV Content",
-                  "description": "Comma-separated rows \u2014 binds each row to T, emits T[] (or stream<T, error?> for large files)."
+                  "description": "Define a row schema below to receive the rows as custom types (e.g., User[], Student[])."
                 },
                 "value": "",
                 "types": [
@@ -932,7 +932,7 @@
                   "rows": {
                     "metadata": {
                       "label": "Rows",
-                      "description": "Content Schema contains a row of CSV Row type"
+                      "description": "Each row of the file arrives as one record."
                     },
                     "value": true,
                     "types": [
@@ -952,7 +952,7 @@
                   "stream": {
                     "metadata": {
                       "label": "Stream (Large Files)",
-                      "description": "Process the file content in chunks"
+                      "description": "Process the file content in chunks."
                     },
                     "value": false,
                     "types": [
@@ -979,7 +979,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Row Schema",
-                      "description": "Define or select the bound row type (T). Content is delivered as T[], or stream<T, error?> when streaming is enabled."
+                      "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
                     "value": "string[][]",
                     "enabled": true,
@@ -1468,7 +1468,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Invoked when a file is created in the monitored directory. Binds the file content to json or a custom record type.",
+            "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (JSON)",
             "badge": "onCreate"
           },
@@ -1497,13 +1497,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Binds the file content to json or a custom record type."
+                "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "JSON Content",
-                  "description": "Binds the file content to json or a custom record type."
+                  "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
                 },
                 "value": "",
                 "types": [
@@ -1520,7 +1520,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content Schema",
-                      "description": "Bound content type (defaults to json)."
+                      "description": "Create a record type describing the file content. Defaults to json."
                     },
                     "value": "json",
                     "enabled": true,
@@ -2008,7 +2008,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Invoked when a file is created in the monitored directory. Binds the file content to xml or a custom record type.",
+            "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (XML)",
             "badge": "onCreate"
           },
@@ -2037,13 +2037,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Binds the file content to xml or a custom record type."
+                "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "XML Content",
-                  "description": "Binds the file content to xml or a custom record type."
+                  "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
                 },
                 "value": "",
                 "types": [
@@ -2060,7 +2060,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content Schema",
-                      "description": "Bound content type (defaults to xml)."
+                      "description": "Create a record type describing the file content. Defaults to xml."
                     },
                     "value": "xml",
                     "enabled": true,
@@ -2548,7 +2548,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Invoked when a file is created in the monitored directory. Delivers the file content as a plain string.",
+            "description": "Invoked when a file is created in the monitored directory. The content arrives as plain text.",
             "addLabel": "Add On Create Handler (Text)",
             "badge": "onCreate"
           },
@@ -2577,13 +2577,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Delivers the file content as a plain string."
+                "description": "The content arrives as plain text."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "Text Content",
-                  "description": "Delivers the file content as a plain string."
+                  "description": "The content arrives as plain text."
                 },
                 "value": "",
                 "types": [
@@ -2600,7 +2600,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content",
-                      "description": "The text file content as a plain string."
+                      "description": "The file content as plain text."
                     },
                     "value": "string",
                     "enabled": false,
@@ -3074,7 +3074,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Invoked when a file is created in the monitored directory. Delivers the raw file content as byte[] (or stream<byte[], error?> for large files).",
+            "description": "Invoked when a file is created in the monitored directory. The content arrives as raw, unparsed bytes.",
             "addLabel": "Add On Create Handler (Raw Bytes)",
             "badge": "onCreate"
           },
@@ -3103,13 +3103,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Delivers the raw file content as byte[] (or stream<byte[], error?> for large files)."
+                "description": "The content arrives as raw, unparsed bytes."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "Raw Bytes Content",
-                  "description": "Delivers the raw file content as byte[] (or stream<byte[], error?> for large files)."
+                  "description": "The content arrives as raw, unparsed bytes."
                 },
                 "value": "",
                 "types": [
@@ -3126,7 +3126,7 @@
                   "stream": {
                     "metadata": {
                       "label": "Stream (Large Files)",
-                      "description": "Deliver the content as stream<byte[], error?> to process large binary files in chunks."
+                      "description": "Process the file content in chunks."
                     },
                     "value": false,
                     "types": [
@@ -3153,7 +3153,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content",
-                      "description": "Raw file content as byte[], or stream<byte[], error?> when streaming is enabled."
+                      "description": "The raw file content as bytes."
                     },
                     "value": "byte[]",
                     "enabled": true,

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/ftp.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/ftp.json
@@ -958,7 +958,7 @@
                   },
                   "payload": {
                     "metadata": {
-                      "label": "Content Schema",
+                      "label": "Row Schema",
                       "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
                     "value": "string[][]",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/ftp.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/ftp.json
@@ -929,26 +929,6 @@
                 "optional": false,
                 "advanced": false,
                 "properties": {
-                  "rows": {
-                    "metadata": {
-                      "label": "Rows",
-                      "description": "Each row of the file arrives as one record."
-                    },
-                    "value": true,
-                    "types": [
-                      {
-                        "fieldType": "METADATA_FLAG",
-                        "selected": true
-                      }
-                    ],
-                    "enabled": true,
-                    "editable": false,
-                    "optional": false,
-                    "advanced": false,
-                    "codedata": {
-                      "type": "METADATA_FLAG"
-                    }
-                  },
                   "stream": {
                     "metadata": {
                       "label": "Stream (Large Files)",
@@ -978,7 +958,7 @@
                   },
                   "payload": {
                     "metadata": {
-                      "label": "Row Schema",
+                      "label": "Content Schema",
                       "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
                     "value": "string[][]",
@@ -1047,7 +1027,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Additional file properties such as size, modification time and permissions."
+                "description": "File properties such as size, modification time and permissions."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -1072,7 +1052,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "Additional file properties such as size, modification time and permissions."
+                  "description": "File properties such as size, modification time and permissions."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -1168,8 +1148,8 @@
           "properties": {
             "afterFileProcessing": {
               "metadata": {
-                "label": "After File Processing",
-                "description": "@ftp:FunctionConfig \u2014 actions performed on the source file after a handler runs."
+                "label": "File Handling Options",
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -1587,7 +1567,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Additional file properties such as size, modification time and permissions."
+                "description": "File properties such as size, modification time and permissions."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -1612,7 +1592,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "Additional file properties such as size, modification time and permissions."
+                  "description": "File properties such as size, modification time and permissions."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -1708,8 +1688,8 @@
           "properties": {
             "afterFileProcessing": {
               "metadata": {
-                "label": "After File Processing",
-                "description": "@ftp:FunctionConfig \u2014 actions performed on the source file after a handler runs."
+                "label": "File Handling Options",
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -2127,7 +2107,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Additional file properties such as size, modification time and permissions."
+                "description": "File properties such as size, modification time and permissions."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -2152,7 +2132,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "Additional file properties such as size, modification time and permissions."
+                  "description": "File properties such as size, modification time and permissions."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -2248,8 +2228,8 @@
           "properties": {
             "afterFileProcessing": {
               "metadata": {
-                "label": "After File Processing",
-                "description": "@ftp:FunctionConfig \u2014 actions performed on the source file after a handler runs."
+                "label": "File Handling Options",
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -2653,7 +2633,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Additional file properties such as size, modification time and permissions."
+                "description": "File properties such as size, modification time and permissions."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -2678,7 +2658,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "Additional file properties such as size, modification time and permissions."
+                  "description": "File properties such as size, modification time and permissions."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -2774,8 +2754,8 @@
           "properties": {
             "afterFileProcessing": {
               "metadata": {
-                "label": "After File Processing",
-                "description": "@ftp:FunctionConfig \u2014 actions performed on the source file after a handler runs."
+                "label": "File Handling Options",
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -3207,7 +3187,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Additional file properties such as size, modification time and permissions."
+                "description": "File properties such as size, modification time and permissions."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -3232,7 +3212,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "Additional file properties such as size, modification time and permissions."
+                  "description": "File properties such as size, modification time and permissions."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -3328,8 +3308,8 @@
           "properties": {
             "afterFileProcessing": {
               "metadata": {
-                "label": "After File Processing",
-                "description": "@ftp:FunctionConfig \u2014 actions performed on the source file after a handler runs."
+                "label": "File Handling Options",
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/ftp.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/ftp.json
@@ -3898,7 +3898,7 @@
         {
           "metadata": {
             "label": "On Error",
-            "description": "Invoked when an error occurs during file processing.",
+            "description": "Invoked when an error occurs while processing a file in the monitored directory.",
             "addLabel": "Add On Error Handler",
             "badge": "onError"
           },
@@ -3922,7 +3922,7 @@
             {
               "metadata": {
                 "label": "FTP Error",
-                "description": "The error that occurred during file processing."
+                "description": "The error that occurred while processing the file."
               },
               "kind": "REQUIRED",
               "type": {
@@ -3946,7 +3946,7 @@
               "name": {
                 "metadata": {
                   "label": "ftpError",
-                  "description": "The error that occurred during file processing."
+                  "description": "The error that occurred while processing the file."
                 },
                 "placeholder": "ftpError",
                 "value": "ftpError",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
@@ -2226,7 +2226,7 @@
                   },
                   "payload": {
                     "metadata": {
-                      "label": "Content Schema",
+                      "label": "Row Schema",
                       "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
                     "value": "string[][]",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
@@ -644,7 +644,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Metadata for the file such as name, path, size and timestamps."
+                "description": "File properties such as name, path, size and timestamps."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -669,7 +669,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "Metadata for the file such as name, path, size and timestamps."
+                  "description": "File properties such as name, path, size and timestamps."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -766,7 +766,7 @@
             "fileHandling": {
               "metadata": {
                 "label": "File Handling Options",
-                "description": "@smb:FunctionConfig \u2014 per-handler file-name filter and the action taken on the source file after the handler runs."
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -1185,7 +1185,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Metadata for the file such as name, path, size and timestamps."
+                "description": "File properties such as name, path, size and timestamps."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -1210,7 +1210,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "Metadata for the file such as name, path, size and timestamps."
+                  "description": "File properties such as name, path, size and timestamps."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -1307,7 +1307,7 @@
             "fileHandling": {
               "metadata": {
                 "label": "File Handling Options",
-                "description": "@smb:FunctionConfig \u2014 per-handler file-name filter and the action taken on the source file after the handler runs."
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -1726,7 +1726,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Metadata for the file such as name, path, size and timestamps."
+                "description": "File properties such as name, path, size and timestamps."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -1751,7 +1751,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "Metadata for the file such as name, path, size and timestamps."
+                  "description": "File properties such as name, path, size and timestamps."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -1848,7 +1848,7 @@
             "fileHandling": {
               "metadata": {
                 "label": "File Handling Options",
-                "description": "@smb:FunctionConfig \u2014 per-handler file-name filter and the action taken on the source file after the handler runs."
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -2197,26 +2197,6 @@
                 "optional": false,
                 "advanced": false,
                 "properties": {
-                  "rows": {
-                    "metadata": {
-                      "label": "Rows",
-                      "description": "Each row of the file arrives as one record."
-                    },
-                    "value": true,
-                    "types": [
-                      {
-                        "fieldType": "METADATA_FLAG",
-                        "selected": true
-                      }
-                    ],
-                    "enabled": true,
-                    "editable": false,
-                    "optional": false,
-                    "advanced": false,
-                    "codedata": {
-                      "type": "METADATA_FLAG"
-                    }
-                  },
                   "stream": {
                     "metadata": {
                       "label": "Stream (Large Files)",
@@ -2246,7 +2226,7 @@
                   },
                   "payload": {
                     "metadata": {
-                      "label": "Row Schema",
+                      "label": "Content Schema",
                       "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
                     "value": "string[][]",
@@ -2315,7 +2295,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Metadata for the file such as name, path, size and timestamps."
+                "description": "File properties such as name, path, size and timestamps."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -2340,7 +2320,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "Metadata for the file such as name, path, size and timestamps."
+                  "description": "File properties such as name, path, size and timestamps."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -2437,7 +2417,7 @@
             "fileHandling": {
               "metadata": {
                 "label": "File Handling Options",
-                "description": "@smb:FunctionConfig \u2014 per-handler file-name filter and the action taken on the source file after the handler runs."
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {
@@ -2870,7 +2850,7 @@
             {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Metadata for the file such as name, path, size and timestamps."
+                "description": "File properties such as name, path, size and timestamps."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -2895,7 +2875,7 @@
               "name": {
                 "metadata": {
                   "label": "fileInfo",
-                  "description": "Metadata for the file such as name, path, size and timestamps."
+                  "description": "File properties such as name, path, size and timestamps."
                 },
                 "placeholder": "fileInfo",
                 "value": "fileInfo",
@@ -2992,7 +2972,7 @@
             "fileHandling": {
               "metadata": {
                 "label": "File Handling Options",
-                "description": "@smb:FunctionConfig \u2014 per-handler file-name filter and the action taken on the source file after the handler runs."
+                "description": "What happens to the source file after the handler runs."
               },
               "types": [
                 {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
@@ -489,7 +489,7 @@
     "path": {
       "metadata": {
         "label": "Monitored Path",
-        "description": "Directory within the SMB share to monitor for file events. Defaults to the service name when left unset."
+        "description": "The folder on the remote server to monitor for file actions (e.g., /uploads or /incoming)"
       },
       "types": [
         {
@@ -538,7 +538,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Invoked when a file is created in the monitored directory. Delivers the file content as a plain string.",
+            "description": "Invoked when a file is created in the monitored directory. The content arrives as plain text.",
             "addLabel": "Add On Create Handler (Text)",
             "badge": "onCreate"
           },
@@ -568,13 +568,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Delivers the file content as a plain string."
+                "description": "The content arrives as plain text."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "Text Content",
-                  "description": "Delivers the file content as a plain string."
+                  "description": "The content arrives as plain text."
                 },
                 "value": "",
                 "types": [
@@ -591,7 +591,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content",
-                      "description": "The text file content as a plain string."
+                      "description": "The file content as plain text."
                     },
                     "value": "string",
                     "enabled": false,
@@ -1065,7 +1065,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Invoked when a file is created in the monitored directory. Binds the file content to json or a custom record type.",
+            "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (JSON)",
             "badge": "onCreate"
           },
@@ -1095,13 +1095,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Binds the file content to json or a custom record type."
+                "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "JSON Content",
-                  "description": "Binds the file content to json or a custom record type."
+                  "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
                 },
                 "value": "",
                 "types": [
@@ -1118,7 +1118,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content Schema",
-                      "description": "Bound content type (defaults to json)."
+                      "description": "Create a record type describing the file content. Defaults to json."
                     },
                     "value": "json",
                     "enabled": true,
@@ -1606,7 +1606,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Invoked when a file is created in the monitored directory. Binds the file content to xml or a custom record type.",
+            "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (XML)",
             "badge": "onCreate"
           },
@@ -1636,13 +1636,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Binds the file content to xml or a custom record type."
+                "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "XML Content",
-                  "description": "Binds the file content to xml or a custom record type."
+                  "description": "Define a schema below to receive the content as a custom type (e.g., User, Student)."
                 },
                 "value": "",
                 "types": [
@@ -1659,7 +1659,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content Schema",
-                      "description": "Bound content type (defaults to xml)."
+                      "description": "Create a record type describing the file content. Defaults to xml."
                     },
                     "value": "xml",
                     "enabled": true,
@@ -2147,7 +2147,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Invoked when a file is created in the monitored directory. Comma-separated rows \u2014 binds each row to T, emits T[] (or stream<T, error?> for large files).",
+            "description": "Invoked when a file is created in the monitored directory. Define a row schema below to receive the rows as custom types (e.g., User[], Student[]).",
             "addLabel": "Add On Create Handler (CSV)",
             "badge": "onCreate"
           },
@@ -2177,13 +2177,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Comma-separated rows \u2014 binds each row to T, emits T[] (or stream<T, error?> for large files)."
+                "description": "Define a row schema below to receive the rows as custom types (e.g., User[], Student[])."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "CSV Content",
-                  "description": "Comma-separated rows \u2014 binds each row to T, emits T[] (or stream<T, error?> for large files)."
+                  "description": "Define a row schema below to receive the rows as custom types (e.g., User[], Student[])."
                 },
                 "value": "",
                 "types": [
@@ -2200,7 +2200,7 @@
                   "rows": {
                     "metadata": {
                       "label": "Rows",
-                      "description": "Content Schema contains a row of CSV Row type"
+                      "description": "Each row of the file arrives as one record."
                     },
                     "value": true,
                     "types": [
@@ -2220,7 +2220,7 @@
                   "stream": {
                     "metadata": {
                       "label": "Stream (Large Files)",
-                      "description": "Process the file content in chunks"
+                      "description": "Process the file content in chunks."
                     },
                     "value": false,
                     "types": [
@@ -2247,7 +2247,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Row Schema",
-                      "description": "Define or select the bound row type (T). Content is delivered as T[], or stream<T, error?> when streaming is enabled."
+                      "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
                     "value": "string[][]",
                     "enabled": true,
@@ -2736,7 +2736,7 @@
         {
           "metadata": {
             "label": "On Create",
-            "description": "Invoked when a file is created in the monitored directory. Delivers the raw file content as byte[] (or stream<byte[], error?> for large files).",
+            "description": "Invoked when a file is created in the monitored directory. The content arrives as raw, unparsed bytes.",
             "addLabel": "Add On Create Handler (Raw Bytes)",
             "badge": "onCreate"
           },
@@ -2766,13 +2766,13 @@
             {
               "metadata": {
                 "label": "Content",
-                "description": "Delivers the raw file content as byte[] (or stream<byte[], error?> for large files)."
+                "description": "The content arrives as raw, unparsed bytes."
               },
               "kind": "DATA_BINDING",
               "type": {
                 "metadata": {
                   "label": "Raw Bytes Content",
-                  "description": "Delivers the raw file content as byte[] (or stream<byte[], error?> for large files)."
+                  "description": "The content arrives as raw, unparsed bytes."
                 },
                 "value": "",
                 "types": [
@@ -2789,7 +2789,7 @@
                   "stream": {
                     "metadata": {
                       "label": "Stream (Large Files)",
-                      "description": "Deliver the content as stream<byte[], error?> to process large binary files in chunks."
+                      "description": "Process the file content in chunks."
                     },
                     "value": false,
                     "types": [
@@ -2816,7 +2816,7 @@
                   "payload": {
                     "metadata": {
                       "label": "Content",
-                      "description": "Raw file content as byte[], or stream<byte[], error?> when streaming is enabled."
+                      "description": "The raw file content as bytes."
                     },
                     "value": "byte[]",
                     "enabled": true,

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
@@ -3450,8 +3450,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "error",
-                "value": "error",
+                "placeholder": "smb:Error",
+                "value": "smb:Error",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -3486,6 +3486,58 @@
               "optional": false,
               "advanced": false,
               "hidden": true,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            },
+            {
+              "metadata": {
+                "label": "SMB Connection (caller)",
+                "description": "SMB connection handle for performing additional file operations within the handler."
+              },
+              "kind": "OPTIONAL",
+              "type": {
+                "metadata": {
+                  "label": "Include SMB Connection (caller)",
+                  "description": "Tick to include the SMB Connection (caller) parameter in the handler signature."
+                },
+                "placeholder": "smb:Caller",
+                "value": false,
+                "types": [
+                  {
+                    "fieldType": "FLAG",
+                    "selected": true,
+                    "ballerinaType": "smb:Caller"
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "caller",
+                  "description": "SMB connection handle for performing additional file operations within the handler."
+                },
+                "placeholder": "caller",
+                "value": "caller",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": false,
+              "editable": true,
+              "optional": true,
+              "advanced": true,
+              "hidden": false,
               "codedata": {
                 "type": "FUNCTION_PARAM"
               }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
@@ -3418,7 +3418,7 @@
         {
           "metadata": {
             "label": "On Error",
-            "description": "Invoked when an error occurs during file processing.",
+            "description": "Invoked when an error occurs while processing a file in the monitored directory.",
             "addLabel": "Add On Error Handler",
             "badge": "onError"
           },
@@ -3442,7 +3442,7 @@
             {
               "metadata": {
                 "label": "SMB Error",
-                "description": "The error that occurred during file processing."
+                "description": "The error that occurred while processing the file."
               },
               "kind": "REQUIRED",
               "type": {
@@ -3466,7 +3466,7 @@
               "name": {
                 "metadata": {
                   "label": "err",
-                  "description": "The error that occurred during file processing."
+                  "description": "The error that occurred while processing the file."
                 },
                 "placeholder": "err",
                 "value": "err",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerFunctionExpansionTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerFunctionExpansionTest.java
@@ -110,9 +110,7 @@ public class TriggerFunctionExpansionTest {
         Assert.assertNotNull(stream, "PAYLOAD_MODIFIER flag must surface as a wire property");
         Assert.assertEquals(stream.getCodedata().getType(), "PAYLOAD_MODIFIER");
         Assert.assertEquals(stream.getCodedata().getTemplate(), "stream<{{type}}, error?>");
-        Value rows = csv.getProperty("rows");
-        Assert.assertNotNull(rows, "METADATA_FLAG marker must surface as a wire property");
-        Assert.assertEquals(rows.getCodedata().getType(), "METADATA_FLAG");
+        Assert.assertNull(csv.getProperty("rows"), "the CSV rows marker was removed from the model");
 
         // Text is a locked (non-bindable) variant: plain REQUIRED string param, no data binding.
         Function text = byName(service, "onFileText");
@@ -133,7 +131,7 @@ public class TriggerFunctionExpansionTest {
     public void testVariantlessComplexPayloadSurfacesCompositionFlags() {
         // Each FTP file format is its own schemaFunction, whose `content` parameter is a
         // COMPLEX_PAYLOAD directly rather than under a VARIATION_SELECTOR. Its composition siblings
-        // (the `stream` toggle, the `rows` marker) must still surface as wire properties, or the
+        // (the `stream` toggle) must still surface as wire properties, or the
         // handler form renders neither.
         Service ftp = ftpTemplate();
         Function csv = byName(ftp, "onFileCsv");
@@ -150,9 +148,7 @@ public class TriggerFunctionExpansionTest {
         Assert.assertNotNull(stream, "variant-less COMPLEX_PAYLOAD must still surface the PAYLOAD_MODIFIER toggle");
         Assert.assertEquals(stream.getCodedata().getType(), "PAYLOAD_MODIFIER");
         Assert.assertEquals(stream.getCodedata().getTemplate(), "stream<{{type}}, error?>");
-        Value rows = csv.getProperty("rows");
-        Assert.assertNotNull(rows, "variant-less COMPLEX_PAYLOAD must still surface the METADATA_FLAG marker");
-        Assert.assertEquals(rows.getCodedata().getType(), "METADATA_FLAG");
+        Assert.assertNull(csv.getProperty("rows"), "the CSV rows marker was removed from the model");
 
         // A payload with no composition siblings (JSON) adds no spurious flags.
         Function json = byName(ftp, "onFileJson");

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/add_function/config/add_ftp_function_aliased.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/add_function/config/add_ftp_function_aliased.json
@@ -127,7 +127,7 @@
     "properties": {
       "afterFileProcessing": {
         "metadata": {
-          "label": "After File Processing",
+          "label": "File Handling Options",
           "description": "@ftp:FunctionConfig — actions performed on the source file after a handler runs."
         },
         "codedata": {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/add_function/config/add_ftp_function_aliased.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/add_function/config/add_ftp_function_aliased.json
@@ -16,7 +16,7 @@
   "function": {
     "metadata": {
       "label": "On Create",
-      "description": "Invoked when a file is created in the monitored directory. Comma-separated rows — binds each row to T, emits T[] (or stream<T, error?> for large files).",
+      "description": "Invoked when a file is created in the monitored directory. Define a row schema below to receive the rows as custom types (e.g., User[], Student[]).",
       "badge": "onCreate"
     },
     "kind": "REMOTE",
@@ -49,7 +49,7 @@
       {
         "metadata": {
           "label": "Content",
-          "description": "Comma-separated rows — binds each row to T, emits T[] (or stream<T, error?> for large files)."
+          "description": "Define a row schema below to receive the rows as custom types (e.g., User[], Student[])."
         },
         "kind": "DATA_BINDING",
         "type": {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/add_service_and_listener/config/ftp_service_model_expression.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/add_service_and_listener/config/ftp_service_model_expression.json
@@ -70,7 +70,7 @@
       },
       "path": {
         "metadata": {
-          "label": "Monitoring Path",
+          "label": "Monitored Path",
           "description": "The folder on the remote server to monitor for file actions (e.g., /uploads or /incoming)"
         },
         "value": "config.path",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/ftp_service_model.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/ftp_service_model.json
@@ -797,7 +797,7 @@
         },
         "path": {
           "metadata": {
-            "label": "Monitoring Path",
+            "label": "Monitored Path",
             "description": "The folder on the remote server to monitor for file actions (e.g., /uploads or /incoming)"
           },
           "codedata": {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/ftp_service_model_sftp_basic_auth.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/ftp_service_model_sftp_basic_auth.json
@@ -1015,7 +1015,7 @@
         },
         "path": {
           "metadata": {
-            "label": "Monitoring Path",
+            "label": "Monitored Path",
             "description": "The folder on the remote server to monitor for file actions (e.g., /uploads or /incoming)"
           },
           "codedata": {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/ftp_service_model.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/ftp_service_model.json
@@ -243,7 +243,7 @@
           {
             "metadata": {
               "label": "File Metadata (fileInfo)",
-              "description": "Additional file properties such as size, modification time and permissions."
+              "description": "File properties such as size, modification time and permissions."
             },
             "kind": "OPTIONAL",
             "type": {
@@ -267,7 +267,7 @@
             "name": {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Additional file properties such as size, modification time and permissions."
+                "description": "File properties such as size, modification time and permissions."
               },
               "placeholder": "fileInfo",
               "value": "fileInfo",
@@ -383,8 +383,8 @@
         "properties": {
           "afterFileProcessing": {
             "metadata": {
-              "label": "After File Processing",
-              "description": "@ftp:FunctionConfig — actions performed on the source file after a handler runs."
+              "label": "File Handling Options",
+              "description": "What happens to the source file after the handler runs."
             },
             "codedata": {
               "type": "COMPLEX_FUNCTION_ANNOTATION",
@@ -766,7 +766,7 @@
           {
             "metadata": {
               "label": "File Metadata (fileInfo)",
-              "description": "Additional file properties such as size, modification time and permissions."
+              "description": "File properties such as size, modification time and permissions."
             },
             "kind": "OPTIONAL",
             "type": {
@@ -790,7 +790,7 @@
             "name": {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Additional file properties such as size, modification time and permissions."
+                "description": "File properties such as size, modification time and permissions."
               },
               "placeholder": "fileInfo",
               "value": "fileInfo",
@@ -906,8 +906,8 @@
         "properties": {
           "afterFileProcessing": {
             "metadata": {
-              "label": "After File Processing",
-              "description": "@ftp:FunctionConfig — actions performed on the source file after a handler runs."
+              "label": "File Handling Options",
+              "description": "What happens to the source file after the handler runs."
             },
             "codedata": {
               "type": "COMPLEX_FUNCTION_ANNOTATION",
@@ -1234,13 +1234,13 @@
         "parameters": [
           {
             "metadata": {
-              "label": "Row Schema",
+              "label": "Content Schema",
               "description": "Create a record type describing one row of the file. Each row arrives as one record."
             },
             "kind": "DATA_BINDING",
             "type": {
               "metadata": {
-                "label": "Row Schema",
+                "label": "Content Schema",
                 "description": "Create a record type describing one row of the file. Each row arrives as one record."
               },
               "codedata": {
@@ -1265,7 +1265,7 @@
             },
             "name": {
               "metadata": {
-                "label": "Row Schema",
+                "label": "Content Schema",
                 "description": "Create a record type describing one row of the file. Each row arrives as one record."
               },
               "placeholder": "content",
@@ -1291,7 +1291,7 @@
           {
             "metadata": {
               "label": "File Metadata (fileInfo)",
-              "description": "Additional file properties such as size, modification time and permissions."
+              "description": "File properties such as size, modification time and permissions."
             },
             "kind": "OPTIONAL",
             "type": {
@@ -1315,7 +1315,7 @@
             "name": {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Additional file properties such as size, modification time and permissions."
+                "description": "File properties such as size, modification time and permissions."
               },
               "placeholder": "fileInfo",
               "value": "fileInfo",
@@ -1420,8 +1420,8 @@
         "properties": {
           "afterFileProcessing": {
             "metadata": {
-              "label": "After File Processing",
-              "description": "@ftp:FunctionConfig — actions performed on the source file after a handler runs."
+              "label": "File Handling Options",
+              "description": "What happens to the source file after the handler runs."
             },
             "codedata": {
               "type": "COMPLEX_FUNCTION_ANNOTATION",
@@ -1711,26 +1711,6 @@
             "optional": true,
             "advanced": true
           },
-          "rows": {
-            "metadata": {
-              "label": "Rows",
-              "description": "Each row of the file arrives as one record."
-            },
-            "codedata": {
-              "type": "METADATA_FLAG"
-            },
-            "value": true,
-            "types": [
-              {
-                "fieldType": "FLAG",
-                "selected": true
-              }
-            ],
-            "enabled": true,
-            "editable": false,
-            "optional": false,
-            "advanced": false
-          },
           "stream": {
             "metadata": {
               "label": "Stream (Large Files)",
@@ -1845,7 +1825,7 @@
           {
             "metadata": {
               "label": "File Metadata (fileInfo)",
-              "description": "Additional file properties such as size, modification time and permissions."
+              "description": "File properties such as size, modification time and permissions."
             },
             "kind": "OPTIONAL",
             "type": {
@@ -1869,7 +1849,7 @@
             "name": {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Additional file properties such as size, modification time and permissions."
+                "description": "File properties such as size, modification time and permissions."
               },
               "placeholder": "fileInfo",
               "value": "fileInfo",
@@ -1974,8 +1954,8 @@
         "properties": {
           "afterFileProcessing": {
             "metadata": {
-              "label": "After File Processing",
-              "description": "@ftp:FunctionConfig — actions performed on the source file after a handler runs."
+              "label": "File Handling Options",
+              "description": "What happens to the source file after the handler runs."
             },
             "codedata": {
               "type": "COMPLEX_FUNCTION_ANNOTATION",
@@ -2356,7 +2336,7 @@
           {
             "metadata": {
               "label": "File Metadata (fileInfo)",
-              "description": "Additional file properties such as size, modification time and permissions."
+              "description": "File properties such as size, modification time and permissions."
             },
             "kind": "OPTIONAL",
             "type": {
@@ -2380,7 +2360,7 @@
             "name": {
               "metadata": {
                 "label": "File Metadata (fileInfo)",
-                "description": "Additional file properties such as size, modification time and permissions."
+                "description": "File properties such as size, modification time and permissions."
               },
               "placeholder": "fileInfo",
               "value": "fileInfo",
@@ -2485,8 +2465,8 @@
         "properties": {
           "afterFileProcessing": {
             "metadata": {
-              "label": "After File Processing",
-              "description": "@ftp:FunctionConfig — actions performed on the source file after a handler runs."
+              "label": "File Handling Options",
+              "description": "What happens to the source file after the handler runs."
             },
             "codedata": {
               "type": "COMPLEX_FUNCTION_ANNOTATION",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/ftp_service_model.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/ftp_service_model.json
@@ -1234,13 +1234,13 @@
         "parameters": [
           {
             "metadata": {
-              "label": "Content Schema",
+              "label": "Row Schema",
               "description": "Create a record type describing one row of the file. Each row arrives as one record."
             },
             "kind": "DATA_BINDING",
             "type": {
               "metadata": {
-                "label": "Content Schema",
+                "label": "Row Schema",
                 "description": "Create a record type describing one row of the file. Each row arrives as one record."
               },
               "codedata": {
@@ -1265,7 +1265,7 @@
             },
             "name": {
               "metadata": {
-                "label": "Content Schema",
+                "label": "Row Schema",
                 "description": "Create a record type describing one row of the file. Each row arrives as one record."
               },
               "placeholder": "content",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/ftp_service_model.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/ftp_service_model.json
@@ -161,14 +161,14 @@
       {
         "metadata": {
           "label": "On Create",
-          "description": "Invoked when a file is created in the monitored directory. Binds the file content to json or a custom record type.",
+          "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
           "badge": "onCreate"
         },
         "kind": "REMOTE",
         "name": {
           "metadata": {
             "label": "JSON",
-            "description": "Invoked when a file is created in the monitored directory. Binds the file content to json or a custom record type."
+            "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student)."
           },
           "placeholder": "onFileJson",
           "value": "onFileJson",
@@ -187,13 +187,13 @@
           {
             "metadata": {
               "label": "Content Schema",
-              "description": "Bound content type (defaults to json)."
+              "description": "Create a record type describing the file content. Defaults to json."
             },
             "kind": "DATA_BINDING",
             "type": {
               "metadata": {
                 "label": "Content Schema",
-                "description": "Bound content type (defaults to json)."
+                "description": "Create a record type describing the file content. Defaults to json."
               },
               "codedata": {
                 "type": "PAYLOAD_TYPE",
@@ -218,7 +218,7 @@
             "name": {
               "metadata": {
                 "label": "Content Schema",
-                "description": "Bound content type (defaults to json)."
+                "description": "Create a record type describing the file content. Defaults to json."
               },
               "placeholder": "content",
               "value": "content",
@@ -684,14 +684,14 @@
       {
         "metadata": {
           "label": "On Create",
-          "description": "Invoked when a file is created in the monitored directory. Binds the file content to xml or a custom record type.",
+          "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
           "badge": "onCreate"
         },
         "kind": "REMOTE",
         "name": {
           "metadata": {
             "label": "XML",
-            "description": "Invoked when a file is created in the monitored directory. Binds the file content to xml or a custom record type."
+            "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student)."
           },
           "placeholder": "onFileXml",
           "value": "onFileXml",
@@ -710,13 +710,13 @@
           {
             "metadata": {
               "label": "Content Schema",
-              "description": "Bound content type (defaults to xml)."
+              "description": "Create a record type describing the file content. Defaults to xml."
             },
             "kind": "DATA_BINDING",
             "type": {
               "metadata": {
                 "label": "Content Schema",
-                "description": "Bound content type (defaults to xml)."
+                "description": "Create a record type describing the file content. Defaults to xml."
               },
               "codedata": {
                 "type": "PAYLOAD_TYPE",
@@ -741,7 +741,7 @@
             "name": {
               "metadata": {
                 "label": "Content Schema",
-                "description": "Bound content type (defaults to xml)."
+                "description": "Create a record type describing the file content. Defaults to xml."
               },
               "placeholder": "content",
               "value": "content",
@@ -1209,14 +1209,14 @@
       {
         "metadata": {
           "label": "On Create",
-          "description": "Invoked when a file is created in the monitored directory. Comma-separated rows — binds each row to T, emits T[] (or stream<T, error?> for large files).",
+          "description": "Invoked when a file is created in the monitored directory. Define a row schema below to receive the rows as custom types (e.g., User[], Student[]).",
           "badge": "onCreate"
         },
         "kind": "REMOTE",
         "name": {
           "metadata": {
             "label": "CSV",
-            "description": "Invoked when a file is created in the monitored directory. Comma-separated rows — binds each row to T, emits T[] (or stream<T, error?> for large files)."
+            "description": "Invoked when a file is created in the monitored directory. Define a row schema below to receive the rows as custom types (e.g., User[], Student[])."
           },
           "placeholder": "onFileCsv",
           "value": "onFileCsv",
@@ -1235,13 +1235,13 @@
           {
             "metadata": {
               "label": "Row Schema",
-              "description": "Define or select the bound row type (T). Content is delivered as T[], or stream<T, error?> when streaming is enabled."
+              "description": "Create a record type describing one row of the file. Each row arrives as one record."
             },
             "kind": "DATA_BINDING",
             "type": {
               "metadata": {
                 "label": "Row Schema",
-                "description": "Define or select the bound row type (T). Content is delivered as T[], or stream<T, error?> when streaming is enabled."
+                "description": "Create a record type describing one row of the file. Each row arrives as one record."
               },
               "codedata": {
                 "type": "PAYLOAD_TYPE",
@@ -1266,7 +1266,7 @@
             "name": {
               "metadata": {
                 "label": "Row Schema",
-                "description": "Define or select the bound row type (T). Content is delivered as T[], or stream<T, error?> when streaming is enabled."
+                "description": "Create a record type describing one row of the file. Each row arrives as one record."
               },
               "placeholder": "content",
               "value": "content",
@@ -1714,7 +1714,7 @@
           "rows": {
             "metadata": {
               "label": "Rows",
-              "description": "Content Schema contains a row of CSV Row type"
+              "description": "Each row of the file arrives as one record."
             },
             "codedata": {
               "type": "METADATA_FLAG"
@@ -1734,7 +1734,7 @@
           "stream": {
             "metadata": {
               "label": "Stream (Large Files)",
-              "description": "Process the file content in chunks"
+              "description": "Process the file content in chunks."
             },
             "codedata": {
               "type": "PAYLOAD_MODIFIER",
@@ -1764,14 +1764,14 @@
       {
         "metadata": {
           "label": "On Create",
-          "description": "Invoked when a file is created in the monitored directory. Delivers the file content as a plain string.",
+          "description": "Invoked when a file is created in the monitored directory. The content arrives as plain text.",
           "badge": "onCreate"
         },
         "kind": "REMOTE",
         "name": {
           "metadata": {
             "label": "Text",
-            "description": "Invoked when a file is created in the monitored directory. Delivers the file content as a plain string."
+            "description": "Invoked when a file is created in the monitored directory. The content arrives as plain text."
           },
           "placeholder": "onFileText",
           "value": "onFileText",
@@ -1790,13 +1790,13 @@
           {
             "metadata": {
               "label": "Content",
-              "description": "The text file content as a plain string."
+              "description": "The file content as plain text."
             },
             "kind": "REQUIRED",
             "type": {
               "metadata": {
                 "label": "Content",
-                "description": "The text file content as a plain string."
+                "description": "The file content as plain text."
               },
               "codedata": {
                 "type": "PAYLOAD_TYPE",
@@ -1820,7 +1820,7 @@
             "name": {
               "metadata": {
                 "label": "Content",
-                "description": "The text file content as a plain string."
+                "description": "The file content as plain text."
               },
               "placeholder": "content",
               "value": "content",
@@ -2275,14 +2275,14 @@
       {
         "metadata": {
           "label": "On Create",
-          "description": "Invoked when a file is created in the monitored directory. Delivers the raw file content as byte[] (or stream<byte[], error?> for large files).",
+          "description": "Invoked when a file is created in the monitored directory. The content arrives as raw, unparsed bytes.",
           "badge": "onCreate"
         },
         "kind": "REMOTE",
         "name": {
           "metadata": {
             "label": "Raw Bytes",
-            "description": "Invoked when a file is created in the monitored directory. Delivers the raw file content as byte[] (or stream<byte[], error?> for large files)."
+            "description": "Invoked when a file is created in the monitored directory. The content arrives as raw, unparsed bytes."
           },
           "placeholder": "onFile",
           "value": "onFile",
@@ -2301,13 +2301,13 @@
           {
             "metadata": {
               "label": "Content",
-              "description": "Raw file content as byte[], or stream<byte[], error?> when streaming is enabled."
+              "description": "The raw file content as bytes."
             },
             "kind": "REQUIRED",
             "type": {
               "metadata": {
                 "label": "Content",
-                "description": "Raw file content as byte[], or stream<byte[], error?> when streaming is enabled."
+                "description": "The raw file content as bytes."
               },
               "codedata": {
                 "type": "PAYLOAD_TYPE",
@@ -2331,7 +2331,7 @@
             "name": {
               "metadata": {
                 "label": "Content",
-                "description": "Raw file content as byte[], or stream<byte[], error?> when streaming is enabled."
+                "description": "The raw file content as bytes."
               },
               "placeholder": "content",
               "value": "content",
@@ -2779,7 +2779,7 @@
           "stream": {
             "metadata": {
               "label": "Stream (Large Files)",
-              "description": "Deliver the content as stream<byte[], error?> to process large binary files in chunks."
+              "description": "Process the file content in chunks."
             },
             "codedata": {
               "type": "PAYLOAD_MODIFIER",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/ftp_service_model.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/ftp_service_model.json
@@ -2950,14 +2950,14 @@
       {
         "metadata": {
           "label": "On Error",
-          "description": "Invoked when an error occurs during file processing.",
+          "description": "Invoked when an error occurs while processing a file in the monitored directory.",
           "badge": "onError"
         },
         "kind": "REMOTE",
         "name": {
           "metadata": {
             "label": "On Error",
-            "description": "Invoked when an error occurs during file processing."
+            "description": "Invoked when an error occurs while processing a file in the monitored directory."
           },
           "placeholder": "onError",
           "value": "onError",
@@ -2976,7 +2976,7 @@
           {
             "metadata": {
               "label": "FTP Error",
-              "description": "The error that occurred during file processing."
+              "description": "The error that occurred while processing the file."
             },
             "kind": "REQUIRED",
             "type": {
@@ -3000,7 +3000,7 @@
             "name": {
               "metadata": {
                 "label": "FTP Error",
-                "description": "The error that occurred during file processing."
+                "description": "The error that occurred while processing the file."
               },
               "placeholder": "ftpError",
               "value": "ftpError",


### PR DESCRIPTION
## Purpose

Reword the FTP, SMB and Azure Files trigger model descriptions so the handler form reads in terms of what the user does, rather than how data binding is implemented, and apply the trigger-model side of the On Create form review.

The On Create descriptions previously narrated the widgets sitting directly beneath them. For CSV, every clause was already on screen:

| Old text | Already shown by |
|---|---|
| "Invoked when a file is created…" | dialog title "New On Create Configuration" |
| "Comma-separated rows" | Format dropdown reading "CSV" |
| "emits T[]" / "stream<T, error?>" | Define Row Schema action + Stream checkbox |

This also brings the file triggers in line with the event triggers, none of whose 25 `DATA_BINDING` descriptions name a Ballerina type.

## Changes

### Descriptions

- **`Monitored Path`** replaces `Monitoring Path` on the path field, with one shared description across the three connectors. `Monitoring Path` reads as the path that *does* the monitoring.
- **Handler descriptions** drop `binds`, `T`, `T[]`, `stream<T, error?>` and `byte[]`, and instead point at the schema action with concrete example types:

  > Invoked when a file is created in the monitored directory. Define a row schema below to receive the rows as custom types (e.g., User[], Student[]).

  `User[]` for CSV, `User` for JSON/XML, since those bind a single value.
- **Azure's extension routing** is folded into the prefix ("Invoked when a .csv file is created…") rather than carried as a separate clause.
- **Azure `documentation` fields** now carry their own values. They previously duplicated the form description verbatim, so rewording alone would have put "Define a row schema below…" into the generated Ballerina doc comments.

### Form simplification

- **Removed the CSV `rows` marker.** It rendered as a permanently checked, non-editable checkbox above the live Stream toggle, which reads as a disabled option rather than a statement about the payload. The array-ness it signalled is now in the handler description and carried by the payload template.
- **"File Handling Options"** is now the after-processing group name in all three connectors; FTP and Azure Files called it "After File Processing".
- **Dropped the `@ftp:` / `@smb:` / `@files:FunctionConfig` prefix** from that group's description — the annotation type is implementation detail. SMB's text also advertised a per-handler file-name filter that the group does not expose.
- **File Metadata** descriptions now share a sentence shape across the three connectors, keeping each protocol's own field list.

### Naming kept deliberately

`Row Schema` is retained for CSV rather than unified with the `Content Schema` label used by JSON and XML. The CSV payload template is `{{type}}[]`: the schema editor edits one row and the handler receives an array of it, whereas JSON and XML templates are `{{type}}`, where the edited type is the content itself. Naming all three "Content Schema" misdescribed CSV in both the form action and the type editor's modal title, which derives from the same label while the editor shows the bare row element.

## Notes

Removing the `rows` flag does not affect generated code. It was presentational only — `composePayloadType` reads the `PAYLOAD_MODIFIER` roles and the parameter template, and the `[]` comes from `payload.codedata.template`. Two `TriggerFunctionExpansionTest` assertions that pinned the marker now assert its absence.

Open question: it is unconfirmed whether these strings also render in the "Add On Create Handler" picker. The `Invoked when a file is created…` prefix is retained on that assumption; if the picker does not use them, it could be dropped as redundant with the dialog title.

## Testing

`:service-model-generator:service-model-generator-ls-extension:test` — **439 tests, 1 failure**.

The failure is `get_service_init_model/config/mqtt_service_model_2.json`, which fails identically on `main` (verified in a clean worktree) and is unrelated to these changes.

## Checklist

- [x] JSON validated for all three files
- [x] Test suite run locally; only a pre-existing unrelated failure remains

## Related

- wso2/product-integrator#2059 — the remaining form-renderer items from the same review (heading wording, Stream checkbox position, schema action tooltip)
