### PR TITLE
Fix agent mode leaking into a new chat and a misleading back arrow

### DIFF
--- a/packages/ballerina-visualizer/src/views/AIPanel/McpManagerPanel/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/McpManagerPanel/index.tsx
@@ -29,6 +29,7 @@ import { Loader } from "../components/Loader";
 
 interface Props {
     onClose: () => void;
+    backTooltip?: string;
 }
 
 // ── Layout ────────────────────────────────────────────────────────────────────
@@ -525,7 +526,7 @@ function scopeHelperText(scope: McpScope): string {
     return "Available across all your projects";
 }
 
-export const McpManagerPanel: React.FC<Props> = ({ onClose }) => {
+export const McpManagerPanel: React.FC<Props> = ({ onClose, backTooltip }) => {
     const { rpcClient } = useRpcContext();
     const [servers, setServers] = useState<McpServerStatusDTO[]>([]);
     const [loadErrors, setLoadErrors] = useState<McpLoadErrorsDTO>({});
@@ -830,7 +831,7 @@ export const McpManagerPanel: React.FC<Props> = ({ onClose }) => {
     return (
         <AIChatView>
             <PanelHeader>
-                <Button appearance="icon" onClick={onClose} tooltip="Back to chat">
+                <Button appearance="icon" onClick={onClose} tooltip={backTooltip ?? "Back"}>
                     <Codicon name="arrow-left" />
                 </Button>
                 <TitleGroup>

--- a/packages/ballerina-visualizer/src/views/AIPanel/SettingsPanel/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/SettingsPanel/index.tsx
@@ -204,6 +204,7 @@ const CancelLink = styled.button`
 
 interface SettingsPanelProps {
     onClose: () => void;
+    backTooltip?: string;
     onNavigate?: (route: PanelRoute) => void;
     mcpToolsEnabled?: boolean;
 }
@@ -342,7 +343,7 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
     return (
         <AIChatView>
             <PanelHeader>
-                <Button appearance="icon" onClick={() => props.onClose()} tooltip="Back to chat">
+                <Button appearance="icon" onClick={() => props.onClose()} tooltip={props.backTooltip ?? "Back"}>
                     <Codicon name="arrow-left" />
                 </Button>
                 <PanelTitle>Settings</PanelTitle>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -86,12 +86,11 @@ import { useFooterLogic } from "./Footer/useFooterLogic";
 import { SettingsPanel } from "../../SettingsPanel";
 import { McpManagerPanel } from "../../McpManagerPanel";
 
-/** Full-page panels reachable from the chat. The chat itself is the empty stack. */
-export type PanelRoute = "settings" | "mcp" | "skills";
-const PANEL_TITLES: Record<PanelRoute, string> = { settings: "Settings", mcp: "MCP Servers", skills: "Skills" };
+export type { PanelRoute } from "./utils/panelNav";
 import WelcomeMessage from "./Welcome";
 import { getOnboardingOpens, incrementOnboardingOpens, convertToUIMessages, isContainsSyntaxError } from "./utils/utils";
 import { applyGenerationStatus, deriveReviewBarState, PanelMessage } from "./utils/reviewBarState";
+import { backTooltipFor, PanelRoute } from "./utils/panelNav";
 import {
     serializeStream, parseStream, appendToLastEntry, upsertComponent, upsertRequestCard,
     buildRequestCardData, buildPlanItem, applyPlanApprovalResolution, appendAbortMarker, applyTaskWriteResult,
@@ -365,7 +364,7 @@ const AIChat: React.FC = () => {
     const activePanel = panelStack[panelStack.length - 1];
     const pushPanel = (route: PanelRoute) => setPanelStack(s => [...s, route]);
     const popPanel = () => setPanelStack(s => s.slice(0, -1));
-    const backTooltip = `Back to ${PANEL_TITLES[panelStack[panelStack.length - 2]] ?? "chat"}`;
+    const backTooltip = backTooltipFor(panelStack);
     const [isAutoApproveEnabled, setIsAutoApproveEnabled] = useState(false);
     const [isWebToolsEnabled, setIsWebToolsEnabled] = useState(false);
     const userWebSearchPreferenceRef = useRef(false);

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -88,6 +88,7 @@ import { McpManagerPanel } from "../../McpManagerPanel";
 
 /** Full-page panels reachable from the chat. The chat itself is the empty stack. */
 export type PanelRoute = "settings" | "mcp" | "skills";
+const PANEL_TITLES: Record<PanelRoute, string> = { settings: "Settings", mcp: "MCP Servers", skills: "Skills" };
 import WelcomeMessage from "./Welcome";
 import { getOnboardingOpens, incrementOnboardingOpens, convertToUIMessages, isContainsSyntaxError } from "./utils/utils";
 import { applyGenerationStatus, deriveReviewBarState, PanelMessage } from "./utils/reviewBarState";
@@ -364,6 +365,7 @@ const AIChat: React.FC = () => {
     const activePanel = panelStack[panelStack.length - 1];
     const pushPanel = (route: PanelRoute) => setPanelStack(s => [...s, route]);
     const popPanel = () => setPanelStack(s => s.slice(0, -1));
+    const backTooltip = `Back to ${PANEL_TITLES[panelStack[panelStack.length - 2]] ?? "chat"}`;
     const [isAutoApproveEnabled, setIsAutoApproveEnabled] = useState(false);
     const [isWebToolsEnabled, setIsWebToolsEnabled] = useState(false);
     const userWebSearchPreferenceRef = useRef(false);
@@ -3008,10 +3010,10 @@ const AIChat: React.FC = () => {
                 </AIChatView>
             )}
             {activePanel === "settings" && (
-                <SettingsPanel onClose={popPanel} onNavigate={pushPanel} mcpToolsEnabled={mcpToolsEnabled} />
+                <SettingsPanel onClose={popPanel} backTooltip={backTooltip} onNavigate={pushPanel} mcpToolsEnabled={mcpToolsEnabled} />
             )}
-            {activePanel === "mcp" && <McpManagerPanel onClose={popPanel} />}
-            {activePanel === "skills" && <SkillsManager onClose={popPanel} onSkillsChange={refreshSkills} />}
+            {activePanel === "mcp" && <McpManagerPanel onClose={popPanel} backTooltip={backTooltip} />}
+            {activePanel === "skills" && <SkillsManager onClose={popPanel} backTooltip={backTooltip} onSkillsChange={refreshSkills} />}
         </>
     );
 };

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -1540,6 +1540,7 @@ const AIChat: React.FC = () => {
             setIsCodeLoading(false);
             setIsLoading(false);
             setBackendRequestTriggered(false);
+            setAgentMode(AgentMode.Edit);
             if (isMigrationEnhancementRunning) {
                 setIsMigrationEnhancementRunning(false);
                 // Re-fetch session so the Resume card appears
@@ -2190,6 +2191,7 @@ const AIChat: React.FC = () => {
         setApprovalRequest(null);
         setContextUsage(null);
         setFollowupSuggestions([]);
+        setAgentMode(AgentMode.Edit);
         await rpcClient.getAiPanelRpcClient().clearChat();
         loadThreads();
     }

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/utils/panelNav.test.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/utils/panelNav.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// L1: the back arrow's label is the only thing telling the user where it goes, and the same arrow
+// serves every panel — so the label has to come from the stack, not from where the panel was reached
+// most often. MCP reached from Settings returning to Settings under a "Back to chat" tooltip is the
+// case that shipped.
+
+import { backTooltipFor, PanelRoute } from "./panelNav";
+
+describe("panel back-arrow tooltip", () => {
+    it("names the chat one level deep", () => {
+        expect(backTooltipFor(["settings"])).toBe("Back to chat");
+        expect(backTooltipFor(["mcp"])).toBe("Back to chat");
+    });
+
+    it("names the panel underneath when nested", () => {
+        expect(backTooltipFor(["settings", "mcp"])).toBe("Back to Settings");
+        expect(backTooltipFor(["settings", "skills"])).toBe("Back to Settings");
+    });
+
+    it("names the immediate parent, not the bottom of the stack", () => {
+        expect(backTooltipFor(["settings", "skills", "mcp"])).toBe("Back to Skills");
+    });
+
+    it("falls back to the chat for an empty stack", () => {
+        expect(backTooltipFor([])).toBe("Back to chat");
+    });
+
+    it("covers every route as a parent", () => {
+        const routes: PanelRoute[] = ["settings", "mcp", "skills"];
+        const labels = routes.map((parent) => backTooltipFor([parent, "mcp"]));
+        expect(labels).toEqual(["Back to Settings", "Back to MCP Servers", "Back to Skills"]);
+    });
+});

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/utils/panelNav.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/utils/panelNav.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** Full-page panels reachable from the chat. The chat itself is the empty stack. */
+export type PanelRoute = "settings" | "mcp" | "skills";
+
+const PANEL_TITLES: Record<PanelRoute, string> = {
+    settings: "Settings",
+    mcp: "MCP Servers",
+    skills: "Skills",
+};
+
+/** The arrow pops one level, so it has to name that level rather than always claiming the chat. */
+export function backTooltipFor(panelStack: PanelRoute[]): string {
+    return `Back to ${PANEL_TITLES[panelStack[panelStack.length - 2]] ?? "chat"}`;
+}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SkillsManager/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SkillsManager/index.tsx
@@ -152,10 +152,11 @@ const EmptyMessage = styled.div`
 
 interface SkillsManagerProps {
     onClose: () => void;
+    backTooltip?: string;
     onSkillsChange?: () => void;
 }
 
-const SkillsManager: React.FC<SkillsManagerProps> = ({ onClose, onSkillsChange }) => {
+const SkillsManager: React.FC<SkillsManagerProps> = ({ onClose, backTooltip, onSkillsChange }) => {
     const { rpcClient } = useRpcContext();
     const [skills, setSkills] = useState<SkillEntry[]>([]);
     const [isLoading, setIsLoading] = useState(false);
@@ -274,7 +275,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ onClose, onSkillsChange }
     return (
         <AIChatView>
             <PanelHeader>
-                <Button appearance="icon" onClick={onClose} tooltip="Back">
+                <Button appearance="icon" onClick={onClose} tooltip={backTooltip ?? "Back"}>
                     <Codicon name="arrow-left" />
                 </Button>
                 <TitleGroup>


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2074
Related to https://github.com/wso2/product-integrator/issues/2075

- Reset the agent mode to Edit when a new chat starts — Plan mode is a per-turn choice, but New Chat
  kept it, so the next chat opened asking "What would you like to plan?"
- Reset it on abort as well, so the mode no longer depends on whether a run finished or was stopped
  (a completed run already reset it)
- Derive the settings/MCP/skills back arrow's tooltip from the panel stack, so it names where it
  actually goes — the MCP panel's arrow said "Back to chat" even when opened from Settings, which is
  where it returns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Reset agent mode to `Edit` when a new chat starts or a run is aborted.
- Set back-arrow tooltips for Settings, MCP, and Skills panels from the panel stack.
- Add optional `backTooltip` props to the panel components.
- Use `Back` as the default tooltip when no destination is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->