### PR TITLE
Fix issues in review mode diff and navigation

### DIFF
--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -247,10 +247,9 @@ export interface ReviewViewItem {
 export interface ReviewModeData {
     views: ReviewViewItem[];
     currentIndex: number;
-    // Distinguishes one generation's review from another's. MainPanel keys its remount on this:
-    // without it, opening review for a later generation reuses the mounted ReviewMode, whose data
-    // is only read on mount, so the previous generation's diagrams stay on screen.
-    generationId?: string;
+    /** MainPanel keys ReviewMode's remount on this; without it a later generation reuses the
+     *  mounted view, whose data is only read on mount. */
+    generationId: string;
     onAccept?: string;
     onReject?: string;
     semanticDiffs?: object[];

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -247,8 +247,7 @@ export interface ReviewViewItem {
 export interface ReviewModeData {
     views: ReviewViewItem[];
     currentIndex: number;
-    /** MainPanel keys ReviewMode's remount on this; without it a later generation reuses the
-     *  mounted view, whose data is only read on mount. */
+    /** MainPanel keys ReviewMode's remount on this; its data is only read on mount. */
     generationId: string;
     onAccept?: string;
     onReject?: string;

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -247,6 +247,10 @@ export interface ReviewViewItem {
 export interface ReviewModeData {
     views: ReviewViewItem[];
     currentIndex: number;
+    // Distinguishes one generation's review from another's. MainPanel keys its remount on this:
+    // without it, opening review for a later generation reuses the mounted ReviewMode, whose data
+    // is only read on mount, so the previous generation's diagrams stay on screen.
+    generationId?: string;
     onAccept?: string;
     onReject?: string;
     semanticDiffs?: object[];

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -1063,6 +1063,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
             const reviewData: ReviewModeData = {
                 views: [],
                 currentIndex: 0,
+                generationId: context.messageId,
                 semanticDiffs,
                 loadDesignDiagrams,
                 affectedPackages,

--- a/packages/ballerina-extension/src/features/ai/agent/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/index.ts
@@ -132,12 +132,6 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
         // no separate temp copy anymore (see existingTempPath below).
         finalizeLastGeneration(projectRootPath, threadId);
 
-        // The previous generation's review is no longer the one being worked on. Imported lazily:
-        // ApprovalViewManager reaches the webview layer and vscode-languageclient through RPCLayer,
-        // which cannot load under jest, and this module is imported by unit tests.
-        const { approvalViewManager } = await import("../state/ApprovalViewManager");
-        approvalViewManager.closeReviewModeIfOpen();
-
         // Create config using factory function. existingTempPath makes the agent operate
         // directly on the real project root instead of AICommandExecutor creating a
         // throwaway temp copy — file edits land live in the real workspace (M1+), so there's

--- a/packages/ballerina-extension/src/features/ai/agent/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/index.ts
@@ -32,6 +32,7 @@ import { getHashedProjectId } from "../../telemetry/common/project-id";
 import { runEventStore } from "../utils/run-event-store";
 import { sendSaveChatNotification } from "../utils/ai-utils";
 import { finalizeRevertibleGeneration } from "../utils/generation-response";
+import { approvalViewManager } from "../state/ApprovalViewManager";
 
 // ==================================
 // Agent Generation Functions
@@ -131,6 +132,9 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
         // Nothing to clean up: edits already land directly in the real workspace, and there's
         // no separate temp copy anymore (see existingTempPath below).
         finalizeLastGeneration(projectRootPath, threadId);
+
+        // The previous generation's review is no longer the one being worked on.
+        approvalViewManager.closeReviewModeIfOpen();
 
         // Create config using factory function. existingTempPath makes the agent operate
         // directly on the real project root instead of AICommandExecutor creating a

--- a/packages/ballerina-extension/src/features/ai/agent/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/index.ts
@@ -32,7 +32,6 @@ import { getHashedProjectId } from "../../telemetry/common/project-id";
 import { runEventStore } from "../utils/run-event-store";
 import { sendSaveChatNotification } from "../utils/ai-utils";
 import { finalizeRevertibleGeneration } from "../utils/generation-response";
-import { approvalViewManager } from "../state/ApprovalViewManager";
 
 // ==================================
 // Agent Generation Functions
@@ -133,7 +132,10 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
         // no separate temp copy anymore (see existingTempPath below).
         finalizeLastGeneration(projectRootPath, threadId);
 
-        // The previous generation's review is no longer the one being worked on.
+        // The previous generation's review is no longer the one being worked on. Imported lazily:
+        // ApprovalViewManager reaches the webview layer and vscode-languageclient through RPCLayer,
+        // which cannot load under jest, and this module is imported by unit tests.
+        const { approvalViewManager } = await import("../state/ApprovalViewManager");
         approvalViewManager.closeReviewModeIfOpen();
 
         // Create config using factory function. existingTempPath makes the agent operate

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -595,20 +595,15 @@ export class ApprovalViewManager {
     }
 
     /**
-     * Close ReviewMode if it is the current view. A review belongs to one generation, so leaving an
-     * earlier one open while the next starts means the user's next click lands on the previous
-     * generation's diagrams — and the bar hides its Review button while review mode is open, so
-     * there is no way back either.
+     * A review belongs to one generation, so an earlier one must not stay open into the next. Same
+     * steps as the panel's own Close (`goBack`), which likewise clears the open generation through
+     * `notifyReviewModeClosed`.
      */
     closeReviewModeIfOpen(): void {
-        const ctx = StateMachine.context();
-        if (ctx.view !== MACHINE_VIEW.ReviewMode) {
+        if (StateMachine.context().view !== MACHINE_VIEW.ReviewMode) {
             return;
         }
         console.log('[ApprovalViewManager] Closing ReviewMode — a new generation is starting');
-        this.openReviewGenerationId = null;
-        // Same as the panel's own Close: return to whatever the user was looking at before, rather
-        // than dropping them on the package overview.
         history.pop();
         updateView(false);
         this.notifyReviewModeClosed();

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -22,7 +22,7 @@ import { AiPanelWebview } from '../../../views/ai-panel/webview';
 import { chatStateStorage } from '../../../views/ai-panel/chatStateStorage';
 import { sendReviewRestoreDidOpenBatch } from '../utils/project/ls-schema-notifications';
 import { VisualizerWebview } from '../../../views/visualizer/webview';
-import { openView as openMainView, StateMachine } from '../../../stateMachine';
+import { history, openView as openMainView, StateMachine, updateView } from '../../../stateMachine';
 import { openPopupView, StateMachinePopup } from '../../../stateMachinePopup';
 import { notifyApprovalOverlayState, RPCLayer } from '../../../RPCLayer';
 
@@ -592,6 +592,26 @@ export class ApprovalViewManager {
             tempProjectPath,
             isWorkspace: review.reviewView.isWorkspace,
         };
+    }
+
+    /**
+     * Close ReviewMode if it is the current view. A review belongs to one generation, so leaving an
+     * earlier one open while the next starts means the user's next click lands on the previous
+     * generation's diagrams — and the bar hides its Review button while review mode is open, so
+     * there is no way back either.
+     */
+    closeReviewModeIfOpen(): void {
+        const ctx = StateMachine.context();
+        if (ctx.view !== MACHINE_VIEW.ReviewMode) {
+            return;
+        }
+        console.log('[ApprovalViewManager] Closing ReviewMode — a new generation is starting');
+        this.openReviewGenerationId = null;
+        // Same as the panel's own Close: return to whatever the user was looking at before, rather
+        // than dropping them on the package overview.
+        history.pop();
+        updateView(false);
+        this.notifyReviewModeClosed();
     }
 
     /**

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -583,6 +583,7 @@ export class ApprovalViewManager {
         return {
             views: [],
             currentIndex: 0,
+            generationId,
             semanticDiffs: review.reviewView.semanticDiffs,
             loadDesignDiagrams: review.reviewView.loadDesignDiagrams,
             affectedPackages: review.affectedPackagePaths

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -594,11 +594,7 @@ export class ApprovalViewManager {
         };
     }
 
-    /**
-     * A review belongs to one generation, so an earlier one must not stay open into the next. Same
-     * steps as the panel's own Close (`goBack`), which likewise clears the open generation through
-     * `notifyReviewModeClosed`.
-     */
+    /** Same steps as the panel's own Close (`goBack`): a review belongs to one generation. */
     closeReviewModeIfOpen(): void {
         if (StateMachine.context().view !== MACHINE_VIEW.ReviewMode) {
             return;

--- a/packages/ballerina-extension/src/features/ai/utils/generation-response.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/generation-response.ts
@@ -26,6 +26,7 @@ import { getHashedProjectId } from "../../telemetry/common/project-id";
 import { Command } from "@wso2/ballerina-core";
 import { chatStateStorage } from "../../../views/ai-panel/chatStateStorage";
 import { sendSaveChatNotification } from "./ai-utils";
+import { approvalViewManager } from "../state/ApprovalViewManager";
 
 /**
  * Implicitly accept whichever generation is still revertible, with the reporting that goes with
@@ -35,6 +36,9 @@ import { sendSaveChatNotification } from "./ai-utils";
  * @returns true if a generation was finalized
  */
 export function finalizeRevertibleGeneration(projectRootPath: string, threadId: string): boolean {
+    // Runs before the early return: the open review belongs to the previous turn either way.
+    approvalViewManager.closeReviewModeIfOpen();
+
     const finalized = chatStateStorage.finalizeLastGenerationIfDone(projectRootPath, threadId);
     if (!finalized) {
         return false;

--- a/packages/ballerina-extension/src/test-support/finalizeLastGeneration.test.ts
+++ b/packages/ballerina-extension/src/test-support/finalizeLastGeneration.test.ts
@@ -118,7 +118,6 @@ describe('finalizeLastGeneration', () => {
         expect(sendSaveChatNotification).not.toHaveBeenCalled();
     });
 
-    // The open review belongs to the turn that just ended, whether or not it was still revertible.
     it('closes review mode even when there was no done generation to finalize', () => {
         chatStateStorage.getOrCreateThread(ROOT, 'thread-noreview');
 

--- a/packages/ballerina-extension/src/test-support/finalizeLastGeneration.test.ts
+++ b/packages/ballerina-extension/src/test-support/finalizeLastGeneration.test.ts
@@ -64,9 +64,13 @@ jest.mock('../features/ai/migration/orchestrator', () => ({ getMigrationSourcePa
 jest.mock('../features/ai/utils/events', () => ({ createWebviewEventHandler: jest.fn() }));
 jest.mock('../features/telemetry/common/project-metrics', () => ({ getProjectMetrics: jest.fn() }));
 jest.mock('../features/telemetry/common/project-id', () => ({ getHashedProjectId: jest.fn() }));
+jest.mock('../features/ai/state/ApprovalViewManager', () => ({
+    approvalViewManager: { closeReviewModeIfOpen: jest.fn() },
+}));
 
 import { finalizeLastGeneration } from '../features/ai/agent';
 import { chatStateStorage } from '../views/ai-panel/chatStateStorage';
+import { approvalViewManager } from '../features/ai/state/ApprovalViewManager';
 
 const ROOT = '/workspace';
 
@@ -112,5 +116,14 @@ describe('finalizeLastGeneration', () => {
 
         expect(sendTelemetryEvent).not.toHaveBeenCalled();
         expect(sendSaveChatNotification).not.toHaveBeenCalled();
+    });
+
+    // The open review belongs to the turn that just ended, whether or not it was still revertible.
+    it('closes review mode even when there was no done generation to finalize', () => {
+        chatStateStorage.getOrCreateThread(ROOT, 'thread-noreview');
+
+        finalizeLastGeneration(ROOT, 'thread-noreview');
+
+        expect(approvalViewManager.closeReviewModeIfOpen).toHaveBeenCalled();
     });
 });

--- a/packages/ballerina-visualizer/src/MainPanel.tsx
+++ b/packages/ballerina-visualizer/src/MainPanel.tsx
@@ -305,7 +305,7 @@ const MainPanel = () => {
 
             try {
                 if (isStaleNavigation()) return;
-                const navTarget = `${value?.view ?? ''}-${value?.identifier ?? ''}-${value?.documentUri ?? ''}-${value?.projectPath ?? ''}`;
+                const navTarget = `${value?.view ?? ''}-${value?.identifier ?? ''}-${value?.documentUri ?? ''}-${value?.projectPath ?? ''}-${value?.reviewData?.generationId ?? ''}`;
                 if (navTarget !== previousNavTargetRef.current) {
                     remountKeyRef.current += 1;
                     previousNavTargetRef.current = navTarget;

--- a/packages/ballerina-visualizer/src/MainPanel.tsx
+++ b/packages/ballerina-visualizer/src/MainPanel.tsx
@@ -921,7 +921,7 @@ const MainPanel = () => {
                         case MACHINE_VIEW.ReviewMode: {
                             const { ReviewMode } = await import("./views/ReviewMode");
                             if (isStaleNavigation()) return;
-                            setViewComponent(<ReviewMode />);
+                            setViewComponent(<ReviewMode key={remountKey} />);
                             break;
                         }
                         case MACHINE_VIEW.EvalsetViewer: {

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -210,7 +210,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
     }, [filePath, position, oldPosition, viewMode, expectedMetadata, changeType, rpcClient]);
 
     // Fetch one version of the enclosing function's flow model.
-    // useFileSchema=true reads the frozen original (file://); false reads the modified temp content (ai://).
+    // useFileSchema=true reads the frozen original (ai://); false reads the live edits (file://).
     const fetchFlowModelVersion = async (useFileSchema: boolean): Promise<Flow | null> => {
         const lookupPosition = getFlowLookupPosition(position, oldPosition, useFileSchema);
         const cacheKey = `${filePath}:${position.startLine}:${position.startColumn}:${position.endLine}:` +

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -22,6 +22,7 @@ import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
 import { ExpectedFlowMetadata, ReadonlyFlowDiagram, ReviewViewMode, getVersionsForChangeType } from "./ReadonlyFlowDiagram";
+import { toComparablePath } from "./path-utils";
 import { ReadonlyTypeDiagram } from "./ReadonlyTypeDiagram";
 import { ReviewNavigation } from "./ReviewNavigation";
 import { Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
@@ -212,12 +213,6 @@ function convertToReviewView(diff: SemanticDiff, projectPath: string, packageNam
     };
 }
 
-
-// Semantic-diff URIs carry the ai:// baseline scheme; package paths are plain, so they only compare
-// once the scheme is dropped.
-function toComparablePath(uri: string): string {
-    return uri.replace(/^[a-z][a-z0-9+.-]*:\/\//, "").replace(/\\/g, "/");
-}
 
 // Helper to extract package name from path
 function getPackageName(path: string): string {

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -213,6 +213,12 @@ function convertToReviewView(diff: SemanticDiff, projectPath: string, packageNam
 }
 
 
+// Semantic-diff URIs carry the ai:// baseline scheme; package paths are plain, so they only compare
+// once the scheme is dropped.
+function toComparablePath(uri: string): string {
+    return uri.replace(/^[a-z][a-z0-9+.-]*:\/\//, "").replace(/\\/g, "/");
+}
+
 // Helper to extract package name from path
 function getPackageName(path: string): string {
     const parts = path.replace(/\\/g, "/").split("/");
@@ -285,7 +291,7 @@ export function ReviewMode(): JSX.Element {
             if (loadDesignDiagrams && semanticDiffs.length > 0) {
                 const pkgsWithDiffs = new Set<string>();
                 for (const diff of semanticDiffs) {
-                    const uriPath = diff.uri.replace(/^[a-z][a-z0-9+.-]*:\/\//, "").replace(/\\/g, "/");
+                    const uriPath = toComparablePath(diff.uri);
                     for (const pkgPath of filteredPackages) {
                         const normalizedPkgPath = pkgPath.replace(/\\/g, "/");
                         if (uriPath.startsWith(normalizedPkgPath + "/") || uriPath === normalizedPkgPath) {
@@ -314,7 +320,7 @@ export function ReviewMode(): JSX.Element {
                 let packageName: string | undefined;
                 if (isWorkspaceProject) {
                     for (const pkgPath of filteredPackages) {
-                        const normalizedUri = diff.uri.replace(/\\/g, "/");
+                        const normalizedUri = toComparablePath(diff.uri);
                         const normalizedPkgPath = pkgPath.replace(/\\/g, "/");
                         if (normalizedUri.startsWith(normalizedPkgPath + "/") || normalizedUri === normalizedPkgPath) {
                             belongsToPackage = pkgPath;

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -22,7 +22,7 @@ import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
 import { ExpectedFlowMetadata, ReadonlyFlowDiagram, ReviewViewMode, getVersionsForChangeType } from "./ReadonlyFlowDiagram";
-import { toComparablePath } from "./path-utils";
+import { diffBelongsToPackage } from "./path-utils";
 import { ReadonlyTypeDiagram } from "./ReadonlyTypeDiagram";
 import { ReviewNavigation } from "./ReviewNavigation";
 import { Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
@@ -286,10 +286,8 @@ export function ReviewMode(): JSX.Element {
             if (loadDesignDiagrams && semanticDiffs.length > 0) {
                 const pkgsWithDiffs = new Set<string>();
                 for (const diff of semanticDiffs) {
-                    const uriPath = toComparablePath(diff.uri);
                     for (const pkgPath of filteredPackages) {
-                        const normalizedPkgPath = pkgPath.replace(/\\/g, "/");
-                        if (uriPath.startsWith(normalizedPkgPath + "/") || uriPath === normalizedPkgPath) {
+                        if (diffBelongsToPackage(diff.uri, pkgPath)) {
                             pkgsWithDiffs.add(pkgPath);
                             break;
                         }
@@ -315,9 +313,7 @@ export function ReviewMode(): JSX.Element {
                 let packageName: string | undefined;
                 if (isWorkspaceProject) {
                     for (const pkgPath of filteredPackages) {
-                        const normalizedUri = toComparablePath(diff.uri);
-                        const normalizedPkgPath = pkgPath.replace(/\\/g, "/");
-                        if (normalizedUri.startsWith(normalizedPkgPath + "/") || normalizedUri === normalizedPkgPath) {
+                        if (diffBelongsToPackage(diff.uri, pkgPath)) {
                             belongsToPackage = pkgPath;
                             packageName = getPackageName(pkgPath);
                             break;

--- a/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.test.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.test.ts
@@ -38,6 +38,30 @@ describe("review mode diff-to-package attribution", () => {
         expect(toComparablePath("ai://C:\\ws\\school\\types.bal")).toBe("C:/ws/school/types.bal");
     });
 
+    it("decodes a percent-encoded path", () => {
+        expect(toComparablePath("ai:///ws/my%20project/school/types.bal")).toBe(
+            "/ws/my project/school/types.bal"
+        );
+        expect(diffBelongsToPackage("ai:///ws/my%20project/school/types.bal", "/ws/my project/school")).toBe(true);
+    });
+
+    it("leaves a malformed escape alone rather than throwing", () => {
+        expect(() => toComparablePath("ai:///ws/100%/school/types.bal")).not.toThrow();
+    });
+
+    it("drops the leading slash the three-slash form leaves before a drive letter", () => {
+        expect(toComparablePath("file:///c:/ws/school/types.bal")).toBe("c:/ws/school/types.bal");
+        expect(diffBelongsToPackage("file:///c:/ws/school/types.bal", "c:\\ws\\school")).toBe(true);
+    });
+
+    it("matches a windows package whose drive letter case differs", () => {
+        expect(diffBelongsToPackage("ai:///C:/ws/school/types.bal", "c:\\ws\\school")).toBe(true);
+    });
+
+    it("matches an uppercase scheme", () => {
+        expect(toComparablePath(`AI://${SCHOOL}/types.bal`)).toBe(`${SCHOOL}/types.bal`);
+    });
+
     it("matches an ai:// diff to its own package and not to a sibling", () => {
         expect(diffBelongsToPackage(`ai://${SCHOOL}/types.bal`, SCHOOL)).toBe(true);
         expect(diffBelongsToPackage(`ai://${SCHOOL}/types.bal`, INSTITUTES)).toBe(false);
@@ -47,25 +71,9 @@ describe("review mode diff-to-package attribution", () => {
         expect(diffBelongsToPackage(`ai://${SCHOOL}-archive/types.bal`, SCHOOL)).toBe(false);
     });
 
-    // The regression this guards: comparing the raw uri never matched, so in a workspace every diff
-    // fell back to the workspace root — losing its package name and collapsing all packages' type
-    // views into a single one.
-    it("would never match with the scheme left on the uri", () => {
-        expect(`ai://${SCHOOL}/types.bal`.startsWith(`${SCHOOL}/`)).toBe(false);
-    });
-
     it("attributes diffs from two packages to their own packages", () => {
         const uris = [`ai://${SCHOOL}/types.bal`, `ai://${INSTITUTES}/types.bal`];
         const owners = uris.map((u) => [SCHOOL, INSTITUTES].find((p) => diffBelongsToPackage(u, p)));
         expect(owners).toEqual([SCHOOL, INSTITUTES]);
-    });
-
-    it("gives each package its own type view instead of collapsing them", () => {
-        const uris = [`ai://${SCHOOL}/types.bal`, `ai://${INSTITUTES}/types.bal`];
-        const seen = new Set<string>();
-        for (const u of uris) {
-            seen.add([SCHOOL, INSTITUTES].find((p) => diffBelongsToPackage(u, p)) ?? "/ws/education");
-        }
-        expect([...seen]).toEqual([SCHOOL, INSTITUTES]);
     });
 });

--- a/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.test.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.test.ts
@@ -18,9 +18,7 @@
 
 import { diffBelongsToPackage, toComparablePath } from "./path-utils";
 
-// Semantic diffs come back against the ai:// baseline scheme while affectedPackages are plain paths.
-// Matching one to the other decides a diff's package — and so its label, its project path, and
-// whether each package gets its own type view.
+// Matching a diff's uri to a package decides its label, its project path, and its type view.
 const SCHOOL = "/ws/education/school";
 const INSTITUTES = "/ws/education/institutes";
 

--- a/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.test.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { diffBelongsToPackage, toComparablePath } from "./path-utils";
+
+// Semantic diffs come back against the ai:// baseline scheme while affectedPackages are plain paths.
+// Matching one to the other decides a diff's package — and so its label, its project path, and
+// whether each package gets its own type view.
+const SCHOOL = "/ws/education/school";
+const INSTITUTES = "/ws/education/institutes";
+
+describe("review mode diff-to-package attribution", () => {
+    it("strips the ai:// baseline scheme", () => {
+        expect(toComparablePath(`ai://${SCHOOL}/types.bal`)).toBe(`${SCHOOL}/types.bal`);
+    });
+
+    it("strips file:// too, and leaves a plain path alone", () => {
+        expect(toComparablePath(`file://${SCHOOL}/types.bal`)).toBe(`${SCHOOL}/types.bal`);
+        expect(toComparablePath(`${SCHOOL}/types.bal`)).toBe(`${SCHOOL}/types.bal`);
+    });
+
+    it("normalises windows separators", () => {
+        expect(toComparablePath("ai://C:\\ws\\school\\types.bal")).toBe("C:/ws/school/types.bal");
+    });
+
+    it("matches an ai:// diff to its own package and not to a sibling", () => {
+        expect(diffBelongsToPackage(`ai://${SCHOOL}/types.bal`, SCHOOL)).toBe(true);
+        expect(diffBelongsToPackage(`ai://${SCHOOL}/types.bal`, INSTITUTES)).toBe(false);
+    });
+
+    it("does not treat a package as a prefix of a longer sibling name", () => {
+        expect(diffBelongsToPackage(`ai://${SCHOOL}-archive/types.bal`, SCHOOL)).toBe(false);
+    });
+
+    // The regression this guards: comparing the raw uri never matched, so in a workspace every diff
+    // fell back to the workspace root — losing its package name and collapsing all packages' type
+    // views into a single one.
+    it("would never match with the scheme left on the uri", () => {
+        expect(`ai://${SCHOOL}/types.bal`.startsWith(`${SCHOOL}/`)).toBe(false);
+    });
+
+    it("attributes diffs from two packages to their own packages", () => {
+        const uris = [`ai://${SCHOOL}/types.bal`, `ai://${INSTITUTES}/types.bal`];
+        const owners = uris.map((u) => [SCHOOL, INSTITUTES].find((p) => diffBelongsToPackage(u, p)));
+        expect(owners).toEqual([SCHOOL, INSTITUTES]);
+    });
+
+    it("gives each package its own type view instead of collapsing them", () => {
+        const uris = [`ai://${SCHOOL}/types.bal`, `ai://${INSTITUTES}/types.bal`];
+        const seen = new Set<string>();
+        for (const u of uris) {
+            seen.add([SCHOOL, INSTITUTES].find((p) => diffBelongsToPackage(u, p)) ?? "/ws/education");
+        }
+        expect([...seen]).toEqual([SCHOOL, INSTITUTES]);
+    });
+});

--- a/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Semantic-diff URIs carry the ai:// baseline scheme; package paths are plain, so they only compare
+ * once the scheme is dropped. Kept in its own module so it can be tested without pulling the whole
+ * ReviewMode view in — same reason position-utils is separate.
+ */
+export function toComparablePath(uri: string): string {
+    return uri.replace(/^[a-z][a-z0-9+.-]*:\/\//, "").replace(/\\/g, "/");
+}
+
+/** Whether a semantic diff's uri falls under the given package root. */
+export function diffBelongsToPackage(uri: string, packagePath: string): boolean {
+    const uriPath = toComparablePath(uri);
+    const pkgPath = packagePath.replace(/\\/g, "/");
+    return uriPath.startsWith(`${pkgPath}/`) || uriPath === pkgPath;
+}

--- a/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.ts
@@ -34,7 +34,6 @@ export function toComparablePath(uri: string): string {
     return decoded.replace(/\\/g, "/").replace(/^\/(?=[A-Za-z]:)/, "");
 }
 
-/** Whether a semantic diff's uri falls under the given package root. */
 export function diffBelongsToPackage(uri: string, packagePath: string): boolean {
     // isPathInside normalises the drive letter and trailing slashes, but not separators.
     return isPathInside(packagePath.replace(/\\/g, "/"), toComparablePath(uri));

--- a/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/path-utils.ts
@@ -16,18 +16,26 @@
  * under the License.
  */
 
+// Deep import: the core barrel pulls in ESM-only LS transport modules that jest cannot load.
+import { isPathInside } from "@wso2/ballerina-core/lib/utils/path-utils";
+
 /**
- * Semantic-diff URIs carry the ai:// baseline scheme; package paths are plain, so they only compare
- * once the scheme is dropped. Kept in its own module so it can be tested without pulling the whole
- * ReviewMode view in — same reason position-utils is separate.
+ * Semantic-diff URIs come from Java's `Path.toUri()` (`SemanticDiffComputer.resolveUri`), so they are
+ * percent-encoded and three-slash — the latter leaving a leading slash before a Windows drive letter.
  */
 export function toComparablePath(uri: string): string {
-    return uri.replace(/^[a-z][a-z0-9+.-]*:\/\//, "").replace(/\\/g, "/");
+    const withoutScheme = uri.replace(/^[a-z][a-z0-9+.-]*:\/\//i, "");
+    let decoded: string;
+    try {
+        decoded = decodeURIComponent(withoutScheme);
+    } catch {
+        decoded = withoutScheme;
+    }
+    return decoded.replace(/\\/g, "/").replace(/^\/(?=[A-Za-z]:)/, "");
 }
 
 /** Whether a semantic diff's uri falls under the given package root. */
 export function diffBelongsToPackage(uri: string, packagePath: string): boolean {
-    const uriPath = toComparablePath(uri);
-    const pkgPath = packagePath.replace(/\\/g, "/");
-    return uriPath.startsWith(`${pkgPath}/`) || uriPath === pkgPath;
+    // isPathInside normalises the drive letter and trailing slashes, but not separators.
+    return isPathInside(packagePath.replace(/\\/g, "/"), toComparablePath(uri));
 }


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2069
Related to https://github.com/wso2/product-integrator/issues/2070

- Close review mode when a new generation starts, so a later turn's changes are not reviewed against
  the previous generation's diagrams
- Give `ReviewMode` the `key={remountKey}` every other view in `MainPanel` already has, so reopening
  it for a different generation actually reloads its data
- Carry a `generationId` on `ReviewModeData` and include it in `navTarget`, so the existing remount
  machinery can tell two generations apart
- Strip the URI scheme when matching a semantic diff to its package — diffs arrive as `ai://…` while
  package paths are plain, so in a workspace project every diff lost its package name and only the
  first type diff produced a view
- Correct the `useFileSchema` comment, which had `ai://` and `file://` the wrong way round


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Close review mode before a new agent generation starts.
- Reload review data when the generation changes.
- Track `generationId` in review data and navigation targets.
- Improve semantic-diff attribution across URI schemes, path separators, and multiple packages.
- Add tests for package matching and type-change views.
- Correct the `useFileSchema` documentation comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->