### PR TITLE
Index smb icon in the icon registry

### DIFF
--- a/packages/ballerina-core/src/icons/brand-icon-registry.ts
+++ b/packages/ballerina-core/src/icons/brand-icon-registry.ts
@@ -50,6 +50,7 @@ export const BRAND_ICON_REGISTRY: Record<string, BrandIcon> = {
     mcp: { glyph: "bi-mcp" },
     solace: { glyph: "bi-solace", color: "#00C895" },
     ftp: { glyph: "bi-ftp" },
+    smb: { glyph: "bi-smb" },
     file: { glyph: "bi-file" },
     mssql: { glyph: "bi-mssql", color: "#b61d1c" },
     postgresql: { glyph: "bi-postgresql", color: "#336791" },


### PR DESCRIPTION
## Purpose
> Fixes: 
https://github.com/wso2/product-integrator/issues/2123
https://github.com/ballerina-platform/ballerina-vscode/issues/836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added the SMB icon to `BRAND_ICON_REGISTRY` using the `bi-smb` glyph. This fixes the white background shown for the SMB icon in dark theme when users select “+ Add Artifact”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->