### PR TITLE
Add approval UI for human-in-the-loop AI chat pauses

### DIFF
--- a/packages/ballerina-core/src/rpc-types/agent-chat/index.ts
+++ b/packages/ballerina-core/src/rpc-types/agent-chat/index.ts
@@ -16,11 +16,12 @@
  * under the License.
  */
 
-import { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse } from "./interfaces";
+import { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse, SubmitDecisionRequest, ApprovalDecision, ApprovalRequest, HumanResponse, DecisionMessage, PendingApprovalInfo } from "./interfaces";
 
 export interface AgentChatAPI {
     getChatMessage: (params: ChatReqMessage) => Promise<ChatRespMessage>;
     abortChatRequest: () => void;
+    submitDecision: (params: SubmitDecisionRequest) => Promise<ChatRespMessage>;
     getTracingStatus: (params?: TraceStatusRequest) => Promise<TraceStatus>;
     showTraceView: (params: TraceInput) => Promise<void>;
     showSessionOverview: (params: SessionInput) => Promise<void>;
@@ -32,4 +33,4 @@ export interface AgentChatAPI {
     switchChatAgent: (params: SwitchAgentRequest) => Promise<SwitchAgentResponse>;
 }
 
-export type { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse };
+export type { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse, SubmitDecisionRequest, ApprovalDecision, ApprovalRequest, HumanResponse, DecisionMessage, PendingApprovalInfo };

--- a/packages/ballerina-core/src/rpc-types/agent-chat/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/agent-chat/interfaces.ts
@@ -20,10 +20,45 @@ export interface ChatReqMessage {
     message: string;
 }
 
+export type ApprovalDecision = 'APPROVE' | 'REJECT';
+
+export interface ApprovalRequest {
+    id: string;
+    sessionId: string;
+    toolName: string;
+    toolDescription: string;
+    arguments: Record<string, any>;
+    toolCallId?: string;
+    batchIndex: number;
+}
+
+export interface HumanResponse {
+    decision: ApprovalDecision;
+    reason?: string;
+}
+
+// Sent from the webview to the extension; the extension fills in `sessionId`
+// from the active agent-chat context before posting to the service's `decision` resource.
+export interface SubmitDecisionRequest {
+    decisions: Record<string, HumanResponse>;
+}
+
+// Mirrors `ai:DecisionMessage`, the wire payload posted to a chat service's `decision` resource.
+export interface DecisionMessage {
+    sessionId: string;
+    decisions: Record<string, HumanResponse>;
+}
+
+export interface PendingApprovalInfo {
+    requests: ApprovalRequest[];
+}
+
 export interface ChatRespMessage {
     message: string;
     traceId?: string;
     executionSteps?: ExecutionStep[];
+    // Present when the agent paused for human approval instead of returning a normal reply.
+    pendingApproval?: PendingApprovalInfo;
 }
 
 export interface ExecutionStep {
@@ -53,11 +88,15 @@ export interface TraceInput {
 }
 
 export interface ChatHistoryMessage {
-    type: 'message' | 'error';
+    type: 'message' | 'error' | 'approval';
     text: string;
     isUser: boolean;
     traceId?: string;
     executionSteps?: ExecutionStep[];
+    // Present when type is 'approval': the requests the agent paused on.
+    pendingApproval?: PendingApprovalInfo;
+    // Present once the pending approval above has been resolved by the user.
+    decisions?: Record<string, HumanResponse>;
 }
 
 export interface ChatHistoryResponse {

--- a/packages/ballerina-core/src/rpc-types/agent-chat/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/agent-chat/interfaces.ts
@@ -97,6 +97,10 @@ export interface ChatHistoryMessage {
     pendingApproval?: PendingApprovalInfo;
     // Present once the pending approval above has been resolved by the user.
     decisions?: Record<string, HumanResponse>;
+    // Set when the service no longer recognizes this batch (e.g. it expired or the run
+    // restarted) and a decision can never be applied, so the card is terminal even though
+    // some requests may still lack a decision.
+    unresolvable?: boolean;
 }
 
 export interface ChatHistoryResponse {

--- a/packages/ballerina-core/src/rpc-types/agent-chat/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/agent-chat/interfaces.ts
@@ -97,9 +97,9 @@ export interface ChatHistoryMessage {
     pendingApproval?: PendingApprovalInfo;
     // Present once the pending approval above has been resolved by the user.
     decisions?: Record<string, HumanResponse>;
-    // Set when the service no longer recognizes this batch (e.g. it expired or the run
-    // restarted) and a decision can never be applied, so the card is terminal even though
-    // some requests may still lack a decision.
+    // Set when the user gives up on this batch via the card's Dismiss action (typically after
+    // repeated failed submissions), so the card is terminal even though some requests may
+    // still lack a decision. This is a client-side choice, not something the service reports.
     unresolvable?: boolean;
 }
 

--- a/packages/ballerina-core/src/rpc-types/agent-chat/rpc-type.ts
+++ b/packages/ballerina-core/src/rpc-types/agent-chat/rpc-type.ts
@@ -17,12 +17,13 @@
  * 
  * THIS FILE INCLUDES AUTO GENERATED CODE
  */
-import { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, SessionInput, SessionInfoResponse, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse } from "./interfaces";
+import { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, SessionInput, SessionInfoResponse, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse, SubmitDecisionRequest } from "./interfaces";
 import { RequestType, NotificationType } from "vscode-messenger-common";
 
 const _preFix = "agent-chat";
 export const getChatMessage: RequestType<ChatReqMessage, ChatRespMessage> = { method: `${_preFix}/getChatMessage` };
 export const abortChatRequest: NotificationType<void> = { method: `${_preFix}/abortChatRequest` };
+export const submitDecision: RequestType<SubmitDecisionRequest, ChatRespMessage> = { method: `${_preFix}/submitDecision` };
 export const getTracingStatus: RequestType<TraceStatusRequest, TraceStatus> = { method: `${_preFix}/getTracingStatus` };
 export const showTraceView: NotificationType<TraceInput> = { method: `${_preFix}/showTraceView` };
 export const showSessionOverview: NotificationType<SessionInput> = { method: `${_preFix}/showSessionOverview` };

--- a/packages/ballerina-extension/src/rpc-managers/agent-chat/rpc-handler.ts
+++ b/packages/ballerina-extension/src/rpc-managers/agent-chat/rpc-handler.ts
@@ -32,7 +32,9 @@ import {
     getSessionInfo,
     getAvailableChatAgents,
     switchChatAgent,
-    SwitchAgentRequest
+    SwitchAgentRequest,
+    submitDecision,
+    SubmitDecisionRequest
 } from "@wso2/ballerina-core";
 import { Messenger } from "vscode-messenger";
 import { AgentChatRpcManager } from "./rpc-manager";
@@ -41,6 +43,7 @@ export function registerAgentChatRpcHandlers(messenger: Messenger) {
     const rpcManger = new AgentChatRpcManager();
     messenger.onRequest(getChatMessage, (args: ChatReqMessage) => rpcManger.getChatMessage(args));
     messenger.onNotification(abortChatRequest, () => rpcManger.abortChatRequest());
+    messenger.onRequest(submitDecision, (args: SubmitDecisionRequest) => rpcManger.submitDecision(args));
     messenger.onRequest(getTracingStatus, (params) => rpcManger.getTracingStatus(params));
     messenger.onNotification(showTraceView, (args: TraceInput) => rpcManger.showTraceView(args));
     messenger.onNotification(showSessionOverview, (args: SessionInput) => rpcManger.showSessionOverview(args));

--- a/packages/ballerina-extension/src/rpc-managers/agent-chat/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/agent-chat/rpc-manager.ts
@@ -32,7 +32,11 @@ import {
     SessionInfoResponse,
     AvailableAgentsResponse,
     SwitchAgentRequest,
-    SwitchAgentResponse
+    SwitchAgentResponse,
+    SubmitDecisionRequest,
+    DecisionMessage,
+    HumanResponse,
+    PendingApprovalInfo
 } from "@wso2/ballerina-core";
 import * as vscode from 'vscode';
 import * as fs from 'fs';
@@ -81,7 +85,18 @@ export class AgentChatRpcManager implements AgentChatAPI {
                     payload,
                     this.currentAbortController.signal
                 );
-                if (response && response.message) {
+                if (response && response.pendingApproval) {
+                    const pendingApproval: PendingApprovalInfo = response.pendingApproval;
+
+                    this.addMessageToHistory(sessionId, {
+                        type: 'approval',
+                        text: '',
+                        isUser: false,
+                        pendingApproval
+                    });
+
+                    resolve({ message: '', pendingApproval } as ChatRespMessage);
+                } else if (response && response.message) {
                     // Find trace and extract tool calls and execution steps
                     const trace = this.findTraceForMessage(extension.agentChatContext.chatSessionId, params.message, response.message);
                     const executionSteps = trace ? this.extractExecutionSteps(trace) : undefined;
@@ -149,6 +164,100 @@ export class AgentChatRpcManager implements AgentChatAPI {
         AgentChatRpcManager.chatHistoryMap.get(sessionId)!.push(message);
     }
 
+    // Merges the decisions just submitted into whichever 'approval' history entry they belong
+    // to (a batch may be resolved across several submitDecision calls, one request at a time),
+    // so a later getChatHistory()/switchChatAgent() replay renders resolved requests collapsed
+    // rather than as if still pending.
+    private resolvePendingApprovalInHistory(sessionId: string, decisions: Record<string, HumanResponse>): void {
+        const history = AgentChatRpcManager.chatHistoryMap.get(sessionId);
+        if (!history) {
+            return;
+        }
+        const decidedIds = Object.keys(decisions);
+        for (let i = history.length - 1; i >= 0; i--) {
+            const entry = history[i];
+            if (entry.type !== 'approval' || !entry.pendingApproval) {
+                continue;
+            }
+            const belongsToThisBatch = entry.pendingApproval.requests.some(r => decidedIds.includes(r.id));
+            if (belongsToThisBatch) {
+                entry.decisions = { ...(entry.decisions || {}), ...decisions };
+                break;
+            }
+        }
+    }
+
+    // The dispatcher attaches `chat` and `decision` as sibling resources under the same
+    // service base path (see ai:Listener's ChatDispatcherService), and `chatEp` is always
+    // built ending in `/chat` (see buildChatEndpoint in features/tryit/activator.ts).
+    private toDecisionEndpoint(chatEp: string): string {
+        return chatEp.replace(/\/chat$/, '/decision');
+    }
+
+    async submitDecision(params: SubmitDecisionRequest): Promise<ChatRespMessage> {
+        return new Promise(async (resolve, reject) => {
+            try {
+                if (
+                    !extension.agentChatContext.chatEp || typeof extension.agentChatContext.chatEp !== 'string' ||
+                    !extension.agentChatContext.chatSessionId || typeof extension.agentChatContext.chatSessionId !== 'string'
+                ) {
+                    throw new Error('Invalid Agent Chat Context: Missing or incorrect ChatEP or ChatSessionID!');
+                }
+
+                const sessionId = extension.agentChatContext.chatSessionId;
+                const decisionEp = this.toDecisionEndpoint(extension.agentChatContext.chatEp);
+                const payload: DecisionMessage = { sessionId, decisions: params.decisions };
+
+                this.currentAbortController = new AbortController();
+                const response = await this.fetchTestData(decisionEp, payload, this.currentAbortController.signal);
+
+                this.resolvePendingApprovalInHistory(sessionId, params.decisions);
+
+                if (response && response.pendingApproval) {
+                    // The run resumed only to pause again (e.g. a further gated call surfaced
+                    // in the same turn), so this is a fresh batch, not a resolution of the last one.
+                    const pendingApproval: PendingApprovalInfo = response.pendingApproval;
+
+                    this.addMessageToHistory(sessionId, {
+                        type: 'approval',
+                        text: '',
+                        isUser: false,
+                        pendingApproval
+                    });
+
+                    resolve({ message: '', pendingApproval } as ChatRespMessage);
+                } else if (response && response.message) {
+                    const trace = this.findTraceForMessage(sessionId, '', response.message);
+                    const executionSteps = trace ? this.extractExecutionSteps(trace) : undefined;
+
+                    this.addMessageToHistory(sessionId, {
+                        type: 'message',
+                        text: response.message,
+                        isUser: false,
+                        traceId: trace?.traceId,
+                        executionSteps
+                    });
+
+                    resolve({
+                        message: response.message,
+                        traceId: trace?.traceId,
+                        executionSteps
+                    } as ChatRespMessage);
+                } else {
+                    reject(new Error("Invalid response format from the decision endpoint."));
+                }
+            } catch (error) {
+                const errorMessage =
+                    error && typeof error === "object" && "message" in error
+                        ? String(error.message)
+                        : "An unknown error occurred";
+                reject(new Error(errorMessage));
+            } finally {
+                this.currentAbortController = null;
+            }
+        });
+    }
+
     abortChatRequest(): void {
         if (this.currentAbortController) {
             this.currentAbortController.abort();
@@ -178,7 +287,21 @@ export class AgentChatRpcManager implements AgentChatAPI {
             });
 
             if (!response.ok) {
-                const errorData = await response.json();
+                const errorData: any = await response.json().catch(() => undefined);
+
+                // The dispatcher maps a paused run (ai:ApprovalRequiredError) to HTTP 403 with a
+                // structured `{ requests: ApprovalRequest[] }` body - not a real error, so surface
+                // it to the caller instead of throwing.
+                if (response.status === 403 && errorData && Array.isArray(errorData.requests)) {
+                    return { pendingApproval: { requests: errorData.requests } };
+                }
+
+                // A `decision` resume naming a session/id with nothing pending maps to 404/400
+                // with a stable `errorType` discriminator (ApprovalNotFoundError/UnknownApprovalIdError).
+                if (errorData?.errorType === 'ApprovalNotFoundError' || errorData?.errorType === 'UnknownApprovalIdError') {
+                    throw new Error(errorData.message || 'The pending approval could not be resumed.');
+                }
+
                 switch (response.status) {
                     case 400:
                         throw new Error("Bad Request: The server could not understand the request.");

--- a/packages/ballerina-extension/src/rpc-managers/agent-chat/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/agent-chat/rpc-manager.ts
@@ -49,6 +49,9 @@ import { v4 as uuidv4 } from "uuid";
 import { updateChatSessionId } from "../../features/tryit/activator";
 
 export class AgentChatRpcManager implements AgentChatAPI {
+    // Shared by getChatMessage and submitDecision. Safe only because the UI serializes them -
+    // input stays disabled while an approval is pending, so the two never overlap. If that
+    // ever changes, give each operation its own controller.
     private currentAbortController: AbortController | null = null;
     // Store chat history per session ID
     private static chatHistoryMap: Map<string, ChatHistoryMessage[]> = new Map();
@@ -169,9 +172,26 @@ export class AgentChatRpcManager implements AgentChatAPI {
     // so a later getChatHistory()/switchChatAgent() replay renders resolved requests collapsed
     // rather than as if still pending.
     private resolvePendingApprovalInHistory(sessionId: string, decisions: Record<string, HumanResponse>): void {
+        const entry = this.findPendingApprovalEntry(sessionId, decisions);
+        if (entry) {
+            entry.decisions = { ...(entry.decisions || {}), ...decisions };
+        }
+    }
+
+    // Marks the matching 'approval' history entry as terminal when the service no longer
+    // recognizes the batch (expired, or the run restarted), so a replay renders it as
+    // dismissed instead of stuck pending forever.
+    private markPendingApprovalUnresolvable(sessionId: string, decisions: Record<string, HumanResponse>): void {
+        const entry = this.findPendingApprovalEntry(sessionId, decisions);
+        if (entry) {
+            entry.unresolvable = true;
+        }
+    }
+
+    private findPendingApprovalEntry(sessionId: string, decisions: Record<string, HumanResponse>): ChatHistoryMessage | undefined {
         const history = AgentChatRpcManager.chatHistoryMap.get(sessionId);
         if (!history) {
-            return;
+            return undefined;
         }
         const decidedIds = Object.keys(decisions);
         for (let i = history.length - 1; i >= 0; i--) {
@@ -179,18 +199,21 @@ export class AgentChatRpcManager implements AgentChatAPI {
             if (entry.type !== 'approval' || !entry.pendingApproval) {
                 continue;
             }
-            const belongsToThisBatch = entry.pendingApproval.requests.some(r => decidedIds.includes(r.id));
-            if (belongsToThisBatch) {
-                entry.decisions = { ...(entry.decisions || {}), ...decisions };
-                break;
+            if (entry.pendingApproval.requests.some(r => decidedIds.includes(r.id))) {
+                return entry;
             }
         }
+        return undefined;
     }
 
     // The dispatcher attaches `chat` and `decision` as sibling resources under the same
     // service base path (see ai:Listener's ChatDispatcherService), and `chatEp` is always
-    // built ending in `/chat` (see buildChatEndpoint in features/tryit/activator.ts).
+    // built ending in `/chat` (see buildChatEndpoint in features/tryit/activator.ts). Assert
+    // the invariant rather than silently posting to the wrong resource if it's ever violated.
     private toDecisionEndpoint(chatEp: string): string {
+        if (!chatEp.endsWith('/chat')) {
+            throw new Error(`Unexpected chat endpoint shape: ${chatEp}`);
+        }
         return chatEp.replace(/\/chat$/, '/decision');
     }
 
@@ -211,11 +234,11 @@ export class AgentChatRpcManager implements AgentChatAPI {
                 this.currentAbortController = new AbortController();
                 const response = await this.fetchTestData(decisionEp, payload, this.currentAbortController.signal);
 
-                this.resolvePendingApprovalInHistory(sessionId, params.decisions);
-
                 if (response && response.pendingApproval) {
                     // The run resumed only to pause again (e.g. a further gated call surfaced
                     // in the same turn), so this is a fresh batch, not a resolution of the last one.
+                    this.resolvePendingApprovalInHistory(sessionId, params.decisions);
+
                     const pendingApproval: PendingApprovalInfo = response.pendingApproval;
 
                     this.addMessageToHistory(sessionId, {
@@ -227,6 +250,8 @@ export class AgentChatRpcManager implements AgentChatAPI {
 
                     resolve({ message: '', pendingApproval } as ChatRespMessage);
                 } else if (response && response.message) {
+                    this.resolvePendingApprovalInHistory(sessionId, params.decisions);
+
                     const trace = this.findTraceForMessage(sessionId, '', response.message);
                     const executionSteps = trace ? this.extractExecutionSteps(trace) : undefined;
 
@@ -244,6 +269,8 @@ export class AgentChatRpcManager implements AgentChatAPI {
                         executionSteps
                     } as ChatRespMessage);
                 } else {
+                    // Response shape didn't match either known case - the batch was never
+                    // actually resolved, so history must keep showing it pending.
                     reject(new Error("Invalid response format from the decision endpoint."));
                 }
             } catch (error) {
@@ -251,7 +278,32 @@ export class AgentChatRpcManager implements AgentChatAPI {
                     error && typeof error === "object" && "message" in error
                         ? String(error.message)
                         : "An unknown error occurred";
-                reject(new Error(errorMessage));
+
+                const errorType = error && typeof error === "object" && "errorType" in error
+                    ? String((error as { errorType: unknown }).errorType)
+                    : undefined;
+                const unresolvable = errorType === 'ApprovalNotFoundError' || errorType === 'UnknownApprovalIdError';
+
+                const sessionId = extension.agentChatContext?.chatSessionId;
+                if (sessionId) {
+                    if (unresolvable) {
+                        this.markPendingApprovalUnresolvable(sessionId, params.decisions);
+                    }
+
+                    this.addMessageToHistory(sessionId, {
+                        type: 'error',
+                        text: errorMessage,
+                        isUser: false
+                    });
+                }
+
+                const errorWithTrace = new Error(JSON.stringify({
+                    message: errorMessage,
+                    traceInfo: {},
+                    unresolvable
+                }));
+
+                reject(errorWithTrace);
             } finally {
                 this.currentAbortController = null;
             }
@@ -298,8 +350,12 @@ export class AgentChatRpcManager implements AgentChatAPI {
 
                 // A `decision` resume naming a session/id with nothing pending maps to 404/400
                 // with a stable `errorType` discriminator (ApprovalNotFoundError/UnknownApprovalIdError).
+                // Attach it to the thrown error so callers can tell this apart from a transient
+                // failure and treat the batch as terminal instead of retryable.
                 if (errorData?.errorType === 'ApprovalNotFoundError' || errorData?.errorType === 'UnknownApprovalIdError') {
-                    throw new Error(errorData.message || 'The pending approval could not be resumed.');
+                    const notFoundError = new Error(errorData.message || 'The pending approval could not be resumed.');
+                    (notFoundError as Error & { errorType?: string }).errorType = errorData.errorType;
+                    throw notFoundError;
                 }
 
                 switch (response.status) {
@@ -337,7 +393,13 @@ export class AgentChatRpcManager implements AgentChatAPI {
             if (error instanceof Error) {
                 errorMessage = error.message;
             }
-            throw new Error(errorMessage);
+            const rewrapped = new Error(errorMessage);
+            // Preserve the errorType tagged above (e.g. ApprovalNotFoundError) so callers can
+            // still distinguish it after this rewrap.
+            if (error && typeof error === "object" && "errorType" in error) {
+                (rewrapped as Error & { errorType?: unknown }).errorType = (error as { errorType: unknown }).errorType;
+            }
+            throw rewrapped;
         }
     }
 
@@ -400,7 +462,10 @@ export class AgentChatRpcManager implements AgentChatAPI {
                     continue;
                 }
 
-                const inputMatches = inputMessages && inputMessages.includes(userMessage);
+                // Guard on a non-empty userMessage: String.prototype.includes('') is always
+                // true, which would otherwise match the first same-session span regardless
+                // of whether it's actually the one this response came from.
+                const inputMatches = userMessage && inputMessages && inputMessages.includes(userMessage);
                 const outputMatches = agentResponse && outputMessages && outputMessages.includes(agentResponse);
 
                 if (inputMatches || outputMatches) {

--- a/packages/ballerina-extension/src/rpc-managers/agent-chat/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/agent-chat/rpc-manager.ts
@@ -172,38 +172,21 @@ export class AgentChatRpcManager implements AgentChatAPI {
     // so a later getChatHistory()/switchChatAgent() replay renders resolved requests collapsed
     // rather than as if still pending.
     private resolvePendingApprovalInHistory(sessionId: string, decisions: Record<string, HumanResponse>): void {
-        const entry = this.findPendingApprovalEntry(sessionId, decisions);
-        if (entry) {
-            entry.decisions = { ...(entry.decisions || {}), ...decisions };
-        }
-    }
-
-    // Marks the matching 'approval' history entry as terminal when the service no longer
-    // recognizes the batch (expired, or the run restarted), so a replay renders it as
-    // dismissed instead of stuck pending forever.
-    private markPendingApprovalUnresolvable(sessionId: string, decisions: Record<string, HumanResponse>): void {
-        const entry = this.findPendingApprovalEntry(sessionId, decisions);
-        if (entry) {
-            entry.unresolvable = true;
-        }
-    }
-
-    private findPendingApprovalEntry(sessionId: string, decisions: Record<string, HumanResponse>): ChatHistoryMessage | undefined {
+        const decidedIds = Object.keys(decisions);
         const history = AgentChatRpcManager.chatHistoryMap.get(sessionId);
         if (!history) {
-            return undefined;
+            return;
         }
-        const decidedIds = Object.keys(decisions);
         for (let i = history.length - 1; i >= 0; i--) {
             const entry = history[i];
             if (entry.type !== 'approval' || !entry.pendingApproval) {
                 continue;
             }
             if (entry.pendingApproval.requests.some(r => decidedIds.includes(r.id))) {
-                return entry;
+                entry.decisions = { ...(entry.decisions || {}), ...decisions };
+                break;
             }
         }
-        return undefined;
     }
 
     // The dispatcher attaches `chat` and `decision` as sibling resources under the same
@@ -279,17 +262,8 @@ export class AgentChatRpcManager implements AgentChatAPI {
                         ? String(error.message)
                         : "An unknown error occurred";
 
-                const errorType = error && typeof error === "object" && "errorType" in error
-                    ? String((error as { errorType: unknown }).errorType)
-                    : undefined;
-                const unresolvable = errorType === 'ApprovalNotFoundError' || errorType === 'UnknownApprovalIdError';
-
                 const sessionId = extension.agentChatContext?.chatSessionId;
                 if (sessionId) {
-                    if (unresolvable) {
-                        this.markPendingApprovalUnresolvable(sessionId, params.decisions);
-                    }
-
                     this.addMessageToHistory(sessionId, {
                         type: 'error',
                         text: errorMessage,
@@ -297,10 +271,12 @@ export class AgentChatRpcManager implements AgentChatAPI {
                     });
                 }
 
+                // A failed decision leaves the batch exactly as it was (see the comment on
+                // the `else` branch above) - the card stays interactive so the user can retry,
+                // possibly with a fuller decision set, rather than being forced to Clear Chat.
                 const errorWithTrace = new Error(JSON.stringify({
                     message: errorMessage,
-                    traceInfo: {},
-                    unresolvable
+                    traceInfo: {}
                 }));
 
                 reject(errorWithTrace);
@@ -350,12 +326,8 @@ export class AgentChatRpcManager implements AgentChatAPI {
 
                 // A `decision` resume naming a session/id with nothing pending maps to 404/400
                 // with a stable `errorType` discriminator (ApprovalNotFoundError/UnknownApprovalIdError).
-                // Attach it to the thrown error so callers can tell this apart from a transient
-                // failure and treat the batch as terminal instead of retryable.
                 if (errorData?.errorType === 'ApprovalNotFoundError' || errorData?.errorType === 'UnknownApprovalIdError') {
-                    const notFoundError = new Error(errorData.message || 'The pending approval could not be resumed.');
-                    (notFoundError as Error & { errorType?: string }).errorType = errorData.errorType;
-                    throw notFoundError;
+                    throw new Error(errorData.message || 'The pending approval could not be resumed.');
                 }
 
                 switch (response.status) {
@@ -393,13 +365,7 @@ export class AgentChatRpcManager implements AgentChatAPI {
             if (error instanceof Error) {
                 errorMessage = error.message;
             }
-            const rewrapped = new Error(errorMessage);
-            // Preserve the errorType tagged above (e.g. ApprovalNotFoundError) so callers can
-            // still distinguish it after this rewrap.
-            if (error && typeof error === "object" && "errorType" in error) {
-                (rewrapped as Error & { errorType?: unknown }).errorType = (error as { errorType: unknown }).errorType;
-            }
-            throw rewrapped;
+            throw new Error(errorMessage);
         }
     }
 

--- a/packages/ballerina-rpc-client/src/rpc-clients/agent-chat/rpc-client.ts
+++ b/packages/ballerina-rpc-client/src/rpc-clients/agent-chat/rpc-client.ts
@@ -44,7 +44,9 @@ import {
     getAvailableChatAgents,
     switchChatAgent,
     activeAgentChanged,
-    tracingStatusChanged
+    tracingStatusChanged,
+    submitDecision,
+    SubmitDecisionRequest
 } from "@wso2/ballerina-core";
 import { HOST_EXTENSION } from "vscode-messenger-common";
 import { Messenger } from "vscode-messenger-webview";
@@ -62,6 +64,10 @@ export class AgentChatRpcClient implements AgentChatAPI {
 
     abortChatRequest(): void {
         return this._messenger.sendNotification(abortChatRequest, HOST_EXTENSION);
+    }
+
+    submitDecision(params: SubmitDecisionRequest): Promise<ChatRespMessage> {
+        return this._messenger.sendRequest(submitDecision, HOST_EXTENSION, params);
     }
 
     getTracingStatus(params: TraceStatusRequest = {}): Promise<TraceStatus> {

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
@@ -24,10 +24,13 @@ import { ApprovalRequest, HumanResponse } from "@wso2/ballerina-core";
 interface ApprovalCardProps {
     requests: ApprovalRequest[];
     decisions?: Record<string, HumanResponse>;
-    // Set when the service no longer recognizes this batch and it can never be resolved;
-    // renders as terminal even if some requests still lack a decision.
+    // Set once the user has dismissed this batch; renders as terminal even if some requests
+    // still lack a decision.
     unresolvable?: boolean;
     onSubmit: (decisions: Record<string, HumanResponse>) => Promise<void>;
+    // Lets the user give up on a batch that keeps failing instead of being stuck with a
+    // disabled chat input. Optional since a fully/terminally rendered card has no use for it.
+    onDismiss?: () => void;
 }
 
 const Card = styled.div`
@@ -37,6 +40,10 @@ const Card = styled.div`
     border: 1px solid var(--vscode-panel-border);
     border-radius: 4px;
     overflow: hidden;
+`;
+
+const HeaderSpacer = styled.div`
+    flex: 1;
 `;
 
 const CardHeader = styled.div`
@@ -234,11 +241,15 @@ function formatArguments(args: Record<string, any>): string {
     }
 }
 
-export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions, unresolvable, onSubmit }) => {
+export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions, unresolvable, onSubmit, onDismiss }) => {
     const [expandedArgs, setExpandedArgs] = useState<Record<string, boolean>>({});
     const [rejectingId, setRejectingId] = useState<string | null>(null);
     const [reasonText, setReasonText] = useState("");
     const [submitting, setSubmitting] = useState(false);
+    // Surfaces a Dismiss option once a submission has failed at least once - most batches
+    // resolve fine on a retry (e.g. a partial decision followed by a fuller one), so this
+    // only appears once the card has actually given the user a reason to give up on it.
+    const [hasFailed, setHasFailed] = useState(false);
 
     const pendingRequests = requests.filter(r => !decisions?.[r.id]);
     const isFullyResolved = requests.length > 0 && pendingRequests.length === 0;
@@ -254,6 +265,7 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
         } catch {
             // Failure is already surfaced as a chat message by the caller; keep the card
             // interactive (and any open reason box open) so the user can retry.
+            setHasFailed(true);
         } finally {
             setSubmitting(false);
         }
@@ -344,6 +356,12 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
                     <Icon name="bi-shield-lock" sx={{ width: 14, height: 14 }} iconSx={{ fontSize: "14px" }} />
                 </WarnIconWrapper>
                 Approval required &middot; {pendingRequests.length} pending
+                <HeaderSpacer />
+                {hasFailed && onDismiss && (
+                    <TextLinkButton onClick={onDismiss} disabled={submitting}>
+                        Dismiss
+                    </TextLinkButton>
+                )}
             </CardHeader>
             {requests.map((req, idx) => {
                 const decided = decisions?.[req.id];

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
@@ -1,0 +1,389 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState } from "react";
+import styled from "@emotion/styled";
+import { Icon, Button } from "@wso2/ui-toolkit";
+import { ApprovalRequest, HumanResponse } from "@wso2/ballerina-core";
+
+interface ApprovalCardProps {
+    requests: ApprovalRequest[];
+    decisions?: Record<string, HumanResponse>;
+    onSubmit: (decisions: Record<string, HumanResponse>) => Promise<void>;
+}
+
+const Card = styled.div`
+    width: 100%;
+    max-width: 520px;
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 4px;
+    overflow: hidden;
+`;
+
+const CardHeader = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--vscode-foreground);
+`;
+
+const WarnIconWrapper = styled.span`
+    display: inline-flex;
+    align-items: center;
+    color: var(--vscode-editorWarning-foreground);
+`;
+
+const RequestRow = styled.div`
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    &:not(:last-of-type) {
+        border-bottom: 1px solid var(--vscode-panel-border);
+    }
+`;
+
+const RequestHeaderRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+`;
+
+const BatchIndex = styled.span`
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    flex-shrink: 0;
+`;
+
+const ToolIconWrapper = styled.span`
+    display: inline-flex;
+    align-items: center;
+    color: var(--vscode-terminal-ansiBrightMagenta);
+`;
+
+const ToolName = styled.span`
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--vscode-foreground);
+`;
+
+const ToolDescription = styled.div`
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+`;
+
+const ArgumentsBlock = styled.pre`
+    margin: 0;
+    font-family: var(--vscode-editor-font-family);
+    font-size: 11px;
+    background: var(--vscode-editor-background);
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 4px;
+    padding: 6px 8px;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+`;
+
+const RowActions = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 2px;
+`;
+
+const SmallButton = styled.button<{ variant: "approve" | "reject" }>`
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    padding: 3px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid ${({ variant }: { variant: "approve" | "reject" }) =>
+        variant === "approve" ? "var(--vscode-terminal-ansiGreen)" : "var(--vscode-errorForeground)"};
+    color: ${({ variant }: { variant: "approve" | "reject" }) =>
+        variant === "approve" ? "var(--vscode-terminal-ansiGreen)" : "var(--vscode-errorForeground)"};
+    background: transparent;
+
+    &:hover:not(:disabled) {
+        background-color: var(--vscode-list-hoverBackground);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+`;
+
+const ReasonBox = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 4px;
+`;
+
+const ReasonInput = styled.textarea`
+    width: 100%;
+    min-height: 44px;
+    resize: vertical;
+    font-family: inherit;
+    font-size: 12px;
+    padding: 6px 8px;
+    background: var(--vscode-editor-background);
+    color: var(--vscode-editor-foreground);
+    border: 1px solid var(--vscode-editorWidget-border);
+    border-radius: 4px;
+    box-sizing: border-box;
+
+    &:focus {
+        outline: none;
+        border-color: var(--vscode-button-background);
+    }
+`;
+
+const ReasonActions = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+`;
+
+const TextLinkButton = styled.button`
+    background: none;
+    border: none;
+    color: var(--vscode-textLink-foreground);
+    font-size: 12px;
+    cursor: pointer;
+    padding: 0;
+
+    &:hover:not(:disabled) {
+        text-decoration: underline;
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+`;
+
+const DecidedBadge = styled.span<{ decision: "APPROVE" | "REJECT" }>`
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: 600;
+    color: ${({ decision }: { decision: "APPROVE" | "REJECT" }) =>
+        decision === "APPROVE" ? "var(--vscode-terminal-ansiGreen)" : "var(--vscode-errorForeground)"};
+`;
+
+const BatchActions = styled.div`
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-top: 1px solid var(--vscode-panel-border);
+`;
+
+const CollapsedSummary = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px 14px;
+    padding: 8px 12px;
+    font-size: 12px;
+`;
+
+const SummaryItem = styled.span<{ decision: "APPROVE" | "REJECT" }>`
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: ${({ decision }: { decision: "APPROVE" | "REJECT" }) =>
+        decision === "APPROVE" ? "var(--vscode-terminal-ansiGreen)" : "var(--vscode-errorForeground)"};
+`;
+
+function formatArguments(args: Record<string, any>): string {
+    try {
+        return JSON.stringify(args, null, 2);
+    } catch {
+        return String(args);
+    }
+}
+
+export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions, onSubmit }) => {
+    const [expandedArgs, setExpandedArgs] = useState<Record<string, boolean>>({});
+    const [rejectingId, setRejectingId] = useState<string | null>(null);
+    const [reasonText, setReasonText] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+
+    const pendingRequests = requests.filter(r => !decisions?.[r.id]);
+    const isFullyResolved = pendingRequests.length === 0;
+
+    const toggleArgs = (id: string) => setExpandedArgs(prev => ({ ...prev, [id]: !prev[id] }));
+
+    const submit = async (partial: Record<string, HumanResponse>) => {
+        setSubmitting(true);
+        try {
+            await onSubmit(partial);
+            setRejectingId(null);
+            setReasonText("");
+        } catch {
+            // Failure is already surfaced as a chat message by the caller; keep the card
+            // interactive (and any open reason box open) so the user can retry.
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const handleApprove = (id: string) => submit({ [id]: { decision: "APPROVE" } });
+
+    const handleStartReject = (id: string) => {
+        setRejectingId(id);
+        setReasonText("");
+    };
+
+    const handleConfirmReject = (id: string) => {
+        const reason = reasonText.trim();
+        submit({ [id]: { decision: "REJECT", ...(reason ? { reason } : {}) } });
+    };
+
+    const handleApproveAll = () => {
+        const decisionsMap: Record<string, HumanResponse> = {};
+        pendingRequests.forEach(r => { decisionsMap[r.id] = { decision: "APPROVE" }; });
+        submit(decisionsMap);
+    };
+
+    const handleRejectAll = () => {
+        const decisionsMap: Record<string, HumanResponse> = {};
+        pendingRequests.forEach(r => { decisionsMap[r.id] = { decision: "REJECT" }; });
+        submit(decisionsMap);
+    };
+
+    if (isFullyResolved) {
+        return (
+            <Card>
+                <CollapsedSummary>
+                    {requests.map(req => {
+                        const decided = decisions![req.id];
+                        return (
+                            <SummaryItem key={req.id} decision={decided.decision}>
+                                <Icon
+                                    name={decided.decision === "APPROVE" ? "bi-check" : "bi-close"}
+                                    sx={{ width: 14, height: 14 }}
+                                    iconSx={{ fontSize: "14px" }}
+                                />
+                                {req.toolName} {decided.decision === "APPROVE" ? "approved" : "rejected"}
+                                {decided.reason ? ` — "${decided.reason}"` : ""}
+                            </SummaryItem>
+                        );
+                    })}
+                </CollapsedSummary>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <WarnIconWrapper>
+                    <Icon name="bi-shield-lock" sx={{ width: 14, height: 14 }} iconSx={{ fontSize: "14px" }} />
+                </WarnIconWrapper>
+                Approval required &middot; {pendingRequests.length} pending
+            </CardHeader>
+            {requests.map((req, idx) => {
+                const decided = decisions?.[req.id];
+                return (
+                    <RequestRow key={req.id}>
+                        <RequestHeaderRow>
+                            <BatchIndex>{idx + 1}/{requests.length}</BatchIndex>
+                            <ToolIconWrapper>
+                                <Icon name="bi-wrench" sx={{ width: 14, height: 14 }} iconSx={{ fontSize: "14px" }} />
+                            </ToolIconWrapper>
+                            <ToolName>{req.toolName}</ToolName>
+                        </RequestHeaderRow>
+                        <ToolDescription>{req.toolDescription}</ToolDescription>
+                        <TextLinkButton onClick={() => toggleArgs(req.id)}>
+                            {expandedArgs[req.id] ? "Hide arguments" : "Show arguments"}
+                        </TextLinkButton>
+                        {expandedArgs[req.id] && (
+                            <ArgumentsBlock>{formatArguments(req.arguments)}</ArgumentsBlock>
+                        )}
+                        {decided ? (
+                            <DecidedBadge decision={decided.decision}>
+                                <Icon
+                                    name={decided.decision === "APPROVE" ? "bi-check" : "bi-close"}
+                                    sx={{ width: 14, height: 14 }}
+                                    iconSx={{ fontSize: "14px" }}
+                                />
+                                {decided.decision === "APPROVE" ? "Approved" : "Rejected"}
+                                {decided.reason ? ` — "${decided.reason}"` : ""}
+                            </DecidedBadge>
+                        ) : rejectingId === req.id ? (
+                            <ReasonBox>
+                                <ReasonInput
+                                    autoFocus
+                                    placeholder="Reason (optional), shown to the agent"
+                                    value={reasonText}
+                                    onChange={(e) => setReasonText(e.target.value)}
+                                    disabled={submitting}
+                                />
+                                <ReasonActions>
+                                    <TextLinkButton onClick={() => setRejectingId(null)} disabled={submitting}>
+                                        Cancel
+                                    </TextLinkButton>
+                                    <SmallButton variant="reject" onClick={() => handleConfirmReject(req.id)} disabled={submitting}>
+                                        Confirm Reject
+                                    </SmallButton>
+                                </ReasonActions>
+                            </ReasonBox>
+                        ) : (
+                            <RowActions>
+                                <SmallButton variant="approve" onClick={() => handleApprove(req.id)} disabled={submitting}>
+                                    <Icon name="bi-check" sx={{ width: 12, height: 12 }} iconSx={{ fontSize: "12px" }} />
+                                    Approve
+                                </SmallButton>
+                                <SmallButton variant="reject" onClick={() => handleStartReject(req.id)} disabled={submitting}>
+                                    <Icon name="bi-close" sx={{ width: 12, height: 12 }} iconSx={{ fontSize: "12px" }} />
+                                    Reject
+                                </SmallButton>
+                            </RowActions>
+                        )}
+                    </RequestRow>
+                );
+            })}
+            {pendingRequests.length > 1 && (
+                <BatchActions>
+                    <Button appearance="primary" onClick={handleApproveAll} disabled={submitting}>
+                        Approve All
+                    </Button>
+                    <Button appearance="secondary" onClick={handleRejectAll} disabled={submitting}>
+                        Reject All
+                    </Button>
+                </BatchActions>
+            )}
+        </Card>
+    );
+};
+
+export default ApprovalCard;

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
@@ -24,6 +24,9 @@ import { ApprovalRequest, HumanResponse } from "@wso2/ballerina-core";
 interface ApprovalCardProps {
     requests: ApprovalRequest[];
     decisions?: Record<string, HumanResponse>;
+    // Set when the service no longer recognizes this batch and it can never be resolved;
+    // renders as terminal even if some requests still lack a decision.
+    unresolvable?: boolean;
     onSubmit: (decisions: Record<string, HumanResponse>) => Promise<void>;
 }
 
@@ -231,14 +234,14 @@ function formatArguments(args: Record<string, any>): string {
     }
 }
 
-export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions, onSubmit }) => {
+export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions, unresolvable, onSubmit }) => {
     const [expandedArgs, setExpandedArgs] = useState<Record<string, boolean>>({});
     const [rejectingId, setRejectingId] = useState<string | null>(null);
     const [reasonText, setReasonText] = useState("");
     const [submitting, setSubmitting] = useState(false);
 
     const pendingRequests = requests.filter(r => !decisions?.[r.id]);
-    const isFullyResolved = pendingRequests.length === 0;
+    const isFullyResolved = requests.length > 0 && pendingRequests.length === 0;
 
     const toggleArgs = (id: string) => setExpandedArgs(prev => ({ ...prev, [id]: !prev[id] }));
 
@@ -279,6 +282,37 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
         pendingRequests.forEach(r => { decisionsMap[r.id] = { decision: "REJECT" }; });
         submit(decisionsMap);
     };
+
+    if (unresolvable) {
+        return (
+            <Card>
+                <CollapsedSummary>
+                    {requests.map(req => {
+                        const decided = decisions?.[req.id];
+                        if (decided) {
+                            return (
+                                <SummaryItem key={req.id} decision={decided.decision}>
+                                    <Icon
+                                        name={decided.decision === "APPROVE" ? "bi-check" : "bi-close"}
+                                        sx={{ width: 14, height: 14 }}
+                                        iconSx={{ fontSize: "14px" }}
+                                    />
+                                    {req.toolName} {decided.decision === "APPROVE" ? "approved" : "rejected"}
+                                    {decided.reason ? ` — "${decided.reason}"` : ""}
+                                </SummaryItem>
+                            );
+                        }
+                        return (
+                            <SummaryItem key={req.id} decision="REJECT">
+                                <Icon name="bi-warning" sx={{ width: 14, height: 14 }} iconSx={{ fontSize: "14px" }} />
+                                {req.toolName} could not be resumed
+                            </SummaryItem>
+                        );
+                    })}
+                </CollapsedSummary>
+            </Card>
+        );
+    }
 
     if (isFullyResolved) {
         return (

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInput.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInput.tsx
@@ -101,9 +101,10 @@ interface StyledInputProps {
     onChange: (val: string) => void;
     onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => void;
     placeholder: string;
+    disabled?: boolean;
 }
 
-const StyledInput = forwardRef<StyledInputRef, StyledInputProps>(({ value, onChange, onKeyDown, placeholder }, ref) => {
+const StyledInput = forwardRef<StyledInputRef, StyledInputProps>(({ value, onChange, onKeyDown, placeholder, disabled }, ref) => {
     const divRef = useRef<HTMLDivElement>(null);
 
     // Provide a focus method to parent
@@ -161,7 +162,7 @@ const StyledInput = forwardRef<StyledInputRef, StyledInputProps>(({ value, onCha
     return (
         <div
             ref={divRef}
-            contentEditable
+            contentEditable={!disabled}
             spellCheck
             suppressContentEditableWarning
             style={{
@@ -177,6 +178,8 @@ const StyledInput = forwardRef<StyledInputRef, StyledInputProps>(({ value, onCha
                 overflowY: "auto",
                 // Left-align text:
                 textAlign: "left",
+                opacity: disabled ? 0.6 : 1,
+                cursor: disabled ? "default" : "text",
             }}
             onInput={handleInput}
             onKeyDown={onKeyDown}
@@ -195,9 +198,13 @@ interface ChatInputProps {
     onStop: () => void;
     /** show "Stop" instead of "Send"? */
     isLoading: boolean;
+    /** disable typing/sending, e.g. while a pending approval blocks the conversation */
+    disabled?: boolean;
+    /** placeholder shown while disabled */
+    placeholder?: string;
 }
 
-const ChatInput: React.FC<ChatInputProps> = ({ value = "", onSend, onStop, isLoading }) => {
+const ChatInput: React.FC<ChatInputProps> = ({ value = "", onSend, onStop, isLoading, disabled = false, placeholder = "Type your message..." }) => {
     const [inputValue, setInputValue] = useState(value);
     const inputRef = useRef<StyledInputRef>(null);
 
@@ -214,6 +221,7 @@ const ChatInput: React.FC<ChatInputProps> = ({ value = "", onSend, onStop, isLoa
      * so normal typing (including repeated keys) won't be affected.
      */
     const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+        if (disabled) return;
         if (e.key === "Enter" && !e.shiftKey) {
             if (!isLoading) {
                 e.preventDefault();
@@ -225,6 +233,7 @@ const ChatInput: React.FC<ChatInputProps> = ({ value = "", onSend, onStop, isLoa
     };
 
     const handleSend = () => {
+        if (disabled) return;
         const toSend = inputValue.trim();
         if (!toSend) return;
         onSend(toSend);
@@ -240,11 +249,12 @@ const ChatInput: React.FC<ChatInputProps> = ({ value = "", onSend, onStop, isLoa
                         value={inputValue}
                         onChange={setInputValue}
                         onKeyDown={handleKeyDown}
-                        placeholder="Type your message..."
+                        placeholder={placeholder}
+                        disabled={disabled}
                     />
                     <ActionButton
                         title={isLoading ? "Stop" : "Send"}
-                        disabled={!inputValue.trim() && !isLoading}
+                        disabled={disabled || (!inputValue.trim() && !isLoading)}
                         onClick={isLoading ? onStop : handleSend}
                     >
                         <Icon name={isLoading ? "bi-stop" : "bi-send"} sx={{ fontSize: "20px", width: "20px", height: "20px" }} />

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
@@ -23,9 +23,10 @@ import styled from "@emotion/styled";
 import ChatInput from "./ChatInput";
 import LoadingIndicator from "./LoadingIndicator";
 import { ExecutionTimeline } from "./ExecutionTimeline";
+import { ApprovalCard } from "./ApprovalCard";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Icon, Button, ThemeColors } from "@wso2/ui-toolkit";
-import { SessionInfoResponse, AgentInfo } from "@wso2/ballerina-core";
+import { SessionInfoResponse, AgentInfo, PendingApprovalInfo, HumanResponse, ChatHistoryMessage } from "@wso2/ballerina-core";
 import ReactMarkdown from "react-markdown";
 import remarkMath from 'remark-math';
 import remarkGfm from 'remark-gfm';
@@ -36,6 +37,7 @@ import { ExecutionStep } from "@wso2/ballerina-core";
 enum ChatMessageType {
     MESSAGE = "message",
     ERROR = "error",
+    APPROVAL = "approval",
 }
 
 interface ChatMessage {
@@ -44,6 +46,16 @@ interface ChatMessage {
     isUser: boolean;
     traceId?: string;
     executionSteps?: ExecutionStep[];
+    // Present when type is APPROVAL: the requests the agent paused on.
+    pendingApproval?: PendingApprovalInfo;
+    // Present once (some or all of) the pending approval above has been resolved.
+    decisions?: Record<string, HumanResponse>;
+}
+
+function isApprovalUnresolved(msg: ChatMessage): boolean {
+    return msg.type === ChatMessageType.APPROVAL
+        && !!msg.pendingApproval
+        && msg.pendingApproval.requests.some(r => !msg.decisions?.[r.id]);
 }
 
 // ---------- WATER MARK ----------
@@ -496,6 +508,22 @@ function toDisplayName(name: string): string {
         .replace("Agent Chat/", "");
 }
 
+function toChatMessage(msg: ChatHistoryMessage): ChatMessage {
+    return {
+        type: msg.type === 'error'
+            ? ChatMessageType.ERROR
+            : msg.type === 'approval'
+                ? ChatMessageType.APPROVAL
+                : ChatMessageType.MESSAGE,
+        text: msg.text,
+        isUser: msg.isUser,
+        traceId: msg.traceId,
+        executionSteps: msg.executionSteps,
+        pendingApproval: msg.pendingApproval,
+        decisions: msg.decisions,
+    };
+}
+
 // Preprocess LaTeX delimiters to convert \(...\) and \[...\] to $...$ and $$...$$
 export function preprocessLatex(text: string): string {
     if (!text || typeof text !== 'string') return text;
@@ -529,6 +557,10 @@ const ChatInterface: React.FC = () => {
     // Check if we have any traces (to enable/disable Session Traces button)
     const hasTraces = messages.some(msg => !msg.isUser && msg.traceId);
 
+    // Block free-text input while the latest turn is an unresolved approval request
+    const lastMessage = messages[messages.length - 1];
+    const isApprovalPending = !!lastMessage && isApprovalUnresolved(lastMessage);
+
     // Load chat history and check tracing status on mount
     useEffect(() => {
         const loadChatHistory = async () => {
@@ -538,13 +570,7 @@ const ChatInterface: React.FC = () => {
                 // Only restore chat if the agent is still running
                 if (history.isAgentRunning && history.messages.length > 0) {
                     // Convert ChatHistoryMessage to ChatMessage format
-                    const chatMessages: ChatMessage[] = history.messages.map(msg => ({
-                        type: msg.type === 'error' ? ChatMessageType.ERROR : ChatMessageType.MESSAGE,
-                        text: msg.text,
-                        isUser: msg.isUser,
-                        traceId: msg.traceId,
-                        executionSteps: msg.executionSteps
-                    }));
+                    const chatMessages: ChatMessage[] = history.messages.map(toChatMessage);
                     setMessages(chatMessages);
                 }
                 // If agent is not running, chat history is cleared automatically
@@ -592,13 +618,7 @@ const ChatInterface: React.FC = () => {
                 const response = await rpcClient.getAgentChatRpcClient().switchChatAgent({ agentName });
                 setActiveAgentName(agentName);
 
-                const chatMessages: ChatMessage[] = response.chatHistory.map((msg: { type: string; text: string; isUser: boolean; traceId?: string; executionSteps?: ExecutionStep[] }) => ({
-                    type: msg.type === 'error' ? ChatMessageType.ERROR : ChatMessageType.MESSAGE,
-                    text: msg.text,
-                    isUser: msg.isUser,
-                    traceId: msg.traceId,
-                    executionSteps: msg.executionSteps
-                }));
+                const chatMessages: ChatMessage[] = response.chatHistory.map(toChatMessage);
                 setMessages(chatMessages);
                 setSessionInfo(null);
                 setShowInfoPopover(false);
@@ -675,13 +695,7 @@ const ChatInterface: React.FC = () => {
             setActiveAgentName(agentName);
 
             // Load the chat history for the switched agent
-            const chatMessages: ChatMessage[] = response.chatHistory.map((msg: { type: string; text: string; isUser: boolean; traceId?: string; executionSteps?: ExecutionStep[] }) => ({
-                type: msg.type === 'error' ? ChatMessageType.ERROR : ChatMessageType.MESSAGE,
-                text: msg.text,
-                isUser: msg.isUser,
-                traceId: msg.traceId,
-                executionSteps: msg.executionSteps
-            }));
+            const chatMessages: ChatMessage[] = response.chatHistory.map(toChatMessage);
             setMessages(chatMessages);
 
             // Reset session info cache
@@ -703,16 +717,23 @@ const ChatInterface: React.FC = () => {
         try {
             const chatResponse = await rpcClient.getAgentChatRpcClient().getChatMessage({ message: text });
 
-            setMessages((prev) => [
-                ...prev,
-                {
-                    type: ChatMessageType.MESSAGE,
-                    text: chatResponse.message,
-                    isUser: false,
-                    traceId: chatResponse.traceId,
-                    executionSteps: chatResponse.executionSteps
-                },
-            ]);
+            if (chatResponse.pendingApproval) {
+                setMessages((prev) => [
+                    ...prev,
+                    { type: ChatMessageType.APPROVAL, text: "", isUser: false, pendingApproval: chatResponse.pendingApproval },
+                ]);
+            } else {
+                setMessages((prev) => [
+                    ...prev,
+                    {
+                        type: ChatMessageType.MESSAGE,
+                        text: chatResponse.message,
+                        isUser: false,
+                        traceId: chatResponse.traceId,
+                        executionSteps: chatResponse.executionSteps
+                    },
+                ]);
+            }
         } catch (error) {
             let errorMessage = "An unknown error occurred";
             let traceId: string | undefined;
@@ -747,6 +768,68 @@ const ChatInterface: React.FC = () => {
             }]);
         } finally {
             setIsLoading(false);
+        }
+    };
+
+    const handleApprovalDecision = async (msgIndex: number, decisions: Record<string, HumanResponse>) => {
+        try {
+            const response = await rpcClient.getAgentChatRpcClient().submitDecision({ decisions });
+
+            setMessages((prev) => {
+                const updated = [...prev];
+                const target = updated[msgIndex];
+                if (target) {
+                    updated[msgIndex] = { ...target, decisions: { ...(target.decisions || {}), ...decisions } };
+                }
+                return updated;
+            });
+
+            if (response.pendingApproval) {
+                setMessages((prev) => [
+                    ...prev,
+                    { type: ChatMessageType.APPROVAL, text: "", isUser: false, pendingApproval: response.pendingApproval },
+                ]);
+            } else if (response.message) {
+                setMessages((prev) => [
+                    ...prev,
+                    {
+                        type: ChatMessageType.MESSAGE,
+                        text: response.message,
+                        isUser: false,
+                        traceId: response.traceId,
+                        executionSteps: response.executionSteps
+                    },
+                ]);
+            }
+        } catch (error) {
+            let errorMessage = "An unknown error occurred";
+            let traceId: string | undefined;
+            let executionSteps: ExecutionStep[] | undefined;
+
+            if (error && typeof error === "object" && "message" in error) {
+                try {
+                    const parsedError = JSON.parse(String(error.message));
+                    if (parsedError.message && parsedError.traceInfo) {
+                        errorMessage = parsedError.message;
+                        traceId = parsedError.traceInfo.traceId;
+                        executionSteps = parsedError.traceInfo.executionSteps;
+                    } else {
+                        errorMessage = String(error.message);
+                    }
+                } catch (parseError) {
+                    errorMessage = String(error.message);
+                }
+            }
+
+            console.error("Submit decision error:", error);
+
+            setMessages((prev) => [...prev, {
+                type: ChatMessageType.ERROR,
+                text: errorMessage,
+                isUser: false,
+                traceId,
+                executionSteps
+            }]);
         }
     };
 
@@ -930,8 +1013,8 @@ const ChatInterface: React.FC = () => {
                                     onViewInTrace={handleViewInTrace}
                                 />
                             )}
-                            <MessageContainer isUser={msg.isUser}>
-                                {!msg.isUser && (
+                            {msg.type === ChatMessageType.APPROVAL && msg.pendingApproval ? (
+                                <MessageContainer isUser={false}>
                                     <ProfilePic>
                                         <Icon
                                             name="bi-ai-agent"
@@ -943,35 +1026,58 @@ const ChatInterface: React.FC = () => {
                                             }}
                                         />
                                     </ProfilePic>
-                                )}
-                                <MessageBubble isUser={msg.isUser} isError={msg.type === ChatMessageType.ERROR}>
-                                    <ReactMarkdown
-                                        remarkPlugins={[remarkMath, remarkGfm]}
-                                        rehypePlugins={[rehypeKatex]}
-                                    >
-                                        {preprocessLatex(msg.text)}
-                                    </ReactMarkdown>
-                                </MessageBubble>
-                                {msg.isUser && (
-                                    <ProfilePic>
-                                        <Icon
-                                            name="bi-user"
-                                            sx={{ width: 18, height: 18 }}
-                                            iconSx={{
-                                                fontSize: "18px",
-                                                color: "var(--vscode-foreground)",
-                                                cursor: "default",
-                                            }}
-                                        />
-                                    </ProfilePic>
-                                )}
-                            </MessageContainer>
-                            {!msg.isUser && isTracingEnabled && msg.traceId && (
-                                <MessageActionsContainer>
-                                    <ShowLogsButton onClick={() => handleShowLogs(idx)} title="View trace logs for this message">
-                                        View Trace
-                                    </ShowLogsButton>
-                                </MessageActionsContainer>
+                                    <ApprovalCard
+                                        requests={msg.pendingApproval.requests}
+                                        decisions={msg.decisions}
+                                        onSubmit={(decisions) => handleApprovalDecision(idx, decisions)}
+                                    />
+                                </MessageContainer>
+                            ) : (
+                                <>
+                                    <MessageContainer isUser={msg.isUser}>
+                                        {!msg.isUser && (
+                                            <ProfilePic>
+                                                <Icon
+                                                    name="bi-ai-agent"
+                                                    sx={{ width: 18, height: 18 }}
+                                                    iconSx={{
+                                                        fontSize: "18px",
+                                                        color: "var(--vscode-terminal-ansiBrightCyan)",
+                                                        cursor: "default",
+                                                    }}
+                                                />
+                                            </ProfilePic>
+                                        )}
+                                        <MessageBubble isUser={msg.isUser} isError={msg.type === ChatMessageType.ERROR}>
+                                            <ReactMarkdown
+                                                remarkPlugins={[remarkMath, remarkGfm]}
+                                                rehypePlugins={[rehypeKatex]}
+                                            >
+                                                {preprocessLatex(msg.text)}
+                                            </ReactMarkdown>
+                                        </MessageBubble>
+                                        {msg.isUser && (
+                                            <ProfilePic>
+                                                <Icon
+                                                    name="bi-user"
+                                                    sx={{ width: 18, height: 18 }}
+                                                    iconSx={{
+                                                        fontSize: "18px",
+                                                        color: "var(--vscode-foreground)",
+                                                        cursor: "default",
+                                                    }}
+                                                />
+                                            </ProfilePic>
+                                        )}
+                                    </MessageContainer>
+                                    {!msg.isUser && isTracingEnabled && msg.traceId && (
+                                        <MessageActionsContainer>
+                                            <ShowLogsButton onClick={() => handleShowLogs(idx)} title="View trace logs for this message">
+                                                View Trace
+                                            </ShowLogsButton>
+                                        </MessageActionsContainer>
+                                    )}
+                                </>
                             )}
                         </React.Fragment>
                     ))}
@@ -999,7 +1105,14 @@ const ChatInterface: React.FC = () => {
                 </Messages>
             </ChatContainer>
             <ChatFooter>
-                <ChatInput value="" onSend={handleSendMessage} onStop={handleStop} isLoading={isLoading} />
+                <ChatInput
+                    value=""
+                    onSend={handleSendMessage}
+                    onStop={handleStop}
+                    isLoading={isLoading}
+                    disabled={isApprovalPending}
+                    placeholder={isApprovalPending ? "Waiting on your decision…" : "Type your message..."}
+                />
                 {/* <FooterText>
                     <SmallInfoIcon className="codicon codicon-info" />
                     <span>Add chat to external application.</span>

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
@@ -50,8 +50,8 @@ interface ChatMessage {
     pendingApproval?: PendingApprovalInfo;
     // Present once (some or all of) the pending approval above has been resolved.
     decisions?: Record<string, HumanResponse>;
-    // Set when the service no longer recognizes this batch (expired, or the run restarted),
-    // so it can never be resolved. Terminal even if some requests still lack a decision.
+    // Set when the user dismisses this batch after it keeps failing to submit. Terminal even
+    // if some requests still lack a decision.
     unresolvable?: boolean;
 }
 
@@ -721,11 +721,10 @@ const ChatInterface: React.FC = () => {
         }
     };
 
-    const parseAgentError = (error: unknown): { errorMessage: string; traceId?: string; executionSteps?: ExecutionStep[]; unresolvable?: boolean } => {
+    const parseAgentError = (error: unknown): { errorMessage: string; traceId?: string; executionSteps?: ExecutionStep[] } => {
         let errorMessage = "An unknown error occurred";
         let traceId: string | undefined;
         let executionSteps: ExecutionStep[] | undefined;
-        let unresolvable: boolean | undefined;
 
         // Try to parse structured error with trace information
         if (error && typeof error === "object" && "message" in error) {
@@ -735,7 +734,6 @@ const ChatInterface: React.FC = () => {
                     errorMessage = parsedError.message;
                     traceId = parsedError.traceInfo.traceId;
                     executionSteps = parsedError.traceInfo.executionSteps;
-                    unresolvable = parsedError.unresolvable;
                 } else {
                     // Fallback to regular error message
                     errorMessage = String(error.message);
@@ -746,7 +744,7 @@ const ChatInterface: React.FC = () => {
             }
         }
 
-        return { errorMessage, traceId, executionSteps, unresolvable };
+        return { errorMessage, traceId, executionSteps };
     };
 
     const appendAgentResponse = (response: {
@@ -816,10 +814,9 @@ const ChatInterface: React.FC = () => {
     // Finds the approval message a batch of decisions belongs to by matching request ids,
     // rather than trusting a snapshotted array index that could point at the wrong message
     // once anything reorders `messages` between the click and the response.
-    const findApprovalMessageIndex = (messages: ChatMessage[], decisions: Record<string, HumanResponse>): number => {
-        const ids = Object.keys(decisions);
+    const findApprovalMessageIndex = (messages: ChatMessage[], requestIds: string[]): number => {
         return messages.findIndex(m =>
-            m.type === ChatMessageType.APPROVAL && m.pendingApproval?.requests.some(r => ids.includes(r.id))
+            m.type === ChatMessageType.APPROVAL && m.pendingApproval?.requests.some(r => requestIds.includes(r.id))
         );
     };
 
@@ -838,7 +835,7 @@ const ChatInterface: React.FC = () => {
 
             setMessages((prev) => {
                 const updated = [...prev];
-                const targetIndex = findApprovalMessageIndex(updated, decisions);
+                const targetIndex = findApprovalMessageIndex(updated, Object.keys(decisions));
                 if (targetIndex !== -1) {
                     const target = updated[targetIndex];
                     updated[targetIndex] = { ...target, decisions: { ...(target.decisions || {}), ...decisions } };
@@ -852,24 +849,13 @@ const ChatInterface: React.FC = () => {
                 return;
             }
 
-            const { errorMessage, traceId, executionSteps, unresolvable } = parseAgentError(error);
+            const { errorMessage, traceId, executionSteps } = parseAgentError(error);
 
             console.error("Submit decision error:", error);
 
-            if (unresolvable) {
-                // The service no longer recognizes this batch (expired, or the run restarted)
-                // and it can never be resolved - mark it terminal so the card stops blocking
-                // input instead of leaving the chat stuck with no way out but Clear Chat.
-                setMessages((prev) => {
-                    const updated = [...prev];
-                    const targetIndex = findApprovalMessageIndex(updated, decisions);
-                    if (targetIndex !== -1) {
-                        updated[targetIndex] = { ...updated[targetIndex], unresolvable: true };
-                    }
-                    return updated;
-                });
-            }
-
+            // Leave the approval card as-is (a failed submitDecision doesn't change what's
+            // pending) so the user can retry, e.g. with a fuller set of decisions - only the
+            // explicit Dismiss action below gives up on it.
             setMessages((prev) => [...prev, {
                 type: ChatMessageType.ERROR,
                 text: errorMessage,
@@ -882,6 +868,20 @@ const ChatInterface: React.FC = () => {
             // otherwise nothing would ever reset isLoading for the session now on screen.
             setIsLoading(false);
         }
+    };
+
+    // Lets the user give up on a batch that keeps failing (e.g. the service genuinely lost
+    // track of it) instead of being stuck forever with a disabled chat input and no way out
+    // but Clear Chat. This is a local, session-only decision - it doesn't call the service.
+    const handleDismissApproval = (requestIds: string[]) => {
+        setMessages((prev) => {
+            const updated = [...prev];
+            const targetIndex = findApprovalMessageIndex(updated, requestIds);
+            if (targetIndex !== -1) {
+                updated[targetIndex] = { ...updated[targetIndex], unresolvable: true };
+            }
+            return updated;
+        });
     };
 
     const handleStop = () => {
@@ -1083,6 +1083,7 @@ const ChatInterface: React.FC = () => {
                                         decisions={msg.decisions}
                                         unresolvable={msg.unresolvable}
                                         onSubmit={handleApprovalDecision}
+                                        onDismiss={() => handleDismissApproval(msg.pendingApproval.requests.map(r => r.id))}
                                     />
                                 </MessageContainer>
                             ) : (

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
@@ -50,11 +50,15 @@ interface ChatMessage {
     pendingApproval?: PendingApprovalInfo;
     // Present once (some or all of) the pending approval above has been resolved.
     decisions?: Record<string, HumanResponse>;
+    // Set when the service no longer recognizes this batch (expired, or the run restarted),
+    // so it can never be resolved. Terminal even if some requests still lack a decision.
+    unresolvable?: boolean;
 }
 
 function isApprovalUnresolved(msg: ChatMessage): boolean {
     return msg.type === ChatMessageType.APPROVAL
         && !!msg.pendingApproval
+        && !msg.unresolvable
         && msg.pendingApproval.requests.some(r => !msg.decisions?.[r.id]);
 }
 
@@ -521,6 +525,7 @@ function toChatMessage(msg: ChatHistoryMessage): ChatMessage {
         executionSteps: msg.executionSteps,
         pendingApproval: msg.pendingApproval,
         decisions: msg.decisions,
+        unresolvable: msg.unresolvable,
     };
 }
 
@@ -716,10 +721,11 @@ const ChatInterface: React.FC = () => {
         }
     };
 
-    const parseAgentError = (error: unknown): { errorMessage: string; traceId?: string; executionSteps?: ExecutionStep[] } => {
+    const parseAgentError = (error: unknown): { errorMessage: string; traceId?: string; executionSteps?: ExecutionStep[]; unresolvable?: boolean } => {
         let errorMessage = "An unknown error occurred";
         let traceId: string | undefined;
         let executionSteps: ExecutionStep[] | undefined;
+        let unresolvable: boolean | undefined;
 
         // Try to parse structured error with trace information
         if (error && typeof error === "object" && "message" in error) {
@@ -729,6 +735,7 @@ const ChatInterface: React.FC = () => {
                     errorMessage = parsedError.message;
                     traceId = parsedError.traceInfo.traceId;
                     executionSteps = parsedError.traceInfo.executionSteps;
+                    unresolvable = parsedError.unresolvable;
                 } else {
                     // Fallback to regular error message
                     errorMessage = String(error.message);
@@ -739,7 +746,7 @@ const ChatInterface: React.FC = () => {
             }
         }
 
-        return { errorMessage, traceId, executionSteps };
+        return { errorMessage, traceId, executionSteps, unresolvable };
     };
 
     const appendAgentResponse = (response: {
@@ -770,13 +777,26 @@ const ChatInterface: React.FC = () => {
     const handleSendMessage = async (text: string) => {
         if (!text.trim()) return;
 
+        // Capture the session token so a reply that lands after the user switched agents (or
+        // cleared chat) gets dropped instead of appended to the new session's transcript.
+        const requestToken = sessionTokenRef.current;
+
         setMessages((prev) => [...prev, { type: ChatMessageType.MESSAGE, text, isUser: true }]);
         setIsLoading(true);
 
         try {
             const chatResponse = await rpcClient.getAgentChatRpcClient().getChatMessage({ message: text });
+
+            if (sessionTokenRef.current !== requestToken) {
+                return;
+            }
+
             appendAgentResponse(chatResponse);
         } catch (error) {
+            if (sessionTokenRef.current !== requestToken) {
+                return;
+            }
+
             const { errorMessage, traceId, executionSteps } = parseAgentError(error);
 
             console.error("Chat message error:", error);
@@ -793,7 +813,17 @@ const ChatInterface: React.FC = () => {
         }
     };
 
-    const handleApprovalDecision = async (msgIndex: number, decisions: Record<string, HumanResponse>) => {
+    // Finds the approval message a batch of decisions belongs to by matching request ids,
+    // rather than trusting a snapshotted array index that could point at the wrong message
+    // once anything reorders `messages` between the click and the response.
+    const findApprovalMessageIndex = (messages: ChatMessage[], decisions: Record<string, HumanResponse>): number => {
+        const ids = Object.keys(decisions);
+        return messages.findIndex(m =>
+            m.type === ChatMessageType.APPROVAL && m.pendingApproval?.requests.some(r => ids.includes(r.id))
+        );
+    };
+
+    const handleApprovalDecision = async (decisions: Record<string, HumanResponse>) => {
         // Lock session-changing actions (switch agent, clear chat) while a decision is in
         // flight, and capture the session token so a response that arrives after the user
         // switched/cleared sessions anyway is dropped instead of applied to the wrong chat.
@@ -808,9 +838,10 @@ const ChatInterface: React.FC = () => {
 
             setMessages((prev) => {
                 const updated = [...prev];
-                const target = updated[msgIndex];
-                if (target) {
-                    updated[msgIndex] = { ...target, decisions: { ...(target.decisions || {}), ...decisions } };
+                const targetIndex = findApprovalMessageIndex(updated, decisions);
+                if (targetIndex !== -1) {
+                    const target = updated[targetIndex];
+                    updated[targetIndex] = { ...target, decisions: { ...(target.decisions || {}), ...decisions } };
                 }
                 return updated;
             });
@@ -821,9 +852,23 @@ const ChatInterface: React.FC = () => {
                 return;
             }
 
-            const { errorMessage, traceId, executionSteps } = parseAgentError(error);
+            const { errorMessage, traceId, executionSteps, unresolvable } = parseAgentError(error);
 
             console.error("Submit decision error:", error);
+
+            if (unresolvable) {
+                // The service no longer recognizes this batch (expired, or the run restarted)
+                // and it can never be resolved - mark it terminal so the card stops blocking
+                // input instead of leaving the chat stuck with no way out but Clear Chat.
+                setMessages((prev) => {
+                    const updated = [...prev];
+                    const targetIndex = findApprovalMessageIndex(updated, decisions);
+                    if (targetIndex !== -1) {
+                        updated[targetIndex] = { ...updated[targetIndex], unresolvable: true };
+                    }
+                    return updated;
+                });
+            }
 
             setMessages((prev) => [...prev, {
                 type: ChatMessageType.ERROR,
@@ -1036,7 +1081,8 @@ const ChatInterface: React.FC = () => {
                                     <ApprovalCard
                                         requests={msg.pendingApproval.requests}
                                         decisions={msg.decisions}
-                                        onSubmit={(decisions) => handleApprovalDecision(idx, decisions)}
+                                        unresolvable={msg.unresolvable}
+                                        onSubmit={handleApprovalDecision}
                                     />
                                 </MessageContainer>
                             ) : (

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
@@ -553,13 +553,19 @@ const ChatInterface: React.FC = () => {
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const infoPopoverRef = useRef<HTMLDivElement>(null);
     const agentDropdownRef = useRef<HTMLDivElement>(null);
+    // Bumped whenever the active session changes (switch agent, clear chat, or a switch pushed
+    // from the extension host). In-flight requests capture this value and drop their response
+    // if it no longer matches, rather than applying it to whatever session is now on screen.
+    const sessionTokenRef = useRef(0);
 
     // Check if we have any traces (to enable/disable Session Traces button)
     const hasTraces = messages.some(msg => !msg.isUser && msg.traceId);
 
-    // Block free-text input while the latest turn is an unresolved approval request
-    const lastMessage = messages[messages.length - 1];
-    const isApprovalPending = !!lastMessage && isApprovalUnresolved(lastMessage);
+    // Block free-text input while any turn has an unresolved approval request. Scanning the
+    // whole list (not just the last message) matters because a failed decision submission
+    // appends an error message after the approval card, which would otherwise become
+    // `lastMessage` and incorrectly report nothing pending.
+    const isApprovalPending = messages.some(isApprovalUnresolved);
 
     // Load chat history and check tracing status on mount
     useEffect(() => {
@@ -615,6 +621,7 @@ const ChatInterface: React.FC = () => {
     useEffect(() => {
         rpcClient.getAgentChatRpcClient().onActiveAgentChanged(async (agentName: string) => {
             try {
+                sessionTokenRef.current++;
                 const response = await rpcClient.getAgentChatRpcClient().switchChatAgent({ agentName });
                 setActiveAgentName(agentName);
 
@@ -691,6 +698,7 @@ const ChatInterface: React.FC = () => {
         if (agentName === activeAgentName || isLoading) return;
 
         try {
+            sessionTokenRef.current++;
             const response = await rpcClient.getAgentChatRpcClient().switchChatAgent({ agentName });
             setActiveAgentName(agentName);
 
@@ -772,8 +780,17 @@ const ChatInterface: React.FC = () => {
     };
 
     const handleApprovalDecision = async (msgIndex: number, decisions: Record<string, HumanResponse>) => {
+        // Lock session-changing actions (switch agent, clear chat) while a decision is in
+        // flight, and capture the session token so a response that arrives after the user
+        // switched/cleared sessions anyway is dropped instead of applied to the wrong chat.
+        const requestToken = sessionTokenRef.current;
+        setIsLoading(true);
         try {
             const response = await rpcClient.getAgentChatRpcClient().submitDecision({ decisions });
+
+            if (sessionTokenRef.current !== requestToken) {
+                return;
+            }
 
             setMessages((prev) => {
                 const updated = [...prev];
@@ -802,6 +819,10 @@ const ChatInterface: React.FC = () => {
                 ]);
             }
         } catch (error) {
+            if (sessionTokenRef.current !== requestToken) {
+                return;
+            }
+
             let errorMessage = "An unknown error occurred";
             let traceId: string | undefined;
             let executionSteps: ExecutionStep[] | undefined;
@@ -830,6 +851,10 @@ const ChatInterface: React.FC = () => {
                 traceId,
                 executionSteps
             }]);
+        } finally {
+            // Always clear the lock, even if the session moved on while this was in flight -
+            // otherwise nothing would ever reset isLoading for the session now on screen.
+            setIsLoading(false);
         }
     };
 
@@ -863,6 +888,7 @@ const ChatInterface: React.FC = () => {
 
     const confirmClearChat = async () => {
         try {
+            sessionTokenRef.current++;
             // Clear the chat history on the backend and get a new session ID
             await rpcClient.getAgentChatRpcClient().clearChatHistory();
             // Clear the messages in the UI

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
@@ -716,6 +716,57 @@ const ChatInterface: React.FC = () => {
         }
     };
 
+    const parseAgentError = (error: unknown): { errorMessage: string; traceId?: string; executionSteps?: ExecutionStep[] } => {
+        let errorMessage = "An unknown error occurred";
+        let traceId: string | undefined;
+        let executionSteps: ExecutionStep[] | undefined;
+
+        // Try to parse structured error with trace information
+        if (error && typeof error === "object" && "message" in error) {
+            try {
+                const parsedError = JSON.parse(String(error.message));
+                if (parsedError.message && parsedError.traceInfo) {
+                    errorMessage = parsedError.message;
+                    traceId = parsedError.traceInfo.traceId;
+                    executionSteps = parsedError.traceInfo.executionSteps;
+                } else {
+                    // Fallback to regular error message
+                    errorMessage = String(error.message);
+                }
+            } catch (parseError) {
+                // If JSON parsing fails, use the original error message
+                errorMessage = String(error.message);
+            }
+        }
+
+        return { errorMessage, traceId, executionSteps };
+    };
+
+    const appendAgentResponse = (response: {
+        pendingApproval?: PendingApprovalInfo;
+        message: string;
+        traceId?: string;
+        executionSteps?: ExecutionStep[];
+    }) => {
+        if (response.pendingApproval) {
+            setMessages((prev) => [
+                ...prev,
+                { type: ChatMessageType.APPROVAL, text: "", isUser: false, pendingApproval: response.pendingApproval },
+            ]);
+        } else {
+            setMessages((prev) => [
+                ...prev,
+                {
+                    type: ChatMessageType.MESSAGE,
+                    text: response.message,
+                    isUser: false,
+                    traceId: response.traceId,
+                    executionSteps: response.executionSteps
+                },
+            ]);
+        }
+    };
+
     const handleSendMessage = async (text: string) => {
         if (!text.trim()) return;
 
@@ -724,46 +775,9 @@ const ChatInterface: React.FC = () => {
 
         try {
             const chatResponse = await rpcClient.getAgentChatRpcClient().getChatMessage({ message: text });
-
-            if (chatResponse.pendingApproval) {
-                setMessages((prev) => [
-                    ...prev,
-                    { type: ChatMessageType.APPROVAL, text: "", isUser: false, pendingApproval: chatResponse.pendingApproval },
-                ]);
-            } else {
-                setMessages((prev) => [
-                    ...prev,
-                    {
-                        type: ChatMessageType.MESSAGE,
-                        text: chatResponse.message,
-                        isUser: false,
-                        traceId: chatResponse.traceId,
-                        executionSteps: chatResponse.executionSteps
-                    },
-                ]);
-            }
+            appendAgentResponse(chatResponse);
         } catch (error) {
-            let errorMessage = "An unknown error occurred";
-            let traceId: string | undefined;
-            let executionSteps: ExecutionStep[] | undefined;
-
-            // Try to parse structured error with trace information
-            if (error && typeof error === "object" && "message" in error) {
-                try {
-                    const parsedError = JSON.parse(String(error.message));
-                    if (parsedError.message && parsedError.traceInfo) {
-                        errorMessage = parsedError.message;
-                        traceId = parsedError.traceInfo.traceId;
-                        executionSteps = parsedError.traceInfo.executionSteps;
-                    } else {
-                        // Fallback to regular error message
-                        errorMessage = String(error.message);
-                    }
-                } catch (parseError) {
-                    // If JSON parsing fails, use the original error message
-                    errorMessage = String(error.message);
-                }
-            }
+            const { errorMessage, traceId, executionSteps } = parseAgentError(error);
 
             console.error("Chat message error:", error);
 
@@ -801,46 +815,13 @@ const ChatInterface: React.FC = () => {
                 return updated;
             });
 
-            if (response.pendingApproval) {
-                setMessages((prev) => [
-                    ...prev,
-                    { type: ChatMessageType.APPROVAL, text: "", isUser: false, pendingApproval: response.pendingApproval },
-                ]);
-            } else if (response.message) {
-                setMessages((prev) => [
-                    ...prev,
-                    {
-                        type: ChatMessageType.MESSAGE,
-                        text: response.message,
-                        isUser: false,
-                        traceId: response.traceId,
-                        executionSteps: response.executionSteps
-                    },
-                ]);
-            }
+            appendAgentResponse(response);
         } catch (error) {
             if (sessionTokenRef.current !== requestToken) {
                 return;
             }
 
-            let errorMessage = "An unknown error occurred";
-            let traceId: string | undefined;
-            let executionSteps: ExecutionStep[] | undefined;
-
-            if (error && typeof error === "object" && "message" in error) {
-                try {
-                    const parsedError = JSON.parse(String(error.message));
-                    if (parsedError.message && parsedError.traceInfo) {
-                        errorMessage = parsedError.message;
-                        traceId = parsedError.traceInfo.traceId;
-                        executionSteps = parsedError.traceInfo.executionSteps;
-                    } else {
-                        errorMessage = String(error.message);
-                    }
-                } catch (parseError) {
-                    errorMessage = String(error.message);
-                }
-            }
+            const { errorMessage, traceId, executionSteps } = parseAgentError(error);
 
             console.error("Submit decision error:", error);
 


### PR DESCRIPTION
## Purpose
$subject.

Fixes https://github.com/wso2/product-integrator/issues/2132

## Preview
https://github.com/user-attachments/assets/08c4793c-d171-4224-9101-3a6c9c4956a4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Add human-in-the-loop approval support to AI chat.
- Extend agent chat RPC contracts and clients with `submitDecision`.
- Handle pending approvals, decisions, repeated approval pauses, and final responses.
- Add `ApprovalCard` for individual or batch approval and rejection.
- Preserve approval state in chat history and disable chat input while approval is pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->