### PR TITLE
Allow stopping a generation while an approval prompt is showing

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/tools/skill-tool/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/skill-tool/index.ts
@@ -21,6 +21,7 @@ import { Skill } from '../../skills/types';
 import { readProjectSkillContent, readUserSkillContent } from './skill-reader';
 import { buildAllDisabledSet } from '../../skills/context';
 import { approvalManager } from '../../../state/ApprovalManager';
+import { SkillEnableStage } from '@wso2/ballerina-core';
 
 export const SKILL_TOOL_NAME = "invoke_skill";
 
@@ -113,6 +114,14 @@ Call this tool once per skill whenever a skill's trigger condition is met. Each 
                     eventHandler({ type: "tool_result", toolName: SKILL_TOOL_NAME, toolOutput: result, toolCallId } as any);
                     return result;
                 } else {
+                    // Self-emitted (not left to the "Continue without it" RPC handler) so an abort resolves it too.
+                    eventHandler({
+                        type: "skill_enable_event",
+                        requestId: toolCallId,
+                        stage: SkillEnableStage.SKIPPED,
+                        skillName: resolved.name,
+                        skillId: effectiveId,
+                    } as any);
                     const result = { found: true, skipped: true, message: `Skill "${resolved.name}" was skipped by the user.` };
                     eventHandler({ type: "tool_result", toolName: SKILL_TOOL_NAME, toolOutput: result, toolCallId } as any);
                     return result;

--- a/packages/ballerina-extension/src/features/ai/agent/tools/task-writer.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/task-writer.ts
@@ -215,6 +215,12 @@ Rules:
                     tasks: allTasks
                 };
             } catch (error) {
+                // Let an abort (e.g. stopping while the plan approval is pending) propagate as a
+                // tool-error instead of surfacing a raw "Failed to process tasks" message — the
+                // turn's own abort handling already shows a clean stopped-by-user message.
+                if ((error as any)?.name === 'AbortError') {
+                    throw error;
+                }
                 console.error("Error in TaskWrite tool:", error);
                 return {
                     success: false,

--- a/packages/ballerina-extension/src/features/ai/agent/tools/task-writer.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/task-writer.ts
@@ -215,9 +215,7 @@ Rules:
                     tasks: allTasks
                 };
             } catch (error) {
-                // Let an abort (e.g. stopping while the plan approval is pending) propagate as a
-                // tool-error instead of surfacing a raw "Failed to process tasks" message — the
-                // turn's own abort handling already shows a clean stopped-by-user message.
+                // Let an abort propagate as a tool-error instead of a raw "Failed to process tasks" message.
                 if ((error as any)?.name === 'AbortError') {
                     throw error;
                 }

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalManager.ts
@@ -660,6 +660,7 @@ export class ApprovalManager {
         approvalViewManager.cleanupAllViews();
 
         const error = new Error(reason);
+        error.name = 'AbortError';
 
         // Cancel plan approvals
         for (const [requestId, resolver] of this.planApprovals.entries()) {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/ClarifyFooter.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/ClarifyFooter.tsx
@@ -21,7 +21,7 @@ import styled from "@emotion/styled";
 import { ClarifyQuestion } from "@wso2/ballerina-core";
 import { FooterContainer } from "./index";
 import { ActionButton } from "../../AgentStreamView/styles";
-import { FooterBox, FooterDivider, FooterHeaderRow, FooterTextInputRow, FooterInput } from "./styles";
+import { FooterBox, FooterDivider, FooterTextInputRow, FooterInput } from "./styles";
 import { AmbientFrame } from "../../../../../components/AgentStatusOrb/shared";
 import StopControl from "./StopControl";
 import { useEscapeToStop } from "./useEscapeToStop";
@@ -57,7 +57,6 @@ const QuestionHeader = styled.div`
     display: flex;
     align-items: baseline;
     flex-wrap: wrap;
-    flex: 1;
     gap: 6px;
     margin-bottom: 8px;
 `;
@@ -237,16 +236,21 @@ const ClarifyFooter: React.FC<ClarifyFooterProps> = ({ questions, requestId, rpc
                                     {qu.tabLabel}
                                 </Tab>
                             ))}
+                            <div style={{ marginLeft: "auto" }}>
+                                <StopControl onStop={onStop} />
+                            </div>
                         </TabRow>
                     )}
 
-                    <FooterHeaderRow style={{ alignItems: "flex-start" }}>
-                        <QuestionHeader>
-                            <QuestionText>{q.question}</QuestionText>
-                            <TypeBadge>{isMulti ? "multiple answer" : "single answer"}</TypeBadge>
-                        </QuestionHeader>
-                        <StopControl onStop={onStop} />
-                    </FooterHeaderRow>
+                    <QuestionHeader>
+                        <QuestionText>{q.question}</QuestionText>
+                        <TypeBadge>{isMulti ? "multiple answer" : "single answer"}</TypeBadge>
+                        {questions.length <= 1 && (
+                            <div style={{ marginLeft: "auto" }}>
+                                <StopControl onStop={onStop} />
+                            </div>
+                        )}
+                    </QuestionHeader>
 
                     <OptionsList>
                         {q.options.map(opt => {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/ClarifyFooter.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/ClarifyFooter.tsx
@@ -21,8 +21,10 @@ import styled from "@emotion/styled";
 import { ClarifyQuestion } from "@wso2/ballerina-core";
 import { FooterContainer } from "./index";
 import { ActionButton } from "../../AgentStreamView/styles";
-import { FooterBox, FooterDivider, FooterTextInputRow, FooterInput } from "./styles";
+import { FooterBox, FooterDivider, FooterHeaderRow, FooterTextInputRow, FooterInput } from "./styles";
 import { AmbientFrame } from "../../../../../components/AgentStatusOrb/shared";
+import StopControl from "./StopControl";
+import { useEscapeToStop } from "./useEscapeToStop";
 
 // ── Clarify-specific styled components ────────────────────────────────────────
 
@@ -55,6 +57,7 @@ const QuestionHeader = styled.div`
     display: flex;
     align-items: baseline;
     flex-wrap: wrap;
+    flex: 1;
     gap: 6px;
     margin-bottom: 8px;
 `;
@@ -133,11 +136,12 @@ interface ClarifyFooterProps {
     questions: ClarifyQuestion[];
     requestId: string;
     rpcClient: any;
+    onStop: () => void;
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-const ClarifyFooter: React.FC<ClarifyFooterProps> = ({ questions, requestId, rpcClient }) => {
+const ClarifyFooter: React.FC<ClarifyFooterProps> = ({ questions, requestId, rpcClient, onStop }) => {
     const [page, setPage] = useState(0);
     const [selections, setSelections] = useState<Record<number, string[]>>(
         () => Object.fromEntries(questions.map((_, i): [number, string[]] => [i, []]))
@@ -149,6 +153,8 @@ const ClarifyFooter: React.FC<ClarifyFooterProps> = ({ questions, requestId, rpc
         () => Object.fromEntries(questions.map((_, i): [number, string] => [i, ""]))
     );
     const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEscapeToStop(onStop);
 
     const q = questions[page];
     const isMulti = q?.selectionType === "multiple";
@@ -234,10 +240,13 @@ const ClarifyFooter: React.FC<ClarifyFooterProps> = ({ questions, requestId, rpc
                         </TabRow>
                     )}
 
-                    <QuestionHeader>
-                        <QuestionText>{q.question}</QuestionText>
-                        <TypeBadge>{isMulti ? "multiple answer" : "single answer"}</TypeBadge>
-                    </QuestionHeader>
+                    <FooterHeaderRow style={{ alignItems: "flex-start" }}>
+                        <QuestionHeader>
+                            <QuestionText>{q.question}</QuestionText>
+                            <TypeBadge>{isMulti ? "multiple answer" : "single answer"}</TypeBadge>
+                        </QuestionHeader>
+                        <StopControl onStop={onStop} />
+                    </FooterHeaderRow>
 
                     <OptionsList>
                         {q.options.map(opt => {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/CommonApprovalFooter.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/CommonApprovalFooter.tsx
@@ -22,6 +22,8 @@ import { FooterContainer } from "./index";
 import { ActionButton } from "../../AgentStreamView/styles";
 import { FooterBox, FooterBoxPrompt, FooterDivider, FooterHeaderRow, FooterTextInputRow, FooterInput, FooterIconBtn } from "./styles";
 import { AmbientFrame } from "../../../../../components/AgentStatusOrb/shared";
+import StopControl from "./StopControl";
+import { useEscapeToStop } from "./useEscapeToStop";
 
 // ── Web tool styles (footer-specific, not shared) ─────────────────────────────
 
@@ -78,13 +80,6 @@ type CommonApprovalFooterProps = PlanCompletionProps | WebToolProps | SkillEnabl
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-// AIChatInput normally owns Escape-to-stop, but it's unmounted while this footer shows.
-const StopControl: React.FC<{ onStop: () => void }> = ({ onStop }) => (
-    <FooterIconBtn onClick={onStop} title="Stop (Escape)">
-        <span className="codicon codicon-stop-circle" />
-    </FooterIconBtn>
-);
-
 const CommonApprovalFooter: React.FC<CommonApprovalFooterProps> = (props) => {
     const [comment, setComment] = useState("");
     const { onStop } = props;
@@ -93,16 +88,7 @@ const CommonApprovalFooter: React.FC<CommonApprovalFooterProps> = (props) => {
         setComment("");
     }, [props.type]);
 
-    useEffect(() => {
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key === "Escape") {
-                event.preventDefault();
-                onStop();
-            }
-        };
-        window.addEventListener("keydown", handleKeyDown);
-        return () => window.removeEventListener("keydown", handleKeyDown);
-    }, [onStop]);
+    useEscapeToStop(onStop);
 
     if (props.type === "web_tool") {
         const { toolName, content, onAllow, onDeny } = props;

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/CommonApprovalFooter.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/CommonApprovalFooter.tsx
@@ -20,7 +20,7 @@ import React, { useState, useEffect } from "react";
 import styled from "@emotion/styled";
 import { FooterContainer } from "./index";
 import { ActionButton } from "../../AgentStreamView/styles";
-import { FooterBox, FooterBoxPrompt, FooterDivider, FooterTextInputRow, FooterInput, FooterIconBtn } from "./styles";
+import { FooterBox, FooterBoxPrompt, FooterDivider, FooterHeaderRow, FooterTextInputRow, FooterInput, FooterIconBtn } from "./styles";
 import { AmbientFrame } from "../../../../../components/AgentStatusOrb/shared";
 
 // ── Web tool styles (footer-specific, not shared) ─────────────────────────────
@@ -53,6 +53,7 @@ type PlanCompletionProps = {
     type: "plan" | "completion";
     onApprove: (enableAutoApprove: boolean) => void;
     onReject: (comment: string) => void;
+    onStop: () => void;
     isSubmitting?: boolean;
 };
 
@@ -62,6 +63,7 @@ type WebToolProps = {
     content: string;
     onAllow: () => void;
     onDeny: () => void;
+    onStop: () => void;
 };
 
 type SkillEnableProps = {
@@ -69,18 +71,38 @@ type SkillEnableProps = {
     skillName: string;
     onEnable: () => void;
     onSkip: () => void;
+    onStop: () => void;
 };
 
 type CommonApprovalFooterProps = PlanCompletionProps | WebToolProps | SkillEnableProps;
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
+// AIChatInput normally owns Escape-to-stop, but it's unmounted while this footer shows.
+const StopControl: React.FC<{ onStop: () => void }> = ({ onStop }) => (
+    <FooterIconBtn onClick={onStop} title="Stop (Escape)">
+        <span className="codicon codicon-stop-circle" />
+    </FooterIconBtn>
+);
+
 const CommonApprovalFooter: React.FC<CommonApprovalFooterProps> = (props) => {
     const [comment, setComment] = useState("");
+    const { onStop } = props;
 
     useEffect(() => {
         setComment("");
     }, [props.type]);
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onStop();
+            }
+        };
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [onStop]);
 
     if (props.type === "web_tool") {
         const { toolName, content, onAllow, onDeny } = props;
@@ -89,10 +111,13 @@ const CommonApprovalFooter: React.FC<CommonApprovalFooterProps> = (props) => {
             <FooterContainer>
                 <AmbientFrame $variant="composer" $state="awaiting-input">
                     <FooterBox>
-                        <WebToolHeader>
-                            <span className="codicon codicon-globe" />
-                            {label}
-                        </WebToolHeader>
+                        <FooterHeaderRow>
+                            <WebToolHeader>
+                                <span className="codicon codicon-globe" />
+                                {label}
+                            </WebToolHeader>
+                            <StopControl onStop={onStop} />
+                        </FooterHeaderRow>
                         <WebToolContent>{content}</WebToolContent>
                         <FooterDivider />
                         <WebToolActions>
@@ -111,10 +136,13 @@ const CommonApprovalFooter: React.FC<CommonApprovalFooterProps> = (props) => {
             <FooterContainer>
                 <AmbientFrame $variant="composer" $state="awaiting-input">
                     <FooterBox>
-                        <WebToolHeader>
-                            <span className="codicon codicon-extensions" />
-                            Skill Disabled
-                        </WebToolHeader>
+                        <FooterHeaderRow>
+                            <WebToolHeader>
+                                <span className="codicon codicon-extensions" />
+                                Skill Disabled
+                            </WebToolHeader>
+                            <StopControl onStop={onStop} />
+                        </FooterHeaderRow>
                         <WebToolContent>{skillName}</WebToolContent>
                         <FooterDivider />
                         <WebToolActions>
@@ -155,7 +183,10 @@ const CommonApprovalFooter: React.FC<CommonApprovalFooterProps> = (props) => {
         <FooterContainer>
             <AmbientFrame $variant="composer" $state="awaiting-input">
                 <FooterBox>
-                    <FooterBoxPrompt>{promptText}</FooterBoxPrompt>
+                    <FooterHeaderRow>
+                        <FooterBoxPrompt>{promptText}</FooterBoxPrompt>
+                        <StopControl onStop={onStop} />
+                    </FooterHeaderRow>
                     <FooterDivider />
                     <ActionButton
                         onClick={() => onApprove(false)}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/StopControl.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/StopControl.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { FooterIconBtn } from "./styles";
+
+// AIChatInput normally owns Escape-to-stop, but it's unmounted while an approval/clarify footer shows.
+const StopControl: React.FC<{ onStop: () => void }> = ({ onStop }) => (
+    <FooterIconBtn onClick={onStop} title="Stop (Escape)">
+        <span className="codicon codicon-stop-circle" />
+    </FooterIconBtn>
+);
+
+export default StopControl;

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/StopControl.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/StopControl.tsx
@@ -19,7 +19,7 @@
 import React from "react";
 import { FooterIconBtn } from "./styles";
 
-// AIChatInput normally owns Escape-to-stop, but it's unmounted while an approval/clarify footer shows.
+// AIChatInput normally owns Escape-to-stop, but it is hidden while an approval/clarify footer shows.
 const StopControl: React.FC<{ onStop: () => void }> = ({ onStop }) => (
     <FooterIconBtn onClick={onStop} title="Stop (Escape)">
         <span className="codicon codicon-stop-circle" />

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.test.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.test.tsx
@@ -23,12 +23,21 @@ import React from "react";
 import { createRoot, Root } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 
-(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+declare global {
+    var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 // The core barrel pulls in ESM-only LS transport modules that jest cannot load.
 jest.mock("@wso2/ballerina-core", () => ({
     __esModule: true,
     TemplateId: { Wildcard: "Wildcard" },
+    // placeholderTags is keyed by Command, so the real fixture needs these to initialise.
+    Command: {
+        Agent: "Agent", Ask: "Ask", Compact: "Compact", Doc: "Doc", Healthcare: "Healthcare",
+        NaturalProgramming: "NaturalProgramming", OpenAPI: "OpenAPI", Tests: "Tests",
+        TypeCreator: "TypeCreator",
+    },
 }));
 
 jest.mock("../../../commandTemplates/data/commandTemplates.const", () => ({
@@ -62,12 +71,22 @@ jest.mock("../../AIChatInput", () => ({
 }));
 
 import Footer from "./index";
+import type { AIChatInputRef } from "../../AIChatInput";
+import { placeholderTags } from "../../../commandTemplates/data/placeholderTags.const";
 
 const noop = (): void => undefined;
-const baseProps = {
-    aiChatInputRef: React.createRef<any>(),
-    tagOptions: {} as any,
-    attachmentOptions: {} as any,
+const baseProps: React.ComponentProps<typeof Footer> = {
+    aiChatInputRef: React.createRef<AIChatInputRef>(),
+    tagOptions: {
+        placeholderTags,
+        loadGeneralTags: async () => [],
+        injectPlaceholderTags: async () => undefined,
+    },
+    attachmentOptions: {
+        multiple: true,
+        acceptResolver: () => "",
+        handleAttachmentSelection: async () => [],
+    },
     inputPlaceholder: "What would you like to change?",
     onSend: async (): Promise<void> => undefined,
     onStop: noop,

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.test.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// L2: `hidden` must hide the footer WITHOUT unmounting it. An approval prompt renders its own
+// footer in the composer's place, and the composer owns the user's draft and attachments as local
+// state — so conditionally rendering it, the obvious way to write this, silently discards both.
+// Nothing on screen distinguishes "hidden" from "unmounted", which is why it is pinned here.
+
+import React from "react";
+import { createRoot, Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The core barrel pulls in ESM-only LS transport modules that jest cannot load. Footer only reads
+// TemplateId, and only for the suggestion chips this test does not render.
+jest.mock("@wso2/ballerina-core", () => ({
+    __esModule: true,
+    TemplateId: { Wildcard: "Wildcard" },
+}));
+
+jest.mock("../../../commandTemplates/data/commandTemplates.const", () => ({
+    __esModule: true,
+    commandTemplates: {},
+    suggestedCommandTemplates: [],
+}));
+
+jest.mock("../../../commandTemplates/utils/utils", () => ({
+    __esModule: true,
+    getTemplateTextById: () => "",
+}));
+
+jest.mock("../../CodeContextCard", () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+// Reaches @wso2/ballerina-rpc-client, which ships ESM. Only the loading indicator draws the orb.
+jest.mock("../../../../../components/AgentStatusOrb/shared", () => ({
+    __esModule: true,
+    Sphere: () => null,
+    Gloss: () => null,
+    ORB_COLORS: { running: [] },
+    ORB_ENERGY: { running: 0 },
+}));
+
+// Stands in for the composer. Its presence in the DOM is the whole point: the draft lives inside
+// the real one as local state, so "still rendered" is what "draft preserved" reduces to.
+jest.mock("../../AIChatInput", () => ({
+    __esModule: true,
+    default: React.forwardRef(() => <div data-testid="composer" />),
+}));
+
+import Footer from "./index";
+
+const noop = () => undefined;
+const baseProps = {
+    aiChatInputRef: React.createRef<any>(),
+    tagOptions: {} as any,
+    attachmentOptions: {} as any,
+    inputPlaceholder: "What would you like to change?",
+    onSend: async () => undefined,
+    onStop: noop,
+    isLoading: false,
+    showSuggestedCommands: false,
+};
+
+describe("Footer hidden prop", () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        root = createRoot(container);
+    });
+
+    afterEach(() => {
+        act(() => root.unmount());
+        container.remove();
+    });
+
+    const render = (hidden?: boolean) => {
+        act(() => {
+            root.render(<Footer {...baseProps} hidden={hidden} />);
+        });
+        return container.querySelector("footer") as HTMLElement;
+    };
+
+    it("keeps the composer mounted while hiding the footer", () => {
+        const footer = render(true);
+        expect(footer.style.display).toBe("none");
+        expect(container.querySelector('[data-testid="composer"]')).not.toBeNull();
+    });
+
+    it("shows the footer when not hidden", () => {
+        const footer = render(false);
+        expect(footer.style.display).toBe("");
+        expect(container.querySelector('[data-testid="composer"]')).not.toBeNull();
+    });
+
+    it("does not remount the composer when hidden is toggled", () => {
+        render(false);
+        const before = container.querySelector('[data-testid="composer"]');
+        render(true);
+        expect(container.querySelector('[data-testid="composer"]')).toBe(before);
+    });
+});

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.test.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.test.tsx
@@ -16,10 +16,8 @@
  * under the License.
  */
 
-// L2: `hidden` must hide the footer WITHOUT unmounting it. An approval prompt renders its own
-// footer in the composer's place, and the composer owns the user's draft and attachments as local
-// state — so conditionally rendering it, the obvious way to write this, silently discards both.
-// Nothing on screen distinguishes "hidden" from "unmounted", which is why it is pinned here.
+// L2: `hidden` must hide the footer WITHOUT unmounting it — the composer owns the draft and
+// attachments as local state, and nothing on screen distinguishes hidden from unmounted.
 
 import React from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -27,8 +25,7 @@ import { act } from "react-dom/test-utils";
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
-// The core barrel pulls in ESM-only LS transport modules that jest cannot load. Footer only reads
-// TemplateId, and only for the suggestion chips this test does not render.
+// The core barrel pulls in ESM-only LS transport modules that jest cannot load.
 jest.mock("@wso2/ballerina-core", () => ({
     __esModule: true,
     TemplateId: { Wildcard: "Wildcard" },
@@ -36,45 +33,43 @@ jest.mock("@wso2/ballerina-core", () => ({
 
 jest.mock("../../../commandTemplates/data/commandTemplates.const", () => ({
     __esModule: true,
-    commandTemplates: {},
-    suggestedCommandTemplates: [],
+    commandTemplates: {} as Record<string, unknown>,
+    suggestedCommandTemplates: [] as unknown[],
 }));
 
 jest.mock("../../../commandTemplates/utils/utils", () => ({
     __esModule: true,
-    getTemplateTextById: () => "",
+    getTemplateTextById: (): string => "",
 }));
 
 jest.mock("../../CodeContextCard", () => ({
     __esModule: true,
-    default: () => null,
+    default: (): null => null,
 }));
 
-// Reaches @wso2/ballerina-rpc-client, which ships ESM. Only the loading indicator draws the orb.
+// Reaches @wso2/ballerina-rpc-client, which ships ESM.
 jest.mock("../../../../../components/AgentStatusOrb/shared", () => ({
     __esModule: true,
-    Sphere: () => null,
-    Gloss: () => null,
-    ORB_COLORS: { running: [] },
+    Sphere: (): null => null,
+    Gloss: (): null => null,
+    ORB_COLORS: { running: [] as string[] },
     ORB_ENERGY: { running: 0 },
 }));
 
-// Stands in for the composer. Its presence in the DOM is the whole point: the draft lives inside
-// the real one as local state, so "still rendered" is what "draft preserved" reduces to.
 jest.mock("../../AIChatInput", () => ({
     __esModule: true,
-    default: React.forwardRef(() => <div data-testid="composer" />),
+    default: React.forwardRef((): JSX.Element => <div data-testid="composer" />),
 }));
 
 import Footer from "./index";
 
-const noop = () => undefined;
+const noop = (): void => undefined;
 const baseProps = {
     aiChatInputRef: React.createRef<any>(),
     tagOptions: {} as any,
     attachmentOptions: {} as any,
     inputPlaceholder: "What would you like to change?",
-    onSend: async () => undefined,
+    onSend: async (): Promise<void> => undefined,
     onStop: noop,
     isLoading: false,
     showSuggestedCommands: false,

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.tsx
@@ -243,6 +243,7 @@ type FooterProps = {
     runningServicesPanel?: RunningServicesPanel;
     skills?: SkillEntry[];
     ambientState?: AgentRunState;
+    hidden?: boolean;
 };
 
 const Footer: React.FC<FooterProps> = ({
@@ -271,11 +272,12 @@ const Footer: React.FC<FooterProps> = ({
     runningServicesPanel,
     skills,
     ambientState,
+    hidden,
 }) => {
     const footerSuggestedCommandTemplates = suggestedCommandTemplates ?? defaultSuggestedCommandTemplates;
 
     return (
-        <FooterContainer>
+        <FooterContainer style={hidden ? { display: "none" } : undefined}>
             {showSuggestedCommands && (
                 <SuggestedCommandsWrapper>
                     {footerSuggestedCommandTemplates.map((item, index) => renderPrompt(item, index, aiChatInputRef))}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/styles.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/styles.ts
@@ -88,6 +88,18 @@ export const FooterInput = styled.input`
 `;
 
 /**
+ * Header row for approval footers — title/content on the left, a corner
+ * control (e.g. stop) on the right.
+ */
+export const FooterHeaderRow = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+`;
+
+/**
  * 24×24 icon button — matches ActionButton in AIChatInput/index.tsx exactly.
  */
 export const FooterIconBtn = styled.button`

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/styles.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/styles.ts
@@ -87,10 +87,6 @@ export const FooterInput = styled.input`
     }
 `;
 
-/**
- * Header row for approval footers — title/content on the left, a corner
- * control (e.g. stop) on the right.
- */
 export const FooterHeaderRow = styled.div`
     display: flex;
     align-items: center;

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/useEscapeToStop.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/useEscapeToStop.ts
@@ -18,10 +18,8 @@
 
 import { useEffect } from "react";
 
-// Mirrors the Escape-to-stop handling in AIChatInput, which is unmounted while these footers show.
-// Listening on window means this sees Escape wherever focus is, so anything the user opened on top —
-// the chat sessions dropdown, a popup — gets first refusal by calling preventDefault on the way up.
-// Without that, one Escape both dismissed the thing on top and aborted the run.
+// On window so Escape is seen wherever focus is; anything opened on top (the sessions dropdown, a
+// popup) gets first refusal via preventDefault, or one Escape would dismiss it AND abort the run.
 export function useEscapeToStop(onStop: () => void) {
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/useEscapeToStop.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/useEscapeToStop.ts
@@ -19,13 +19,17 @@
 import { useEffect } from "react";
 
 // Mirrors the Escape-to-stop handling in AIChatInput, which is unmounted while these footers show.
+// Listening on window means this sees Escape wherever focus is, so anything the user opened on top —
+// the chat sessions dropdown, a popup — gets first refusal by calling preventDefault on the way up.
+// Without that, one Escape both dismissed the thing on top and aborted the run.
 export function useEscapeToStop(onStop: () => void) {
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key === "Escape") {
-                event.preventDefault();
-                onStop();
+            if (event.key !== "Escape" || event.defaultPrevented) {
+                return;
             }
+            event.preventDefault();
+            onStop();
         };
         window.addEventListener("keydown", handleKeyDown);
         return () => window.removeEventListener("keydown", handleKeyDown);

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/useEscapeToStop.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/useEscapeToStop.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect } from "react";
+
+// Mirrors the Escape-to-stop handling in AIChatInput, which is unmounted while these footers show.
+export function useEscapeToStop(onStop: () => void) {
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onStop();
+            }
+        };
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [onStop]);
+}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -335,6 +335,10 @@ const AIChat: React.FC = () => {
     // staleness has to be judged against a ref, not the captured isLoading value.
     const isLoadingRef = useRef(false);
     isLoadingRef.current = isLoading;
+    // Set by the "abort" notification (always delivered before generateAgent's RPC rejection,
+    // whose error loses its name crossing the vscode-messenger boundary) so handleSendQuery's
+    // catch can recognize an abort without trusting that error.
+    const abortHandledRef = useRef(false);
     const [followupSuggestions, setFollowupSuggestions] = useState<FollowupSuggestion[]>([]);
     const [isCompacting, setIsCompacting] = useState(false);
     // Tools currently in flight, oldest first, for the composer's loading
@@ -1525,6 +1529,7 @@ const AIChat: React.FC = () => {
 
         } else if (type === "abort") {
             console.log("Received abort signal");
+            abortHandledRef.current = true;
             activeScaffoldKeyRef.current = null;
             setIsWebToolsEnabled(userWebSearchPreferenceRef.current);
             setWebToolApprovalRequest(null);
@@ -1761,10 +1766,9 @@ const AIChat: React.FC = () => {
             setIsCompacting(false);
             setIsLoading(false);
             setIsCodeLoading(false);
-            if (error.name === "AbortError") {
-                updateLastMessage((lastContent) =>
-                    lastContent + `\n\n<error data-system="true" data-auth="${SYSTEM_ERROR_SECRET}">Generation stopped by the user</error>`
-                );
+            if (abortHandledRef.current || error.name === "AbortError") {
+                abortHandledRef.current = false;
+                // The "abort" notification already appended the interruption marker.
             } else if (error?.name === "UsageLimitError" || error?.statusCode === 429) {
                 setIsUsageExceeded(true);
                 fetchUsage();

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2915,6 +2915,7 @@ const AIChat: React.FC = () => {
                                     questions={activeClarifyItem.data.questions}
                                     requestId={activeClarifyItem.data.requestId}
                                     rpcClient={rpcClient}
+                                    onStop={handleStop}
                                 />
                             );
                         }

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -1515,6 +1515,7 @@ const AIChat: React.FC = () => {
             console.log("Received stop signal");
             setIsWebToolsEnabled(userWebSearchPreferenceRef.current);
             setWebToolApprovalRequest(null);
+            setApprovalRequest(null);
             setIsCompacting(false);
             setIsCodeLoading(false);
             setIsLoading(false);
@@ -1533,6 +1534,7 @@ const AIChat: React.FC = () => {
             activeScaffoldKeyRef.current = null;
             setIsWebToolsEnabled(userWebSearchPreferenceRef.current);
             setWebToolApprovalRequest(null);
+            setApprovalRequest(null);
             setMessages(prevMessages => {
                 const msgs = [...prevMessages];
                 const targetIndex = ensureAssistantMessage(msgs);

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2913,58 +2913,55 @@ const AIChat: React.FC = () => {
                             (item: StreamItem) => item.kind === "ask" && (item as any).data?.stage === "asking"
                         ) as { kind: "ask"; data: { requestId: string; questions: any[] } } | undefined;
 
-                        if (activeClarifyItem) {
-                            return (
-                                <ClarifyFooter
-                                    questions={activeClarifyItem.data.questions}
-                                    requestId={activeClarifyItem.data.requestId}
-                                    rpcClient={rpcClient}
-                                    onStop={handleStop}
-                                />
-                            );
-                        }
-
                         const activeSkillEnableItem = lastStreamItems.find(
                             (item: StreamItem) => item.kind === "skill_enable" && (item as any).data?.stage === "prompting"
                         ) as { kind: "skill_enable"; data: { requestId: string; skillName: string; skillId: string } } | undefined;
 
-                        if (activeSkillEnableItem) {
-                            const { requestId, skillName, skillId } = activeSkillEnableItem.data;
-                            return (
-                                <CommonApprovalFooter
-                                    type="skill_enable"
-                                    skillName={skillName}
-                                    onEnable={() => rpcClient.getAiPanelRpcClient().enableSkillFromChat({ requestId, skillId })}
-                                    onSkip={() => rpcClient.getAiPanelRpcClient().cancelSkillEnable({ requestId })}
-                                    onStop={handleStop}
-                                />
-                            );
-                        }
+                        const approvalFooter = activeClarifyItem ? (
+                            <ClarifyFooter
+                                questions={activeClarifyItem.data.questions}
+                                requestId={activeClarifyItem.data.requestId}
+                                rpcClient={rpcClient}
+                                onStop={handleStop}
+                            />
+                        ) : activeSkillEnableItem ? (
+                            <CommonApprovalFooter
+                                type="skill_enable"
+                                skillName={activeSkillEnableItem.data.skillName}
+                                onEnable={() => rpcClient.getAiPanelRpcClient().enableSkillFromChat({
+                                    requestId: activeSkillEnableItem.data.requestId,
+                                    skillId: activeSkillEnableItem.data.skillId,
+                                })}
+                                onSkip={() => rpcClient.getAiPanelRpcClient().cancelSkillEnable({
+                                    requestId: activeSkillEnableItem.data.requestId,
+                                })}
+                                onStop={handleStop}
+                            />
+                        ) : webToolApprovalRequest ? (
+                            <CommonApprovalFooter
+                                type="web_tool"
+                                toolName={webToolApprovalRequest.toolName}
+                                content={webToolApprovalRequest.content}
+                                onAllow={handleWebToolAllow}
+                                onDeny={handleWebToolDeny}
+                                onStop={handleStop}
+                            />
+                        ) : approvalRequest ? (
+                            <CommonApprovalFooter
+                                type={approvalRequest.approvalType}
+                                onApprove={handleApprovalApprove}
+                                onReject={handleApprovalReject}
+                                onStop={handleStop}
+                            />
+                        ) : null;
 
-                        if (webToolApprovalRequest) {
-                            return (
-                                <CommonApprovalFooter
-                                    type="web_tool"
-                                    toolName={webToolApprovalRequest.toolName}
-                                    content={webToolApprovalRequest.content}
-                                    onAllow={handleWebToolAllow}
-                                    onDeny={handleWebToolDeny}
-                                    onStop={handleStop}
-                                />
-                            );
-                        }
-                        if (approvalRequest) {
-                            return (
-                                <CommonApprovalFooter
-                                    type={approvalRequest.approvalType}
-                                    onApprove={handleApprovalApprove}
-                                    onReject={handleApprovalReject}
-                                    onStop={handleStop}
-                                />
-                            );
-                        }
+                        // The composer stays mounted behind an approval footer — unmounting it would
+                        // discard whatever the user had typed and attached while waiting.
                         return (
+                        <>
+                            {approvalFooter}
                             <Footer
+                            hidden={!!approvalFooter}
                             aiChatInputRef={aiChatInputRef}
                             tagOptions={{
                                 placeholderTags: placeholderTags,
@@ -3009,6 +3006,7 @@ const AIChat: React.FC = () => {
                             }}
                             skills={skills}
                         />
+                        </>
                         );
                     })()}
                 </AIChatView>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2955,8 +2955,7 @@ const AIChat: React.FC = () => {
                             />
                         ) : null;
 
-                        // The composer stays mounted behind an approval footer — unmounting it would
-                        // discard whatever the user had typed and attached while waiting.
+                        // Kept mounted behind the approval footer so the draft and attachments survive.
                         return (
                         <>
                             {approvalFooter}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2931,6 +2931,7 @@ const AIChat: React.FC = () => {
                                     skillName={skillName}
                                     onEnable={() => rpcClient.getAiPanelRpcClient().enableSkillFromChat({ requestId, skillId })}
                                     onSkip={() => rpcClient.getAiPanelRpcClient().cancelSkillEnable({ requestId })}
+                                    onStop={handleStop}
                                 />
                             );
                         }
@@ -2943,6 +2944,7 @@ const AIChat: React.FC = () => {
                                     content={webToolApprovalRequest.content}
                                     onAllow={handleWebToolAllow}
                                     onDeny={handleWebToolDeny}
+                                    onStop={handleStop}
                                 />
                             );
                         }
@@ -2952,6 +2954,7 @@ const AIChat: React.FC = () => {
                                     type={approvalRequest.approvalType}
                                     onApprove={handleApprovalApprove}
                                     onReject={handleApprovalReject}
+                                    onStop={handleStop}
                                 />
                             );
                         }

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -335,9 +335,7 @@ const AIChat: React.FC = () => {
     // staleness has to be judged against a ref, not the captured isLoading value.
     const isLoadingRef = useRef(false);
     isLoadingRef.current = isLoading;
-    // Set by the "abort" notification (always delivered before generateAgent's RPC rejection,
-    // whose error loses its name crossing the vscode-messenger boundary) so handleSendQuery's
-    // catch can recognize an abort without trusting that error.
+    // Set by the "abort" notification, which always arrives before the RPC error (whose name is lost in transit).
     const abortHandledRef = useRef(false);
     const [followupSuggestions, setFollowupSuggestions] = useState<FollowupSuggestion[]>([]);
     const [isCompacting, setIsCompacting] = useState(false);

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -366,8 +366,11 @@ export function SessionHistoryDropdown({
             e.preventDefault();
             if (confirmDelete) { setConfirmDelete(null); } else if (renaming) { cancelRename(); } else { onClose(); }
         };
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
+        // Capture phase: the approval footers listen for Escape on window to stop the run, and a
+        // bubble-phase listener here is not reliably ahead of that. Capture runs before any
+        // bubble-phase handler in this document, so the dropdown can claim the key first.
+        document.addEventListener('keydown', handleKeyDown, true);
+        return () => document.removeEventListener('keydown', handleKeyDown, true);
     }, [onClose, confirmDelete, renaming]);
 
     const filtered = search.trim()

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -366,9 +366,8 @@ export function SessionHistoryDropdown({
             e.preventDefault();
             if (confirmDelete) { setConfirmDelete(null); } else if (renaming) { cancelRename(); } else { onClose(); }
         };
-        // Capture phase: the approval footers listen for Escape on window to stop the run, and a
-        // bubble-phase listener here is not reliably ahead of that. Capture runs before any
-        // bubble-phase handler in this document, so the dropdown can claim the key first.
+        // Capture runs before any bubble-phase handler, so the dropdown claims Escape ahead of the
+        // approval footers' window listener.
         document.addEventListener('keydown', handleKeyDown, true);
         return () => document.removeEventListener('keydown', handleKeyDown, true);
     }, [onClose, confirmDelete, renaming]);

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -362,6 +362,8 @@ export function SessionHistoryDropdown({
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key !== 'Escape') { return; }
+            // Claim the key so a footer's Escape-to-stop does not also abort the run behind us.
+            e.preventDefault();
             if (confirmDelete) { setConfirmDelete(null); } else if (renaming) { cancelRename(); } else { onClose(); }
         };
         document.addEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2050
Related to https://github.com/wso2/product-integrator/issues/2073

- Add a stop control to the approval footers, so a generation can be stopped while a plan, task,
  web-tool or skill-enable prompt is showing — those footers replace the composer, which is what
  normally owns Stop and Escape
- Extend the same control to the clarify (Ask) footer, at the end of its title row
- Stop the raw abort error from duplicating the interruption marker, so stopping leaves one clean
  `[Request interrupted by user]` line instead of a red error box beside it
- Clear the plan-approval and skill-enable cards when a generation stops or aborts, so a resolved
  prompt does not stay on screen with dead buttons
- Keep Escape from aborting a run it was meant to dismiss a menu for: the sessions dropdown now
  claims the key in the capture phase, and the footer hook ignores an Escape already handled
- Keep the composer mounted behind an approval footer instead of unmounting it, so a message typed
  (and files attached) while waiting for the prompt are still there once it is answered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added stop controls and Escape-key handling to approval and clarification footers.
- Preserved composer input and attachments while approval footers are displayed.
- Prevented duplicate interruption messages after aborts.
- Cleared pending approval cards when generation stops or aborts.
- Added `SKIPPED` skill events when users decline activation.
- Improved Escape-key handling for session history menus.
- Added tests for hidden footer behavior and composer preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->