### PR TITLE
Theme the WSO2 Integrator Copilot orb to the VS Code accent color

### DIFF
--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
@@ -22,9 +22,8 @@ import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { SHARED_COMMANDS, AgentRunStatus } from "@wso2/ballerina-core";
 import { Codicon, Icon } from "@wso2/ui-toolkit";
 import { ShaderOrb } from "./ShaderOrb";
+import { useOrbColors } from "./orbTheme";
 import {
-    BRAND_ORANGE,
-    ORB_COLORS,
     ORB_ENERGY,
     Sphere,
     Gloss,
@@ -110,8 +109,8 @@ const SendButton = styled.button`
     border-radius: 9px;
     padding: 0;
     font-size: 16px;
-    color: #ffffff;
-    background: linear-gradient(135deg, #6b5ce8, ${BRAND_ORANGE});
+    color: var(--vscode-button-foreground);
+    background: var(--vscode-button-background);
     cursor: pointer;
     transition: filter 0.15s ease, transform 0.15s ease;
     &:hover {
@@ -146,7 +145,7 @@ export function CopilotHeroBox({ placeholder }: { placeholder: string }) {
     // point, just in its idle prompt form.
     const state = status?.state ?? "idle";
     const active = state !== "idle";
-    const colors = ORB_COLORS[state];
+    const colors = useOrbColors(state);
     const label = active && status ? activeStateLabel(status) : null;
 
     const openCopilot = () => {
@@ -196,7 +195,7 @@ export function CopilotHeroBox({ placeholder }: { placeholder: string }) {
                         <Icon
                             name="bi-ai-chat"
                             sx={{ width: 20, height: 20 }}
-                            iconSx={{ fontSize: "20px", color: "#ffffff", cursor: "inherit" }}
+                            iconSx={{ fontSize: "20px", color: "var(--vscode-button-foreground)", cursor: "inherit" }}
                         />
                     </IconOverlay>
                 </OrbHolder>

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/ShaderOrb.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/ShaderOrb.tsx
@@ -105,11 +105,14 @@ void main() {
     // Narrow mix bands + a luminance term keep the flow visible even when
     // the palette hues are close (the structure reads as light/dark, not
     // just hue shifts).
-    float band = smoothstep(0.3, 0.72, f);
+    // Narrower bands => crisper light/dark boundaries that sweep as the field
+    // flows, so the motion reads even when the palette is a single hue.
+    float band = smoothstep(0.36, 0.66, f);
     vec3 col = mix(u_c0, u_c1, band);
     float f2 = fbm(uv * 3.0 - q + vec2(-t * 0.25, t * 0.35));
-    col = mix(col, u_c2, smoothstep(0.42, 0.8, f2) * (0.6 + 0.4 * u_energy));
-    col *= 0.62 + 0.85 * f;
+    col = mix(col, u_c2, smoothstep(0.4, 0.74, f2) * (0.6 + 0.4 * u_energy));
+    // Wider brightness swing tracking the flow => more visible movement.
+    col *= 0.48 + 1.15 * f;
 
     // Slight glass highlight (the Gloss overlay adds the main reflection)
     // and gentle spherical shading toward the rim.

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
@@ -24,13 +24,12 @@ import { AgentRunStatus, AgentRunState } from "@wso2/ballerina-core";
 import { Icon } from "@wso2/ui-toolkit";
 import { ShaderOrb } from "./ShaderOrb";
 import { MiniChat } from "./MiniChat";
+import { useOrbColors } from "./orbTheme";
 import {
     Anchor,
     ANCHOR_STORAGE_KEY,
-    BRAND_ORANGE,
     EDGE_MARGIN,
     loadAnchor,
-    ORB_COLORS,
     ORB_ENERGY,
     ORB_SIZE,
     Sphere,
@@ -118,11 +117,6 @@ const bloom = keyframes`
 const fadeIn = keyframes`
     from { opacity: 0; transform: translateX(6px); }
     to { opacity: 1; transform: translateX(0); }
-`;
-
-const hueCycle = keyframes`
-    from { filter: blur(8px) hue-rotate(0deg); }
-    to { filter: blur(8px) hue-rotate(360deg); }
 `;
 
 const haloPulse = keyframes`
@@ -267,7 +261,7 @@ const Aura = styled.div<{ colors: [string, string, string]; state: AgentRunState
     opacity: ${(props: Pick<OrbStyleProps, "state">) => (props.state === "idle" ? 0.45 : props.state === "running" ? 1 : 0.85)};
     ${(props: Pick<OrbStyleProps, "state">) =>
         props.state === "running"
-            ? css`animation: ${rotate} 2.8s linear infinite, ${hueCycle} 5s linear infinite;`
+            ? css`animation: ${rotate} 2.8s linear infinite;`
             : props.state === "idle"
                 ? css`animation: ${rotate} 14s linear infinite;`
                 : css`animation: ${rotate} 9s linear infinite;`}
@@ -276,12 +270,12 @@ const Aura = styled.div<{ colors: [string, string, string]; state: AgentRunState
     }
 `;
 
-/** Thin brand ring at the sphere's edge — the logo's circle as an accent. */
+/** Thin rim at the sphere's edge — a soft on-accent highlight, theme-driven. */
 const BrandRing = styled.div`
     position: absolute;
     inset: 0;
     border-radius: 50%;
-    border: 1.5px solid rgba(241, 78, 35, 0.55);
+    border: 1.5px solid color-mix(in srgb, var(--vscode-button-foreground) 35%, transparent);
     pointer-events: none;
 `;
 
@@ -291,7 +285,7 @@ const SpinArc = styled.div`
     inset: -2px;
     border-radius: 50%;
     border: 2px solid transparent;
-    border-top-color: ${BRAND_ORANGE};
+    border-top-color: var(--vscode-button-foreground);
     animation: ${rotate} 1.1s linear infinite;
     pointer-events: none;
     @media (prefers-reduced-motion: reduce) {
@@ -367,12 +361,15 @@ export function AgentStatusOrb() {
         }
     }, [orbHidden]);
 
+    // Resolve orb colors before any early return so the hook order stays stable
+    // across renders (status is null while the orb is hidden).
+    const colors = useOrbColors(status?.state ?? "idle");
+
     if (orbHidden) {
         return null;
     }
 
     const state = status.state;
-    const colors = ORB_COLORS[state];
     const label = state === "idle" ? "Chat with WSO2 Integration Intelligence" : activeStateLabel(status);
     const dragging = dragPos !== null && !snapping;
     // Active states keep the pill visible the whole time. Idle shows the
@@ -547,7 +544,7 @@ export function AgentStatusOrb() {
                     <Icon
                         name="bi-ai-chat"
                         sx={{ width: 26, height: 26 }}
-                        iconSx={{ fontSize: "26px", color: "#ffffff", cursor: "inherit" }}
+                        iconSx={{ fontSize: "26px", color: "var(--vscode-button-foreground)", cursor: "inherit" }}
                     />
                 </IconOverlay>
             </OrbButton>

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.test.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.test.ts
@@ -82,9 +82,9 @@ describe("shiftLightness", () => {
 });
 
 describe("stateColorVar", () => {
-    it("maps idle/running to the primary accent and the transient states to semantic tokens", () => {
+    it("maps idle to the primary accent, running to the progress-bar token, and the transient states to semantic tokens", () => {
         expect(stateColorVar("idle")).toBe("var(--vscode-button-background)");
-        expect(stateColorVar("running")).toBe("var(--vscode-button-background)");
+        expect(stateColorVar("running")).toBe("var(--vscode-progressBar-background, var(--vscode-button-background))");
         expect(stateColorVar("awaiting-input")).toContain("--vscode-charts-yellow");
         expect(stateColorVar("completed")).toBe("var(--vscode-charts-green)");
         expect(stateColorVar("error")).toContain("--vscode-errorForeground");

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.test.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -28,6 +28,7 @@ import {
     rgbToHsl,
     shiftLightness,
     stateColorVar,
+    subscribeToThemeChanges,
 } from "./orbTheme";
 
 describe("hexToRgb", () => {
@@ -73,9 +74,10 @@ describe("shiftLightness", () => {
     });
 
     it("clamps at the extremes instead of overflowing", () => {
-        expect(hexToRgb(shiftLightness("#ffffff", 0.5))).toEqual(hexToRgb(shiftLightness("#ffffff", 0.5)));
+        const nearWhite = hexToRgb(shiftLightness("#ffffff", 0.5));
         const nearBlack = hexToRgb(shiftLightness("#000000", -0.5));
-        expect(nearBlack.every((c) => c >= 0 && c <= 255)).toBe(true);
+        expect(nearWhite.every((c) => c > 0 && c < 255)).toBe(true);
+        expect(nearBlack.every((c) => c > 0 && c < 255)).toBe(true);
     });
 });
 
@@ -105,10 +107,102 @@ describe("ambientBorderColor", () => {
     });
 });
 
-describe("resolveCssColorToHex (no DOM)", () => {
+const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
+const computedStyleDescriptor = Object.getOwnPropertyDescriptor(globalThis, "getComputedStyle");
+const mutationObserverDescriptor = Object.getOwnPropertyDescriptor(globalThis, "MutationObserver");
+
+function restoreGlobalProperty(name: string, descriptor?: PropertyDescriptor): void {
+    if (descriptor) {
+        Object.defineProperty(globalThis, name, descriptor);
+    } else {
+        Reflect.deleteProperty(globalThis, name);
+    }
+}
+
+afterEach(() => {
+    restoreGlobalProperty("document", documentDescriptor);
+    restoreGlobalProperty("getComputedStyle", computedStyleDescriptor);
+    restoreGlobalProperty("MutationObserver", mutationObserverDescriptor);
+});
+
+describe("resolveCssColorToHex", () => {
+    function mockComputedColor(color: string): void {
+        const probe = { style: { cssText: "", color: "" }, remove: jest.fn() };
+        Object.defineProperty(globalThis, "document", {
+            configurable: true,
+            value: {
+                body: { appendChild: jest.fn() },
+                createElement: jest.fn(() => probe),
+            },
+        });
+        Object.defineProperty(globalThis, "getComputedStyle", {
+            configurable: true,
+            value: jest.fn(() => ({ color })),
+        });
+    }
+
+    it("parses legacy and modern computed RGB syntax", () => {
+        mockComputedColor("rgba(85, 103, 213, 0.5)");
+        expect(resolveCssColorToHex("var(--vscode-button-background)")).toBe("#5567d5");
+
+        mockComputedColor("rgb(85 103 213 / 0.5)");
+        expect(resolveCssColorToHex("var(--vscode-button-background)")).toBe("#5567d5");
+    });
+
     it("returns the BI fallback accent when there is no document", () => {
-        // Runs under @jest-environment node, so `document` is undefined.
+        restoreGlobalProperty("document");
         expect(resolveCssColorToHex("var(--vscode-button-background)")).toBe("#5567D5");
+    });
+});
+
+describe("subscribeToThemeChanges", () => {
+    it("shares one observer across both theme metadata roots", () => {
+        const documentElement = {};
+        const body = {};
+        const observe = jest.fn();
+        const disconnect = jest.fn();
+        let callback: MutationCallback | undefined;
+        class FakeMutationObserver {
+            constructor(next: MutationCallback) {
+                callback = next;
+            }
+
+            observe = observe;
+            disconnect = disconnect;
+        }
+        Object.defineProperty(globalThis, "document", {
+            configurable: true,
+            value: { documentElement, body },
+        });
+        Object.defineProperty(globalThis, "MutationObserver", {
+            configurable: true,
+            value: FakeMutationObserver,
+        });
+
+        const firstListener = jest.fn();
+        const secondListener = jest.fn();
+        const unsubscribeFirst = subscribeToThemeChanges(firstListener);
+        const unsubscribeSecond = subscribeToThemeChanges(secondListener);
+
+        const options = {
+            attributes: true,
+            attributeFilter: ["class", "data-vscode-theme-kind", "data-vscode-theme-id", "style"],
+        };
+        expect(observe).toHaveBeenCalledTimes(2);
+        expect(observe).toHaveBeenNthCalledWith(1, documentElement, options);
+        expect(observe).toHaveBeenNthCalledWith(2, body, options);
+
+        callback?.([], {} as MutationObserver);
+        expect(firstListener).toHaveBeenCalledTimes(1);
+        expect(secondListener).toHaveBeenCalledTimes(1);
+
+        unsubscribeFirst();
+        callback?.([], {} as MutationObserver);
+        expect(firstListener).toHaveBeenCalledTimes(1);
+        expect(secondListener).toHaveBeenCalledTimes(2);
+
+        unsubscribeSecond();
+        expect(disconnect).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.test.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * @jest-environment node
+ */
+
+import {
+    ambientBorderColor,
+    deriveOrbColors,
+    hexToRgb,
+    hslToRgb,
+    resolveCssColorToHex,
+    rgbToHex,
+    rgbToHsl,
+    shiftLightness,
+    stateColorVar,
+} from "./orbTheme";
+
+describe("hexToRgb", () => {
+    it("parses #rrggbb (any case)", () => {
+        expect(hexToRgb("#ffffff")).toEqual([255, 255, 255]);
+        expect(hexToRgb("#000000")).toEqual([0, 0, 0]);
+        expect(hexToRgb("#5567D5")).toEqual([85, 103, 213]);
+    });
+
+    it("expands #rgb shorthand", () => {
+        expect(hexToRgb("#fff")).toEqual([255, 255, 255]);
+        expect(hexToRgb("#0a0")).toEqual([0, 170, 0]);
+    });
+});
+
+describe("rgbToHex", () => {
+    it("formats and clamps", () => {
+        expect(rgbToHex([85, 103, 213])).toBe("#5567d5");
+        expect(rgbToHex([300, -5, 128])).toBe("#ff0080");
+    });
+});
+
+describe("rgb <-> hsl round trip", () => {
+    it("recovers the original rgb within rounding", () => {
+        for (const rgb of [[85, 103, 213], [255, 0, 0], [16, 200, 120], [128, 128, 128]] as [number, number, number][]) {
+            const [r, g, b] = hslToRgb(rgbToHsl(rgb)).map(Math.round);
+            expect(Math.abs(r - rgb[0])).toBeLessThanOrEqual(1);
+            expect(Math.abs(g - rgb[1])).toBeLessThanOrEqual(1);
+            expect(Math.abs(b - rgb[2])).toBeLessThanOrEqual(1);
+        }
+    });
+});
+
+describe("shiftLightness", () => {
+    it("lightens and darkens while keeping hue", () => {
+        const base = "#5567d5";
+        const lighter = shiftLightness(base, 0.15);
+        const darker = shiftLightness(base, -0.15);
+        expect(rgbToHsl(hexToRgb(lighter))[2]).toBeGreaterThan(rgbToHsl(hexToRgb(base))[2]);
+        expect(rgbToHsl(hexToRgb(darker))[2]).toBeLessThan(rgbToHsl(hexToRgb(base))[2]);
+        // Hue is preserved (same family), within rounding.
+        expect(Math.abs(rgbToHsl(hexToRgb(lighter))[0] - rgbToHsl(hexToRgb(base))[0])).toBeLessThan(2);
+    });
+
+    it("clamps at the extremes instead of overflowing", () => {
+        expect(hexToRgb(shiftLightness("#ffffff", 0.5))).toEqual(hexToRgb(shiftLightness("#ffffff", 0.5)));
+        const nearBlack = hexToRgb(shiftLightness("#000000", -0.5));
+        expect(nearBlack.every((c) => c >= 0 && c <= 255)).toBe(true);
+    });
+});
+
+describe("stateColorVar", () => {
+    it("maps idle/running to the primary accent and the transient states to semantic tokens", () => {
+        expect(stateColorVar("idle")).toBe("var(--vscode-button-background)");
+        expect(stateColorVar("running")).toBe("var(--vscode-button-background)");
+        expect(stateColorVar("awaiting-input")).toContain("--vscode-charts-yellow");
+        expect(stateColorVar("completed")).toBe("var(--vscode-charts-green)");
+        expect(stateColorVar("error")).toContain("--vscode-errorForeground");
+    });
+});
+
+describe("ambientBorderColor", () => {
+    it("floors the accent states toward focusBorder so the frame stays visible", () => {
+        for (const state of ["idle", "running"] as const) {
+            const c = ambientBorderColor(state);
+            expect(c).toContain("--vscode-button-background");
+            expect(c).toContain("--vscode-focusBorder");
+        }
+    });
+
+    it("leaves the vivid semantic states pure (no focusBorder blend)", () => {
+        for (const state of ["awaiting-input", "completed", "error"] as const) {
+            expect(ambientBorderColor(state)).toBe(stateColorVar(state));
+        }
+    });
+});
+
+describe("resolveCssColorToHex (no DOM)", () => {
+    it("returns the BI fallback accent when there is no document", () => {
+        // Runs under @jest-environment node, so `document` is undefined.
+        expect(resolveCssColorToHex("var(--vscode-button-background)")).toBe("#5567D5");
+    });
+});
+
+describe("deriveOrbColors", () => {
+    it("produces a [darker, base, lighter] triad around the resolved base", () => {
+        const [dark, base, light] = deriveOrbColors("idle"); // base falls back to #5567D5 (no DOM)
+        expect(base).toBe("#5567D5");
+        expect(rgbToHsl(hexToRgb(dark))[2]).toBeLessThan(rgbToHsl(hexToRgb(base))[2]);
+        expect(rgbToHsl(hexToRgb(light))[2]).toBeGreaterThan(rgbToHsl(hexToRgb(base))[2]);
+    });
+});

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -141,17 +141,28 @@ export function shiftLightness(hex: string, delta: number): string {
     return rgbToHex(hslToRgb([h, s, clamp(l + delta, 0.06, 0.96)]));
 }
 
-/** Parse `rgb(r, g, b)` / `rgba(r, g, b, a)`; null if it isn't one. */
+/** Parse legacy comma-separated and modern space-separated CSS rgb() values. */
 function parseRgbFunc(value: string): Rgb | null {
-    const match = value.match(/rgba?\(([^)]+)\)/i);
+    const match = value.trim().match(/^rgba?\((.*)\)$/i);
     if (!match) {
         return null;
     }
-    const parts = match[1].split(",").map((p) => parseFloat(p.trim()));
-    if (parts.length < 3 || parts.some((n, i) => i < 3 && Number.isNaN(n))) {
+    const content = match[1].trim();
+    const components = content.includes(",")
+        ? content.split(",")
+        : content.split(/\s*\/\s*/)[0].trim().split(/\s+/);
+    const channels = components.slice(0, 3).map((component) => {
+        const channel = component.trim().match(/^(\d+(?:\.\d+)?|\.\d+)(%)?$/);
+        if (!channel) {
+            return null;
+        }
+        const value = Number(channel[1]);
+        return channel[2] ? value * 2.55 : value;
+    });
+    if (components.length < 3 || channels.some((channel) => channel === null)) {
         return null;
     }
-    return [parts[0], parts[1], parts[2]];
+    return channels as Rgb;
 }
 
 /**
@@ -185,23 +196,45 @@ export function deriveOrbColors(state: AgentRunState): [string, string, string] 
 
 /**
  * The shader-ready hex triad for a run state, re-resolved when the VS Code
- * theme changes. VS Code stamps the theme onto `<html>`'s `class` /
- * `data-vscode-theme-kind`, so a MutationObserver there catches every switch
- * (mirrors bi-diagram's `ThemeListener`). `ShaderOrb` lerps toward the new
- * `colors` each frame, so the change crossfades.
+ * theme changes. VS Code stamps theme metadata on `<body>`, while some webview
+ * hosts update root styles; one shared observer watches both roots. `ShaderOrb`
+ * lerps toward the new `colors` each frame, so the change crossfades.
  */
+const THEME_ATTRIBUTE_FILTER = ["class", "data-vscode-theme-kind", "data-vscode-theme-id", "style"];
+const themeChangeListeners = new Set<() => void>();
+let themeObserver: MutationObserver | undefined;
+
+export function subscribeToThemeChanges(listener: () => void): () => void {
+    if (typeof document === "undefined" || !document.body || typeof MutationObserver === "undefined") {
+        return () => undefined;
+    }
+    themeChangeListeners.add(listener);
+    if (!themeObserver) {
+        themeObserver = new MutationObserver(() => {
+            for (const listener of themeChangeListeners) {
+                listener();
+            }
+        });
+        const options = { attributes: true, attributeFilter: THEME_ATTRIBUTE_FILTER };
+        themeObserver.observe(document.documentElement, options);
+        themeObserver.observe(document.body, options);
+    }
+    return () => {
+        themeChangeListeners.delete(listener);
+        if (themeChangeListeners.size === 0) {
+            themeObserver?.disconnect();
+            themeObserver = undefined;
+        }
+    };
+}
+
 export function useOrbColors(state: AgentRunState): [string, string, string] {
     const [colors, setColors] = useState<[string, string, string]>(() => deriveOrbColors(state));
 
     useEffect(() => {
-        setColors(deriveOrbColors(state));
-        const observer = new MutationObserver((mutations) => {
-            if (mutations.some((m) => m.attributeName === "class" || m.attributeName === "data-vscode-theme-kind")) {
-                setColors(deriveOrbColors(state));
-            }
-        });
-        observer.observe(document.documentElement, { attributes: true });
-        return () => observer.disconnect();
+        const updateColors = () => setColors(deriveOrbColors(state));
+        updateColors();
+        return subscribeToThemeChanges(updateColors);
     }, [state]);
 
     return colors;

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.ts
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Theme-driven colors for the ambient Copilot surfaces.
+ *
+ * The orb takes its identity from the VS Code primary accent
+ * (`--vscode-button-background`) so it matches the BI extension's own look and
+ * changes with the editor theme, instead of a fixed standalone palette. The
+ * transient run states keep a color-coded meaning, but sourced from VS Code
+ * semantic tokens so they too follow light/dark and custom themes.
+ *
+ * CSS surfaces can consume `stateColorVar()` (a `var(--vscode-*)` string) and
+ * theme-react for free. The WebGL shader (`ShaderOrb`) cannot read CSS vars, so
+ * it needs concrete hex; `useOrbColors()` resolves the token to a hex triad and
+ * re-resolves whenever the theme changes.
+ */
+
+import { useEffect, useState } from "react";
+import { AgentRunState } from "@wso2/ballerina-core";
+
+/** BI's `DefaultColors.PRIMARY` (@wso2/ui-toolkit) — used only if resolution fails. */
+const FALLBACK_ACCENT = "#5567D5";
+
+type Rgb = [number, number, number];
+type Hsl = [number, number, number];
+
+/**
+ * The base VS Code color token for each run state. All resolve per theme:
+ * idle/running follow the primary accent; the transient states stay
+ * color-coded via semantic tokens.
+ */
+export function stateColorVar(state: AgentRunState): string {
+    switch (state) {
+        case "awaiting-input":
+            return "var(--vscode-charts-yellow, var(--vscode-editorWarning-foreground))";
+        case "completed":
+            return "var(--vscode-charts-green)";
+        case "error":
+            return "var(--vscode-errorForeground, var(--vscode-charts-red))";
+        case "idle":
+        case "running":
+        default:
+            return "var(--vscode-button-background)";
+    }
+}
+
+/**
+ * Border/glow color for the ambient frame around the composer & hero input.
+ *
+ * The primary accent (idle/running) can sit close to the panel background in
+ * some themes, making a thin accent border nearly invisible. Blend it toward
+ * `--vscode-focusBorder` — the theme's designed-visible ring color — so the
+ * frame keeps its accent identity but never disappears. The transient states
+ * are already vivid (yellow/green/red), so they stay pure.
+ */
+export function ambientBorderColor(state: AgentRunState): string {
+    if (state === "idle" || state === "running") {
+        return "color-mix(in srgb, var(--vscode-button-background) 70%, var(--vscode-focusBorder))";
+    }
+    return stateColorVar(state);
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+}
+
+/** Parse `#rgb` / `#rrggbb`. */
+export function hexToRgb(hex: string): Rgb {
+    let value = hex.trim().replace(/^#/, "");
+    if (value.length === 3) {
+        value = value.split("").map((ch) => ch + ch).join("");
+    }
+    const int = parseInt(value, 16);
+    return [(int >> 16) & 255, (int >> 8) & 255, int & 255];
+}
+
+export function rgbToHex([r, g, b]: Rgb): string {
+    const hex = (n: number) => clamp(Math.round(n), 0, 255).toString(16).padStart(2, "0");
+    return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+export function rgbToHsl([r, g, b]: Rgb): Hsl {
+    const rn = r / 255;
+    const gn = g / 255;
+    const bn = b / 255;
+    const max = Math.max(rn, gn, bn);
+    const min = Math.min(rn, gn, bn);
+    const delta = max - min;
+    const l = (max + min) / 2;
+    if (delta === 0) {
+        return [0, 0, l];
+    }
+    const s = delta / (1 - Math.abs(2 * l - 1));
+    let h: number;
+    if (max === rn) {
+        h = ((gn - bn) / delta) % 6;
+    } else if (max === gn) {
+        h = (bn - rn) / delta + 2;
+    } else {
+        h = (rn - gn) / delta + 4;
+    }
+    h = (h * 60 + 360) % 360;
+    return [h, s, l];
+}
+
+export function hslToRgb([h, s, l]: Hsl): Rgb {
+    const c = (1 - Math.abs(2 * l - 1)) * s;
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = l - c / 2;
+    let rp = 0;
+    let gp = 0;
+    let bp = 0;
+    if (h < 60) { [rp, gp, bp] = [c, x, 0]; }
+    else if (h < 120) { [rp, gp, bp] = [x, c, 0]; }
+    else if (h < 180) { [rp, gp, bp] = [0, c, x]; }
+    else if (h < 240) { [rp, gp, bp] = [0, x, c]; }
+    else if (h < 300) { [rp, gp, bp] = [x, 0, c]; }
+    else { [rp, gp, bp] = [c, 0, x]; }
+    return [(rp + m) * 255, (gp + m) * 255, (bp + m) * 255];
+}
+
+/** Shift a color's HSL lightness by `delta` (−1..1), keeping hue and saturation. */
+export function shiftLightness(hex: string, delta: number): string {
+    const [h, s, l] = rgbToHsl(hexToRgb(hex));
+    return rgbToHex(hslToRgb([h, s, clamp(l + delta, 0.06, 0.96)]));
+}
+
+/** Parse `rgb(r, g, b)` / `rgba(r, g, b, a)`; null if it isn't one. */
+function parseRgbFunc(value: string): Rgb | null {
+    const match = value.match(/rgba?\(([^)]+)\)/i);
+    if (!match) {
+        return null;
+    }
+    const parts = match[1].split(",").map((p) => parseFloat(p.trim()));
+    if (parts.length < 3 || parts.some((n, i) => i < 3 && Number.isNaN(n))) {
+        return null;
+    }
+    return [parts[0], parts[1], parts[2]];
+}
+
+/**
+ * Resolve any CSS color expression (a `var(...)` chain, a token, or a literal)
+ * to a concrete `#rrggbb`. A throwaway probe lets the browser resolve the full
+ * `var()` fallback chain and any named color to a computed `rgb(...)`.
+ */
+export function resolveCssColorToHex(cssExpr: string): string {
+    if (typeof document === "undefined" || !document.body) {
+        return FALLBACK_ACCENT;
+    }
+    const probe = document.createElement("span");
+    probe.style.cssText = "position:absolute;width:0;height:0;opacity:0;pointer-events:none;";
+    probe.style.color = cssExpr;
+    document.body.appendChild(probe);
+    const resolved = getComputedStyle(probe).color;
+    probe.remove();
+    const rgb = parseRgbFunc(resolved);
+    return rgb ? rgbToHex(rgb) : FALLBACK_ACCENT;
+}
+
+/**
+ * The three shader stops for a run state: a monochromatic triad
+ * `[darker, base, lighter]` around the state's resolved base color, so the
+ * liquid shader keeps depth while reading as a single hue.
+ */
+export function deriveOrbColors(state: AgentRunState): [string, string, string] {
+    const base = resolveCssColorToHex(stateColorVar(state));
+    return [shiftLightness(base, -0.15), base, shiftLightness(base, 0.12)];
+}
+
+/**
+ * The shader-ready hex triad for a run state, re-resolved when the VS Code
+ * theme changes. VS Code stamps the theme onto `<html>`'s `class` /
+ * `data-vscode-theme-kind`, so a MutationObserver there catches every switch
+ * (mirrors bi-diagram's `ThemeListener`). `ShaderOrb` lerps toward the new
+ * `colors` each frame, so the change crossfades.
+ */
+export function useOrbColors(state: AgentRunState): [string, string, string] {
+    const [colors, setColors] = useState<[string, string, string]>(() => deriveOrbColors(state));
+
+    useEffect(() => {
+        setColors(deriveOrbColors(state));
+        const observer = new MutationObserver((mutations) => {
+            if (mutations.some((m) => m.attributeName === "class" || m.attributeName === "data-vscode-theme-kind")) {
+                setColors(deriveOrbColors(state));
+            }
+        });
+        observer.observe(document.documentElement, { attributes: true });
+        return () => observer.disconnect();
+    }, [state]);
+
+    return colors;
+}

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/orbTheme.ts
@@ -31,7 +31,7 @@
  * re-resolves whenever the theme changes.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AgentRunState } from "@wso2/ballerina-core";
 
 /** BI's `DefaultColors.PRIMARY` (@wso2/ui-toolkit) — used only if resolution fails. */
@@ -42,8 +42,9 @@ type Hsl = [number, number, number];
 
 /**
  * The base VS Code color token for each run state. All resolve per theme:
- * idle/running follow the primary accent; the transient states stay
- * color-coded via semantic tokens.
+ * idle follows the primary accent; running uses the progress-bar token so it
+ * reads as distinct from idle even when motion is disabled; the transient
+ * states stay color-coded via semantic tokens.
  */
 export function stateColorVar(state: AgentRunState): string {
     switch (state) {
@@ -53,8 +54,9 @@ export function stateColorVar(state: AgentRunState): string {
             return "var(--vscode-charts-green)";
         case "error":
             return "var(--vscode-errorForeground, var(--vscode-charts-red))";
-        case "idle":
         case "running":
+            return "var(--vscode-progressBar-background, var(--vscode-button-background))";
+        case "idle":
         default:
             return "var(--vscode-button-background)";
     }
@@ -230,10 +232,19 @@ export function subscribeToThemeChanges(listener: () => void): () => void {
 
 export function useOrbColors(state: AgentRunState): [string, string, string] {
     const [colors, setColors] = useState<[string, string, string]>(() => deriveOrbColors(state));
+    const isFirstRun = useRef(true);
 
     useEffect(() => {
         const updateColors = () => setColors(deriveOrbColors(state));
-        updateColors();
+        // The lazy useState initializer already resolved the initial state's
+        // colors, so skip the redundant mount-time probe; only recompute here
+        // when `state` actually changes. Theme changes still recompute via the
+        // subscription below.
+        if (isFirstRun.current) {
+            isFirstRun.current = false;
+        } else {
+            updateColors();
+        }
         return subscribeToThemeChanges(updateColors);
     }, [state]);
 

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -22,9 +22,7 @@ import { keyframes } from "@emotion/react";
 import { AgentRunState, AgentRunStatus, ChatNotify, MACHINE_VIEW } from "@wso2/ballerina-core";
 import { BallerinaRpcClient, useRpcContext } from "@wso2/ballerina-rpc-client";
 import type { MiniChatPrompt } from "./promptHandoff";
-
-/** WSO2 brand orange — the pulse-icon color from wso2.com/about/brand. */
-export const BRAND_ORANGE = "#F14E23";
+import { ambientBorderColor } from "./orbTheme";
 
 /** Floating orb geometry, shared with the mini chat for anchor-relative placement. */
 export const ORB_SIZE = 56;
@@ -51,14 +49,6 @@ export function loadAnchor(): Anchor {
     return stored && (ANCHORS as readonly string[]).includes(stored) ? (stored as Anchor) : "bottom-right";
 }
 
-export const ORB_COLORS: Record<AgentRunState, [string, string, string]> = {
-    "idle": ["#6b5ce8", BRAND_ORANGE, "#ffb199"],
-    "running": ["#4facfe", "#a78bfa", "#f472b6"],
-    "awaiting-input": ["#fbbf24", "#f59e0b", "#fb923c"],
-    "completed": ["#34d399", "#10b981", "#6ee7b7"],
-    "error": ["#f87171", "#ef4444", "#fb7185"],
-};
-
 /** Flow speed / contrast of the shader per state (0 = still, 1 = lively). */
 export const ORB_ENERGY: Record<AgentRunState, number> = {
     "idle": 0.35,
@@ -81,8 +71,9 @@ interface AmbientFrameProps {
     $variant?: AmbientFrameVariant;
 }
 
-function ambientColors(props: AmbientFrameProps): [string, string, string] {
-    return ORB_COLORS[props.$state ?? "idle"];
+/** The frame's base color (accent floored to focusBorder for visibility); tinted in CSS. */
+function ambientBase(props: AmbientFrameProps): string {
+    return ambientBorderColor(props.$state ?? "idle");
 }
 
 /**
@@ -96,27 +87,35 @@ export const AmbientFrame = styled.div<AmbientFrameProps>`
     padding: ${(props: AmbientFrameProps) => props.$variant === "hero" ? "1.5px" : "1px"};
     border-radius: ${(props: AmbientFrameProps) => props.$variant === "hero" ? "14px" : "10px"};
     background: ${(props: AmbientFrameProps) => {
-        const [first, second, third] = ambientColors(props);
-        return `linear-gradient(120deg, ${first}, ${second}, ${third}, ${first})`;
+        // Monochromatic gradient tinted from the state's accent so the frame
+        // reads as one theme color (light stop → base → dark stop).
+        const base = ambientBase(props);
+        return `linear-gradient(120deg,`
+            + ` color-mix(in srgb, ${base} 82%, #ffffff),`
+            + ` ${base},`
+            + ` color-mix(in srgb, ${base} 80%, #000000),`
+            + ` color-mix(in srgb, ${base} 82%, #ffffff))`;
     }};
     background-size: 300% 300%;
     animation: ${ambientGradientShift} 9s ease infinite;
     box-shadow: ${(props: AmbientFrameProps) => {
-        const [first, second] = ambientColors(props);
+        const base = ambientBase(props);
         const hero = props.$variant === "hero";
         const active = !!props.$state && props.$state !== "idle";
-        const outerStrength = hero ? 25 : active ? 20 : 12;
-        const innerStrength = hero ? 12 : active ? 13 : 7;
-        const outerSize = hero ? 18 : active ? 16 : 12;
-        const innerSize = hero ? 10 : active ? 10 : 8;
-        return `0 0 ${outerSize}px color-mix(in srgb, ${first} ${outerStrength}%, transparent), 0 0 ${innerSize}px color-mix(in srgb, ${second} ${innerStrength}%, transparent)`;
+        // Idle composer used to be the faintest (12/7); bump it so the frame
+        // stays legible where the accent is muted or near the panel background.
+        const outerStrength = hero ? 25 : active ? 20 : 18;
+        const innerStrength = hero ? 12 : active ? 13 : 11;
+        const outerSize = hero ? 18 : active ? 16 : 14;
+        const innerSize = hero ? 10 : active ? 10 : 9;
+        return `0 0 ${outerSize}px color-mix(in srgb, ${base} ${outerStrength}%, transparent), 0 0 ${innerSize}px color-mix(in srgb, ${base} ${innerStrength}%, transparent)`;
     }};
     transition: box-shadow 0.25s ease;
 
     &:focus-within {
         box-shadow: ${(props: AmbientFrameProps) => {
-            const [first, second] = ambientColors(props);
-            return `0 0 22px color-mix(in srgb, ${first} 34%, transparent), 0 0 13px color-mix(in srgb, ${second} 20%, transparent)`;
+            const base = ambientBase(props);
+            return `0 0 22px color-mix(in srgb, ${base} 34%, transparent), 0 0 13px color-mix(in srgb, ${base} 20%, transparent)`;
         }};
     }
 

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -51,11 +51,13 @@ export function loadAnchor(): Anchor {
 
 /** Flow speed / contrast of the shader per state (0 = still, 1 = lively). */
 export const ORB_ENERGY: Record<AgentRunState, number> = {
-    "idle": 0.35,
+    // Raised across the board so the single-hue orb visibly flows (the motion,
+    // not the color, is what carries "alive"). Running stays at the ceiling.
+    "idle": 0.6,
     "running": 1.0,
-    "awaiting-input": 0.55,
-    "completed": 0.45,
-    "error": 0.5,
+    "awaiting-input": 0.72,
+    "completed": 0.6,
+    "error": 0.65,
 };
 
 const ambientGradientShift = keyframes`

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.tsx
@@ -28,7 +28,8 @@ import { AttachmentOptions } from "../../AIChatInput/hooks/useAttachments";
 import { getTemplateTextById } from "../../../commandTemplates/utils/utils";
 import CodeContextCard from "../../CodeContextCard";
 import { AgentMode } from "../../AIChatInput/ModeToggle";
-import { Gloss, ORB_COLORS, ORB_ENERGY, Sphere } from "../../../../../components/AgentStatusOrb/shared";
+import { Gloss, ORB_ENERGY, Sphere } from "../../../../../components/AgentStatusOrb/shared";
+import { useOrbColors } from "../../../../../components/AgentStatusOrb/orbTheme";
 
 export const FooterContainer = styled.footer({
     padding: "20px 20px 12px",
@@ -166,12 +167,13 @@ function useStickyLabel(value: string, minVisibleMs = MIN_LABEL_VISIBLE_MS): str
  */
 const LoadingIndicator: React.FC<{ label: string }> = React.memo(({ label }) => {
     const shownLabel = useStickyLabel(label);
+    const runningColors = useOrbColors("running");
     return (
         // aria-live sits on the stable container: the label itself remounts on
         // every change, and a replaced node is not announced.
         <LoadingIndicatorContainer aria-live="polite">
             <LoadingOrb aria-hidden="true">
-                <Sphere colors={ORB_COLORS.running} energy={ORB_ENERGY.running} />
+                <Sphere colors={runningColors} energy={ORB_ENERGY.running} />
                 <Gloss />
             </LoadingOrb>
             {/* Keyed so a changed label remounts and replays the enter animation. */}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Welcome/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Welcome/index.tsx
@@ -71,7 +71,11 @@ const WelcomeOrbHalo = styled.div`
         position: absolute;
         inset: -14px;
         border-radius: 50%;
-        background: radial-gradient(circle, rgba(107, 92, 232, 0.28), rgba(241, 78, 35, 0.12) 42%, transparent 70%);
+        background: radial-gradient(
+            circle,
+            color-mix(in srgb, var(--vscode-button-background) 28%, transparent),
+            transparent 70%
+        );
         filter: blur(8px);
         pointer-events: none;
     }
@@ -154,7 +158,7 @@ const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ isOnboarding = false })
                             <Icon
                                 name="bi-ai-chat"
                                 sx={{ width: 24, height: 24 }}
-                                iconSx={{ fontSize: "24px", color: "#ffffff", cursor: "default" }}
+                                iconSx={{ fontSize: "24px", color: "var(--vscode-button-foreground)", cursor: "default" }}
                             />
                         </IconOverlay>
                     </WelcomeOrb>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Welcome/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Welcome/index.tsx
@@ -21,10 +21,10 @@ import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Icon, Typography } from "@wso2/ui-toolkit";
 import React, { useCallback, useState } from "react";
 import { ShaderOrb } from "../../../../../components/AgentStatusOrb/ShaderOrb";
+import { useOrbColors } from "../../../../../components/AgentStatusOrb/orbTheme";
 import {
     Gloss,
     IconOverlay,
-    ORB_COLORS,
     ORB_ENERGY,
     Sphere,
 } from "../../../../../components/AgentStatusOrb/shared";
@@ -131,6 +131,7 @@ const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ isOnboarding = false })
     const { rpcClient } = useRpcContext();
     const [webglFailed, setWebglFailed] = useState(false);
     const handleWebglFailed = useCallback(() => setWebglFailed(true), []);
+    const idleColors = useOrbColors("idle");
 
     return (
         <PanelWrapper>
@@ -139,10 +140,10 @@ const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ isOnboarding = false })
                 <WelcomeOrbHalo>
                     <WelcomeOrb role="img" aria-label="WSO2 Integration Intelligence">
                         {webglFailed ? (
-                            <Sphere colors={ORB_COLORS.idle} energy={ORB_ENERGY.idle} />
+                            <Sphere colors={idleColors} energy={ORB_ENERGY.idle} />
                         ) : (
                             <ShaderOrb
-                                colors={ORB_COLORS.idle}
+                                colors={idleColors}
                                 energy={ORB_ENERGY.idle}
                                 size={WELCOME_ORB_SIZE}
                                 onContextFailed={handleWebglFailed}


### PR DESCRIPTION
## Fixes

wso2/product-integrator#2162

## Purpose

Theme the floating orb, landing-page hero box, and AI-panel composer/welcome/footer surfaces to the VS Code accent color instead of the fixed purple/orange gradient palette:

- New `orbTheme.ts`: per-state CSS tokens (`stateColorVar`/`ambientBorderColor`), hex/hsl helpers, `resolveCssColorToHex` (probe-based `var()` resolution for the WebGL shader, which can't read CSS vars), and the `useOrbColors` hook that re-resolves on theme change via a `MutationObserver` on `<html>` (mirrors bi-diagram's ThemeListener).
- Retire `ORB_COLORS`/`BRAND_ORANGE`; `AmbientFrame`, `Sphere`, the orb ring/spinner, glyphs, and the hero send button now use `var(--vscode-*)` tokens.
- Run states stay color-coded via semantic tokens (`charts-yellow`/`green`, `errorForeground`); drop the running-state hue-rotate that would rainbow a single accent.
- Floor the composer/hero frame border toward `--vscode-focusBorder` so it stays visible when the accent is close to the panel background.
- Shader/energy tuning so the single-hue orb still reads as alive (crisper light/dark sweep bands, wider brightness swing, raised per-state flow energy).

## Tests

- `orbTheme.test.ts` covering the pure color helpers — `runStateColor` token mapping, hex/hsl conversion, and `resolveCssColorToHex`.

## Screen shots
<img width="1128" height="356" alt="Screenshot 2026-08-11 at 11 15 58" src="https://github.com/user-attachments/assets/b49707ba-1948-4dd3-b268-1f3eb466ea9d" />
<img width="526" height="329" alt="Screenshot 2026-08-11 at 11 15 43" src="https://github.com/user-attachments/assets/82da8920-97bb-4973-b7a7-46d467f1d68d" />
<img width="1110" height="366" alt="Screenshot 2026-08-11 at 11 18 14" src="https://github.com/user-attachments/assets/2741e918-2854-4cd4-aabf-3e4253f257d8" />
<img width="471" height="184" alt="Screenshot 2026-08-11 at 11 18 24" src="https://github.com/user-attachments/assets/eb701b74-285c-4440-ab9d-f153187abc1a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added VS Code accent-color theming for the orb, hero box, AI composer, welcome panel, and footer.
- Added runtime color updates when the VS Code theme changes.
- Replaced fixed color palettes with semantic VS Code tokens and monochromatic state-based styling.
- Tuned shader flow, brightness, energy, borders, and glow behavior.
- Added tests for color conversion, state mapping, CSS resolution, lightness adjustment, and derived orb colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
