### PR TITLE
Sync PR - Register the create.config.toml command

### DIFF
--- a/packages/ballerina-extension/src/features/project/activator.ts
+++ b/packages/ballerina-extension/src/features/project/activator.ts
@@ -27,6 +27,7 @@ import { activatePasteXMLAsRecord } from "./cmds/xml-to-record";
 import { activatePackCommand } from "./cmds/pack";
 import { activateRenameCommand } from "./cmds/rename";
 import { activateExtractCommand } from "./cmds/extract";
+import { activateCreateConfigTomlCommand } from "./cmds/create-config-toml";
 import { activateConfigRunCommand } from "./cmds/configRun";
 import { activateTryItCommand } from "../tryit/activator";
 import { activateIntegrationRunnerState } from "./integration-runner-state";
@@ -72,4 +73,7 @@ export function activate() {
 
     // activate the extract command
     activateExtractCommand();
+
+    // activate the create Config.toml code action command
+    activateCreateConfigTomlCommand();
 }

--- a/packages/ballerina-extension/src/features/project/cmds/create-config-toml.ts
+++ b/packages/ballerina-extension/src/features/project/cmds/create-config-toml.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/packages/ballerina-extension/src/features/project/cmds/create-config-toml.ts
+++ b/packages/ballerina-extension/src/features/project/cmds/create-config-toml.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { commands, Position, TextDocument, Uri, window, workspace, WorkspaceEdit } from "vscode";
+import * as fs from 'fs';
+
+// Emitted by AddToConfigTomlCodeAction on the language server side when the project has no Config.toml yet.
+const CREATE_CONFIG_TOML_COMMAND = "create.config.toml";
+
+function activateCreateConfigTomlCommand() {
+    // register the create Config.toml code action command handler
+    commands.registerCommand(CREATE_CONFIG_TOML_COMMAND, async (configTomlPath: string, content: string) => {
+        try {
+            // The arguments arrive through command execution, so they are unchecked at runtime.
+            if (typeof configTomlPath !== 'string' || !configTomlPath || typeof content !== 'string') {
+                window.showErrorMessage(
+                    `${CREATE_CONFIG_TOML_COMMAND} expects a non-empty configTomlPath string and a content string.`);
+                return;
+            }
+
+            const uri: Uri = Uri.file(configTomlPath);
+            const edit = new WorkspaceEdit();
+
+            if (fs.existsSync(configTomlPath)) {
+                // The file appeared after the code action was computed. Append instead of prepending so the
+                // existing entries are not pushed below the generated ones.
+                const existing: TextDocument = await workspace.openTextDocument(uri);
+                const endOfFile = existing.lineAt(existing.lineCount - 1).range.end;
+                const prefix = existing.getText().endsWith('\n') || existing.getText().length === 0 ? '' : '\n';
+                edit.insert(uri, endOfFile, `${prefix}${content}`);
+            } else {
+                edit.createFile(uri, { overwrite: false, ignoreIfExists: true });
+                edit.insert(uri, new Position(0, 0), content);
+            }
+
+            if (!await workspace.applyEdit(edit)) {
+                window.showErrorMessage(`Failed to update ${configTomlPath}.`);
+                return;
+            }
+
+            const document: TextDocument = await workspace.openTextDocument(uri);
+            // save() also resolves false for an already-clean document, so only treat it as a
+            // failure while there are still unpersisted changes.
+            if (!await document.save() && document.isDirty) {
+                window.showErrorMessage(`Failed to save ${configTomlPath}.`);
+                return;
+            }
+            await window.showTextDocument(document, { preview: false });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Unknown error occurred.";
+            window.showErrorMessage(`Failed to create Config.toml: ${message}`);
+        }
+    });
+}
+
+export { activateCreateConfigTomlCommand };


### PR DESCRIPTION
The "Add to Config.toml" / "Add all to Config.toml" code actions return a command-based code action when the project has no Config.toml yet, leaving the file creation to the extension (AddToConfigTomlCodeAction passes the target path and the generated entries as the two command arguments). That handler was added in the ballerina extension by #3303 under src/project/cmds, but was not carried over when the tree moved to src/features/project, so the command has had no handler since.

Restore it at the current path, so selecting the code action creates Config.toml with the generated entries instead of failing with "command 'create.config.toml' not found".

Fixes wso2/product-integrator#2033
Sync of wso2/vscode-extensions#2456

The upstream PR also carried Trivy dependency work (.trivyignore, pnpm-config.json, .pnpmfile.cjs and the lockfiles). That is not ported here: this repo keeps its own dependency tree and already carries equivalent overrides for those advisories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Restores the `create.config.toml` command handler.
- Enables the “Add to Config.toml” and “Add all to Config.toml” code actions.
- Creates or updates `Config.toml` from generated entries.
- Adds validation and error handling for file edits, saves, and unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->