### PR TITLE
Add human-in-the-loop approval for agent tools

### DIFF
--- a/packages/ballerina-core/src/interfaces/service.ts
+++ b/packages/ballerina-core/src/interfaces/service.ts
@@ -305,6 +305,7 @@ export interface PropertyModel {
     advanced?: boolean;
     items?: string[];
     allowItemCreate?: boolean;
+    showOptionalSuffix?: boolean;
     choices?: PropertyModel[];
     properties?: ConfigProperties;
     addNewButton?: boolean;

--- a/packages/ballerina-core/src/interfaces/service.ts
+++ b/packages/ballerina-core/src/interfaces/service.ts
@@ -304,6 +304,7 @@ export interface PropertyModel {
     optional?: boolean;
     advanced?: boolean;
     items?: string[];
+    allowItemCreate?: boolean;
     choices?: PropertyModel[];
     properties?: ConfigProperties;
     addNewButton?: boolean;

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
@@ -655,10 +655,13 @@ public class AgentToolBuilder extends NodeBuilder {
         if (predicateName.isEmpty()) {
             return;
         }
-        // Mirror the tool's own signature exactly, using the same param list generate() built it
-        // from (stashed on ctx) — each ToolKind resolves params differently, so this must not
-        // recompute with a fixed kind.
+        // Mirror the tool's own signature, using the same param list generate() built it from
+        // (stashed on ctx) — each ToolKind resolves params differently, so this must not recompute
+        // with a fixed kind. The leading `ai:Context ctx` param is excluded: the `ai` compiler
+        // plugin strips it from the tool's own signature before comparing against the predicate's,
+        // so including it here would make the predicate's signature look mismatched.
         String paramDecls = ctx.resolvedParams.stream()
+                .filter(param -> !(ctx.includeContext && "ctx".equals(param.name())))
                 .map(ToolParam::decl)
                 .collect(Collectors.joining(", "));
         ctx.sb.token()

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
@@ -628,13 +628,13 @@ public class AgentToolBuilder extends NodeBuilder {
 
     // Emit a sibling `isolated function` predicate stub for the @ai:AgentTool `requiresApproval` gate,
     // when the form requested one (codedata.data.generateApprovalFunction == "true"). The predicate
-    // mirrors the tool wrapper's own parameter list (the exact list its signature was built from,
-    // via the same FUNCTION.resolveParams) and returns boolean, satisfying the RequiresApproval
-    // contract (the ai module binds the proposed call's arguments to the predicate by name). Its
-    // name is the `requiresApproval` annotation value. Must be called AFTER the tool declaration has
-    // been flushed via textEdit(DECLARATION) (so the token buffer is empty); it appends a second
-    // DECLARATION text edit to the same file, which build() returns alongside the tool's. FUNCTION
-    // kind only — matches the original feature's scope (Create Tool from Function).
+    // mirrors the tool wrapper's own parameter list (the exact list its signature was built from) and
+    // returns boolean, satisfying the RequiresApproval contract (the ai module binds the proposed
+    // call's arguments to the predicate by name). Its name is the `requiresApproval` annotation value.
+    // Must be called AFTER the tool declaration has been flushed via textEdit(DECLARATION) (so the
+    // token buffer is empty); it appends a second DECLARATION text edit to the same file, which
+    // build() returns alongside the tool's. Called from buildFunctionBody, buildRemoteActionBody, and
+    // buildResourceActionBody — i.e. every ToolKind that reaches this via a real wrapped node.
     private static void appendApprovalPredicate(ToolGenContext ctx) {
         Map<String, Object> data = ctx.wrappedNode != null ? ctx.wrappedNode.codedata().data() : null;
         if (data == null || !"true".equals(String.valueOf(data.get("generateApprovalFunction")))) {
@@ -645,6 +645,8 @@ public class AgentToolBuilder extends NodeBuilder {
         if (predicateName.isEmpty()) {
             return;
         }
+        // resolveParams is the shared enum-level default (only AGENT_CALL overrides it), so any
+        // ToolKind constant yields the same result here — FUNCTION is used as a stand-in.
         String paramDecls = ToolKind.FUNCTION.resolveParams(ctx).stream()
                 .map(ToolParam::decl)
                 .collect(Collectors.joining(", "));
@@ -682,7 +684,7 @@ public class AgentToolBuilder extends NodeBuilder {
                 .stepOut()
                 .functionParameters(flowNode, ignoredKeys);
 
-        return finishActionBody(sourceBuilder, flowNode, returnType);
+        return finishActionBody(ctx, flowNode, returnType);
     }
 
     private static Map<Path, List<TextEdit>> buildResourceActionBody(ToolGenContext ctx, ReturnInfo returnInfo) {
@@ -748,7 +750,7 @@ public class AgentToolBuilder extends NodeBuilder {
                 .stepOut()
                 .functionParameters(flowNode, ignoredKeys);
 
-        return finishActionBody(sourceBuilder, flowNode, returnType);
+        return finishActionBody(ctx, flowNode, returnType);
     }
 
     private static void beginActionBody(SourceBuilder sourceBuilder, FlowNode flowNode, String returnType) {
@@ -762,8 +764,9 @@ public class AgentToolBuilder extends NodeBuilder {
         }
     }
 
-    private static Map<Path, List<TextEdit>> finishActionBody(SourceBuilder sourceBuilder, FlowNode flowNode,
+    private static Map<Path, List<TextEdit>> finishActionBody(ToolGenContext ctx, FlowNode flowNode,
                                                                 String returnType) {
+        SourceBuilder sourceBuilder = ctx.sb;
         if (!returnType.isEmpty()) {
             sourceBuilder.token().keyword(SyntaxKind.RETURN_KEYWORD)
                     .name(flowNode.getProperty(Property.VARIABLE_KEY).orElseThrow().value().toString())
@@ -772,6 +775,9 @@ public class AgentToolBuilder extends NodeBuilder {
         sourceBuilder.token().keyword(SyntaxKind.CLOSE_BRACE_TOKEN);
         sourceBuilder.textEdit(SourceBuilder.SourceKind.DECLARATION);
         sourceBuilder.acceptImport();
+        // If the form asked to scaffold a conditional-approval predicate, emit it as a sibling
+        // declaration reusing the tool wrapper's exact parameter list (mirrors buildFunctionBody).
+        appendApprovalPredicate(ctx);
         return sourceBuilder.build();
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
@@ -233,6 +233,7 @@ public class AgentToolBuilder extends NodeBuilder {
     private static Map<Path, List<TextEdit>> generate(ToolKind kind, ToolGenContext ctx) {
         ctx.sb.acceptImport(Constants.Ai.BALLERINA_ORG, Constants.Ai.AI_PACKAGE);
         List<ToolParam> params = kind.resolveParams(ctx);
+        ctx.resolvedParams = params;
         ReturnInfo returnInfo = kind.resolveReturn(ctx);
 
         emitDoc(ctx, params, returnInfo);
@@ -639,12 +640,12 @@ public class AgentToolBuilder extends NodeBuilder {
     // call's arguments to the predicate by name). Its name is the `requiresApproval` annotation value.
     // Must be called AFTER the tool declaration has been flushed via textEdit(DECLARATION) (so the
     // token buffer is empty); it appends a second DECLARATION text edit to the same file, which
-    // build() returns alongside the tool's. Called from buildFunctionBody, buildRemoteActionBody,
-    // buildResourceActionBody, and CUSTOM's buildBody — every ToolKind whose form exposes the
-    // "Requires Approval" gate.
+    // build() returns alongside the tool's. Called from every ToolKind's body builder
+    // (buildFunctionBody, buildRemoteActionBody, buildResourceActionBody, CUSTOM's buildBody, and
+    // buildAgentCallBody) — every path whose form exposes the "Requires Approval" gate.
     private static void appendApprovalPredicate(ToolGenContext ctx) {
-        // CUSTOM tools have no wrapped node — generateApprovalFunction/requiresApproval live
-        // directly on the tool's own data (ctx.data) instead, mirroring emitAnnotation's fallback.
+        // CUSTOM and AGENT_CALL tools have no wrapped node — generateApprovalFunction/requiresApproval
+        // live directly on the tool's own data (ctx.data) instead, mirroring emitAnnotation's fallback.
         Map<String, Object> data = ctx.wrappedNode != null ? ctx.wrappedNode.codedata().data() : ctx.data;
         if (data == null || !"true".equals(String.valueOf(data.get("generateApprovalFunction")))) {
             return;
@@ -654,9 +655,10 @@ public class AgentToolBuilder extends NodeBuilder {
         if (predicateName.isEmpty()) {
             return;
         }
-        // resolveParams is the shared enum-level default (only AGENT_CALL overrides it), so any
-        // ToolKind constant yields the same result here — FUNCTION is used as a stand-in.
-        String paramDecls = ToolKind.FUNCTION.resolveParams(ctx).stream()
+        // Mirror the tool's own signature exactly, using the same param list generate() built it
+        // from (stashed on ctx) — each ToolKind resolves params differently, so this must not
+        // recompute with a fixed kind.
+        String paramDecls = ctx.resolvedParams.stream()
                 .map(ToolParam::decl)
                 .collect(Collectors.joining(", "));
         ctx.sb.token()
@@ -814,6 +816,7 @@ public class AgentToolBuilder extends NodeBuilder {
                 .endOfStatement();
         sourceBuilder.token().keyword(SyntaxKind.CLOSE_BRACE_TOKEN);
         sourceBuilder.textEdit(SourceBuilder.SourceKind.DECLARATION).acceptImport();
+        appendApprovalPredicate(ctx);
         return sourceBuilder.build();
     }
 
@@ -1119,6 +1122,10 @@ public class AgentToolBuilder extends NodeBuilder {
         private final String agentReceiver;
         private final String hostClassName;
         private final boolean includeContext;
+        // The tool signature's parameter list, stashed by generate() so appendApprovalPredicate can
+        // mirror it exactly (each ToolKind resolves params differently — AGENT_CALL uses `query`,
+        // not the wrapped node's params — so recomputing with a fixed kind would be wrong).
+        private List<ToolParam> resolvedParams = List.of();
 
         private ToolGenContext(SourceBuilder sb, FlowNode wrappedNode, Map<String, Object> data,
                                String connection, String description,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
@@ -288,27 +288,35 @@ public class AgentToolBuilder extends NodeBuilder {
         }
     }
 
-    private static void emitAnnotation(ToolGenContext ctx) {
-        // CUSTOM tools (and AGENT_CALL) have no wrapped node — auth/requiresApproval live directly
-        // on the tool's own data (ctx.data) instead. Checking both keys (not just "auth") keeps a
-        // custom tool's requiresApproval from being dropped when auth was never set.
-        boolean useTopLevelData = ctx.data != null
-                && (ctx.data.containsKey("auth") || ctx.data.containsKey("requiresApproval"));
-        Map<String, Object> data = useTopLevelData
-                ? ctx.data
-                : ctx.wrappedNode != null ? ctx.wrappedNode.codedata().data() : null;
-        if (data == null) {
-            ctx.sb.token().name("@ai:AgentTool").name(System.lineSeparator());
-            return;
+    // Looks up a single annotation-data key across both places it can live: the tool's own data
+    // (ctx.data — authoritative for CUSTOM/AGENT_CALL, which have no wrapped node) and the wrapped
+    // node's data (where the form originally writes auth/requiresApproval for FUNCTION/REMOTE/
+    // RESOURCE tools). ctx.data wins when both have the key. Resolving key-by-key — instead of
+    // picking one map wholesale for every field — means a key present in only one of the two maps
+    // is never silently dropped, and emitAnnotation/appendApprovalPredicate can't disagree about
+    // where a given field lives.
+    private static Object resolveToolData(ToolGenContext ctx, String key) {
+        if (ctx.data != null && ctx.data.containsKey(key)) {
+            return ctx.data.get(key);
         }
+        if (ctx.wrappedNode != null) {
+            Map<String, Object> wrappedData = ctx.wrappedNode.codedata().data();
+            if (wrappedData != null && wrappedData.containsKey(key)) {
+                return wrappedData.get(key);
+            }
+        }
+        return null;
+    }
 
+    private static void emitAnnotation(ToolGenContext ctx) {
         // Each entry is a fully-rendered mapping field (already indented) to place inside the
         // `@ai:AgentTool { ... }` record. When empty, a bare `@ai:AgentTool` is emitted instead.
         List<String> annotationFields = new ArrayList<>();
 
         // auth: { ... } — OAuth client configuration block.
-        if (data.containsKey("auth")) {
-            String authStr = data.get("auth").toString();
+        Object authValue = resolveToolData(ctx, "auth");
+        if (authValue != null) {
+            String authStr = authValue.toString();
             JsonObject authConfig = gson.fromJson(authStr, JsonObject.class);
 
             List<String> fields = new ArrayList<>();
@@ -352,9 +360,9 @@ public class AgentToolBuilder extends NodeBuilder {
 
         // requiresApproval: <boolean|isolated function> — human-in-the-loop gate. The value is
         // emitted verbatim: "true" for the toggle, or an identifier for a predicate function pointer.
-        if (data.containsKey("requiresApproval")) {
-            Object approvalValue = data.get("requiresApproval");
-            String approval = approvalValue == null ? "" : approvalValue.toString().trim();
+        Object approvalValue = resolveToolData(ctx, "requiresApproval");
+        if (approvalValue != null) {
+            String approval = approvalValue.toString().trim();
             if (!approval.isEmpty()) {
                 annotationFields.add("    requiresApproval: " + approval);
             }
@@ -644,13 +652,12 @@ public class AgentToolBuilder extends NodeBuilder {
     // (buildFunctionBody, buildRemoteActionBody, buildResourceActionBody, CUSTOM's buildBody, and
     // buildAgentCallBody) — every path whose form exposes the "Requires Approval" gate.
     private static void appendApprovalPredicate(ToolGenContext ctx) {
-        // CUSTOM and AGENT_CALL tools have no wrapped node — generateApprovalFunction/requiresApproval
-        // live directly on the tool's own data (ctx.data) instead, mirroring emitAnnotation's fallback.
-        Map<String, Object> data = ctx.wrappedNode != null ? ctx.wrappedNode.codedata().data() : ctx.data;
-        if (data == null || !"true".equals(String.valueOf(data.get("generateApprovalFunction")))) {
+        // Same per-key resolution as emitAnnotation, so the two can't disagree about whether the
+        // gate is set or which name it uses.
+        if (!"true".equals(String.valueOf(resolveToolData(ctx, "generateApprovalFunction")))) {
             return;
         }
-        Object approvalValue = data.get("requiresApproval");
+        Object approvalValue = resolveToolData(ctx, "requiresApproval");
         String predicateName = approvalValue == null ? "" : approvalValue.toString().trim();
         if (predicateName.isEmpty()) {
             return;

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
@@ -291,60 +291,79 @@ public class AgentToolBuilder extends NodeBuilder {
         Map<String, Object> data = ctx.data != null && ctx.data.containsKey("auth")
                 ? ctx.data
                 : ctx.wrappedNode != null ? ctx.wrappedNode.codedata().data() : null;
-        if (data == null || !data.containsKey("auth")) {
+        if (data == null) {
             ctx.sb.token().name("@ai:AgentTool").name(System.lineSeparator());
             return;
         }
 
-        String authStr = data.get("auth").toString();
-        JsonObject authConfig = gson.fromJson(authStr, JsonObject.class);
+        // Each entry is a fully-rendered mapping field (already indented) to place inside the
+        // `@ai:AgentTool { ... }` record. When empty, a bare `@ai:AgentTool` is emitted instead.
+        List<String> annotationFields = new ArrayList<>();
 
-        StringBuilder sb = new StringBuilder();
-        sb.append("@ai:AgentTool {").append(System.lineSeparator());
-        sb.append("    auth: {").append(System.lineSeparator());
+        // auth: { ... } — OAuth client configuration block.
+        if (data.containsKey("auth")) {
+            String authStr = data.get("auth").toString();
+            JsonObject authConfig = gson.fromJson(authStr, JsonObject.class);
 
-        List<String> fields = new ArrayList<>();
-        for (Map.Entry<String, JsonElement> entry : authConfig.entrySet()) {
-            String key = entry.getKey();
-            JsonElement valueElement = entry.getValue();
-            String value = valueElement.isJsonArray() ? valueElement.toString() : valueElement.getAsString();
+            List<String> fields = new ArrayList<>();
+            for (Map.Entry<String, JsonElement> entry : authConfig.entrySet()) {
+                String key = entry.getKey();
+                JsonElement valueElement = entry.getValue();
+                String value = valueElement.isJsonArray() ? valueElement.toString() : valueElement.getAsString();
 
-            if (value == null || value.isEmpty() || value.equals("()") || value.trim().matches("\\{\\s*}")) {
-                continue;
-            }
-
-            if (key.equals("scopes")) {
-                if (value.startsWith("[") && value.endsWith("]")) {
-                    fields.add("        " + key + ": " + value);
+                if (value == null || value.isEmpty() || value.equals("()") || value.trim().matches("\\{\\s*}")) {
                     continue;
                 }
-                String[] scopeParts = value.split(",");
-                List<String> scopeItems = new ArrayList<>();
-                for (String part : scopeParts) {
-                    String trimmed = part.trim();
-                    if (!trimmed.isEmpty()) {
-                        scopeItems.add(trimmed);
+
+                if (key.equals("scopes")) {
+                    if (value.startsWith("[") && value.endsWith("]")) {
+                        fields.add("        " + key + ": " + value);
+                        continue;
                     }
+                    String[] scopeParts = value.split(",");
+                    List<String> scopeItems = new ArrayList<>();
+                    for (String part : scopeParts) {
+                        String trimmed = part.trim();
+                        if (!trimmed.isEmpty()) {
+                            scopeItems.add(trimmed);
+                        }
+                    }
+                    if (scopeItems.isEmpty()) {
+                        continue;
+                    }
+                    fields.add("        " + key + ": [" + String.join(", ", scopeItems) + "]");
+                } else {
+                    fields.add("        " + key + ": " + value);
                 }
-                if (scopeItems.isEmpty()) {
-                    continue;
-                }
-                fields.add("        " + key + ": [" + String.join(", ", scopeItems) + "]");
-            } else {
-                fields.add("        " + key + ": " + value);
+            }
+
+            if (!fields.isEmpty()) {
+                annotationFields.add("    auth: {" + System.lineSeparator()
+                        + String.join("," + System.lineSeparator(), fields) + System.lineSeparator()
+                        + "    }");
             }
         }
 
-        if (fields.isEmpty()) {
+        // requiresApproval: <boolean|isolated function> — human-in-the-loop gate. The value is
+        // emitted verbatim: "true" for the toggle, or an identifier for a predicate function pointer.
+        if (data.containsKey("requiresApproval")) {
+            Object approvalValue = data.get("requiresApproval");
+            String approval = approvalValue == null ? "" : approvalValue.toString().trim();
+            if (!approval.isEmpty()) {
+                annotationFields.add("    requiresApproval: " + approval);
+            }
+        }
+
+        if (annotationFields.isEmpty()) {
             ctx.sb.token().name("@ai:AgentTool").name(System.lineSeparator());
             return;
         }
 
-        sb.append(String.join("," + System.lineSeparator(), fields)).append(System.lineSeparator());
-        sb.append("    }").append(System.lineSeparator());
-        sb.append("}");
+        String sb = "@ai:AgentTool {" + System.lineSeparator()
+                + String.join("," + System.lineSeparator(), annotationFields) + System.lineSeparator()
+                + "}";
 
-        ctx.sb.token().name(sb.toString()).name(System.lineSeparator());
+        ctx.sb.token().name(sb).name(System.lineSeparator());
     }
 
     private enum ToolKind {
@@ -595,6 +614,9 @@ public class AgentToolBuilder extends NodeBuilder {
         sourceBuilder.token()
                 .keyword(SyntaxKind.CLOSE_BRACE_TOKEN);
         sourceBuilder.textEdit(SourceBuilder.SourceKind.DECLARATION).acceptImport();
+        // If the form asked to scaffold a conditional-approval predicate, emit it as a sibling
+        // declaration reusing the tool wrapper's exact parameter list.
+        appendApprovalPredicate(ctx);
         Map<Path, List<TextEdit>> textEdits = sourceBuilder.build();
         List<TextEdit> te = new ArrayList<>();
         Path p = addIsolateKeyword(ctx.semanticModel, funcName.trim(), ctx.filePath, te, ctx.workspaceManager);
@@ -602,6 +624,48 @@ public class AgentToolBuilder extends NodeBuilder {
             textEdits.computeIfAbsent(p, ignored -> new ArrayList<>()).addAll(te);
         }
         return textEdits;
+    }
+
+    // Emit a sibling `isolated function` predicate stub for the @ai:AgentTool `requiresApproval` gate,
+    // when the form requested one (codedata.data.generateApprovalFunction == "true"). The predicate
+    // mirrors the tool wrapper's own parameter list (the exact list its signature was built from,
+    // via the same FUNCTION.resolveParams) and returns boolean, satisfying the RequiresApproval
+    // contract (the ai module binds the proposed call's arguments to the predicate by name). Its
+    // name is the `requiresApproval` annotation value. Must be called AFTER the tool declaration has
+    // been flushed via textEdit(DECLARATION) (so the token buffer is empty); it appends a second
+    // DECLARATION text edit to the same file, which build() returns alongside the tool's. FUNCTION
+    // kind only — matches the original feature's scope (Create Tool from Function).
+    private static void appendApprovalPredicate(ToolGenContext ctx) {
+        Map<String, Object> data = ctx.wrappedNode != null ? ctx.wrappedNode.codedata().data() : null;
+        if (data == null || !"true".equals(String.valueOf(data.get("generateApprovalFunction")))) {
+            return;
+        }
+        Object approvalValue = data.get("requiresApproval");
+        String predicateName = approvalValue == null ? "" : approvalValue.toString().trim();
+        if (predicateName.isEmpty()) {
+            return;
+        }
+        String paramDecls = ToolKind.FUNCTION.resolveParams(ctx).stream()
+                .map(ToolParam::decl)
+                .collect(Collectors.joining(", "));
+        ctx.sb.token()
+                .keyword(SyntaxKind.ISOLATED_KEYWORD)
+                .keyword(SyntaxKind.FUNCTION_KEYWORD)
+                .name(predicateName)
+                .keyword(SyntaxKind.OPEN_PAREN_TOKEN)
+                .name(paramDecls)
+                .keyword(SyntaxKind.CLOSE_PAREN_TOKEN)
+                .keyword(SyntaxKind.RETURNS_KEYWORD)
+                .name("boolean")
+                .keyword(SyntaxKind.OPEN_BRACE_TOKEN)
+                .newLine()
+                .comment("// TODO: inspect the proposed arguments and return true to require approval")
+                .newLine()
+                .keyword(SyntaxKind.RETURN_KEYWORD)
+                .name("true")
+                .endOfStatement()
+                .keyword(SyntaxKind.CLOSE_BRACE_TOKEN);
+        ctx.sb.textEdit(SourceBuilder.SourceKind.DECLARATION);
     }
 
     private static Map<Path, List<TextEdit>> buildRemoteActionBody(ToolGenContext ctx, ReturnInfo returnInfo) {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
@@ -288,7 +288,12 @@ public class AgentToolBuilder extends NodeBuilder {
     }
 
     private static void emitAnnotation(ToolGenContext ctx) {
-        Map<String, Object> data = ctx.data != null && ctx.data.containsKey("auth")
+        // CUSTOM tools (and AGENT_CALL) have no wrapped node — auth/requiresApproval live directly
+        // on the tool's own data (ctx.data) instead. Checking both keys (not just "auth") keeps a
+        // custom tool's requiresApproval from being dropped when auth was never set.
+        boolean useTopLevelData = ctx.data != null
+                && (ctx.data.containsKey("auth") || ctx.data.containsKey("requiresApproval"));
+        Map<String, Object> data = useTopLevelData
                 ? ctx.data
                 : ctx.wrappedNode != null ? ctx.wrappedNode.codedata().data() : null;
         if (data == null) {
@@ -391,6 +396,7 @@ public class AgentToolBuilder extends NodeBuilder {
                 }
                 ctx.sb.token().keyword(SyntaxKind.CLOSE_BRACE_TOKEN);
                 ctx.sb.textEdit(SourceBuilder.SourceKind.DECLARATION).acceptImport();
+                appendApprovalPredicate(ctx);
                 return ctx.sb.build();
             }
         },
@@ -633,10 +639,13 @@ public class AgentToolBuilder extends NodeBuilder {
     // call's arguments to the predicate by name). Its name is the `requiresApproval` annotation value.
     // Must be called AFTER the tool declaration has been flushed via textEdit(DECLARATION) (so the
     // token buffer is empty); it appends a second DECLARATION text edit to the same file, which
-    // build() returns alongside the tool's. Called from buildFunctionBody, buildRemoteActionBody, and
-    // buildResourceActionBody — i.e. every ToolKind that reaches this via a real wrapped node.
+    // build() returns alongside the tool's. Called from buildFunctionBody, buildRemoteActionBody,
+    // buildResourceActionBody, and CUSTOM's buildBody — every ToolKind whose form exposes the
+    // "Requires Approval" gate.
     private static void appendApprovalPredicate(ToolGenContext ctx) {
-        Map<String, Object> data = ctx.wrappedNode != null ? ctx.wrappedNode.codedata().data() : null;
+        // CUSTOM tools have no wrapped node — generateApprovalFunction/requiresApproval live
+        // directly on the tool's own data (ctx.data) instead, mirroring emitAnnotation's fallback.
+        Map<String, Object> data = ctx.wrappedNode != null ? ctx.wrappedNode.codedata().data() : ctx.data;
         if (data == null || !"true".equals(String.valueOf(data.get("generateApprovalFunction")))) {
             return;
         }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/agentsmanager/SourceGeneratorTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/agentsmanager/SourceGeneratorTest.java
@@ -64,6 +64,7 @@ public class SourceGeneratorTest extends AbstractLSTest {
                 {Path.of("custom_agent_tool_approval_unconditional_source.json")},
                 {Path.of("custom_agent_tool_approval_existing_source.json")},
                 {Path.of("custom_agent_tool_approval_generate_source.json")},
+                {Path.of("function_agent_tool_approval_with_auth_source.json")},
                 {Path.of("custom_agent_definition_tool_source.json")},
                 {Path.of("agent_definition_builtin_agent_tool_source.json")},
                 {Path.of("agent_definition_custom_agent_tool_source.json")}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/agentsmanager/SourceGeneratorTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/agentsmanager/SourceGeneratorTest.java
@@ -61,6 +61,9 @@ public class SourceGeneratorTest extends AbstractLSTest {
                 {Path.of("agent_model_source_default.json")},
                 {Path.of("memory_manager_source.json")},
                 {Path.of("custom_agent_tool_source.json")},
+                {Path.of("custom_agent_tool_approval_unconditional_source.json")},
+                {Path.of("custom_agent_tool_approval_existing_source.json")},
+                {Path.of("custom_agent_tool_approval_generate_source.json")},
                 {Path.of("custom_agent_definition_tool_source.json")},
                 {Path.of("agent_definition_builtin_agent_tool_source.json")},
                 {Path.of("agent_definition_custom_agent_tool_source.json")}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/custom_agent_tool_approval_existing_source.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/custom_agent_tool_approval_existing_source.json
@@ -1,0 +1,142 @@
+{
+  "source": "agent_1/agents.bal",
+  "description": "Custom agent tool referencing an existing approval predicate function",
+  "diagram": {
+    "id": "custom-agent-tool",
+    "metadata": {
+      "label": "Agent Tool",
+      "description": ""
+    },
+    "codedata": {
+      "node": "AGENT_TOOL",
+      "isNew": true,
+      "data": {
+        "toolKind": "CUSTOM",
+        "requiresApproval": "isHighValue"
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Name",
+          "description": "Name of the tool"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "lookup",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "functionNameDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the tool"
+        },
+        "valueType": "DOC_TEXT",
+        "value": "Looks up a value.",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "string",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "typeDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the return value"
+        },
+        "valueType": "DOC_TEXT",
+        "value": "The matching value.",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "value": {
+          "query": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "valueType": "TYPE",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "valueType": "IDENTIFIER",
+                "value": "query",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "parameterDescription": {
+                "valueType": "DOC_TEXT",
+                "value": "The lookup query.",
+                "optional": true,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "agent_1/agents.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "import ballerina/ai;"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "# Looks up a value.\n# + query - The lookup query.\n# + return - The matching value.\n@ai:AgentTool {\n    requiresApproval: isHighValue\n}\nisolated function lookup(string query) returns string {\n    panic error(\"not implemented\");\n}"
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/custom_agent_tool_approval_generate_source.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/custom_agent_tool_approval_generate_source.json
@@ -1,0 +1,156 @@
+{
+  "source": "agent_1/agents.bal",
+  "description": "Custom agent tool that scaffolds a new approval predicate mirroring the tool params",
+  "diagram": {
+    "id": "custom-agent-tool",
+    "metadata": {
+      "label": "Agent Tool",
+      "description": ""
+    },
+    "codedata": {
+      "node": "AGENT_TOOL",
+      "isNew": true,
+      "data": {
+        "toolKind": "CUSTOM",
+        "requiresApproval": "requireApproval",
+        "generateApprovalFunction": "true"
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Name",
+          "description": "Name of the tool"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "lookup",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "functionNameDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the tool"
+        },
+        "valueType": "DOC_TEXT",
+        "value": "Looks up a value.",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "string",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "typeDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the return value"
+        },
+        "valueType": "DOC_TEXT",
+        "value": "The matching value.",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "value": {
+          "query": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "valueType": "TYPE",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "valueType": "IDENTIFIER",
+                "value": "query",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "parameterDescription": {
+                "valueType": "DOC_TEXT",
+                "value": "The lookup query.",
+                "optional": true,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "agent_1/agents.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "import ballerina/ai;"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "isolated function requireApproval(string query) returns boolean {\n    // TODO: inspect the proposed arguments and return true to require approval\n    return true;\n}"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "# Looks up a value.\n# + query - The lookup query.\n# + return - The matching value.\n@ai:AgentTool {\n    requiresApproval: requireApproval\n}\nisolated function lookup(string query) returns string {\n    panic error(\"not implemented\");\n}"
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/custom_agent_tool_approval_unconditional_source.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/custom_agent_tool_approval_unconditional_source.json
@@ -1,0 +1,142 @@
+{
+  "source": "agent_1/agents.bal",
+  "description": "Custom agent tool with unconditional human-in-the-loop approval",
+  "diagram": {
+    "id": "custom-agent-tool",
+    "metadata": {
+      "label": "Agent Tool",
+      "description": ""
+    },
+    "codedata": {
+      "node": "AGENT_TOOL",
+      "isNew": true,
+      "data": {
+        "toolKind": "CUSTOM",
+        "requiresApproval": "true"
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Name",
+          "description": "Name of the tool"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "lookup",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "functionNameDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the tool"
+        },
+        "valueType": "DOC_TEXT",
+        "value": "Looks up a value.",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "string",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "typeDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the return value"
+        },
+        "valueType": "DOC_TEXT",
+        "value": "The matching value.",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "value": {
+          "query": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "valueType": "TYPE",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "valueType": "IDENTIFIER",
+                "value": "query",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "parameterDescription": {
+                "valueType": "DOC_TEXT",
+                "value": "The lookup query.",
+                "optional": true,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "agent_1/agents.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "import ballerina/ai;"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "# Looks up a value.\n# + query - The lookup query.\n# + return - The matching value.\n@ai:AgentTool {\n    requiresApproval: true\n}\nisolated function lookup(string query) returns string {\n    panic error(\"not implemented\");\n}"
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/function_agent_tool_approval_with_auth_source.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/function_agent_tool_approval_with_auth_source.json
@@ -1,0 +1,189 @@
+{
+  "source": "agent_1/agents.bal",
+  "description": "Function agent tool keeps requiresApproval and its predicate when OAuth auth is also configured",
+  "diagram": {
+    "id": "function-agent-tool-approval-auth",
+    "metadata": {
+      "label": "Agent Tool",
+      "description": ""
+    },
+    "codedata": {
+      "node": "AGENT_TOOL",
+      "isNew": true,
+      "data": {
+        "auth": "{\"clientId\":\"\\\"abc\\\"\"}",
+        "requiresApproval": "isHighValue",
+        "generateApprovalFunction": "true",
+        "node": {
+          "id": "0",
+          "metadata": {
+            "label": "refundOrder",
+            "description": ""
+          },
+          "codedata": {
+            "node": "FUNCTION_CALL",
+            "symbol": "refundOrder",
+            "data": {
+              "auth": "{\"clientId\":\"\\\"abc\\\"\"}",
+              "requiresApproval": "isHighValue",
+              "generateApprovalFunction": "true"
+            }
+          },
+          "returning": false,
+          "properties": {
+            "type": {
+              "value": "string",
+              "optional": true,
+              "editable": false,
+              "advanced": false
+            },
+            "orderId": {
+              "value": "orderId",
+              "codedata": {
+                "kind": "REQUIRED"
+              },
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "parameters": {
+              "value": {
+                "orderId": {
+                  "value": {
+                    "variable": {
+                      "value": "orderId",
+                      "optional": false,
+                      "editable": true,
+                      "advanced": false
+                    }
+                  },
+                  "optional": false,
+                  "editable": false,
+                  "advanced": false
+                }
+              },
+              "optional": false,
+              "editable": false,
+              "advanced": false
+            }
+          },
+          "flags": 0
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Name",
+          "description": "Name of the tool"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "refundOrderTool",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "functionNameDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the tool"
+        },
+        "valueType": "DOC_TEXT",
+        "value": "Refunds an order.",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "value": {
+          "orderId": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "valueType": "TYPE",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "valueType": "IDENTIFIER",
+                "value": "orderId",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "parameterDescription": {
+                "valueType": "DOC_TEXT",
+                "value": "The order to refund.",
+                "optional": true,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "agent_1/agents.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "import ballerina/ai;"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "isolated function isHighValue(string orderId) returns boolean {\n    // TODO: inspect the proposed arguments and return true to require approval\n    return true;\n}"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "# Refunds an order.\n# + orderId - The order to refund.\n@ai:AgentTool {\n    auth: {\n        clientId: \"abc\"\n    },\n    requiresApproval: isHighValue\n}\n@display {label: \"\", iconPath: \"\"}\nisolated function refundOrderTool(string orderId) returns string {\n    string result = refundOrder(orderId);\n    return result;\n}"
+      }
+    ]
+  }
+}

--- a/packages/ballerina-side-panel/src/components/Form/types.ts
+++ b/packages/ballerina-side-panel/src/components/Form/types.ts
@@ -56,6 +56,9 @@ export type FormField = {
     /** AUTOCOMPLETE only: allow typing a value not in `items` (creates a new entry). Defaults to
      * true when unset, preserving the editor's original behavior; set false for a strict pick-list. */
     allowItemCreate?: boolean;
+    /** AUTOCOMPLETE only: append "(Optional)" to the label when `optional` is true. Off by default —
+     * opt in per field rather than changing every optional autocomplete's label at once. */
+    showOptionalSuffix?: boolean;
     itemOptions?: OptionProps[]
     choices?: PropertyModel[];
     dynamicFormFields?: { [key: string]: FormField[] }

--- a/packages/ballerina-side-panel/src/components/Form/types.ts
+++ b/packages/ballerina-side-panel/src/components/Form/types.ts
@@ -53,6 +53,9 @@ export type FormField = {
     advanceProps?: FormField[];
     diagnostics?: DiagnosticMessage[];
     items?: string[];
+    /** AUTOCOMPLETE only: allow typing a value not in `items` (creates a new entry). Defaults to
+     * true when unset, preserving the editor's original behavior; set false for a strict pick-list. */
+    allowItemCreate?: boolean;
     itemOptions?: OptionProps[]
     choices?: PropertyModel[];
     dynamicFormFields?: { [key: string]: FormField[] }

--- a/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
@@ -74,8 +74,9 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
                 })}
                 // Append "(Optional)" AFTER capitalize() — capitalize is lodash startCase, which strips
                 // parentheses and title-cases words, so a paren'd label can't be passed through directly.
-                // Symmetric with required fields showing "*".
-                label={field.optional ? `${capitalize(field.label)} (Optional)` : capitalize(field.label)}
+                // Opt-in via showOptionalSuffix, so this doesn't relabel every optional autocomplete.
+                label={field.optional && field.showOptionalSuffix
+                    ? `${capitalize(field.label)} (Optional)` : capitalize(field.label)}
                 items={field.items}
                 allowItemCreate={field.allowItemCreate ?? true}
                 required={!field.optional}

--- a/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
@@ -24,6 +24,10 @@ import { FormField } from "../Form/types";
 import { buildRequiredRule, capitalize, getValueForDropdown } from "./utils";
 import { useFormContext } from "../../context";
 import { SubPanel, SubPanelView } from "@wso2/ballerina-core";
+import { buildValidate } from "../Form/validationRules";
+import { useFieldDiagnostics } from "../Form/useFieldDiagnostics";
+import { dedupeMessages } from "../Form/DiagnosticsStore";
+import { WarningBanner } from "../Form/WarningBanner";
 
 interface AutoCompleteEditorProps {
     field: FormField;
@@ -32,43 +36,68 @@ interface AutoCompleteEditorProps {
 
 export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
     const { field, openSubPanel } = props;
-    const { form } = useFormContext();
-    const { register, setValue, watch } = form;
+    const { form, fileName } = useFormContext();
+    const { register, setValue, watch, formState: { errors } } = form;
 
     const value = watch(field.key);
 
+    // Live diagnostics: client rules (e.g. the identifier check on a free-typed value) run on
+    // every change, same as TextEditor — react-hook-form's default `onSubmit` mode otherwise
+    // leaves `errors` empty until submit is attempted, so a `validations[]` failure would go
+    // unseen until save.
+    const liveDiagnostics = useFieldDiagnostics(field, {
+        filePath: fileName,
+        moduleName: field.codedata?.moduleName,
+    });
+
+    const validationError = errors[field.key]?.message;
+    const errorMsg = dedupeMessages([
+        validationError ? String(validationError) : undefined,
+        ...liveDiagnostics.errors.map((diagnostic) => diagnostic.message),
+        ...(field.diagnostics ?? []).map((diagnostic) => diagnostic.message),
+    ]).join("\n");
+    const warningMsg = dedupeMessages(
+        liveDiagnostics.warnings.map((diagnostic) => diagnostic.message)
+    ).join("\n");
+
     return (
-        <AutoComplete
-            id={field.key}
-            description={field.documentation}
-            value={value as string}
-            {...register(field.key, {
-                required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
-                value: getValueForDropdown(field)
-            })}
-            // Append "(Optional)" AFTER capitalize() — capitalize is lodash startCase, which strips
-            // parentheses and title-cases words, so a paren'd label can't be passed through directly.
-            // Symmetric with required fields showing "*".
-            label={field.optional ? `${capitalize(field.label)} (Optional)` : capitalize(field.label)}
-            items={field.items}
-            allowItemCreate={field.allowItemCreate ?? true}
-            required={!field.optional}
-            disabled={!field.editable}
-            onValueChange={(val: string) => {
-                // Preserve existing value when Combobox fires with empty on blur (e.g., click away without selecting)
-                const currentValue = value ?? getValueForDropdown(field) ?? field.value;
-                const newVal = (val === "" || val === undefined || val === null) && currentValue
-                    ? currentValue
-                    : val;
-                setValue(field.key, newVal);
-                field.onValueChange?.(newVal);
-            }}
-            sx={{
-                marginRight: "-4px",
-                "& [id='dropdown-container']": {
-                    width: "292px",
-                }
-            }}
-        />
+        <div style={{ width: "100%" }}>
+            <AutoComplete
+                id={field.key}
+                description={field.documentation}
+                value={value as string}
+                errorMsg={errorMsg || undefined}
+                {...register(field.key, {
+                    required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
+                    value: getValueForDropdown(field),
+                    validate: buildValidate(field)
+                })}
+                // Append "(Optional)" AFTER capitalize() — capitalize is lodash startCase, which strips
+                // parentheses and title-cases words, so a paren'd label can't be passed through directly.
+                // Symmetric with required fields showing "*".
+                label={field.optional ? `${capitalize(field.label)} (Optional)` : capitalize(field.label)}
+                items={field.items}
+                allowItemCreate={field.allowItemCreate ?? true}
+                required={!field.optional}
+                disabled={!field.editable}
+                onValueChange={(val: string) => {
+                    // Preserve existing value when Combobox fires with empty on blur (e.g., click away without selecting)
+                    const currentValue = value ?? getValueForDropdown(field) ?? field.value;
+                    const newVal = (val === "" || val === undefined || val === null) && currentValue
+                        ? currentValue
+                        : val;
+                    setValue(field.key, newVal);
+                    field.onValueChange?.(newVal);
+                    liveDiagnostics.onValueChange(newVal);
+                }}
+                sx={{
+                    marginRight: "-4px",
+                    "& [id='dropdown-container']": {
+                        width: "292px",
+                    }
+                }}
+            />
+            {warningMsg && <WarningBanner warningMsg={warningMsg} />}
+        </div>
     );
 }

--- a/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
@@ -51,7 +51,7 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
             // Symmetric with required fields showing "*".
             label={field.optional ? `${capitalize(field.label)} (Optional)` : capitalize(field.label)}
             items={field.items}
-            allowItemCreate={true}
+            allowItemCreate={field.allowItemCreate ?? true}
             required={!field.optional}
             disabled={!field.editable}
             onValueChange={(val: string) => {

--- a/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
@@ -46,7 +46,10 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
                 required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
                 value: getValueForDropdown(field)
             })}
-            label={capitalize(field.label)}
+            // Append "(Optional)" AFTER capitalize() — capitalize is lodash startCase, which strips
+            // parentheses and title-cases words, so a paren'd label can't be passed through directly.
+            // Symmetric with required fields showing "*".
+            label={field.optional ? `${capitalize(field.label)} (Optional)` : capitalize(field.label)}
             items={field.items}
             allowItemCreate={true}
             required={!field.optional}

--- a/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
@@ -212,6 +212,7 @@ function mapPropertiesToFormFields(properties: { [key: string]: PropertyModel; }
             advanced: property.advanced,
             diagnostics: [],
             items,
+            allowItemCreate: (property as { allowItemCreate?: boolean }).allowItemCreate,
             choices: property.choices,
             placeholder: property.placeholder,
             addNewButton: property.addNewButton,

--- a/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
@@ -24,16 +24,22 @@ import { FieldFactory } from "./FieldFactory";
 import { useFormContext } from "../../context";
 import { getPrimaryInputType, PropertyModel } from "@wso2/ballerina-core";
 
+// align-items: start is deliberate. Grid's default (stretch) combined with height:100% controls
+// (e.g. the AutoComplete editor's container) inflates a revealed sub-field to the full row height,
+// so its input/chevron stretches down over the following section. Self-sizing the items keeps each
+// sub-field at its natural height, matching how fields render inside the normal flex form rows.
 const Form = styled.div`
     display: grid;
     gap: 20px;
     width: 100%;
+    align-items: start;
 `;
 
 const FormSection = styled.div`
     display: grid;
     gap: 20px;
     width: 100%;
+    align-items: start;
 `;
 
 const Label = styled.div`
@@ -188,7 +194,8 @@ function mapPropertiesToFormFields(properties: { [key: string]: PropertyModel; }
         }
 
         let items = undefined;
-        if (getPrimaryInputType(property.types)?.fieldType === "MULTIPLE_SELECT" || getPrimaryInputType(property.types)?.fieldType === "SINGLE_SELECT") {
+        const primaryFieldType = getPrimaryInputType(property.types)?.fieldType;
+        if (primaryFieldType === "MULTIPLE_SELECT" || primaryFieldType === "SINGLE_SELECT" || primaryFieldType === "AUTOCOMPLETE") {
             items = property.items;
         }
 

--- a/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
@@ -212,7 +212,7 @@ function mapPropertiesToFormFields(properties: { [key: string]: PropertyModel; }
             advanced: property.advanced,
             diagnostics: [],
             items,
-            allowItemCreate: (property as { allowItemCreate?: boolean }).allowItemCreate,
+            allowItemCreate: property.allowItemCreate,
             choices: property.choices,
             placeholder: property.placeholder,
             addNewButton: property.addNewButton,

--- a/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
@@ -213,6 +213,7 @@ function mapPropertiesToFormFields(properties: { [key: string]: PropertyModel; }
             diagnostics: [],
             items,
             allowItemCreate: property.allowItemCreate,
+            showOptionalSuffix: property.showOptionalSuffix,
             choices: property.choices,
             placeholder: property.placeholder,
             addNewButton: property.addNewButton,

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
@@ -60,7 +60,7 @@ import { RelativeLoader } from "../../../components/RelativeLoader";
 import styled from "@emotion/styled";
 import { URI, Utils } from "vscode-uri";
 import { cloneDeep } from "lodash";
-import { buildAgentToolFields, createDefaultParameterValue, createToolInputFields, createToolParameters, prepareToolInputFields, stripCodeFences, stripCodeFencesInline } from "./formUtils";
+import { buildAgentToolFields, buildRequiresApprovalField, collectLocalFunctionNames, createDefaultParameterValue, createRequiresApprovalField, createToolInputFields, createToolParameters, prepareToolInputFields, stripCodeFences, stripCodeFencesInline } from "./formUtils";
 import { ImplementationBadge } from "../../../components/ImplementationBadge";
 import { FUNCTION_CALL, METHOD_CALL, REMOTE_ACTION_CALL, RESOURCE_ACTION_CALL } from "../../../constants";
 import { NewToolSelectionMode } from "./NewTool";
@@ -445,109 +445,12 @@ function reorderFunctionCategories(categories: PanelCategory[]): PanelCategory[]
 const getConnectionFieldName = (name: string): string =>
     name.startsWith("self.") ? name.slice("self.".length) : name;
 
-// Categories in the FUNCTION search response that are NOT the project's own functions: standard
-// library and imported/third-party modules (plus agent tools). We offer only the user's own
-// module-level functions as approval-predicate candidates, so these are skipped.
-const NON_LOCAL_FUNCTION_CATEGORIES = ["Standard Library", "Agent Tools"];
-function isLocalFunctionCategory(label: string | undefined): boolean {
-    if (!label) return true;
-    return !NON_LOCAL_FUNCTION_CATEGORIES.includes(label) && !label.includes("Imported");
-}
-
-// Recursively collect the names of the project's own functions from raw search-result categories,
-// to offer as approval-predicate candidates. The list-level search response has no reliable return
-// type to filter on (codedata.inferredReturnType is only populated in niche type-inference cases,
-// not for ordinary `boolean` returns), so we offer all local functions and let the compiler/LS flag
-// an incompatible pick after generation — the RequiresApproval contract (params mirror the tool,
-// returns boolean) is verified there, not here. Agent-tool functions are excluded.
-function collectLocalFunctionNames(items: (Category | AvailableNode)[], acc: Set<string>): void {
-    for (const item of items) {
-        if (item && "items" in item && Array.isArray((item as Category).items)) {
-            if (isLocalFunctionCategory((item as Category).metadata?.label)) {
-                collectLocalFunctionNames((item as Category).items as (Category | AvailableNode)[], acc);
-            }
-            continue;
-        }
-        const node = item as AvailableNode;
-        const name = node?.codedata?.symbol;
-        if (name && !(node.metadata?.data as NodeMetadata)?.isAgentTool) {
-            acc.add(name);
-        }
-    }
-}
-
-// Rebuild the static "Requires Approval" CONDITIONAL_FIELDS field with the runtime-fetched picker
-// candidates injected into its "On" branch. `items` populate the AUTOCOMPLETE dropdown; the label,
-// description and placeholder are preserved from the static definition.
-function buildRequiresApprovalField(baseField: FormField, candidates: string[]): FormField {
-    const onChoice = baseField.choices?.[0];
-    const approvalProp = onChoice?.properties?.approvalFunction;
-    if (!approvalProp) {
-        return baseField;
-    }
-    return {
-        ...baseField,
-        choices: [
-            {
-                ...onChoice,
-                properties: {
-                    ...onChoice.properties,
-                    approvalFunction: {
-                        ...approvalProp,
-                        items: candidates,
-                    },
-                },
-            },
-            ...baseField.choices.slice(1),
-        ],
-    };
-}
-
-// Tool Name + Description are shared with UseAgentToolForm's "Use Agent Tool" flow via
-// buildAgentToolFields; Requires Approval is appended locally, scoped to this form only.
+// Tool Name + Description are shared with the "Use Connection"/"Create Custom Tool" flows via
+// buildAgentToolFields; Requires Approval (createRequiresApprovalField, shared across all three
+// tool-creation paths) is appended here, scoped to this form only.
 const INITIAL_FIELDS: FormField[] = [
     ...buildAgentToolFields("", ""),
-    {
-        // The annotation value is `boolean | isolated function`: checking the box alone emits
-        // `requiresApproval: true`; picking a function in the revealed sub-field emits that
-        // function reference instead, so approval becomes conditional at runtime. Modeled as
-        // CONDITIONAL_FIELDS (CheckBoxConditionalEditor) so the function picker is a part of this
-        // field rather than a separate, disconnected form entry.
-        key: `requiresApproval`,
-        label: "Requires Approval",
-        type: "CONDITIONAL_FIELDS",
-        optional: true,
-        editable: true,
-        documentation: "Pause this tool before it runs and wait for human approval.",
-        value: false,
-        types: [{ fieldType: "CONDITIONAL_FIELDS", selected: false }],
-        enabled: true,
-        choices: [
-            {
-                metadata: { label: "On" },
-                properties: {
-                    approvalFunction: {
-                        metadata: {
-                            // "(optional)" is appended by AutoCompleteEditor for optional fields; keeping
-                            // it here would double up (capitalize() = startCase would also mangle it).
-                            label: "Approval Function",
-                            description:
-                                "Decides per call whether approval is needed. Pick one of your functions, or type a name to create one.",
-                        },
-                        // AUTOCOMPLETE (not EXPRESSION): the annotation slot takes a function *reference*
-                        // (a bare name), never a call expression. `items` are injected at runtime in
-                        // loadFunctionCallFields; free-typed names are accepted (AutoCompleteEditor
-                        // sets allowItemCreate) and drive the "create a new predicate" path.
-                        types: [{ fieldType: "AUTOCOMPLETE", selected: true }],
-                        value: "",
-                        optional: true,
-                        editable: true,
-                    },
-                },
-            },
-            { metadata: { label: "Off" }, properties: {} },
-        ],
-    } as unknown as FormField,
+    createRequiresApprovalField(),
 ];
 
 export function AIAgentSidePanel(props: BIFlowDiagramProps) {

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
@@ -778,7 +778,11 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
     // module's functions; stdlib/imported/agent-tool categories are filtered out by the collector.
     // Shared by both the "Use Function" and "Use Connection" tool-creation paths. Return-type/
     // signature compatibility is verified by the compiler after generation.
-    const fetchCompatibleApprovalFunctions = async (toolFunctionSymbol?: string): Promise<string[]> => {
+    // Returns `null` (rather than `[]`) when the fetch itself fails, so callers can tell "search
+    // failed" apart from "this project has no eligible functions" and fall back to the plain
+    // checkbox instead of silently offering a picker backed by an empty list. See
+    // formUtils.buildRequiresApprovalField for why that distinction matters.
+    const fetchCompatibleApprovalFunctions = async (toolFunctionSymbol?: string): Promise<string[] | null> => {
         try {
             const request: BISearchRequest = {
                 position: {
@@ -798,7 +802,7 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             return Array.from(names);
         } catch (error) {
             console.error(">>> Error fetching compatible approval functions", error);
-            return [];
+            return null;
         }
     };
 
@@ -877,7 +881,7 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             // the boolean-returning ones as candidates. Injected into the "Requires Approval" control's
             // "On" branch so the picker sits under the checkbox; free-typed names drive the create path.
             const approvalCandidates = await fetchCompatibleApprovalFunctions(node.codedata?.symbol);
-            compatibleApprovalFunctionsRef.current = approvalCandidates;
+            compatibleApprovalFunctionsRef.current = approvalCandidates ?? [];
 
             setFields((prevFields) => [
                 ...prevFields.map((field) => {
@@ -947,7 +951,7 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             // Same approval-predicate picker as the function-call path: fetch the project's
             // module-level functions and inject them into the "Requires Approval" control.
             const approvalCandidates = await fetchCompatibleApprovalFunctions();
-            compatibleApprovalFunctionsRef.current = approvalCandidates;
+            compatibleApprovalFunctionsRef.current = approvalCandidates ?? [];
 
             setFields((prevFields) => [
                 ...prevFields.map((field) => {

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
@@ -60,7 +60,7 @@ import { RelativeLoader } from "../../../components/RelativeLoader";
 import styled from "@emotion/styled";
 import { URI, Utils } from "vscode-uri";
 import { cloneDeep } from "lodash";
-import { buildAgentToolFields, buildRequiresApprovalField, collectLocalFunctionNames, createDefaultParameterValue, createRequiresApprovalField, createToolInputFields, createToolParameters, prepareToolInputFields, stripCodeFences, stripCodeFencesInline } from "./formUtils";
+import { buildAgentToolFields, buildApprovalToolData, buildRequiresApprovalField, collectLocalFunctionNames, createDefaultParameterValue, createRequiresApprovalField, createToolInputFields, createToolParameters, prepareToolInputFields, stripCodeFences, stripCodeFencesInline } from "./formUtils";
 import { ImplementationBadge } from "../../../components/ImplementationBadge";
 import { FUNCTION_CALL, METHOD_CALL, REMOTE_ACTION_CALL, RESOURCE_ACTION_CALL } from "../../../constants";
 import { NewToolSelectionMode } from "./NewTool";
@@ -1320,27 +1320,17 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
 
         // Mark the tool as requiring human-in-the-loop approval. This rides along in codedata.data
         // (like `auth` above) and is rendered into the @ai:AgentTool annotation by the language
-        // server. The gate is the checkbox itself, not the function field — unchecking it must not
-        // leak a function picked earlier and left registered, since CheckBoxConditionalEditor doesn't
-        // clear the "on"-state sub-field on uncheck.
-        //
-        // Three cases when checked:
-        //   - no function       -> `requiresApproval: true` (unconditional).
-        //   - existing function -> `requiresApproval: <name>` (reference an already-defined predicate).
-        //   - new (free-typed)  -> `requiresApproval: <name>` PLUS generateApprovalFunction, telling
-        //                          the LS to also scaffold a correctly-signed predicate stub.
+        // server. The gate is the checkbox itself, not the function field — unchecking it yields an
+        // empty object, so a function picked earlier and left registered can't leak (buildApprovalToolData
+        // reads the checkbox first), which matters since CheckBoxConditionalEditor doesn't clear the
+        // "on"-state sub-field on uncheck.
         if (targetNode) {
-            const requiresApproval = data["requiresApproval"] === true || data["requiresApproval"] === "true";
-            if (requiresApproval) {
-                const approvalFn = typeof data["approvalFunction"] === "string" ? data["approvalFunction"].trim() : "";
-                const data_: Record<string, string> = {
-                    ...(targetNode.codedata.data as Record<string, string>),
-                    requiresApproval: approvalFn || "true",
+            const approvalData = buildApprovalToolData(data, compatibleApprovalFunctionsRef.current);
+            if (Object.keys(approvalData).length > 0) {
+                targetNode.codedata.data = {
+                    ...targetNode.codedata.data,
+                    ...approvalData,
                 };
-                if (approvalFn && !compatibleApprovalFunctionsRef.current.includes(approvalFn)) {
-                    data_.generateApprovalFunction = "true";
-                }
-                targetNode.codedata.data = data_;
             }
         }
 

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
@@ -442,10 +442,113 @@ function reorderFunctionCategories(categories: PanelCategory[]): PanelCategory[]
     return categories;
 }
 
-const INITIAL_FIELDS: FormField[] = buildAgentToolFields("", "");
-
 const getConnectionFieldName = (name: string): string =>
     name.startsWith("self.") ? name.slice("self.".length) : name;
+
+// Categories in the FUNCTION search response that are NOT the project's own functions: standard
+// library and imported/third-party modules (plus agent tools). We offer only the user's own
+// module-level functions as approval-predicate candidates, so these are skipped.
+const NON_LOCAL_FUNCTION_CATEGORIES = ["Standard Library", "Agent Tools"];
+function isLocalFunctionCategory(label: string | undefined): boolean {
+    if (!label) return true;
+    return !NON_LOCAL_FUNCTION_CATEGORIES.includes(label) && !label.includes("Imported");
+}
+
+// Recursively collect the names of the project's own functions from raw search-result categories,
+// to offer as approval-predicate candidates. The list-level search response has no reliable return
+// type to filter on (codedata.inferredReturnType is only populated in niche type-inference cases,
+// not for ordinary `boolean` returns), so we offer all local functions and let the compiler/LS flag
+// an incompatible pick after generation — the RequiresApproval contract (params mirror the tool,
+// returns boolean) is verified there, not here. Agent-tool functions are excluded.
+function collectLocalFunctionNames(items: (Category | AvailableNode)[], acc: Set<string>): void {
+    for (const item of items) {
+        if (item && "items" in item && Array.isArray((item as Category).items)) {
+            if (isLocalFunctionCategory((item as Category).metadata?.label)) {
+                collectLocalFunctionNames((item as Category).items as (Category | AvailableNode)[], acc);
+            }
+            continue;
+        }
+        const node = item as AvailableNode;
+        const name = node?.codedata?.symbol;
+        if (name && !(node.metadata?.data as NodeMetadata)?.isAgentTool) {
+            acc.add(name);
+        }
+    }
+}
+
+// Rebuild the static "Requires Approval" CONDITIONAL_FIELDS field with the runtime-fetched picker
+// candidates injected into its "On" branch. `items` populate the AUTOCOMPLETE dropdown; the label,
+// description and placeholder are preserved from the static definition.
+function buildRequiresApprovalField(baseField: FormField, candidates: string[]): FormField {
+    const onChoice = baseField.choices?.[0];
+    const approvalProp = onChoice?.properties?.approvalFunction;
+    if (!approvalProp) {
+        return baseField;
+    }
+    return {
+        ...baseField,
+        choices: [
+            {
+                ...onChoice,
+                properties: {
+                    ...onChoice.properties,
+                    approvalFunction: {
+                        ...approvalProp,
+                        items: candidates,
+                    },
+                },
+            },
+            ...baseField.choices.slice(1),
+        ],
+    };
+}
+
+// Tool Name + Description are shared with UseAgentToolForm's "Use Agent Tool" flow via
+// buildAgentToolFields; Requires Approval is appended locally, scoped to this form only.
+const INITIAL_FIELDS: FormField[] = [
+    ...buildAgentToolFields("", ""),
+    {
+        // The annotation value is `boolean | isolated function`: checking the box alone emits
+        // `requiresApproval: true`; picking a function in the revealed sub-field emits that
+        // function reference instead, so approval becomes conditional at runtime. Modeled as
+        // CONDITIONAL_FIELDS (CheckBoxConditionalEditor) so the function picker is a part of this
+        // field rather than a separate, disconnected form entry.
+        key: `requiresApproval`,
+        label: "Requires Approval",
+        type: "CONDITIONAL_FIELDS",
+        optional: true,
+        editable: true,
+        documentation: "Pause this tool before it runs and wait for human approval.",
+        value: false,
+        types: [{ fieldType: "CONDITIONAL_FIELDS", selected: false }],
+        enabled: true,
+        choices: [
+            {
+                metadata: { label: "On" },
+                properties: {
+                    approvalFunction: {
+                        metadata: {
+                            // "(optional)" is appended by AutoCompleteEditor for optional fields; keeping
+                            // it here would double up (capitalize() = startCase would also mangle it).
+                            label: "Approval Function",
+                            description:
+                                "Decides per call whether approval is needed. Pick one of your functions, or type a name to create one.",
+                        },
+                        // AUTOCOMPLETE (not EXPRESSION): the annotation slot takes a function *reference*
+                        // (a bare name), never a call expression. `items` are injected at runtime in
+                        // loadFunctionCallFields; free-typed names are accepted (AutoCompleteEditor
+                        // sets allowItemCreate) and drive the "create a new predicate" path.
+                        types: [{ fieldType: "AUTOCOMPLETE", selected: true }],
+                        value: "",
+                        optional: true,
+                        editable: true,
+                    },
+                },
+            },
+            { metadata: { label: "Off" }, properties: {} },
+        ],
+    } as unknown as FormField,
+];
 
 export function AIAgentSidePanel(props: BIFlowDiagramProps) {
     const { agentNode, projectPath, onSubmit, mode = NewToolSelectionMode.ALL, onViewChange, onAgentToolCreated, onCancel, connectionDependency } = props;
@@ -493,6 +596,10 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
     const parameterFieldsRef = useRef<ToolParameterItem[]>([]);
     const oauthConfigPropertiesRef = useRef<{ key: string; property: Property }[]>([]);
     const isSelectingNodeRef = useRef<boolean>(false);
+    // Names of existing module functions offered in the approval-predicate picker. Source of truth
+    // for the pick-vs-create decision at submit: a name in here is referenced as-is; a name NOT in
+    // here (free-typed) signals the LS to scaffold a new correctly-signed predicate.
+    const compatibleApprovalFunctionsRef = useRef<string[]>([]);
 
     // Create custom diagnostic filter for Tool Input parameters
     const customDiagnosticFilter = useCallback((diagnostics: Diagnostic[]) => {
@@ -762,6 +869,34 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
         return extractRecordTypeFieldsFromEntries(entries);
     };
 
+    // Fetch the project's own module-level functions (excluding the tool's own function) as
+    // approval-predicate candidates. Reuses the FUNCTION search with an empty queryMap, which returns
+    // the current module's functions; stdlib/imported/agent-tool categories are filtered out by the
+    // collector. Return-type/signature compatibility is verified by the compiler after generation.
+    const fetchCompatibleApprovalFunctions = async (toolFunctionSymbol?: string): Promise<string[]> => {
+        try {
+            const request: BISearchRequest = {
+                position: {
+                    startLine: targetRef.current.startLine,
+                    endLine: targetRef.current.endLine,
+                },
+                filePath: agentFilePath.current,
+                queryMap: undefined,
+                searchKind: "FUNCTION",
+            };
+            const response = await rpcClient.getBIDiagramRpcClient().search(request);
+            const names = new Set<string>();
+            collectLocalFunctionNames((response?.categories ?? []) as (Category | AvailableNode)[], names);
+            if (toolFunctionSymbol) {
+                names.delete(toolFunctionSymbol);
+            }
+            return Array.from(names);
+        } catch (error) {
+            console.error(">>> Error fetching compatible approval functions", error);
+            return [];
+        }
+    };
+
     const loadFunctionCallFields = async (node: AvailableNode): Promise<void> => {
         try {
             const functionNodeResponse = await rpcClient.getBIDiagramRpcClient().getFunctionNode({
@@ -833,10 +968,22 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             const oauthRecordTypeFields = extractRecordTypeFieldsFromEntries(oauthProperties);
             setRecordTypeFields([...nodeRecordTypeFields, ...oauthRecordTypeFields]);
 
+            // Build the approval-predicate picker: fetch the project's module-level functions and keep
+            // the boolean-returning ones as candidates. Injected into the "Requires Approval" control's
+            // "On" branch so the picker sits under the checkbox; free-typed names drive the create path.
+            const approvalCandidates = await fetchCompatibleApprovalFunctions(node.codedata?.symbol);
+            compatibleApprovalFunctionsRef.current = approvalCandidates;
+
             setFields((prevFields) => [
-                ...prevFields.map((field) =>
-                    field.key === "description" ? { ...field, value: templateDescription } : field
-                ),
+                ...prevFields.map((field) => {
+                    if (field.key === "description") {
+                        return { ...field, value: templateDescription };
+                    }
+                    if (field.key === "requiresApproval") {
+                        return buildRequiresApprovalField(field, approvalCandidates);
+                    }
+                    return field;
+                }),
                 ...toolInputFields,
                 ...functionParameterFields.map(field => ({
                     ...field,
@@ -1252,6 +1399,32 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                     ...targetNode.codedata.data,
                     auth: JSON.stringify(config),
                 };
+            }
+        }
+
+        // Mark the tool as requiring human-in-the-loop approval. This rides along in codedata.data
+        // (like `auth` above) and is rendered into the @ai:AgentTool annotation by the language
+        // server. The gate is the checkbox itself, not the function field — unchecking it must not
+        // leak a function picked earlier and left registered, since CheckBoxConditionalEditor doesn't
+        // clear the "on"-state sub-field on uncheck.
+        //
+        // Three cases when checked:
+        //   - no function       -> `requiresApproval: true` (unconditional).
+        //   - existing function -> `requiresApproval: <name>` (reference an already-defined predicate).
+        //   - new (free-typed)  -> `requiresApproval: <name>` PLUS generateApprovalFunction, telling
+        //                          the LS to also scaffold a correctly-signed predicate stub.
+        if (targetNode) {
+            const requiresApproval = data["requiresApproval"] === true || data["requiresApproval"] === "true";
+            if (requiresApproval) {
+                const approvalFn = typeof data["approvalFunction"] === "string" ? data["approvalFunction"].trim() : "";
+                const data_: Record<string, string> = {
+                    ...(targetNode.codedata.data as Record<string, string>),
+                    requiresApproval: approvalFn || "true",
+                };
+                if (approvalFn && !compatibleApprovalFunctionsRef.current.includes(approvalFn)) {
+                    data_.generateApprovalFunction = "true";
+                }
+                targetNode.codedata.data = data_;
             }
         }
 

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
@@ -869,10 +869,12 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
         return extractRecordTypeFieldsFromEntries(entries);
     };
 
-    // Fetch the project's own module-level functions (excluding the tool's own function) as
-    // approval-predicate candidates. Reuses the FUNCTION search with an empty queryMap, which returns
-    // the current module's functions; stdlib/imported/agent-tool categories are filtered out by the
-    // collector. Return-type/signature compatibility is verified by the compiler after generation.
+    // Fetch the project's own module-level functions (excluding the tool's own function, when it is
+    // one — connection-based tools have no local function to exclude) as approval-predicate
+    // candidates. Reuses the FUNCTION search with an empty queryMap, which returns the current
+    // module's functions; stdlib/imported/agent-tool categories are filtered out by the collector.
+    // Shared by both the "Use Function" and "Use Connection" tool-creation paths. Return-type/
+    // signature compatibility is verified by the compiler after generation.
     const fetchCompatibleApprovalFunctions = async (toolFunctionSymbol?: string): Promise<string[]> => {
         try {
             const request: BISearchRequest = {
@@ -1039,10 +1041,21 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             const oauthRecordTypeFields = extractRecordTypeFieldsFromEntries(oauthProperties);
             setRecordTypeFields([...nodeRecordTypeFields, ...oauthRecordTypeFields]);
 
+            // Same approval-predicate picker as the function-call path: fetch the project's
+            // module-level functions and inject them into the "Requires Approval" control.
+            const approvalCandidates = await fetchCompatibleApprovalFunctions();
+            compatibleApprovalFunctionsRef.current = approvalCandidates;
+
             setFields((prevFields) => [
-                ...prevFields.map((field) =>
-                    field.key === "description" ? { ...field, value: templateDescription } : field
-                ),
+                ...prevFields.map((field) => {
+                    if (field.key === "description") {
+                        return { ...field, value: templateDescription };
+                    }
+                    if (field.key === "requiresApproval") {
+                        return buildRequiresApprovalField(field, approvalCandidates);
+                    }
+                    return field;
+                }),
                 ...toolInputFields,
                 ...nodeParameterFields.map(field => ({
                     ...field,

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentToolForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentToolForm.tsx
@@ -194,6 +194,14 @@ function parseRequiresApproval(annotationValue: string): ExistingApprovalConfig 
     return raw === "true" ? {} : { functionName: raw };
 }
 
+// Ensure the function the tool currently references is always a selectable candidate, even if the
+// module-function fetch didn't surface it. Edit forms use a strict (no-create) picker, so without
+// this a referenced-but-unlisted function would be silently dropped on save.
+function withExistingCandidate(candidates: string[], existing?: ExistingApprovalConfig): string[] {
+    const name = existing?.functionName;
+    return name && !candidates.includes(name) ? [...candidates, name] : candidates;
+}
+
 // Insert, replace, or remove a scalar `key: value` field (no nested braces, unlike auth's record
 // value) inside an @ai:AgentTool annotation string. Mirrors the auth block's matchBraced-based
 // upsert in spirit, but auth's value is itself a `{ ... }` record while requiresApproval's value is
@@ -443,11 +451,16 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
                     });
 
                     oauthPropertiesRef.current = oauthProperties;
-                    compatibleApprovalFunctionsRef.current = approvalCandidates;
+                    const existingApproval = parseRequiresApproval(annotationValue);
+                    const approvalItems = withExistingCandidate(approvalCandidates, existingApproval);
+                    compatibleApprovalFunctionsRef.current = approvalItems;
                     const existingConfig = parseAuth(annotationValue, oauthProperties.map(({ key }) => key));
                     const { oauthFields, oauthRecordFields } = buildOAuthFields(oauthProperties, existingConfig);
+                    // Edit restricts the picker to existing functions (allowCreate=false): this path
+                    // rewrites the annotation source directly and never reaches AgentToolBuilder, so a
+                    // free-typed new name would leave `requiresApproval: <name>` with no such function.
                     const requiresApprovalField = buildRequiresApprovalField(
-                        createRequiresApprovalField(parseRequiresApproval(annotationValue)), approvalCandidates
+                        createRequiresApprovalField(existingApproval, false), approvalItems
                     );
 
                     setToolNode(node);
@@ -471,14 +484,19 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
 
                     oauthPropertiesRef.current = oauthProperties;
                     const annotationValue = findAgentToolAnnotation(model)?.value ?? "";
-                    compatibleApprovalFunctionsRef.current = approvalCandidates.filter(
-                        (name) => name !== String(model.name.value)
+                    const existingApproval = parseRequiresApproval(annotationValue);
+                    const approvalItems = withExistingCandidate(
+                        approvalCandidates.filter((name) => name !== String(model.name.value)),
+                        existingApproval
                     );
+                    compatibleApprovalFunctionsRef.current = approvalItems;
                     const existingConfig = parseAuth(annotationValue, oauthProperties.map(({ key }) => key));
                     const { oauthFields, oauthRecordFields } = buildOAuthFields(oauthProperties, existingConfig);
+                    // Edit restricts the picker to existing functions (allowCreate=false) — see the
+                    // top-level edit branch; the class-edit save likewise rebuilds annotation text
+                    // directly rather than going through AgentToolBuilder's predicate scaffolding.
                     const requiresApprovalField = buildRequiresApprovalField(
-                        createRequiresApprovalField(parseRequiresApproval(annotationValue)),
-                        compatibleApprovalFunctionsRef.current
+                        createRequiresApprovalField(existingApproval, false), approvalItems
                     );
 
                     setFunctionModel(model);
@@ -698,9 +716,10 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
                                     `@ai:AgentTool {\n    ${configBlock}\n}`);
                             }
                         }
-                        // Edits reference the typed approval-function name as-is (no stub scaffolding —
-                        // this path rewrites already-generated source text directly, bypassing
-                        // AgentToolBuilder's codegen where the predicate stub is normally emitted).
+                        // Edits reference an existing function only (the edit picker is a strict
+                        // pick-list — allowCreate=false), so no predicate scaffolding is needed: this
+                        // path rewrites already-generated source text directly and never reaches
+                        // AgentToolBuilder's codegen where a new predicate stub would be emitted.
                         annotationStr = upsertScalarAnnotationField(
                             annotationStr, "requiresApproval", resolveApprovalSource(data)
                         );

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentToolForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentToolForm.tsx
@@ -41,6 +41,7 @@ import { convertConfig, convertNodePropertyToFormField, getImportsForProperty } 
 import ArtifactForm from "../Forms/ArtifactForm";
 import { AgentToolHostClass, fetchOAuthConfigProperties } from "./utils";
 import {
+    buildApprovalToolData,
     buildRequiresApprovalField,
     collectLocalFunctionNames,
     createRequiresApprovalField,
@@ -663,14 +664,10 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
             // codedata.data and is rendered into the @ai:AgentTool annotation by the language server
             // (AgentToolBuilder.emitAnnotation / appendApprovalPredicate). Only consulted on create —
             // isEdit rewrites the already-existing annotation text directly below instead.
-            const approvalSourceForCreate = resolveApprovalSource(data);
             updatedNode.codedata.data = {
                 ...updatedNode.codedata.data,
                 ...(Object.keys(auth).length > 0 ? { auth: JSON.stringify(auth) } : {}),
-                ...(approvalSourceForCreate ? { requiresApproval: approvalSourceForCreate } : {}),
-                ...(approvalSourceForCreate && approvalSourceForCreate !== "true"
-                    && !compatibleApprovalFunctionsRef.current.includes(approvalSourceForCreate)
-                    ? { generateApprovalFunction: "true" } : {}),
+                ...buildApprovalToolData(data, compatibleApprovalFunctionsRef.current),
             };
 
             let response;

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentToolForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentToolForm.tsx
@@ -19,9 +19,13 @@
 import { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import {
+    AvailableNode,
+    BISearchRequest,
+    Category,
     DIRECTORY_MAP,
     FlowNode,
     FunctionModel,
+    LinePosition,
     LineRange,
     NodeProperties,
     Property,
@@ -36,6 +40,12 @@ import { RelativeLoader } from "../../../components/RelativeLoader";
 import { convertConfig, convertNodePropertyToFormField, getImportsForProperty } from "../../../utils/bi";
 import ArtifactForm from "../Forms/ArtifactForm";
 import { AgentToolHostClass, fetchOAuthConfigProperties } from "./utils";
+import {
+    buildRequiresApprovalField,
+    collectLocalFunctionNames,
+    createRequiresApprovalField,
+    ExistingApprovalConfig,
+} from "./formUtils";
 import {
     convertParameterToParamValue,
     convertSchemaToFormFields,
@@ -173,6 +183,54 @@ function toAuthSource(key: string, value: unknown, isExpression: boolean): strin
     return JSON.stringify(text);
 }
 
+// Parse an existing `requiresApproval: <boolean|identifier>` field out of an @ai:AgentTool
+// annotation, to prefill the "Requires Approval" control when editing a custom tool that already
+// has the gate set.
+function parseRequiresApproval(annotationValue: string): ExistingApprovalConfig | undefined {
+    const match = /requiresApproval\s*:\s*([^,}]+)/.exec(annotationValue);
+    if (!match) return undefined;
+    const raw = match[1].trim();
+    return raw === "true" ? {} : { functionName: raw };
+}
+
+// Insert, replace, or remove a scalar `key: value` field (no nested braces, unlike auth's record
+// value) inside an @ai:AgentTool annotation string. Mirrors the auth block's matchBraced-based
+// upsert in spirit, but auth's value is itself a `{ ... }` record while requiresApproval's value is
+// a bare boolean or identifier, so a brace-unaware match up to the next comma/close-brace suffices.
+function upsertScalarAnnotationField(annotationStr: string, key: string, source: string | undefined): string {
+    const match = new RegExp(`${key}\\s*:\\s*[^,}]+`).exec(annotationStr);
+    if (match) {
+        let s = match.index;
+        let e = match.index + match[0].length;
+        if (source) {
+            return annotationStr.slice(0, s) + `${key}: ${source}` + annotationStr.slice(e);
+        }
+        const lead = annotationStr.slice(0, s).match(/,\s*$/);
+        const trail = annotationStr.slice(e).match(/^\s*,/);
+        if (lead) s -= lead[0].length;
+        else if (trail) e += trail[0].length;
+        return (annotationStr.slice(0, s) + annotationStr.slice(e))
+            .replace(/@ai:AgentTool\s*\{\s*\}/, "@ai:AgentTool");
+    }
+    if (!source) {
+        return annotationStr;
+    }
+    if (annotationStr.match(/@ai:AgentTool\s*\{/)) {
+        return annotationStr.replace(/@ai:AgentTool\s*\{/, `@ai:AgentTool {\n    ${key}: ${source},`);
+    }
+    return annotationStr.replace(/@ai:AgentTool/, `@ai:AgentTool {\n    ${key}: ${source}\n}`);
+}
+
+// Compute the `requiresApproval` annotation-value source from the form's checkbox + picker state,
+// or undefined when the gate is off (signalling removal to upsertScalarAnnotationField / callers
+// that build the annotation from scratch).
+function resolveApprovalSource(data: FormValues): string | undefined {
+    const checked = data["requiresApproval"] === true || data["requiresApproval"] === "true";
+    if (!checked) return undefined;
+    const approvalFn = typeof data["approvalFunction"] === "string" ? data["approvalFunction"].trim() : "";
+    return approvalFn || "true";
+}
+
 function findAgentToolAnnotation(model: FunctionModel): { key: string; value: string } | undefined {
     const props = (model?.properties ?? {}) as Record<string, any>;
     for (const [key, prop] of Object.entries(props)) {
@@ -194,9 +252,40 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
     const [saving, setSaving] = useState(false);
     const [loading, setLoading] = useState(true);
     const oauthPropertiesRef = useRef<{ key: string; property: Property }[]>([]);
+    // Names of existing module functions offered in the approval-predicate picker. Only consulted
+    // on tool creation (see handleSubmit) to decide whether a free-typed name should scaffold a new
+    // predicate stub; edits reference the typed name as-is (see the module doc comment on
+    // upsertScalarAnnotationField's callers) since annotation-string surgery has no code-gen path.
+    const compatibleApprovalFunctionsRef = useRef<string[]>([]);
 
     const isEdit = Boolean(editContext);
     const isClassEdit = Boolean(editContext?.inClass);
+
+    // Fetch the project's own module-level functions (excluding the tool's own function, when
+    // editing one) as approval-predicate candidates. Shared shape with the function/connection
+    // tool-creation forms; see formUtils.collectLocalFunctionNames for the filtering rules.
+    const fetchCompatibleApprovalFunctions = async (
+        position: LinePosition, excludeName?: string
+    ): Promise<string[]> => {
+        try {
+            const request: BISearchRequest = {
+                position: { startLine: position, endLine: position },
+                filePath,
+                queryMap: undefined,
+                searchKind: "FUNCTION",
+            };
+            const response = await rpcClient.getBIDiagramRpcClient().search(request);
+            const names = new Set<string>();
+            collectLocalFunctionNames((response?.categories ?? []) as (Category | AvailableNode)[], names);
+            if (excludeName) {
+                names.delete(excludeName);
+            }
+            return Array.from(names);
+        } catch (error) {
+            console.error(">>> Error fetching compatible approval functions", error);
+            return [];
+        }
+    };
 
     const applyToolFieldDocs = (field: FormField) => {
         if (field.key === "functionName") {
@@ -326,13 +415,14 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
                     ?? targetLineRange?.startLine ?? { line: 0, offset: 0 };
 
                 if (editContext && !editContext.inClass) {
-                    const [res, oauthProperties] = await Promise.all([
+                    const [res, oauthProperties, approvalCandidates] = await Promise.all([
                         rpcClient.getBIDiagramRpcClient().getFunctionNode({
                             functionName: editContext.functionName,
                             fileName,
                             projectPath,
                         }),
                         fetchOAuthConfigProperties(rpcClient, filePath, oauthStartLine),
+                        fetchCompatibleApprovalFunctions(oauthStartLine, editContext.functionName),
                     ]);
                     if (cancelled) return;
                     const node = res.functionDefinition as FlowNode;
@@ -352,34 +442,46 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
                     });
 
                     oauthPropertiesRef.current = oauthProperties;
+                    compatibleApprovalFunctionsRef.current = approvalCandidates;
                     const existingConfig = parseAuth(annotationValue, oauthProperties.map(({ key }) => key));
                     const { oauthFields, oauthRecordFields } = buildOAuthFields(oauthProperties, existingConfig);
+                    const requiresApprovalField = buildRequiresApprovalField(
+                        createRequiresApprovalField(parseRequiresApproval(annotationValue)), approvalCandidates
+                    );
 
                     setToolNode(node);
-                    setFields([...baseFields, ...oauthFields]);
+                    setFields([...baseFields, requiresApprovalField, ...oauthFields]);
                     setRecordTypeFields(oauthRecordFields);
                     setFormRange(node.codedata?.lineRange as LineRange);
                     return;
                 }
 
                 if (editContext && editContext.inClass && editContext.lineRange) {
-                    const [modelResp, oauthProperties] = await Promise.all([
+                    const [modelResp, oauthProperties, approvalCandidates] = await Promise.all([
                         rpcClient.getServiceDesignerRpcClient().getFunctionFromSource({
                             filePath,
                             codedata: { lineRange: editContext.lineRange as any },
                         }),
                         fetchOAuthConfigProperties(rpcClient, filePath, oauthStartLine),
+                        fetchCompatibleApprovalFunctions(oauthStartLine),
                     ]);
                     if (cancelled) return;
                     const model = modelResp.function;
 
                     oauthPropertiesRef.current = oauthProperties;
                     const annotationValue = findAgentToolAnnotation(model)?.value ?? "";
+                    compatibleApprovalFunctionsRef.current = approvalCandidates.filter(
+                        (name) => name !== String(model.name.value)
+                    );
                     const existingConfig = parseAuth(annotationValue, oauthProperties.map(({ key }) => key));
                     const { oauthFields, oauthRecordFields } = buildOAuthFields(oauthProperties, existingConfig);
+                    const requiresApprovalField = buildRequiresApprovalField(
+                        createRequiresApprovalField(parseRequiresApproval(annotationValue)),
+                        compatibleApprovalFunctionsRef.current
+                    );
 
                     setFunctionModel(model);
-                    setFields([...buildClassToolFields(model), ...oauthFields]);
+                    setFields([...buildClassToolFields(model), requiresApprovalField, ...oauthFields]);
                     setRecordTypeFields(oauthRecordFields);
                     setFormRange(editContext.lineRange);
                     return;
@@ -387,13 +489,14 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
 
                 const insertionPosition = targetLineRange?.startLine
                     ?? await rpcClient.getBIDiagramRpcClient().getEndOfFile({ filePath });
-                const [templateResponse, oauthProperties] = await Promise.all([
+                const [templateResponse, oauthProperties, approvalCandidates] = await Promise.all([
                     rpcClient.getBIDiagramRpcClient().getNodeTemplate({
                         position: insertionPosition,
                         filePath,
                         id: { node: "AGENT_TOOL" },
                     }),
                     fetchOAuthConfigProperties(rpcClient, filePath, oauthStartLine),
+                    fetchCompatibleApprovalFunctions(insertionPosition),
                 ]);
                 if (cancelled) return;
 
@@ -419,10 +522,12 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
                 baseFields.forEach(applyToolFieldDocs);
 
                 oauthPropertiesRef.current = oauthProperties;
+                compatibleApprovalFunctionsRef.current = approvalCandidates;
                 const { oauthFields, oauthRecordFields } = buildOAuthFields(oauthProperties, {});
+                const requiresApprovalField = buildRequiresApprovalField(createRequiresApprovalField(), approvalCandidates);
 
                 setToolNode(node);
-                setFields([...baseFields, ...oauthFields]);
+                setFields([...baseFields, requiresApprovalField, ...oauthFields]);
                 setRecordTypeFields(oauthRecordFields);
                 if (!targetLineRange && !cancelled) {
                     setFormRange({ startLine: insertionPosition, endLine: insertionPosition });
@@ -473,8 +578,16 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
                         expressionKeys.add(key);
                     }
                 }
+                // Compose every annotation field the form knows about (auth, requiresApproval) rather
+                // than assuming auth is the only one — otherwise saving without touching the approval
+                // gate would silently drop it, since this rebuilds the annotation value from scratch.
+                const fragments: string[] = [];
                 const authFragment = buildAuthAnnotation(rawAuth, expressionKeys);
-                (updatedModel.properties as any)[annotation.key].value = authFragment ? `{\n    ${authFragment}\n}` : "";
+                if (authFragment) fragments.push(authFragment);
+                const approvalSource = resolveApprovalSource(data);
+                if (approvalSource) fragments.push(`requiresApproval: ${approvalSource}`);
+                (updatedModel.properties as any)[annotation.key].value = fragments.length > 0
+                    ? `{\n    ${fragments.join(",\n    ")}\n}` : "";
             }
 
             const lineRange = functionModel.codedata?.lineRange ?? editContext?.lineRange;
@@ -546,9 +659,18 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
                 const source = toAuthSource(key, value, isExpression);
                 if (source) auth[key] = source;
             }
+            // Mirrors AIAgentSidePanel's function/connection tool-creation paths: rides along in
+            // codedata.data and is rendered into the @ai:AgentTool annotation by the language server
+            // (AgentToolBuilder.emitAnnotation / appendApprovalPredicate). Only consulted on create —
+            // isEdit rewrites the already-existing annotation text directly below instead.
+            const approvalSourceForCreate = resolveApprovalSource(data);
             updatedNode.codedata.data = {
                 ...updatedNode.codedata.data,
                 ...(Object.keys(auth).length > 0 ? { auth: JSON.stringify(auth) } : {}),
+                ...(approvalSourceForCreate ? { requiresApproval: approvalSourceForCreate } : {}),
+                ...(approvalSourceForCreate && approvalSourceForCreate !== "true"
+                    && !compatibleApprovalFunctionsRef.current.includes(approvalSourceForCreate)
+                    ? { generateApprovalFunction: "true" } : {}),
             };
 
             let response;
@@ -579,6 +701,12 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
                                     `@ai:AgentTool {\n    ${configBlock}\n}`);
                             }
                         }
+                        // Edits reference the typed approval-function name as-is (no stub scaffolding —
+                        // this path rewrites already-generated source text directly, bypassing
+                        // AgentToolBuilder's codegen where the predicate stub is normally emitted).
+                        annotationStr = upsertScalarAnnotationField(
+                            annotationStr, "requiresApproval", resolveApprovalSource(data)
+                        );
                         properties.annotations.value = annotationStr.replace(/\s+$/, "\n");
                     }
                 }

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentToolForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentToolForm.tsx
@@ -188,7 +188,7 @@ function toAuthSource(key: string, value: unknown, isExpression: boolean): strin
 // annotation, to prefill the "Requires Approval" control when editing a custom tool that already
 // has the gate set.
 function parseRequiresApproval(annotationValue: string): ExistingApprovalConfig | undefined {
-    const match = /requiresApproval\s*:\s*([^,}]+)/.exec(annotationValue);
+    const match = /\brequiresApproval\b\s*:\s*([^,}]+)/.exec(annotationValue);
     if (!match) return undefined;
     const raw = match[1].trim();
     return raw === "true" ? {} : { functionName: raw };
@@ -207,7 +207,7 @@ function withExistingCandidate(candidates: string[], existing?: ExistingApproval
 // upsert in spirit, but auth's value is itself a `{ ... }` record while requiresApproval's value is
 // a bare boolean or identifier, so a brace-unaware match up to the next comma/close-brace suffices.
 function upsertScalarAnnotationField(annotationStr: string, key: string, source: string | undefined): string {
-    const match = new RegExp(`${key}\\s*:\\s*[^,}]+`).exec(annotationStr);
+    const match = new RegExp(`\\b${key}\\b\\s*:\\s*[^,}]+`).exec(annotationStr);
     if (match) {
         let s = match.index;
         let e = match.index + match[0].length;
@@ -215,7 +215,9 @@ function upsertScalarAnnotationField(annotationStr: string, key: string, source:
             return annotationStr.slice(0, s) + `${key}: ${source}` + annotationStr.slice(e);
         }
         const lead = annotationStr.slice(0, s).match(/,\s*$/);
-        const trail = annotationStr.slice(e).match(/^\s*,/);
+        // `\s*` after the comma also swallows the removed field's now-blank line (its trailing
+        // newline + the next field's leading indentation), so removal doesn't leave an empty line.
+        const trail = annotationStr.slice(e).match(/^\s*,\s*/);
         if (lead) s -= lead[0].length;
         else if (trail) e += trail[0].length;
         return (annotationStr.slice(0, s) + annotationStr.slice(e))
@@ -273,9 +275,14 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
     // Fetch the project's own module-level functions (excluding the tool's own function, when
     // editing one) as approval-predicate candidates. Shared shape with the function/connection
     // tool-creation forms; see formUtils.collectLocalFunctionNames for the filtering rules.
+    // Returns `null` (rather than `[]`) when the fetch itself fails, distinguishing "search failed"
+    // from "no eligible functions" — see formUtils.buildRequiresApprovalField for why the create
+    // flow (below) needs that distinction. The edit flows fold `null` back to `[]` immediately since
+    // their strict pick-list (allowCreate=false) plus prefilled existing value is already safe either
+    // way: there's no free-typed "create a new predicate" path for a fetch failure to corrupt.
     const fetchCompatibleApprovalFunctions = async (
         position: LinePosition, excludeName?: string
-    ): Promise<string[]> => {
+    ): Promise<string[] | null> => {
         try {
             const request: BISearchRequest = {
                 position: { startLine: position, endLine: position },
@@ -292,7 +299,7 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
             return Array.from(names);
         } catch (error) {
             console.error(">>> Error fetching compatible approval functions", error);
-            return [];
+            return null;
         }
     };
 
@@ -452,7 +459,10 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
 
                     oauthPropertiesRef.current = oauthProperties;
                     const existingApproval = parseRequiresApproval(annotationValue);
-                    const approvalItems = withExistingCandidate(approvalCandidates, existingApproval);
+                    // A failed fetch folds to [] here (not the create flow's hide-the-picker
+                    // fallback): allowCreate=false plus the prefilled existing value below already
+                    // keep this safe — there's no free-typed "create a new predicate" path to corrupt.
+                    const approvalItems = withExistingCandidate(approvalCandidates ?? [], existingApproval);
                     compatibleApprovalFunctionsRef.current = approvalItems;
                     const existingConfig = parseAuth(annotationValue, oauthProperties.map(({ key }) => key));
                     const { oauthFields, oauthRecordFields } = buildOAuthFields(oauthProperties, existingConfig);
@@ -485,8 +495,9 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
                     oauthPropertiesRef.current = oauthProperties;
                     const annotationValue = findAgentToolAnnotation(model)?.value ?? "";
                     const existingApproval = parseRequiresApproval(annotationValue);
+                    // Same fold-to-[] rationale as the top-level edit branch above.
                     const approvalItems = withExistingCandidate(
-                        approvalCandidates.filter((name) => name !== String(model.name.value)),
+                        (approvalCandidates ?? []).filter((name) => name !== String(model.name.value)),
                         existingApproval
                     );
                     compatibleApprovalFunctionsRef.current = approvalItems;
@@ -541,8 +552,11 @@ export function AgentToolForm(props: AgentToolFormProps): JSX.Element {
                 baseFields.forEach(applyToolFieldDocs);
 
                 oauthPropertiesRef.current = oauthProperties;
-                compatibleApprovalFunctionsRef.current = approvalCandidates;
+                compatibleApprovalFunctionsRef.current = approvalCandidates ?? [];
                 const { oauthFields, oauthRecordFields } = buildOAuthFields(oauthProperties, {});
+                // Unlike the edit branches above, this is a create flow (allowCreate=true): on a
+                // failed fetch, propagate null through so buildRequiresApprovalField falls back to
+                // the plain checkbox rather than offering a free-typed picker over an empty list.
                 const requiresApprovalField = buildRequiresApprovalField(createRequiresApprovalField(), approvalCandidates);
 
                 setToolNode(node);

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentToolForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentToolForm.tsx
@@ -191,7 +191,9 @@ function parseRequiresApproval(annotationValue: string): ExistingApprovalConfig 
     const match = /\brequiresApproval\b\s*:\s*([^,}]+)/.exec(annotationValue);
     if (!match) return undefined;
     const raw = match[1].trim();
-    return raw === "true" ? {} : { functionName: raw };
+    if (raw === "true") return {};
+    if (raw === "false") return undefined;
+    return { functionName: raw };
 }
 
 // Ensure the function the tool currently references is always a selectable candidate, even if the

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentToolForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentToolForm.tsx
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
-import { ArtifactData, FlowNode, NodePosition } from "@wso2/ballerina-core";
+import { ArtifactData, AvailableNode, BISearchRequest, Category, FlowNode, LinePosition, NodePosition } from "@wso2/ballerina-core";
 import { FormField, FormValues } from "@wso2/ballerina-side-panel";
 import { Icon } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
@@ -26,7 +26,7 @@ import ArtifactForm from "../Forms/ArtifactForm";
 import { RelativeLoader } from "../../../components/RelativeLoader";
 import { ImplementationBadge } from "../../../components/ImplementationBadge";
 import { addToolToAgentNode, AgentToolHostClass, buildAgentCallToolNode, refreshAgentNodeLineRange, resolveAgentNodePosition } from "./utils";
-import { buildAgentToolFields, stripCodeFencesInline } from "./formUtils";
+import { buildAgentToolFields, buildApprovalToolData, buildRequiresApprovalField, collectLocalFunctionNames, createRequiresApprovalField, stripCodeFencesInline } from "./formUtils";
 
 const LoaderContainer = styled.div`
     display: flex;
@@ -74,25 +74,53 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
     const [ready, setReady] = useState<boolean>(false);
     const [saving, setSaving] = useState<boolean>(false);
     const [includeContext, setIncludeContext] = useState<boolean>(false);
+    const [fields, setFields] = useState<FormField[]>([]);
+    // Candidate list backing the approval-predicate picker; consulted at submit to decide whether a
+    // free-typed name should scaffold a new predicate stub. See formUtils.buildApprovalToolData.
+    const compatibleApprovalFunctionsRef = useRef<string[]>([]);
+
+    // Fetch the project's own module-level functions as approval-predicate candidates. Same shape as
+    // the other tool-creation forms; see formUtils.collectLocalFunctionNames for the filtering rules.
+    const fetchCompatibleApprovalFunctions = async (filePath: string, position: LinePosition): Promise<string[]> => {
+        try {
+            const request: BISearchRequest = {
+                position: { startLine: position, endLine: position },
+                filePath,
+                queryMap: undefined,
+                searchKind: "FUNCTION",
+            };
+            const response = await rpcClient.getBIDiagramRpcClient().search(request);
+            const names = new Set<string>();
+            collectLocalFunctionNames((response?.categories ?? []) as (Category | AvailableNode)[], names);
+            return Array.from(names);
+        } catch (error) {
+            console.error(">>> Error fetching compatible approval functions", error);
+            return [];
+        }
+    };
 
     useEffect(() => {
-        if (hostClass) {
-            setAgentFilePath(hostClass.filePath);
-            setReady(true);
-            return;
-        }
         (async () => {
-            const fileName = agentNode?.codedata?.lineRange?.fileName ?? "agents.bal";
-            const { filePath } = await rpcClient.getVisualizerRpcClient().joinProjectPath({ segments: [fileName] });
+            const filePath = hostClass
+                ? hostClass.filePath
+                : (await rpcClient.getVisualizerRpcClient().joinProjectPath({
+                    segments: [agentNode?.codedata?.lineRange?.fileName ?? "agents.bal"],
+                })).filePath;
+            const position = agentNode?.codedata?.lineRange?.startLine ?? { line: 0, offset: 0 };
+            const approvalCandidates = await fetchCompatibleApprovalFunctions(filePath, position);
+            compatibleApprovalFunctionsRef.current = approvalCandidates;
+
             setAgentFilePath(filePath);
+            setFields([
+                ...buildAgentToolFields(
+                    `${agentVarName}Tool`,
+                    `Delegates a query to ${agentLabel === "Agent" ? "the generic agent" : agentLabel}.`
+                ),
+                buildRequiresApprovalField(createRequiresApprovalField(), approvalCandidates),
+            ]);
             setReady(true);
         })();
     }, [agentNode]);
-
-    const fields: FormField[] = buildAgentToolFields(
-        `${agentVarName}Tool`,
-        `Delegates a query to ${agentLabel === "Agent" ? "the generic agent" : agentLabel}.`
-    );
 
     const handleSubmit = async (data: FormValues) => {
         if (saving) {
@@ -104,10 +132,11 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
             const toolName = String(data["name"] ?? "").trim() || `${agentVarName}Tool`;
             const description = stripCodeFencesInline(String(data["description"] ?? ""));
             const toolFilePath = hostClass ? hostClass.filePath : agentFilePath;
+            const approvalData = buildApprovalToolData(data, compatibleApprovalFunctionsRef.current);
             const toolResponse = await rpcClient.getBIDiagramRpcClient().getSourceCode({
                 filePath: toolFilePath,
                 flowNode: buildAgentCallToolNode(toolName, agentVarName, includeContext, description,
-                    hostClass, agentReceiver),
+                    hostClass, agentReceiver, approvalData),
                 artifactData,
             });
             let agentPosition: NodePosition | undefined;

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentToolForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentToolForm.tsx
@@ -81,7 +81,13 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
 
     // Fetch the project's own module-level functions as approval-predicate candidates. Same shape as
     // the other tool-creation forms; see formUtils.collectLocalFunctionNames for the filtering rules.
-    const fetchCompatibleApprovalFunctions = async (filePath: string, position: LinePosition): Promise<string[]> => {
+    // Returns `null` (not `[]`) on fetch failure, so it can be told apart from a project with no
+    // eligible functions — see formUtils.buildRequiresApprovalField for why the create flow below
+    // needs that distinction (an empty-by-failure list plus allowCreate=true risks a re-picked
+    // existing function silently generating a duplicate/broken predicate).
+    const fetchCompatibleApprovalFunctions = async (
+        filePath: string, position: LinePosition
+    ): Promise<string[] | null> => {
         try {
             const request: BISearchRequest = {
                 position: { startLine: position, endLine: position },
@@ -95,20 +101,23 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
             return Array.from(names);
         } catch (error) {
             console.error(">>> Error fetching compatible approval functions", error);
-            return [];
+            return null;
         }
     };
 
     useEffect(() => {
+        let cancelled = false;
         (async () => {
             const filePath = hostClass
                 ? hostClass.filePath
                 : (await rpcClient.getVisualizerRpcClient().joinProjectPath({
                     segments: [agentNode?.codedata?.lineRange?.fileName ?? "agents.bal"],
                 })).filePath;
+            if (cancelled) return;
             const position = agentNode?.codedata?.lineRange?.startLine ?? { line: 0, offset: 0 };
             const approvalCandidates = await fetchCompatibleApprovalFunctions(filePath, position);
-            compatibleApprovalFunctionsRef.current = approvalCandidates;
+            if (cancelled) return;
+            compatibleApprovalFunctionsRef.current = approvalCandidates ?? [];
 
             setAgentFilePath(filePath);
             setFields([
@@ -120,7 +129,10 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
             ]);
             setReady(true);
         })();
-    }, [agentNode]);
+        return () => {
+            cancelled = true;
+        };
+    }, [agentNode, hostClass, agentVarName, agentLabel]);
 
     const handleSubmit = async (data: FormValues) => {
         if (saving) {

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @wso2/ballerina-core's barrel re-exports WSConnection, which requires vscode-ws-jsonrpc — an
+// ESM-only package jest can't load without extra transform config. formUtils only uses the pure
+// getPrimaryInputType from it at runtime, so we stub that (matching src/utils/bi.test.ts).
+jest.mock("@wso2/ballerina-core", () => ({
+    getPrimaryInputType: (types: any[]) => types?.[0],
+}));
+
+import { FormValues } from "@wso2/ballerina-side-panel";
+import { buildApprovalToolData } from "./formUtils";
+
+// The picker's existing-function candidate list. A typed approval-function name present here is an
+// existing predicate (referenced as-is); one absent from it is new (drives generateApprovalFunction).
+const EXISTING_FUNCTIONS = ["isHighValue", "needsReview"];
+
+describe("buildApprovalToolData", () => {
+    it("returns nothing when the gate is unchecked", () => {
+        // Even a stale function name left in the sub-field must be ignored while the box is off,
+        // since the checkbox is the gate (CheckBoxConditionalEditor keeps the sub-field on uncheck).
+        const data: FormValues = { requiresApproval: false, approvalFunction: "isHighValue" };
+        expect(buildApprovalToolData(data, EXISTING_FUNCTIONS)).toEqual({});
+    });
+
+    it("emits unconditional approval when checked with no function picked", () => {
+        const data: FormValues = { requiresApproval: true, approvalFunction: "" };
+        expect(buildApprovalToolData(data, EXISTING_FUNCTIONS)).toEqual({ requiresApproval: "true" });
+    });
+
+    it("references an existing function without requesting generation", () => {
+        const data: FormValues = { requiresApproval: true, approvalFunction: "isHighValue" };
+        expect(buildApprovalToolData(data, EXISTING_FUNCTIONS)).toEqual({ requiresApproval: "isHighValue" });
+    });
+
+    it("requests scaffolding for a new (free-typed) function name", () => {
+        const data: FormValues = { requiresApproval: true, approvalFunction: "brandNewPredicate" };
+        expect(buildApprovalToolData(data, EXISTING_FUNCTIONS)).toEqual({
+            requiresApproval: "brandNewPredicate",
+            generateApprovalFunction: "true",
+        });
+    });
+
+    it("treats the string 'true' checkbox value the same as boolean true", () => {
+        // Form state can carry the checkbox as the string "true" depending on the field's origin.
+        const data: FormValues = { requiresApproval: "true", approvalFunction: "" };
+        expect(buildApprovalToolData(data, EXISTING_FUNCTIONS)).toEqual({ requiresApproval: "true" });
+    });
+
+    it("trims surrounding whitespace and matches candidates on the trimmed name", () => {
+        const data: FormValues = { requiresApproval: true, approvalFunction: "  isHighValue  " };
+        expect(buildApprovalToolData(data, EXISTING_FUNCTIONS)).toEqual({ requiresApproval: "isHighValue" });
+    });
+
+    it("falls back to unconditional when the picked value is not a string", () => {
+        const data: FormValues = { requiresApproval: true, approvalFunction: undefined };
+        expect(buildApprovalToolData(data, EXISTING_FUNCTIONS)).toEqual({ requiresApproval: "true" });
+    });
+
+    it("treats every name as new when the candidate list is empty", () => {
+        const data: FormValues = { requiresApproval: true, approvalFunction: "isHighValue" };
+        expect(buildApprovalToolData(data, [])).toEqual({
+            requiresApproval: "isHighValue",
+            generateApprovalFunction: "true",
+        });
+    });
+});

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
@@ -394,11 +394,26 @@ export function createRequiresApprovalField(
 // Rebuild the static "Requires Approval" field with the runtime-fetched picker candidates injected
 // into its "On" branch. `items` populate the AUTOCOMPLETE dropdown; the label, description and
 // placeholder are preserved from the static definition.
-export function buildRequiresApprovalField(baseField: FormField, candidates: string[]): FormField {
+// `candidates` is `null` when the fetch itself failed (as opposed to a project with no eligible
+// functions, which is `[]`) — an empty list can't be told apart from a failure by buildApprovalToolData,
+// which treats any name absent from the list as new. Surfacing a picker over an empty-by-failure list
+// would let a user re-pick their existing `isHighValue`, have it read as new, and silently regenerate
+// a duplicate/broken predicate. So on failure the "On" branch drops the picker entirely and falls back
+// to the plain unconditional-approval checkbox until the candidate list is actually known.
+export function buildRequiresApprovalField(baseField: FormField, candidates: string[] | null): FormField {
     const onChoice = baseField.choices?.[0];
     const approvalProp = onChoice?.properties?.approvalFunction;
     if (!approvalProp) {
         return baseField;
+    }
+    if (candidates === null) {
+        return {
+            ...baseField,
+            choices: [
+                { ...onChoice, properties: {} },
+                ...baseField.choices.slice(1),
+            ],
+        };
     }
     return {
         ...baseField,

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { ValueTypeConstraint, ToolParameters, getPrimaryInputType } from "@wso2/ballerina-core";
+import { AvailableNode, Category, NodeMetadata, ValueTypeConstraint, ToolParameters, getPrimaryInputType } from "@wso2/ballerina-core";
 import { FormField, Parameter } from "@wso2/ballerina-side-panel";
 
 const SQL_PARAMETERIZED_TYPES = ["sql:ParameterizedQuery", "sql:ParameterizedCallQuery"];
@@ -293,6 +293,115 @@ export const stripCodeFences = (text: string): string => text.replace(CODE_FENCE
 // Same, for fields that must stay on a single line (tool descriptions are written into source).
 export const stripCodeFencesInline = (text: string): string =>
     text.replace(CODE_FENCE_REGEX, "").replace(/\n/g, " ").trim();
+
+// Categories in the FUNCTION search response that are NOT the project's own functions: standard
+// library and imported/third-party modules (plus agent tools). Approval-predicate pickers offer
+// only the user's own module-level functions as candidates, so these are skipped.
+const NON_LOCAL_FUNCTION_CATEGORIES = ["Standard Library", "Agent Tools"];
+function isLocalFunctionCategory(label: string | undefined): boolean {
+    if (!label) return true;
+    return !NON_LOCAL_FUNCTION_CATEGORIES.includes(label) && !label.includes("Imported");
+}
+
+// Recursively collect the names of the project's own functions from raw search-result categories,
+// to offer as approval-predicate candidates. The list-level search response has no reliable return
+// type to filter on (codedata.inferredReturnType is only populated in niche type-inference cases,
+// not for ordinary `boolean` returns), so all local functions are offered and the compiler/LS flags
+// an incompatible pick after generation — the RequiresApproval contract (params mirror the tool,
+// returns boolean) is verified there, not here. Agent-tool functions are excluded.
+export function collectLocalFunctionNames(items: (Category | AvailableNode)[], acc: Set<string>): void {
+    for (const item of items) {
+        if (item && "items" in item && Array.isArray((item as Category).items)) {
+            if (isLocalFunctionCategory((item as Category).metadata?.label)) {
+                collectLocalFunctionNames((item as Category).items as (Category | AvailableNode)[], acc);
+            }
+            continue;
+        }
+        const node = item as AvailableNode;
+        const name = node?.codedata?.symbol;
+        if (name && !(node.metadata?.data as NodeMetadata)?.isAgentTool) {
+            acc.add(name);
+        }
+    }
+}
+
+// Prefill state for the "Requires Approval" control, parsed from an existing @ai:AgentTool
+// annotation when editing a tool that already has the gate set.
+export interface ExistingApprovalConfig {
+    functionName?: string;
+}
+
+// The static "Requires Approval" CONDITIONAL_FIELDS field, shared by every tool-creation path
+// (function, connection, custom). The annotation value is `boolean | isolated function`: checking
+// the box alone emits `requiresApproval: true`; picking a function in the revealed sub-field emits
+// that function reference instead, so approval becomes conditional at runtime. Modeled as
+// CONDITIONAL_FIELDS (CheckBoxConditionalEditor) so the function picker is part of this field
+// rather than a separate, disconnected form entry.
+export function createRequiresApprovalField(existing?: ExistingApprovalConfig): FormField {
+    return {
+        key: "requiresApproval",
+        label: "Requires Approval",
+        type: "CONDITIONAL_FIELDS",
+        optional: true,
+        editable: true,
+        documentation: "Pause this tool before it runs and wait for human approval.",
+        value: Boolean(existing),
+        types: [{ fieldType: "CONDITIONAL_FIELDS", selected: false }],
+        enabled: true,
+        choices: [
+            {
+                metadata: { label: "On" },
+                properties: {
+                    approvalFunction: {
+                        metadata: {
+                            // "(optional)" is appended by AutoCompleteEditor for optional fields; keeping
+                            // it here would double up (capitalize() = startCase would also mangle it).
+                            label: "Approval Function",
+                            description:
+                                "Decides per call whether approval is needed. Pick one of your functions, or type a name to create one.",
+                        },
+                        // AUTOCOMPLETE (not EXPRESSION): the annotation slot takes a function *reference*
+                        // (a bare name), never a call expression. `items` are injected at runtime once the
+                        // candidate list is fetched; free-typed names are accepted (AutoCompleteEditor
+                        // sets allowItemCreate) and drive the "create a new predicate" path.
+                        types: [{ fieldType: "AUTOCOMPLETE", selected: true }],
+                        value: existing?.functionName || "",
+                        optional: true,
+                        editable: true,
+                    },
+                },
+            },
+            { metadata: { label: "Off" }, properties: {} },
+        ],
+    } as unknown as FormField;
+}
+
+// Rebuild the static "Requires Approval" field with the runtime-fetched picker candidates injected
+// into its "On" branch. `items` populate the AUTOCOMPLETE dropdown; the label, description and
+// placeholder are preserved from the static definition.
+export function buildRequiresApprovalField(baseField: FormField, candidates: string[]): FormField {
+    const onChoice = baseField.choices?.[0];
+    const approvalProp = onChoice?.properties?.approvalFunction;
+    if (!approvalProp) {
+        return baseField;
+    }
+    return {
+        ...baseField,
+        choices: [
+            {
+                ...onChoice,
+                properties: {
+                    ...onChoice.properties,
+                    approvalFunction: {
+                        ...approvalProp,
+                        items: candidates,
+                    },
+                },
+            },
+            ...baseField.choices.slice(1),
+        ],
+    };
+}
 
 export function buildAgentToolFields(nameValue: string, descriptionValue: string): FormField[] {
     return [

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
@@ -17,7 +17,7 @@
  */
 
 import { AvailableNode, Category, NodeMetadata, ValueTypeConstraint, ToolParameters, getPrimaryInputType } from "@wso2/ballerina-core";
-import { FormField, Parameter } from "@wso2/ballerina-side-panel";
+import { FormField, FormValues, Parameter } from "@wso2/ballerina-side-panel";
 
 const SQL_PARAMETERIZED_TYPES = ["sql:ParameterizedQuery", "sql:ParameterizedCallQuery"];
 const isSqlParameterizedField = (field: FormField): boolean =>
@@ -401,6 +401,32 @@ export function buildRequiresApprovalField(baseField: FormField, candidates: str
             ...baseField.choices.slice(1),
         ],
     };
+}
+
+// The `codedata.data` fields that carry the human-in-the-loop gate into AgentToolBuilder's code
+// generator, derived from the "Requires Approval" control's submitted state. Shared by every
+// tool-creation path (function, connection, custom, agent-call) so they emit identical data.
+//   - box unchecked        -> {} (no gate).
+//   - checked, no function  -> { requiresApproval: "true" } (unconditional).
+//   - checked, existing fn  -> { requiresApproval: <name> } (reference an already-defined predicate).
+//   - checked, new fn       -> { requiresApproval: <name>, generateApprovalFunction: "true" } (the LS
+//                              also scaffolds a correctly-signed predicate stub).
+// `compatibleFunctions` is the picker's candidate list; a typed name absent from it is treated as new.
+export function buildApprovalToolData(
+    data: FormValues, compatibleFunctions: string[]
+): { requiresApproval?: string; generateApprovalFunction?: string } {
+    const checked = data["requiresApproval"] === true || data["requiresApproval"] === "true";
+    if (!checked) {
+        return {};
+    }
+    const approvalFn = typeof data["approvalFunction"] === "string" ? data["approvalFunction"].trim() : "";
+    const result: { requiresApproval?: string; generateApprovalFunction?: string } = {
+        requiresApproval: approvalFn || "true",
+    };
+    if (approvalFn && !compatibleFunctions.includes(approvalFn)) {
+        result.generateApprovalFunction = "true";
+    }
+    return result;
 }
 
 export function buildAgentToolFields(nameValue: string, descriptionValue: string): FormField[] {

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
@@ -372,7 +372,13 @@ export function createRequiresApprovalField(
                         // candidate list is fetched. When allowCreate is true, free-typed names are accepted
                         // (drive the "create a new predicate" path); when false, the picker is a strict
                         // pick-list of existing functions.
-                        types: [{ fieldType: "AUTOCOMPLETE", selected: true }],
+                        // The identifier rule guards the free-typed path: without it, a value like
+                        // "my predicate" goes straight into both `requiresApproval: <name>` and the
+                        // generated `isolated function <name>(...)`, producing invalid Ballerina source.
+                        types: [{
+                            fieldType: "AUTOCOMPLETE", selected: true,
+                            validations: [{ rule: "common.validate.identifier", message: "Invalid identifier" }],
+                        }],
                         allowItemCreate: allowCreate,
                         value: existing?.functionName || "",
                         optional: true,

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
@@ -337,7 +337,13 @@ export interface ExistingApprovalConfig {
 // that function reference instead, so approval becomes conditional at runtime. Modeled as
 // CONDITIONAL_FIELDS (CheckBoxConditionalEditor) so the function picker is part of this field
 // rather than a separate, disconnected form entry.
-export function createRequiresApprovalField(existing?: ExistingApprovalConfig): FormField {
+// `allowCreate` controls whether the picker accepts a free-typed (new) function name. Create flows
+// pass true (a new name drives predicate scaffolding via AgentToolBuilder); edit flows pass false —
+// those paths rewrite source directly and never reach the generator, so a new name would produce a
+// dangling reference. Restricting edits to existing functions keeps the annotation always resolvable.
+export function createRequiresApprovalField(
+    existing?: ExistingApprovalConfig, allowCreate: boolean = true
+): FormField {
     return {
         key: "requiresApproval",
         label: "Requires Approval",
@@ -357,14 +363,17 @@ export function createRequiresApprovalField(existing?: ExistingApprovalConfig): 
                             // "(optional)" is appended by AutoCompleteEditor for optional fields; keeping
                             // it here would double up (capitalize() = startCase would also mangle it).
                             label: "Approval Function",
-                            description:
-                                "Decides per call whether approval is needed. Pick one of your functions, or type a name to create one.",
+                            description: allowCreate
+                                ? "Decides per call whether approval is needed. Pick one of your functions, or type a name to create one."
+                                : "Decides per call whether approval is needed. Pick one of your existing functions.",
                         },
                         // AUTOCOMPLETE (not EXPRESSION): the annotation slot takes a function *reference*
                         // (a bare name), never a call expression. `items` are injected at runtime once the
-                        // candidate list is fetched; free-typed names are accepted (AutoCompleteEditor
-                        // sets allowItemCreate) and drive the "create a new predicate" path.
+                        // candidate list is fetched. When allowCreate is true, free-typed names are accepted
+                        // (drive the "create a new predicate" path); when false, the picker is a strict
+                        // pick-list of existing functions.
                         types: [{ fieldType: "AUTOCOMPLETE", selected: true }],
+                        allowItemCreate: allowCreate,
                         value: existing?.functionName || "",
                         optional: true,
                         editable: true,

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
@@ -383,6 +383,7 @@ export function createRequiresApprovalField(
                             validations: [{ rule: "common.validate.identifier", message: "Invalid identifier" }],
                         }],
                         allowItemCreate: allowCreate,
+                        showOptionalSuffix: true,
                         value: existing?.functionName || "",
                         optional: true,
                         editable: true,

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
@@ -297,6 +297,9 @@ export const stripCodeFencesInline = (text: string): string =>
 // Categories in the FUNCTION search response that are NOT the project's own functions: standard
 // library and imported/third-party modules (plus agent tools). Approval-predicate pickers offer
 // only the user's own module-level functions as candidates, so these are skipped.
+// Matched by label rather than a structural field because the category itself carries no org/module
+// info (only the leaf AvailableNode.codedata does, one level down) — this is a wording-fragile check,
+// not a considered choice. If the LS ever renames these labels, this filter silently stops working.
 const NON_LOCAL_FUNCTION_CATEGORIES = ["Standard Library", "Agent Tools"];
 function isLocalFunctionCategory(label: string | undefined): boolean {
     if (!label) return true;

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/utils.ts
@@ -616,7 +616,8 @@ export function buildAgentToolNode(wrappedNode: FlowNode, toolName: string, desc
 }
 
 export function buildAgentCallToolNode(toolName: string, agentVarName: string, includeContext: boolean,
-    description: string, hostClass?: AgentToolHostClass, agentReceiver?: string): FlowNode {
+    description: string, hostClass?: AgentToolHostClass, agentReceiver?: string,
+    approvalData?: { requiresApproval?: string; generateApprovalFunction?: string }): FlowNode {
     const data: AgentToolData = {
         toolKind: "AGENT_CALL",
         agentVarName,
@@ -624,6 +625,7 @@ export function buildAgentCallToolNode(toolName: string, agentVarName: string, i
         description,
         ...(agentReceiver ? { agentReceiver } : {}),
         ...(hostClass ? { hostClassName: hostClass.className, filePath: hostClass.filePath } : {}),
+        ...(approvalData ?? {}),
     };
     return createAgentToolNode(toolName, data);
 }

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/utils.ts
@@ -604,12 +604,16 @@ export interface AgentToolHostClass {
 export function buildAgentToolNode(wrappedNode: FlowNode, toolName: string, description: string, connection: string,
     toolParameters?: ToolParameters, hostClass?: AgentToolHostClass, includeContext = false): FlowNode {
     const auth = wrappedNode.codedata.data?.auth;
+    const requiresApproval = wrappedNode.codedata.data?.requiresApproval;
+    const generateApprovalFunction = wrappedNode.codedata.data?.generateApprovalFunction;
     const data: AgentToolData = {
         node: wrappedNode,
         connection,
         description,
         includeContext,
         ...(typeof auth === "string" ? { auth } : {}),
+        ...(requiresApproval !== undefined ? { requiresApproval } : {}),
+        ...(generateApprovalFunction !== undefined ? { generateApprovalFunction } : {}),
         ...(hostClass ? { hostClassName: hostClass.className, filePath: hostClass.filePath } : {}),
     };
     return createAgentToolNode(toolName, data, toolParameters ? { parameters: toolParameters } : {});


### PR DESCRIPTION
## Purpose
$subject.

Fixes https://github.com/wso2/product-integrator/issues/2131

## Preview
**add tool → Use Function:**
- Conditional approval: create a new predicate function

https://github.com/user-attachments/assets/1cf13697-cc54-433e-880e-e6849273a4bc

- Conditional approval:  pick an existing function

https://github.com/user-attachments/assets/f7101b74-3a7d-4c21-b133-aba4c3de458d

- Always require approval (no predicate function)

https://github.com/user-attachments/assets/e74d0c7c-6662-4d9a-918f-80c3b56f056f

**add tool → Use Connection:**

https://github.com/user-attachments/assets/b0daed71-1d3e-48c3-a5eb-114417346995

**add tool → Create Custom Tool:**

https://github.com/user-attachments/assets/aeea5f6e-3b13-4e63-a752-17126c82a833

**add tool → Use Agent:**

https://github.com/user-attachments/assets/83e409c3-b109-4fd0-8a25-26a7043b1c19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added human-in-the-loop approval for function, connection, custom, and agent tools.
- Added unconditional approval and existing or generated approval predicates.
- Added approval metadata handling, validation, and source generation.
- Added tests for approval configuration and source generation.
- Improved form diagnostics, optional labels, conditional layout, autocomplete configuration, and field value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->