### PR TITLE
Land on the newly created integration

### DIFF
--- a/packages/ballerina-extension/src/features/bi/integration-wizard.ts
+++ b/packages/ballerina-extension/src/features/bi/integration-wizard.ts
@@ -35,7 +35,7 @@ import {
     isAlreadyOpenFolder,
     openInVSCode,
     refreshProjectInfoAndWait,
-    resolveCreateLandingContext,
+    resolveCreateNamingContext,
 } from "../../utils/bi";
 import { generateArtifactInPlace, openPackageOverview, schedulePendingIntegration } from "./pending-artifact";
 import { extension } from "../../BalExtensionContext";
@@ -118,17 +118,16 @@ export async function createIntegration(params: CreateIntegrationRequest): Promi
     const { packageRoot, openRoot } = await createBIComponent(projectRequest);
     await cleanupStaging();
 
-    const landingContext = resolveCreateLandingContext(packageRoot, openRoot, projectRequest);
+    const namingContext = resolveCreateNamingContext(packageRoot, openRoot, projectRequest);
 
     // Live path only when the extension has ALREADY activated `openRoot` — a just-converted
     // workspace at the same path is open in VS Code but still needs the reload.
     const addedIntoActiveWorkspace = isAlreadyOpenFolder(openRoot) && isSamePath(StateMachine.context().workspacePath, openRoot);
 
     if (addedIntoActiveWorkspace) {
-        // The project was already open, so it cannot be new: the new integration is the
-        // news here and its own overview is where to land.
+        // The new integration is the news here, and its own overview is where to land.
         if (params.artifact) {
-            await generateArtifactInPlace(packageRoot, params.artifact, true);
+            await generateArtifactInPlace(packageRoot, params.artifact);
         } else {
             // Refresh BEFORE navigating: the package overview fetches project structure
             // on mount, so navigating first would show it a spinner instead of the page.
@@ -144,10 +143,9 @@ export async function createIntegration(params: CreateIntegrationRequest): Promi
         packageRoot,
         integrationName: params.project.integrationName,
         payload: params.artifact,
-        projectName: landingContext.projectName,
-        isNewProject: landingContext.isNewProject,
+        projectName: namingContext.projectName,
+        isNewProject: namingContext.isNewProject,
         componentLabel: "integration",
-        landing: landingContext.landing,
     });
     openInVSCode(openRoot);
 }
@@ -159,7 +157,7 @@ export async function createIntegration(params: CreateIntegrationRequest): Promi
  */
 export async function addIntegrationArtifact(params: AddIntegrationArtifactRequest): Promise<void> {
     await cleanupStaging();
-    await generateArtifactInPlace(params.packageRoot, params.artifact, true);
+    await generateArtifactInPlace(params.packageRoot, params.artifact);
 }
 
 /** Discards the session's temp staging package. Called on abandon and, race-free, on every (re)open. */

--- a/packages/ballerina-extension/src/features/bi/pending-artifact.ts
+++ b/packages/ballerina-extension/src/features/bi/pending-artifact.ts
@@ -43,34 +43,6 @@ import {
 /** Payload file location inside the scaffolded project (target/ is gitignored by the scaffold). */
 const PENDING_ARTIFACT_RELATIVE_PATH = path.join("target", ".wizard-pending-artifact.json");
 
-let finishingIntegrationCreate = false;
-
-/**
- * Whether a Create Integration submit is being finished right now.
- *
- * Scaffolding a package makes the language server publish artifacts for a package the project
- * structure does not know yet, and `updateProjectArtifacts` answers that by navigating to the
- * workspace overview. During a create that is wrong: the create decides where to land, and the
- * fallback would replace the new integration's overview a moment after it opened.
- */
-export function isFinishingIntegrationCreate(): boolean {
-    return finishingIntegrationCreate;
-}
-
-/**
- * Runs `task` with {@link isFinishingIntegrationCreate} reporting true. Not re-entrant, and
- * does not need to be: the post-reload path runs once per activation, and the in-place path is
- * driven by the wizard webview, which is not open then.
- */
-async function whileFinishingIntegrationCreate<T>(task: () => PromiseLike<T>): Promise<T> {
-    finishingIntegrationCreate = true;
-    try {
-        return await task();
-    } finally {
-        finishingIntegrationCreate = false;
-    }
-}
-
 /** Human-readable labels for progress and error messages, per artifact kind. */
 const ARTIFACT_KIND_LABELS = INTEGRATION_ARTIFACT_LABELS;
 
@@ -128,10 +100,6 @@ export async function schedulePendingIntegration(schedule: PendingIntegrationSch
  * activation; never throws. No progress toast: the startup screen already narrates the wait.
  */
 export async function checkAndRunPendingArtifact(): Promise<void> {
-    return whileFinishingIntegrationCreate(runPendingArtifact);
-}
-
-async function runPendingArtifact(): Promise<void> {
     try {
         const stored = readPendingIntegrationPointer();
         if (!stored) {
@@ -247,10 +215,10 @@ export async function generateArtifactInPlace(
     }
 
     try {
-        const claimedView = await whileFinishingIntegrationCreate(() => window.withProgress(
+        const claimedView = await window.withProgress(
             { location: ProgressLocation.Notification, title: `Generating your ${label}...` },
             () => generatePendingArtifact(payload, packageRoot)
-        ));
+        );
         if (!claimedView) {
             openPackageOverview(packageRoot);
         }

--- a/packages/ballerina-extension/src/features/bi/pending-artifact.ts
+++ b/packages/ballerina-extension/src/features/bi/pending-artifact.ts
@@ -43,6 +43,34 @@ import {
 /** Payload file location inside the scaffolded project (target/ is gitignored by the scaffold). */
 const PENDING_ARTIFACT_RELATIVE_PATH = path.join("target", ".wizard-pending-artifact.json");
 
+/**
+ * Depth rather than a boolean: the in-place and post-reload paths can overlap, and the first
+ * one to finish must not clear the flag out from under the other.
+ */
+let integrationCreateDepth = 0;
+
+/**
+ * Whether a Create Integration submit is being finished right now.
+ *
+ * Scaffolding a package makes the language server publish artifacts for a package the project
+ * structure does not know yet, and `updateProjectArtifacts` answers that by navigating to the
+ * workspace overview. During a create that is wrong: the create flow decides where to land, and
+ * the fallback would replace the new integration's overview a moment after it opened.
+ */
+export function isFinishingIntegrationCreate(): boolean {
+    return integrationCreateDepth > 0;
+}
+
+/** Runs `task` with {@link isFinishingIntegrationCreate} reporting true. */
+async function whileFinishingIntegrationCreate<T>(task: () => PromiseLike<T>): Promise<T> {
+    integrationCreateDepth++;
+    try {
+        return await task();
+    } finally {
+        integrationCreateDepth--;
+    }
+}
+
 /** Human-readable labels for progress and error messages, per artifact kind. */
 const ARTIFACT_KIND_LABELS = INTEGRATION_ARTIFACT_LABELS;
 
@@ -104,6 +132,10 @@ export async function schedulePendingIntegration(schedule: PendingIntegrationSch
  * activation; never throws. No progress toast: the startup screen already narrates the wait.
  */
 export async function checkAndRunPendingArtifact(): Promise<void> {
+    return whileFinishingIntegrationCreate(runPendingArtifact);
+}
+
+async function runPendingArtifact(): Promise<void> {
     try {
         const stored = readPendingIntegrationPointer();
         if (!stored) {
@@ -252,10 +284,10 @@ export async function generateArtifactInPlace(
     }
 
     try {
-        await window.withProgress(
+        await whileFinishingIntegrationCreate(() => window.withProgress(
             { location: ProgressLocation.Notification, title: `Generating your ${label}...` },
             () => generatePendingArtifact(payload, packageRoot, landOnPackageOverview)
-        );
+        ));
         // A non-silent refresh lands on the workspace overview, which would clobber the
         // package overview navigated to above.
         StateMachine.refreshProjectInfo({ silent: landOnPackageOverview });

--- a/packages/ballerina-extension/src/features/bi/pending-artifact.ts
+++ b/packages/ballerina-extension/src/features/bi/pending-artifact.ts
@@ -165,14 +165,14 @@ async function runPendingArtifact(): Promise<void> {
         // An empty integration has no payload: there is nothing to generate, only
         // the landing view below to open.
         if (!payload) {
-            ensureLandedOnNewIntegration(stored);
+            openPackageOverview(stored.projectRoot);
             return;
         }
 
         const label = ARTIFACT_KIND_LABELS[payload.kind];
         if (!label || payload.version !== 1) {
             console.error(`[IntegrationWizard] Unsupported pending artifact payload:`, payload);
-            ensureLandedOnNewIntegration(stored);
+            openPackageOverview(stored.projectRoot);
             return;
         }
 
@@ -182,8 +182,9 @@ async function runPendingArtifact(): Promise<void> {
             `opensStoredPackage=${opensStoredPackage}, insideOpenWorkspace=${insideOpenWorkspace}, ` +
             `addedIntoWorkspace=${addedIntoWorkspace}`
         );
+        let claimedView = false;
         try {
-            await generatePendingArtifact(payload, stored.projectRoot);
+            claimedView = await generatePendingArtifact(payload, stored.projectRoot);
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             console.error(`[IntegrationWizard] Failed to generate pending ${payload.kind} artifact:`, error);
@@ -192,27 +193,16 @@ async function runPendingArtifact(): Promise<void> {
                 `Your integration was created; you can add the artifact from the Artifacts panel.`
             );
         }
-        // Whatever generation did (navigated, didn't, or failed), never leave the window
-        // on the startup screen.
-        ensureLandedOnNewIntegration(stored);
+        // Unconditional, and it has to be: this runs after awaiting generation, and the
+        // project explorer's own startup navigation lands during that await. Standing down
+        // because something had already navigated is what left the window on the workspace
+        // overview — a create is the last word on where a create ends up.
+        if (!claimedView) {
+            openPackageOverview(stored.projectRoot);
+        }
     } catch (error) {
         console.error("[IntegrationWizard] Unexpected error while checking pending artifact:", error);
     }
-}
-
-/**
- * Guarantees the window lands on a real view after a wizard create. Acts only when
- * nothing has navigated yet (machine still in `extensionReady`), so it stays a no-op on
- * paths that navigate themselves.
- */
-function ensureLandedOnNewIntegration(pointer: PendingIntegrationArtifactPointer): void {
-    // Read the raw machine value rather than `StateMachine.state()`: the shared
-    // `MachineStateValue` type predates the startup states and does not include
-    // `extensionReady`, which is exactly the one being tested here.
-    if (StateMachine.service().getSnapshot().value !== "extensionReady") {
-        return;
-    }
-    openPackageOverview(pointer.projectRoot);
 }
 
 /** Reads and immediately deletes the payload file; undefined when missing (empty integration) or unreadable. */
@@ -256,10 +246,13 @@ export async function generateArtifactInPlace(
     }
 
     try {
-        await whileFinishingIntegrationCreate(() => window.withProgress(
+        const claimedView = await whileFinishingIntegrationCreate(() => window.withProgress(
             { location: ProgressLocation.Notification, title: `Generating your ${label}...` },
             () => generatePendingArtifact(payload, packageRoot)
         ));
+        if (!claimedView) {
+            openPackageOverview(packageRoot);
+        }
         // Silent: a non-silent refresh lands on the workspace overview, which would clobber
         // the package overview navigated to above.
         StateMachine.refreshProjectInfo({ silent: true });
@@ -274,15 +267,18 @@ export async function generateArtifactInPlace(
 }
 
 /**
- * Runs the kind-specific generation and navigates to the result. All files target
- * `projectRoot` (the new package), which is also where the window lands: the integration
- * the user just created is the thing they came here to see, whether it went into a project
- * that already existed or one this same submit created.
+ * Runs the kind-specific generation. All files target `projectRoot` (the new package).
+ *
+ * Returns whether generation claimed the view for a destination of its own, in which case the
+ * caller leaves it alone. Only the agent does that — it hands off to a wizard rather than
+ * finishing here. Everything else leaves the caller to land on the new integration, which is
+ * the thing the user came to see whether it went into a project that already existed or one
+ * this same submit created.
  */
 async function generatePendingArtifact(
     payload: PendingIntegrationArtifactPayload,
     projectRoot: string
-): Promise<void> {
+): Promise<boolean> {
     switch (payload.kind) {
         case "SERVICE": {
             if (!payload.serviceInitModel) {
@@ -295,8 +291,7 @@ async function generatePendingArtifact(
                 projectPath: projectRoot,
                 serviceInitModel: payload.serviceInitModel,
             });
-            openPackageOverview(projectRoot);
-            return;
+            return false;
         }
         case "AUTOMATION":
         case "WORKFLOW": {
@@ -310,8 +305,7 @@ async function generatePendingArtifact(
                 flowNode: payload.flowNode,
                 isFunctionNodeUpdate: true,
             });
-            openPackageOverview(projectRoot);
-            return;
+            return false;
         }
         case "AI_CHAT_AGENT": {
             // Pragmatic v1: the agent's multi-RPC orchestration stays webview-side —
@@ -321,7 +315,7 @@ async function generatePendingArtifact(
                 view: MACHINE_VIEW.AIChatAgentWizard,
                 identifier: payload.aiAgent?.name,
             });
-            return;
+            return true;
         }
         default:
             throw new Error(`Unsupported artifact kind: ${(payload as PendingIntegrationArtifactPayload).kind}`);

--- a/packages/ballerina-extension/src/features/bi/pending-artifact.ts
+++ b/packages/ballerina-extension/src/features/bi/pending-artifact.ts
@@ -43,31 +43,31 @@ import {
 /** Payload file location inside the scaffolded project (target/ is gitignored by the scaffold). */
 const PENDING_ARTIFACT_RELATIVE_PATH = path.join("target", ".wizard-pending-artifact.json");
 
-/**
- * Depth rather than a boolean: the in-place and post-reload paths can overlap, and the first
- * one to finish must not clear the flag out from under the other.
- */
-let integrationCreateDepth = 0;
+let finishingIntegrationCreate = false;
 
 /**
  * Whether a Create Integration submit is being finished right now.
  *
  * Scaffolding a package makes the language server publish artifacts for a package the project
  * structure does not know yet, and `updateProjectArtifacts` answers that by navigating to the
- * workspace overview. During a create that is wrong: the create flow decides where to land, and
- * the fallback would replace the new integration's overview a moment after it opened.
+ * workspace overview. During a create that is wrong: the create decides where to land, and the
+ * fallback would replace the new integration's overview a moment after it opened.
  */
 export function isFinishingIntegrationCreate(): boolean {
-    return integrationCreateDepth > 0;
+    return finishingIntegrationCreate;
 }
 
-/** Runs `task` with {@link isFinishingIntegrationCreate} reporting true. */
+/**
+ * Runs `task` with {@link isFinishingIntegrationCreate} reporting true. Not re-entrant, and
+ * does not need to be: the post-reload path runs once per activation, and the in-place path is
+ * driven by the wizard webview, which is not open then.
+ */
 async function whileFinishingIntegrationCreate<T>(task: () => PromiseLike<T>): Promise<T> {
-    integrationCreateDepth++;
+    finishingIntegrationCreate = true;
     try {
         return await task();
     } finally {
-        integrationCreateDepth--;
+        finishingIntegrationCreate = false;
     }
 }
 

--- a/packages/ballerina-extension/src/features/bi/pending-artifact.ts
+++ b/packages/ballerina-extension/src/features/bi/pending-artifact.ts
@@ -328,10 +328,11 @@ async function generatePendingArtifact(
  * resolves inside a workspace.
  */
 export function openPackageOverview(projectRoot: string): void {
+    openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.PackageOverview, projectPath: projectRoot });
     // Claimed as well as navigated: the project explorer issues its own Open Overview once its
     // tree finishes loading, which can be after this lands, and would otherwise replace the
-    // integration the user just made with the workspace overview a moment later.
+    // integration the user just made. Claimed AFTER the navigation above, so that navigation
+    // does not consume its own claim.
     claimCreateLanding(projectRoot);
-    openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.PackageOverview, projectPath: projectRoot });
 }
 

--- a/packages/ballerina-extension/src/features/bi/pending-artifact.ts
+++ b/packages/ballerina-extension/src/features/bi/pending-artifact.ts
@@ -28,7 +28,7 @@ import {
     MACHINE_VIEW,
     PendingIntegrationArtifactPayload,
 } from "@wso2/ballerina-core";
-import { openView, StateMachine } from "../../stateMachine";
+import { openView, StateMachine, whenNavigationDeliverable } from "../../stateMachine";
 import { claimCreateLanding } from "../../utils/state-machine-utils";
 import { ServiceDesignerRpcManager } from "../../rpc-managers/service-designer/rpc-manager";
 import { BiDiagramRpcManager } from "../../rpc-managers/bi-diagram/rpc-manager";
@@ -105,7 +105,14 @@ export async function schedulePendingIntegration(schedule: PendingIntegrationSch
  * function's own `alreadyViewingAddedPackage` check. A claim planted there would be one nothing
  * ever spends, and the project explorer's Show Overview would walk into it.
  */
-function landOnNewIntegrationAfterReload(projectRoot: string): void {
+async function landOnNewIntegrationAfterReload(projectRoot: string): Promise<void> {
+    // Awaited because the machine handles `OPEN_VIEW` only in `extensionReady` and
+    // `viewActive.viewReady`. Generation is asynchronous, so by the time it returns the machine may
+    // be mid-load, where the landing would be dropped without trace and the window would silently
+    // stay wherever startup left it. The deleted `extensionReady` guard used to make delivery
+    // certain as a side effect of when it allowed the landing at all; this replaces that half of
+    // its job, `claimedView` having replaced the other.
+    await whenNavigationDeliverable();
     openPackageOverview(projectRoot);
     claimCreateLanding(projectRoot);
 }
@@ -151,14 +158,14 @@ export async function checkAndRunPendingArtifact(): Promise<void> {
         // An empty integration has no payload: there is nothing to generate, only
         // the landing view below to open.
         if (!payload) {
-            landOnNewIntegrationAfterReload(stored.projectRoot);
+            await landOnNewIntegrationAfterReload(stored.projectRoot);
             return;
         }
 
         const label = ARTIFACT_KIND_LABELS[payload.kind];
         if (!label || payload.version !== 1) {
             console.error(`[IntegrationWizard] Unsupported pending artifact payload:`, payload);
-            landOnNewIntegrationAfterReload(stored.projectRoot);
+            await landOnNewIntegrationAfterReload(stored.projectRoot);
             return;
         }
 
@@ -184,7 +191,7 @@ export async function checkAndRunPendingArtifact(): Promise<void> {
         // because something had already navigated is what left the window on the workspace
         // overview — a create is the last word on where a create ends up.
         if (!claimedView) {
-            landOnNewIntegrationAfterReload(stored.projectRoot);
+            await landOnNewIntegrationAfterReload(stored.projectRoot);
         }
     } catch (error) {
         console.error("[IntegrationWizard] Unexpected error while checking pending artifact:", error);

--- a/packages/ballerina-extension/src/features/bi/pending-artifact.ts
+++ b/packages/ballerina-extension/src/features/bi/pending-artifact.ts
@@ -29,6 +29,7 @@ import {
     PendingIntegrationArtifactPayload,
 } from "@wso2/ballerina-core";
 import { openView, StateMachine } from "../../stateMachine";
+import { claimCreateLanding } from "../../utils/state-machine-utils";
 import { ServiceDesignerRpcManager } from "../../rpc-managers/service-designer/rpc-manager";
 import { BiDiagramRpcManager } from "../../rpc-managers/bi-diagram/rpc-manager";
 import {
@@ -327,6 +328,10 @@ async function generatePendingArtifact(
  * resolves inside a workspace.
  */
 export function openPackageOverview(projectRoot: string): void {
+    // Claimed as well as navigated: the project explorer issues its own Open Overview once its
+    // tree finishes loading, which can be after this lands, and would otherwise replace the
+    // integration the user just made with the workspace overview a moment later.
+    claimCreateLanding(projectRoot);
     openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.PackageOverview, projectPath: projectRoot });
 }
 

--- a/packages/ballerina-extension/src/features/bi/pending-artifact.ts
+++ b/packages/ballerina-extension/src/features/bi/pending-artifact.ts
@@ -35,7 +35,6 @@ import { BiDiagramRpcManager } from "../../rpc-managers/bi-diagram/rpc-manager";
 import {
     clearPendingIntegrationPointer,
     isPendingPointerFresh,
-    PendingIntegrationArtifactPointer,
     readPendingIntegrationPointer,
     writePendingIntegrationPointer,
 } from "./startup-progress";
@@ -94,6 +93,24 @@ export async function schedulePendingIntegration(schedule: PendingIntegrationSch
 }
 
 /**
+ * The post-reload landing: claims as well as navigates.
+ *
+ * Startup issues navigations of its own whose order relative to this one varies run to run, so
+ * a workspace overview arriving behind it would otherwise replace the new integration. Claimed
+ * AFTER navigating, so this navigation does not spend its own claim.
+ *
+ * The in-place path deliberately uses {@link openPackageOverview} instead. It runs in a settled
+ * window with no startup navigation to race, and the one navigation that can follow it — the
+ * untracked-package fallback in `updateProjectArtifacts` — is already covered there by that
+ * function's own `alreadyViewingAddedPackage` check. A claim planted there would be one nothing
+ * ever spends, and the project explorer's Show Overview would walk into it.
+ */
+function landOnNewIntegrationAfterReload(projectRoot: string): void {
+    openPackageOverview(projectRoot);
+    claimCreateLanding(projectRoot);
+}
+
+/**
  * Finishes a wizard submit that spanned the last folder reload: generates the configured
  * first artifact and lands on the new integration. Consume-immediately — the pointer and
  * payload file are cleared BEFORE generation, so a failure can never loop. Safe on every
@@ -134,14 +151,14 @@ export async function checkAndRunPendingArtifact(): Promise<void> {
         // An empty integration has no payload: there is nothing to generate, only
         // the landing view below to open.
         if (!payload) {
-            openPackageOverview(stored.projectRoot);
+            landOnNewIntegrationAfterReload(stored.projectRoot);
             return;
         }
 
         const label = ARTIFACT_KIND_LABELS[payload.kind];
         if (!label || payload.version !== 1) {
             console.error(`[IntegrationWizard] Unsupported pending artifact payload:`, payload);
-            openPackageOverview(stored.projectRoot);
+            landOnNewIntegrationAfterReload(stored.projectRoot);
             return;
         }
 
@@ -167,7 +184,7 @@ export async function checkAndRunPendingArtifact(): Promise<void> {
         // because something had already navigated is what left the window on the workspace
         // overview — a create is the last word on where a create ends up.
         if (!claimedView) {
-            openPackageOverview(stored.projectRoot);
+            landOnNewIntegrationAfterReload(stored.projectRoot);
         }
     } catch (error) {
         console.error("[IntegrationWizard] Unexpected error while checking pending artifact:", error);
@@ -297,10 +314,5 @@ async function generatePendingArtifact(
  */
 export function openPackageOverview(projectRoot: string): void {
     openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.PackageOverview, projectPath: projectRoot });
-    // Claimed as well as navigated: the project explorer issues its own Open Overview once its
-    // tree finishes loading, which can be after this lands, and would otherwise replace the
-    // integration the user just made. Claimed AFTER the navigation above, so that navigation
-    // does not consume its own claim.
-    claimCreateLanding(projectRoot);
 }
 

--- a/packages/ballerina-extension/src/features/bi/pending-artifact.ts
+++ b/packages/ballerina-extension/src/features/bi/pending-artifact.ts
@@ -35,7 +35,6 @@ import {
     clearPendingIntegrationPointer,
     isPendingPointerFresh,
     PendingIntegrationArtifactPointer,
-    PendingIntegrationLanding,
     readPendingIntegrationPointer,
     writePendingIntegrationPointer,
 } from "./startup-progress";
@@ -92,14 +91,12 @@ export interface PendingIntegrationSchedule {
     isNewProject?: boolean;
     /** Defaults to "integration" on read. */
     componentLabel?: IntegrationComponentLabel;
-    /** Where the reloaded window should land. */
-    landing: PendingIntegrationLanding;
 }
 
 /**
  * Records the create so the reloaded window can finish it. Written even for an empty
- * integration or a library — it is also what lets the new window narrate the create and
- * know where to land. Call right before `openInVSCode(openRoot)`.
+ * integration or a library — it is also what lets the new window narrate the create.
+ * Call right before `openInVSCode(openRoot)`.
  */
 export async function schedulePendingIntegration(schedule: PendingIntegrationSchedule): Promise<void> {
     const { packageRoot, payload } = schedule;
@@ -117,11 +114,9 @@ export async function schedulePendingIntegration(schedule: PendingIntegrationSch
         projectName: schedule.projectName,
         isNewProject: schedule.isNewProject,
         componentLabel: schedule.componentLabel,
-        landing: schedule.landing,
     });
     console.log(
-        `[IntegrationWizard] Scheduled pending ${payload?.kind ?? "empty"} integration for project: ${packageRoot} ` +
-        `(landing=${schedule.landing})`
+        `[IntegrationWizard] Scheduled pending ${payload?.kind ?? "empty"} integration for project: ${packageRoot}`
     );
 }
 
@@ -167,19 +162,17 @@ async function runPendingArtifact(): Promise<void> {
             return;
         }
 
-        const landOnPackageOverview = resolveLandsOnPackage(stored, opensStoredPackage);
-
         // An empty integration has no payload: there is nothing to generate, only
         // the landing view below to open.
         if (!payload) {
-            ensureLandedOnNewIntegration(stored, landOnPackageOverview);
+            ensureLandedOnNewIntegration(stored);
             return;
         }
 
         const label = ARTIFACT_KIND_LABELS[payload.kind];
         if (!label || payload.version !== 1) {
             console.error(`[IntegrationWizard] Unsupported pending artifact payload:`, payload);
-            ensureLandedOnNewIntegration(stored, landOnPackageOverview);
+            ensureLandedOnNewIntegration(stored);
             return;
         }
 
@@ -187,10 +180,10 @@ async function runPendingArtifact(): Promise<void> {
         console.log(
             `[IntegrationWizard] Pending artifact: kind=${payload.kind}, projectRoot=${stored.projectRoot}, ` +
             `opensStoredPackage=${opensStoredPackage}, insideOpenWorkspace=${insideOpenWorkspace}, ` +
-            `addedIntoWorkspace=${addedIntoWorkspace}, landOnPackageOverview=${landOnPackageOverview}`
+            `addedIntoWorkspace=${addedIntoWorkspace}`
         );
         try {
-            await generatePendingArtifact(payload, stored.projectRoot, landOnPackageOverview);
+            await generatePendingArtifact(payload, stored.projectRoot);
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             console.error(`[IntegrationWizard] Failed to generate pending ${payload.kind} artifact:`, error);
@@ -201,23 +194,10 @@ async function runPendingArtifact(): Promise<void> {
         }
         // Whatever generation did (navigated, didn't, or failed), never leave the window
         // on the startup screen.
-        ensureLandedOnNewIntegration(stored, landOnPackageOverview);
+        ensureLandedOnNewIntegration(stored);
     } catch (error) {
         console.error("[IntegrationWizard] Unexpected error while checking pending artifact:", error);
     }
-}
-
-/**
- * Whether this create lands on the new package's own overview rather than the project
- * overview. The submit already decided (`landing`); a pointer written by an older build
- * has no such field, so it falls back to the previous rule — package overview only when
- * the package itself is the opened folder.
- */
-function resolveLandsOnPackage(
-    pointer: PendingIntegrationArtifactPointer,
-    opensStoredPackage: boolean
-): boolean {
-    return pointer.landing ? pointer.landing === "package" : opensStoredPackage;
 }
 
 /**
@@ -225,21 +205,14 @@ function resolveLandsOnPackage(
  * nothing has navigated yet (machine still in `extensionReady`), so it stays a no-op on
  * paths that navigate themselves.
  */
-function ensureLandedOnNewIntegration(
-    pointer: PendingIntegrationArtifactPointer,
-    landOnPackageOverview: boolean
-): void {
+function ensureLandedOnNewIntegration(pointer: PendingIntegrationArtifactPointer): void {
     // Read the raw machine value rather than `StateMachine.state()`: the shared
     // `MachineStateValue` type predates the startup states and does not include
     // `extensionReady`, which is exactly the one being tested here.
     if (StateMachine.service().getSnapshot().value !== "extensionReady") {
         return;
     }
-    if (landOnPackageOverview) {
-        openPackageOverview(pointer.projectRoot);
-        return;
-    }
-    openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.WorkspaceOverview });
+    openPackageOverview(pointer.projectRoot);
 }
 
 /** Reads and immediately deletes the payload file; undefined when missing (empty integration) or unreadable. */
@@ -274,8 +247,7 @@ function consumePendingArtifactPayload(projectRoot: string): PendingIntegrationA
  */
 export async function generateArtifactInPlace(
     packageRoot: string,
-    payload: PendingIntegrationArtifactPayload,
-    landOnPackageOverview = false
+    payload: PendingIntegrationArtifactPayload
 ): Promise<void> {
     const label = ARTIFACT_KIND_LABELS[payload.kind];
     if (!label || payload.version !== 1) {
@@ -286,11 +258,11 @@ export async function generateArtifactInPlace(
     try {
         await whileFinishingIntegrationCreate(() => window.withProgress(
             { location: ProgressLocation.Notification, title: `Generating your ${label}...` },
-            () => generatePendingArtifact(payload, packageRoot, landOnPackageOverview)
+            () => generatePendingArtifact(payload, packageRoot)
         ));
-        // A non-silent refresh lands on the workspace overview, which would clobber the
-        // package overview navigated to above.
-        StateMachine.refreshProjectInfo({ silent: landOnPackageOverview });
+        // Silent: a non-silent refresh lands on the workspace overview, which would clobber
+        // the package overview navigated to above.
+        StateMachine.refreshProjectInfo({ silent: true });
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`[IntegrationWizard] Failed to generate ${payload.kind} artifact in place:`, error);
@@ -303,14 +275,13 @@ export async function generateArtifactInPlace(
 
 /**
  * Runs the kind-specific generation and navigates to the result. All files target
- * `projectRoot` (the new package). `landOnPackageOverview`: true when the new package is
- * the thing to show (standalone, or added into an existing project); false when the
- * project itself was just created, so the window stays on the project overview.
+ * `projectRoot` (the new package), which is also where the window lands: the integration
+ * the user just created is the thing they came here to see, whether it went into a project
+ * that already existed or one this same submit created.
  */
 async function generatePendingArtifact(
     payload: PendingIntegrationArtifactPayload,
-    projectRoot: string,
-    landOnPackageOverview: boolean
+    projectRoot: string
 ): Promise<void> {
     switch (payload.kind) {
         case "SERVICE": {
@@ -324,9 +295,7 @@ async function generatePendingArtifact(
                 projectPath: projectRoot,
                 serviceInitModel: payload.serviceInitModel,
             });
-            if (landOnPackageOverview) {
-                openPackageOverview(projectRoot);
-            }
+            openPackageOverview(projectRoot);
             return;
         }
         case "AUTOMATION":
@@ -341,9 +310,7 @@ async function generatePendingArtifact(
                 flowNode: payload.flowNode,
                 isFunctionNodeUpdate: true,
             });
-            if (landOnPackageOverview) {
-                openPackageOverview(projectRoot);
-            }
+            openPackageOverview(projectRoot);
             return;
         }
         case "AI_CHAT_AGENT": {

--- a/packages/ballerina-extension/src/features/bi/startup-progress.ts
+++ b/packages/ballerina-extension/src/features/bi/startup-progress.ts
@@ -35,14 +35,8 @@ export const PENDING_INTEGRATION_ARTIFACT_KEY = "ballerina.pendingIntegrationArt
 export const PENDING_ARTIFACT_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 /**
- * Where the reloaded window lands once the create finishes. A brand-new project opens on
- * its own overview (the user just made the project, so that is the thing they made);
- * adding into a project that already exists opens the new package instead, since the
- * project itself is not the news.
+ * globalState value written before the reload; the filled artifact model lives in the project's `target/.wizard-pending-artifact.json`.
  */
-export type PendingIntegrationLanding = "project" | "package";
-
-/** globalState value written before the reload; the filled artifact model lives in the project's `target/.wizard-pending-artifact.json`. */
 export interface PendingIntegrationArtifactPointer {
     projectRoot: string;
     /** epoch ms — used to discard stale entries (> 10 min). */
@@ -57,8 +51,6 @@ export interface PendingIntegrationArtifactPointer {
     isNewProject?: boolean;
     /** Integration vs library — the progress screen names them differently. */
     componentLabel?: IntegrationComponentLabel;
-    /** Decided at submit time, where all the routing context is; absent on pointers written by an older build. */
-    landing?: PendingIntegrationLanding;
 }
 
 /** What the reloaded window narrates while it finishes a create started before the reload. */

--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -1006,6 +1006,52 @@ export const StateMachine = {
     },
 };
 
+/**
+ * Whether an `OPEN_VIEW` sent right now would be acted on.
+ *
+ * The machine handles it in `extensionReady` and `viewActive.viewReady` only — there is no
+ * root-level handler — so one sent while a view is mid-load is dropped without trace.
+ */
+function handlesOpenView(): boolean {
+    const value = stateService.getSnapshot().value;
+    return value === "extensionReady" || StateMachine.isReady();
+}
+
+/**
+ * Resolves once a navigation sent now would be delivered, for a caller whose navigation must not
+ * be silently dropped — the post-create landing being the one that matters, since dropping it
+ * leaves the window wherever startup happened to put it.
+ *
+ * Bounded, and proceeds anyway on expiry rather than stalling a create indefinitely: the same
+ * principle {@link VISUALIZER_WEBVIEW_READY_TIMEOUT_MS} already applies to waiting on the webview.
+ */
+export function whenNavigationDeliverable(timeoutMs = VISUALIZER_WEBVIEW_READY_TIMEOUT_MS): Promise<boolean> {
+    if (handlesOpenView()) {
+        return Promise.resolve(true);
+    }
+    return new Promise<boolean>((resolve) => {
+        let settled = false;
+        const finish = (delivered: boolean) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            clearTimeout(timer);
+            subscription.unsubscribe();
+            resolve(delivered);
+        };
+        const timer = setTimeout(() => {
+            console.warn(`Timed out after ${timeoutMs}ms waiting for a state that accepts navigation; sending anyway.`);
+            finish(false);
+        }, timeoutMs);
+        const subscription = stateService.subscribe(() => {
+            if (handlesOpenView()) {
+                finish(true);
+            }
+        });
+    });
+}
+
 export interface OpenViewOptions {
     /**
      * Take `viewLocation.view` literally, skipping the single-integration redirect in
@@ -1045,7 +1091,7 @@ export function openView(
     if (options?.exactView) {
         releaseCreateLanding();
     } else {
-        override = resolveCreateLandingOverride(viewLocation)
+        override = resolveCreateLandingOverride(viewLocation, handlesOpenView())
             ?? resolveSingleIntegrationOverride(viewLocation, StateMachine.context());
     }
     const location = override ?? viewLocation;

--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -1031,8 +1031,8 @@ export function openView(
     // Two rules can redirect a workspace-overview navigation, both skipped for a caller that
     // means that view literally (Home):
     //
-    //   - a create that just landed on its new integration keeps it, for a few seconds, against
-    //     an incidental navigation arriving behind it;
+    //   - a create that just landed on its new integration keeps it against the one navigation
+    //     arriving behind it (the claim is consumed here, whichever way it resolves);
     //   - a workspace holding a single integration opens on that integration rather than on a
     //     one-item list. Applied to every navigation, not just the first: the project explorer
     //     re-navigates once its tree finishes loading, seconds after startup.

--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -36,6 +36,8 @@ import {
     getNodeByName,
     getNodeByUid,
     getView,
+    releaseCreateLanding,
+    resolveCreateLandingOverride,
     resolveSingleIntegrationOverride
 } from './utils/state-machine-utils';
 import * as path from 'path';
@@ -1026,19 +1028,27 @@ export function openView(
     }
     extension.hasPullModuleResolved = false;
     extension.hasPullModuleNotification = false;
-    // A workspace holding a single integration opens on that integration rather than a one-item
-    // workspace overview. Applied to every navigation, not just the first: the project explorer
-    // re-navigates once its tree finishes loading, seconds after startup, and a first-navigation
-    // gate would let that second one land back on the workspace overview.
+    // Two rules can redirect a workspace-overview navigation, both skipped for a caller that
+    // means that view literally (Home):
     //
-    // The override REPLACES the location rather than merging into it. The fields a redirected
+    //   - a create that just landed on its new integration keeps it, for a few seconds, against
+    //     an incidental navigation arriving behind it;
+    //   - a workspace holding a single integration opens on that integration rather than on a
+    //     one-item list. Applied to every navigation, not just the first: the project explorer
+    //     re-navigates once its tree finishes loading, seconds after startup.
+    //
+    // An override REPLACES the location rather than merging into it. The fields a redirected
     // navigation carried describe a target that no longer applies, and `identifier` with
     // `artifactType` would survive onto the overview's history entry and send `updateView`
     // hunting for an artifact that this view does not have.
-    const singleIntegrationOverride = options?.exactView
-        ? undefined
-        : resolveSingleIntegrationOverride(viewLocation, StateMachine.context());
-    const location = singleIntegrationOverride ?? viewLocation;
+    let override: VisualizerLocation | undefined;
+    if (options?.exactView) {
+        releaseCreateLanding();
+    } else {
+        override = resolveCreateLandingOverride(viewLocation)
+            ?? resolveSingleIntegrationOverride(viewLocation, StateMachine.context());
+    }
+    const location = override ?? viewLocation;
     const projectPath = location.projectPath || StateMachine.context().projectPath;
     const { orgName, packageName } = getOrgAndPackageName(StateMachine.context().projectInfo, projectPath);
     location.org = orgName;

--- a/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
+++ b/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
@@ -144,12 +144,9 @@ describe("resolveSingleIntegrationOverride", () => {
 describe("resolveCreateLandingOverride", () => {
     const CREATED = `${WORKSPACE_ROOT}/orders`;
 
-    afterEach(() => {
-        releaseCreateLanding();
-        jest.useRealTimers();
-    });
+    afterEach(releaseCreateLanding);
 
-    it("sends a workspace-overview navigation back to the package a create just landed on", () => {
+    it("sends the navigation after a create back to the package it landed on", () => {
         claimCreateLanding(CREATED);
 
         expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toEqual({
@@ -169,14 +166,13 @@ describe("resolveCreateLandingOverride", () => {
         expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
     });
 
-    // The claim outranks a navigation the window did not ask for. It must not outlive that
-    // window and start redirecting navigations the user made themselves.
-    it("expires, so a later workspace-overview navigation is left alone", () => {
-        jest.useFakeTimers();
+    // The claim exists to outrank the ONE navigation racing the create. Holding it past that
+    // would redirect a workspace overview the user asked for later, which is why it is
+    // consumed on the next navigation whichever way that one resolves.
+    it("is spent by the navigation it answers, not held for the next one", () => {
         claimCreateLanding(CREATED);
 
-        jest.advanceTimersByTime(60_000);
-
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeTruthy();
         expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
     });
 
@@ -184,9 +180,10 @@ describe("resolveCreateLandingOverride", () => {
         ["a package overview", { view: MACHINE_VIEW.PackageOverview, projectPath: `${WORKSPACE_ROOT}/shipping` }],
         ["another view", { view: MACHINE_VIEW.ServiceDesigner }],
         ["a bare navigation", {}],
-    ])("leaves %s alone even while a claim is live", (_label, viewLocation) => {
+    ])("lapses on %s — the window has moved on", (_label, viewLocation) => {
         claimCreateLanding(CREATED);
 
         expect(resolveCreateLandingOverride(viewLocation)).toBeUndefined();
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
     });
 });

--- a/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
+++ b/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
@@ -143,16 +143,14 @@ describe("resolveSingleIntegrationOverride", () => {
 
 describe("resolveCreateLandingOverride", () => {
     const CREATED = `${WORKSPACE_ROOT}/orders`;
+    const redirected = { view: MACHINE_VIEW.PackageOverview, projectPath: CREATED };
 
     afterEach(releaseCreateLanding);
 
-    it("sends the navigation after a create back to the package it landed on", () => {
+    it("sends a workspace-overview navigation back to the package the create landed on", () => {
         claimCreateLanding(CREATED);
 
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toEqual({
-            view: MACHINE_VIEW.PackageOverview,
-            projectPath: CREATED,
-        });
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toEqual(redirected);
     });
 
     it("does nothing without a claim", () => {
@@ -166,24 +164,35 @@ describe("resolveCreateLandingOverride", () => {
         expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
     });
 
-    // The claim exists to outrank the ONE navigation racing the create. Holding it past that
-    // would redirect a workspace overview the user asked for later, which is why it is
-    // consumed on the next navigation whichever way that one resolves.
-    it("is spent by the navigation it answers, not held for the next one", () => {
-        claimCreateLanding(CREATED);
-
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeTruthy();
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
-    });
-
+    // The regression this rule exists for. Startup fires a bare "show the visualizer" whose
+    // order relative to the create varies run to run; when it landed after the create it used
+    // to spend the claim, and the workspace overview behind it then won. A bare navigation
+    // resolves against the context, which the landing has already pointed at the new package,
+    // so passing it through costs nothing.
     it.each<[string, VisualizerLocation]>([
-        ["a package overview", { view: MACHINE_VIEW.PackageOverview, projectPath: `${WORKSPACE_ROOT}/shipping` }],
-        ["another view", { view: MACHINE_VIEW.ServiceDesigner }],
         ["a bare navigation", {}],
-    ])("lapses on %s — the window has moved on", (_label, viewLocation) => {
+        ["a bare navigation carrying a document", { documentUri: "/workspace/orders/main.bal" }],
+        ["a package overview", { view: MACHINE_VIEW.PackageOverview, projectPath: CREATED }],
+    ])("survives %s, so the workspace overview behind it is still redirected", (_label, viewLocation) => {
         claimCreateLanding(CREATED);
 
         expect(resolveCreateLandingOverride(viewLocation)).toBeUndefined();
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toEqual(redirected);
+    });
+
+    it("is spent by the navigation it answers, not held for the next one", () => {
+        claimCreateLanding(CREATED);
+
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toEqual(redirected);
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
+    });
+
+    // Anything naming a view of its own is the user moving on, and must not leave a claim
+    // behind to redirect a workspace overview they ask for later.
+    it("is released by a navigation to somewhere else", () => {
+        claimCreateLanding(CREATED);
+
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.ServiceDesigner })).toBeUndefined();
         expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
     });
 });

--- a/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
+++ b/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
@@ -46,7 +46,13 @@ jest.mock("../stateMachine", () => ({
     openView: jest.fn(),
 }));
 
-import { getSoleIntegration, resolveSingleIntegrationOverride } from "../utils/state-machine-utils";
+import {
+    claimCreateLanding,
+    getSoleIntegration,
+    releaseCreateLanding,
+    resolveCreateLandingOverride,
+    resolveSingleIntegrationOverride,
+} from "../utils/state-machine-utils";
 
 const WORKSPACE_ROOT = "/workspace";
 
@@ -132,5 +138,55 @@ describe("resolveSingleIntegrationOverride", () => {
         expect(
             resolveSingleIntegrationOverride({}, { projectPath: "/standalone", projectStructure: workspaceOf(pkg("standalone")) })
         ).toBeUndefined();
+    });
+});
+
+describe("resolveCreateLandingOverride", () => {
+    const CREATED = `${WORKSPACE_ROOT}/orders`;
+
+    afterEach(() => {
+        releaseCreateLanding();
+        jest.useRealTimers();
+    });
+
+    it("sends a workspace-overview navigation back to the package a create just landed on", () => {
+        claimCreateLanding(CREATED);
+
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toEqual({
+            view: MACHINE_VIEW.PackageOverview,
+            projectPath: CREATED,
+        });
+    });
+
+    it("does nothing without a claim", () => {
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
+    });
+
+    it("does nothing once the claim is released", () => {
+        claimCreateLanding(CREATED);
+        releaseCreateLanding();
+
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
+    });
+
+    // The claim outranks a navigation the window did not ask for. It must not outlive that
+    // window and start redirecting navigations the user made themselves.
+    it("expires, so a later workspace-overview navigation is left alone", () => {
+        jest.useFakeTimers();
+        claimCreateLanding(CREATED);
+
+        jest.advanceTimersByTime(60_000);
+
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
+    });
+
+    it.each<[string, VisualizerLocation]>([
+        ["a package overview", { view: MACHINE_VIEW.PackageOverview, projectPath: `${WORKSPACE_ROOT}/shipping` }],
+        ["another view", { view: MACHINE_VIEW.ServiceDesigner }],
+        ["a bare navigation", {}],
+    ])("leaves %s alone even while a claim is live", (_label, viewLocation) => {
+        claimCreateLanding(CREATED);
+
+        expect(resolveCreateLandingOverride(viewLocation)).toBeUndefined();
     });
 });

--- a/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
+++ b/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
@@ -143,56 +143,71 @@ describe("resolveSingleIntegrationOverride", () => {
 
 describe("resolveCreateLandingOverride", () => {
     const CREATED = `${WORKSPACE_ROOT}/orders`;
+    const OTHER = `${WORKSPACE_ROOT}/shipping`;
     const redirected = { view: MACHINE_VIEW.PackageOverview, projectPath: CREATED };
+    const workspaceOverview: VisualizerLocation = { view: MACHINE_VIEW.WorkspaceOverview };
 
     afterEach(releaseCreateLanding);
 
     it("sends a workspace-overview navigation back to the package the create landed on", () => {
         claimCreateLanding(CREATED);
 
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toEqual(redirected);
+        expect(resolveCreateLandingOverride(workspaceOverview, true)).toEqual(redirected);
     });
 
     it("does nothing without a claim", () => {
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
+        expect(resolveCreateLandingOverride(workspaceOverview, true)).toBeUndefined();
     });
 
     it("does nothing once the claim is released", () => {
         claimCreateLanding(CREATED);
         releaseCreateLanding();
 
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
+        expect(resolveCreateLandingOverride(workspaceOverview, true)).toBeUndefined();
     });
 
-    // The regression this rule exists for. Startup fires a bare "show the visualizer" whose
-    // order relative to the create varies run to run; when it landed after the create it used
-    // to spend the claim, and the workspace overview behind it then won. A bare navigation
-    // resolves against the context, which the landing has already pointed at the new package,
-    // so passing it through costs nothing.
+    // The regression the spend rule exists for. Startup fires a bare "show the visualizer" whose
+    // order relative to the create varies run to run; when it landed after the create it used to
+    // spend the claim, and the workspace overview behind it then won.
     it.each<[string, VisualizerLocation]>([
         ["a bare navigation", {}],
         ["a bare navigation carrying a document", { documentUri: "/workspace/orders/main.bal" }],
-        ["a package overview", { view: MACHINE_VIEW.PackageOverview, projectPath: CREATED }],
+        ["the claimed package's own overview", { view: MACHINE_VIEW.PackageOverview, projectPath: CREATED }],
+        ["a package overview naming no path", { view: MACHINE_VIEW.PackageOverview }],
     ])("survives %s, so the workspace overview behind it is still redirected", (_label, viewLocation) => {
         claimCreateLanding(CREATED);
 
-        expect(resolveCreateLandingOverride(viewLocation)).toBeUndefined();
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toEqual(redirected);
+        expect(resolveCreateLandingOverride(viewLocation, true)).toBeUndefined();
+        expect(resolveCreateLandingOverride(workspaceOverview, true)).toEqual(redirected);
     });
 
     it("is spent by the navigation it answers, not held for the next one", () => {
         claimCreateLanding(CREATED);
 
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toEqual(redirected);
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
+        expect(resolveCreateLandingOverride(workspaceOverview, true)).toEqual(redirected);
+        expect(resolveCreateLandingOverride(workspaceOverview, true)).toBeUndefined();
     });
 
-    // Anything naming a view of its own is the user moving on, and must not leave a claim
-    // behind to redirect a workspace overview they ask for later.
-    it("is released by a navigation to somewhere else", () => {
+    // Anything that leaves the created package is the user moving on, and must not leave a claim
+    // behind to redirect a workspace overview they ask for later. A DIFFERENT package's overview
+    // counts: several commands navigate to one (the config generator, Try It, the doc command).
+    it.each<[string, VisualizerLocation]>([
+        ["another view", { view: MACHINE_VIEW.ServiceDesigner }],
+        ["a different package's overview", { view: MACHINE_VIEW.PackageOverview, projectPath: OTHER }],
+    ])("is released by a navigation to %s", (_label, viewLocation) => {
         claimCreateLanding(CREATED);
 
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.ServiceDesigner })).toBeUndefined();
-        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.WorkspaceOverview })).toBeUndefined();
+        expect(resolveCreateLandingOverride(viewLocation, true)).toBeUndefined();
+        expect(resolveCreateLandingOverride(workspaceOverview, true)).toBeUndefined();
+    });
+
+    // `OPEN_VIEW` is dropped outside `extensionReady` and `viewActive.viewReady`. Spending the
+    // claim on a navigation that never happens would leave the next workspace overview unopposed.
+    it("ignores a navigation that will not be delivered, claim intact", () => {
+        claimCreateLanding(CREATED);
+
+        expect(resolveCreateLandingOverride(workspaceOverview, false)).toBeUndefined();
+        expect(resolveCreateLandingOverride({ view: MACHINE_VIEW.ServiceDesigner }, false)).toBeUndefined();
+        expect(resolveCreateLandingOverride(workspaceOverview, true)).toEqual(redirected);
     });
 });

--- a/packages/ballerina-extension/src/utils/bi.ts
+++ b/packages/ballerina-extension/src/utils/bi.ts
@@ -51,7 +51,7 @@ import { extension } from "../BalExtensionContext";
 import { scheduleMigrationEnhancement, writeEnhanceToml } from "../features/ai/migration/orchestrator";
 // Imported from `startup-progress` rather than `pending-artifact`: that module pulls in the
 // RPC managers, which import this file back.
-import { PendingIntegrationLanding, writePendingIntegrationPointer } from "../features/bi/startup-progress";
+import { writePendingIntegrationPointer } from "../features/bi/startup-progress";
 import { runBackgroundTerminalCommand } from "./runCommand";
 import { stringify as stringifyYaml } from "yaml";
 
@@ -957,37 +957,32 @@ export async function createBIComponent(projectRequest: ProjectRequest): Promise
 }
 
 /**
- * Naming and landing for a create, resolved once at submit time (the only point that knows
- * whether the project was created by this same submit) and carried across the reload.
+ * Naming for a create, resolved once at submit time — the only point that knows whether the
+ * project was created by this same submit — and carried across the reload for the startup
+ * progress screen. Where the window lands is not part of it: every create opens the new
+ * integration, whether or not it also made the project.
  */
-export interface CreateLandingContext {
+export interface CreateNamingContext {
     /** Display name of the project the package went into; undefined for a standalone package. */
     projectName?: string;
     /** Whether this submit created the project too. */
     isNewProject: boolean;
-    /**
-     * A brand-new project lands on the project overview — the project is what the user just
-     * made. Adding into a project that already existed lands on the new package instead.
-     */
-    landing: PendingIntegrationLanding;
 }
 
-export function resolveCreateLandingContext(
+export function resolveCreateNamingContext(
     packageRoot: string,
     openRoot: string,
     request: Pick<ProjectRequest, 'newProject' | 'convertToWorkspace' | 'workspaceName'>
-): CreateLandingContext {
+): CreateNamingContext {
     // The folder to open being the package itself means no project was involved.
     if (isSamePath(packageRoot, openRoot)) {
-        return { isNewProject: false, landing: "package" };
+        return { isNewProject: false };
     }
-    const isNewProject = !!request.newProject || !!request.convertToWorkspace;
     return {
         // The form's project name is authoritative for a new project; for an existing one
         // read the title it was actually created with.
         projectName: request.workspaceName?.trim() || getExistingProjectInfo(openRoot).name || path.basename(openRoot),
-        isNewProject,
-        landing: isNewProject ? "project" : "package",
+        isNewProject: !!request.newProject || !!request.convertToWorkspace,
     };
 }
 
@@ -1465,18 +1460,17 @@ export async function createBIProject(params: any): Promise<void> {
     }
     // Components go into an existing workspace when the target resolves inside one, else standalone.
     const { packageRoot, openRoot } = await createBIComponent(params);
-    // No artifact is configured on this path, so the pointer carries only the narration
-    // and the landing view for the window that opens next.
-    const landingContext = resolveCreateLandingContext(packageRoot, openRoot, params);
+    // No artifact is configured on this path, so the pointer carries only the narration for
+    // the window that opens next.
+    const namingContext = resolveCreateNamingContext(packageRoot, openRoot, params);
     const componentLabel: IntegrationComponentLabel = params.isLibrary ? "library" : "integration";
     await writePendingIntegrationPointer({
         projectRoot: packageRoot,
         timestamp: Date.now(),
         integrationName: params.projectName,
-        projectName: landingContext.projectName,
-        isNewProject: landingContext.isNewProject,
+        projectName: namingContext.projectName,
+        isNewProject: namingContext.isNewProject,
         componentLabel,
-        landing: landingContext.landing,
     });
     openInVSCode(openRoot);
 }

--- a/packages/ballerina-extension/src/utils/project-artifacts.ts
+++ b/packages/ballerina-extension/src/utils/project-artifacts.ts
@@ -22,6 +22,7 @@ import { openView, StateMachine } from "../stateMachine";
 import { ExtendedLangClient } from "../core/extended-language-client";
 import { ArtifactsUpdated, ArtifactNotificationHandler } from "./project-artifacts-handler";
 import { isLibraryProject } from "./config";
+import { isFinishingIntegrationCreate } from "../features/bi/pending-artifact";
 
 // Tracks projects whose artifacts could not be fetched (e.g., the initial load raced with a
 // missing-module pull and the compilation failed). Used to recover with a full rebuild once
@@ -302,7 +303,14 @@ async function rebuildAndPublishArtifacts(
         const alreadyViewingAddedPackage =
             StateMachine.context().view === MACHINE_VIEW.PackageOverview &&
             untrackedProjectPaths.some((p) => isSamePath(p, StateMachine.context().projectPath));
-        if (untrackedProjectPaths.length > 0 && !alreadyViewingAddedPackage) {
+        // That check alone only holds once the create flow has already navigated, and it
+        // races the rebuild awaited above: the wizard's post-reload path generates the
+        // artifact BEFORE it navigates, so a notification resolving in that window sees
+        // whatever the window was showing beforehand and sends it to the workspace
+        // overview — which is the flash of the new integration being replaced a moment
+        // after it appeared. While a create is being finished it owns the landing view
+        // outright, whichever order the two happen to complete in.
+        if (untrackedProjectPaths.length > 0 && !alreadyViewingAddedPackage && !isFinishingIntegrationCreate()) {
             // Where the fire-and-forget refresh this replaces used to land the window
             // when a package joined the project: the overview is the view guaranteed to
             // be consistent with the rebuilt structure.

--- a/packages/ballerina-extension/src/utils/project-artifacts.ts
+++ b/packages/ballerina-extension/src/utils/project-artifacts.ts
@@ -22,7 +22,6 @@ import { openView, StateMachine } from "../stateMachine";
 import { ExtendedLangClient } from "../core/extended-language-client";
 import { ArtifactsUpdated, ArtifactNotificationHandler } from "./project-artifacts-handler";
 import { isLibraryProject } from "./config";
-import { isFinishingIntegrationCreate } from "../features/bi/pending-artifact";
 
 // Tracks projects whose artifacts could not be fetched (e.g., the initial load raced with a
 // missing-module pull and the compilation failed). Used to recover with a full rebuild once
@@ -303,14 +302,7 @@ async function rebuildAndPublishArtifacts(
         const alreadyViewingAddedPackage =
             StateMachine.context().view === MACHINE_VIEW.PackageOverview &&
             untrackedProjectPaths.some((p) => isSamePath(p, StateMachine.context().projectPath));
-        // That check alone only holds once the create flow has already navigated, and it
-        // races the rebuild awaited above: the wizard's post-reload path generates the
-        // artifact BEFORE it navigates, so a notification resolving in that window sees
-        // whatever the window was showing beforehand and sends it to the workspace
-        // overview — which is the flash of the new integration being replaced a moment
-        // after it appeared. While a create is being finished it owns the landing view
-        // outright, whichever order the two happen to complete in.
-        if (untrackedProjectPaths.length > 0 && !alreadyViewingAddedPackage && !isFinishingIntegrationCreate()) {
+        if (untrackedProjectPaths.length > 0 && !alreadyViewingAddedPackage) {
             // Where the fire-and-forget refresh this replaces used to land the window
             // when a package joined the project: the overview is the view guaranteed to
             // be consistent with the rebuilt structure.

--- a/packages/ballerina-extension/src/utils/state-machine-utils.ts
+++ b/packages/ballerina-extension/src/utils/state-machine-utils.ts
@@ -28,25 +28,19 @@ import { getConstructBodyString } from "./history/util";
 import { extension } from "../BalExtensionContext";
 import path from "path";
 
+/** The package a create landed on, held until the next navigation resolves. */
+let createLanding: string | undefined;
+
 /**
- * How long a create's landing view outranks an incidental workspace-overview navigation.
+ * Marks a package as the view a create just landed on.
  *
- * Bounded by time because there is nothing better to bound it by: the navigation being
- * outranked comes from the project explorer, a different extension issuing its own Open
- * Overview once its tree finishes loading, on a schedule this one cannot observe or
- * coordinate with. Long enough to cover that load, short enough that it cannot affect a
- * navigation the user made themselves.
- */
-const CREATE_LANDING_PRIORITY_MS = 10_000;
-
-let createLanding: { projectPath: string; expiresAt: number } | undefined;
-
-/**
- * Marks a package as the view a create just landed on, so a workspace-overview navigation
- * arriving in the next few seconds shows it instead of replacing it.
+ * The project explorer issues its own Open Overview once its tree finishes loading, which can
+ * be after a create has landed, and would replace the new integration with the workspace
+ * overview. Claim AFTER navigating: {@link resolveCreateLandingOverride} consumes the claim on
+ * the next navigation, and the landing must not consume its own.
  */
 export function claimCreateLanding(projectPath: string): void {
-    createLanding = { projectPath, expiresAt: Date.now() + CREATE_LANDING_PRIORITY_MS };
+    createLanding = projectPath;
 }
 
 /** Drops the claim — for a caller that means the workspace overview literally, i.e. Home. */
@@ -55,18 +49,23 @@ export function releaseCreateLanding(): void {
 }
 
 /**
- * Redirects a workspace-overview navigation back to the package a create just landed on, or
- * undefined when there is no live claim or the navigation is not one.
+ * Redirects the first navigation after a create back to the package it landed on, when that
+ * navigation is to the workspace overview.
+ *
+ * The claim covers the gap between landing and whatever navigates next — not a span of time.
+ * It is consumed either way, so a navigation that is not the workspace overview means the
+ * window has moved on and the claim simply lapses. Nothing after that first navigation can be
+ * mistaken for the one racing the create.
  */
 export function resolveCreateLandingOverride(viewLocation: VisualizerLocation): VisualizerLocation | undefined {
-    if (viewLocation.view !== MACHINE_VIEW.WorkspaceOverview || !createLanding) {
+    if (!createLanding) {
         return undefined;
     }
-    if (Date.now() >= createLanding.expiresAt) {
-        createLanding = undefined;
-        return undefined;
-    }
-    return { view: MACHINE_VIEW.PackageOverview, projectPath: createLanding.projectPath };
+    const claimed = createLanding;
+    createLanding = undefined;
+    return viewLocation.view === MACHINE_VIEW.WorkspaceOverview
+        ? { view: MACHINE_VIEW.PackageOverview, projectPath: claimed }
+        : undefined;
 }
 
 /**

--- a/packages/ballerina-extension/src/utils/state-machine-utils.ts
+++ b/packages/ballerina-extension/src/utils/state-machine-utils.ts
@@ -49,23 +49,31 @@ export function releaseCreateLanding(): void {
 }
 
 /**
- * Redirects the first navigation after a create back to the package it landed on, when that
- * navigation is to the workspace overview.
+ * Redirects a workspace-overview navigation after a create back to the package it landed on.
  *
- * The claim covers the gap between landing and whatever navigates next — not a span of time.
- * It is consumed either way, so a navigation that is not the workspace overview means the
- * window has moved on and the claim simply lapses. Nothing after that first navigation can be
- * mistaken for the one racing the create.
+ * Startup issues more than one navigation, and their order relative to the create varies run to
+ * run: a bare "show the visualizer" arrives either side of the landing, and the workspace
+ * overview follows it. Spending the claim on the first navigation of any kind therefore made the
+ * fix intermittent — the bare one would spend it, leaving the workspace overview to win.
+ *
+ * So only the navigation the claim exists for spends it. A bare navigation resolves against the
+ * context, which the landing has already pointed at the new package, so letting it pass changes
+ * nothing. A navigation naming some other view is the user moving on, and releases the claim so
+ * it cannot affect a workspace overview they ask for later.
  */
 export function resolveCreateLandingOverride(viewLocation: VisualizerLocation): VisualizerLocation | undefined {
     if (!createLanding) {
         return undefined;
     }
-    const claimed = createLanding;
-    createLanding = undefined;
-    return viewLocation.view === MACHINE_VIEW.WorkspaceOverview
-        ? { view: MACHINE_VIEW.PackageOverview, projectPath: claimed }
-        : undefined;
+    if (viewLocation.view === MACHINE_VIEW.WorkspaceOverview) {
+        const claimed = createLanding;
+        createLanding = undefined;
+        return { view: MACHINE_VIEW.PackageOverview, projectPath: claimed };
+    }
+    if (viewLocation.view && viewLocation.view !== MACHINE_VIEW.PackageOverview) {
+        createLanding = undefined;
+    }
+    return undefined;
 }
 
 /**

--- a/packages/ballerina-extension/src/utils/state-machine-utils.ts
+++ b/packages/ballerina-extension/src/utils/state-machine-utils.ts
@@ -36,8 +36,8 @@ let createLanding: string | undefined;
  *
  * The project explorer issues its own Open Overview once its tree finishes loading, which can
  * be after a create has landed, and would replace the new integration with the workspace
- * overview. Claim AFTER navigating: {@link resolveCreateLandingOverride} consumes the claim on
- * the next navigation, and the landing must not consume its own.
+ * overview. Claim AFTER navigating: {@link resolveCreateLandingOverride} spends the claim on the
+ * next workspace-overview navigation, and the landing must not spend its own.
  */
 export function claimCreateLanding(projectPath: string): void {
     createLanding = projectPath;
@@ -61,8 +61,15 @@ export function releaseCreateLanding(): void {
  * nothing. A navigation naming some other view is the user moving on, and releases the claim so
  * it cannot affect a workspace overview they ask for later.
  */
-export function resolveCreateLandingOverride(viewLocation: VisualizerLocation): VisualizerLocation | undefined {
-    if (!createLanding) {
+export function resolveCreateLandingOverride(
+    viewLocation: VisualizerLocation,
+    deliverable: boolean
+): VisualizerLocation | undefined {
+    // `OPEN_VIEW` is handled only in `extensionReady` and `viewActive.viewReady`, so a navigation
+    // sent mid-load is dropped. Spending the claim on one that never happens would leave the next
+    // workspace overview unopposed, so a navigation that will not be delivered is not an event
+    // this claim has any business reacting to.
+    if (!createLanding || !deliverable) {
         return undefined;
     }
     if (viewLocation.view === MACHINE_VIEW.WorkspaceOverview) {
@@ -70,7 +77,14 @@ export function resolveCreateLandingOverride(viewLocation: VisualizerLocation): 
         createLanding = undefined;
         return { view: MACHINE_VIEW.PackageOverview, projectPath: claimed };
     }
-    if (viewLocation.view && viewLocation.view !== MACHINE_VIEW.PackageOverview) {
+    // Only the claimed package's own overview leaves the claim standing. Any other view — including
+    // a different package's overview, reachable from the config generator, Try It, the doc command
+    // and the BI diagram manager — is the user somewhere else, and must not leave a claim behind to
+    // redirect them back here.
+    const staysOnClaimedPackage =
+        viewLocation.view === MACHINE_VIEW.PackageOverview &&
+        (!viewLocation.projectPath || isSamePath(viewLocation.projectPath, createLanding));
+    if (viewLocation.view && !staysOnClaimedPackage) {
         createLanding = undefined;
     }
     return undefined;

--- a/packages/ballerina-extension/src/utils/state-machine-utils.ts
+++ b/packages/ballerina-extension/src/utils/state-machine-utils.ts
@@ -29,6 +29,47 @@ import { extension } from "../BalExtensionContext";
 import path from "path";
 
 /**
+ * How long a create's landing view outranks an incidental workspace-overview navigation.
+ *
+ * Bounded by time because there is nothing better to bound it by: the navigation being
+ * outranked comes from the project explorer, a different extension issuing its own Open
+ * Overview once its tree finishes loading, on a schedule this one cannot observe or
+ * coordinate with. Long enough to cover that load, short enough that it cannot affect a
+ * navigation the user made themselves.
+ */
+const CREATE_LANDING_PRIORITY_MS = 10_000;
+
+let createLanding: { projectPath: string; expiresAt: number } | undefined;
+
+/**
+ * Marks a package as the view a create just landed on, so a workspace-overview navigation
+ * arriving in the next few seconds shows it instead of replacing it.
+ */
+export function claimCreateLanding(projectPath: string): void {
+    createLanding = { projectPath, expiresAt: Date.now() + CREATE_LANDING_PRIORITY_MS };
+}
+
+/** Drops the claim — for a caller that means the workspace overview literally, i.e. Home. */
+export function releaseCreateLanding(): void {
+    createLanding = undefined;
+}
+
+/**
+ * Redirects a workspace-overview navigation back to the package a create just landed on, or
+ * undefined when there is no live claim or the navigation is not one.
+ */
+export function resolveCreateLandingOverride(viewLocation: VisualizerLocation): VisualizerLocation | undefined {
+    if (viewLocation.view !== MACHINE_VIEW.WorkspaceOverview || !createLanding) {
+        return undefined;
+    }
+    if (Date.now() >= createLanding.expiresAt) {
+        createLanding = undefined;
+        return undefined;
+    }
+    return { view: MACHINE_VIEW.PackageOverview, projectPath: createLanding.projectPath };
+}
+
+/**
  * The single integration a workspace holds, or undefined when it holds anything else.
  *
  * Cardinality counts packages, not integrations: a workspace pairing one integration with a


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Creating an integration does not reliably end up on the integration that was just created.

Fixes: https://github.com/wso2/product-integrator/issues/2088

- **From the project creation form**, the window lands on the project overview. The new integration is one click away, on a page the user did not ask for.
- **From the Add button on the project overview**, it lands on the new integration correctly — so the same action behaves differently depending on where it was started.

There is also an intermittent version of the first symptom: the new integration appears and is then replaced by the project overview a second or two later.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Creating an integration ends on that integration, from either entry point, every time.

## Approach
> Describe how you are implementing the solutions.

Three separate defects sat behind one symptom. They are separate commits.

### 1. The landing was split by design

`resolveCreateLandingContext` decided where to go:

```ts
landing: isNewProject ? "project" : "package"
```

A submit that also created the project landed on the project, on the reasoning that the project was the thing the user had just made. That is the primary bug, and it explains the difference between the two entry points: Add from the project overview goes through the in-place path, where the project already exists, so `isNewProject` is false and it lands on the package.

Every create now lands on the new integration. That leaves the choice with one outcome, so the machinery carrying it is gone: the `landing` field on the pending pointer, `PendingIntegrationLanding`, `resolveLandsOnPackage`, and the `landOnPackageOverview` parameter threaded through generation. `CreateLandingContext` keeps only the naming it also carried and is renamed `CreateNamingContext` to match. Pointers written by an older build simply lose a field that no longer has a reader, so a create spanning the upgrade still lands correctly.

### 2. The landing stood down whenever anything else had navigated

`ensureLandedOnNewIntegration` acted only while the machine was still in `extensionReady`:

```ts
if (StateMachine.service().getSnapshot().value !== "extensionReady") return;
```

`checkAndRunPendingArtifact` fires the moment the machine reaches `extensionReady` and then awaits reading the payload and generating the artifact. Other startup navigation lands during those awaits, so by the time the create tried to land it saw `viewReady` and gave up.

The guard existed to avoid overriding generation that had navigated somewhere deliberate. That is now stated directly rather than inferred from machine state: `generatePendingArtifact` returns whether it claimed the view, which only the AI Chat Agent does, since it hands off to its own wizard. Everything else lands unconditionally.

### 3. Startup navigations arrive behind the landing

Even landing last is not enough, because the create is not the only thing navigating. Instrumenting `openView` across two runs of the same action showed three navigations in different orders:

```
worked   (bare) -> openPackageOverview -> Workspace Overview   [redirected]
failed   openPackageOverview -> (bare) -> Workspace Overview   [not redirected]
```

The bare navigation is startup asking for the visualizer with nothing specific; the workspace overview follows it. The create's position among them shifts because it waits on an artifact-generation RPC — which is why this was intermittent rather than consistently broken.

So the landing is claimed as well as performed. `claimCreateLanding` records the package, and a workspace-overview navigation arriving afterwards is redirected to it. The rules that make it safe:

- **Only the post-reload path claims.** The in-place path — Add from the project overview — runs in a settled window with no startup navigation racing it, and the one navigation that can follow it, the untracked-package fallback in `updateProjectArtifacts`, is already covered there by that function's own `alreadyViewingAddedPackage` check. Claiming there would plant a claim nothing ever spends, and the project explorer's Show Overview would then walk into it: that handler passes no `exactView`, so it would be redirected back to the package just left and the click would appear dead. Caught in review on the backport.
- **Only a workspace-overview navigation spends the claim.** An earlier version spent it on the first navigation of any kind, which let the bare one consume a claim meant for the workspace overview — that is the failing run above.
- **A bare navigation passes through untouched.** It resolves against the context, which the landing has already pointed at the new package, so nothing is lost by ignoring it.
- **A navigation naming any other view releases the claim.** That is the user moving on, and the claim must not survive to redirect a workspace overview they ask for later.
- **Home passes `exactView` and releases the claim**, so the deliberate route to the workspace overview always works.

The claim is bounded by the navigation it answers rather than by a duration. An earlier revision used a timeout; that was wrong about who owns the competing navigation — the project explorer only *invokes* `BI.project-explorer.overview`, a command registered in this repo, so there was nothing to out-wait.

## UI Component Development
- [x] Added reusable UI components to the ui-toolkit — N/A, no new UI. This changes which existing view a create ends on.
- [x] Use ui-toolkit components wherever possible — N/A, as above.
- [x] Matches with the native VSCode look and feel — unchanged; both destinations are existing views.

## User stories
> Summary of user stories addressed by this change

As a developer creating an integration, I want to land on the integration I just created and stay there, whichever entry point I started from.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Creating an integration now opens the new integration instead of the project overview, including when the same action creates the project. Fixes a related issue where the new integration would briefly appear and then be replaced by the project overview.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR.

N/A — no documented behaviour changes. The screens and navigation controls are unchanged; only which view a create ends on differs.

## Training
N/A

## Certification
N/A — no user-facing concept or workflow is added or removed.

## Marketing
N/A

## Automation tests
 - Unit tests
   > `singleIntegrationLanding.test.ts` covers `resolveCreateLandingOverride`: the redirect itself, that a bare navigation survives it (the intermittency above, pinned as a regression case), that it is spent by the navigation it answers and not held for the next, and that a navigation elsewhere releases it. Full host suite: 120 passing.
   > Not covered: the landing itself. Reproducing it needs an awaited rebuild in a notification handler racing a navigation in the create flow, against a real state machine — the host suite mocks `vscode` and has no extension host, so this would need scaffolding well beyond the fix. Verified by hand instead, over repeated runs, since a single passing run proves nothing about an intermittent fault.
 - Integration tests
   > None added. Labelled `Checks/Run Ballerina UI Tests` so the existing UI suite runs against it. Worth e2e coverage — create from the form, assert the integration overview is still showing once the structure settles — which would need a wait on the post-create rebuild rather than a fixed delay.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript only, no Java changed
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
#810 (merged) landed the single-integration rule in the same `openView` seam. The two overrides are independent and ordered there: the create's claim is consulted first, then the single-integration rule.

## Migrations (if applicable)
N/A — no persisted state beyond the pending-create pointer, which loses a field rather than gaining one. A create started on an older build and finished on this one still lands correctly.

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested

macOS 15 (darwin 25.5.0), VS Code, Node 20. Verified by hand across both entry points and repeated runs of the create-form path, which is the one that was intermittent.

## Learning
> Describe the research phase.

The fault was intermittent, and three successive fixes were reasoned from what could navigate rather than from what did. Each addressed a real defect and none resolved the symptom, because the remaining cause was an ordering that only shows up about half the time — a passing run looked like a fix.

Instrumenting `openView` to log every navigation with its caller settled it in one round trip, and should have been the first step rather than the fourth. The specific thing it revealed, which no amount of reading would have: the competing navigations are two separate startup calls, and the create's position between them moves because it waits on an RPC.

Worth recording for whoever touches this next: `goBack` does not route through `openView` at all — it replays history via `updateView` — so navigation rules added there cannot affect Back. That fact is what identified a stale `projectPath` write in the `webViewLoaded` assign, rather than the redirect, as the cause of a regression that broke Home and Back together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Ensure integration creation consistently opens the new integration overview.
- Add navigation-based landing claims to prevent workspace navigation from replacing the new integration view.
- Remove obsolete landing state and simplify naming-context resolution.
- Update pending integration generation and navigation flows to use the new claim model.
- Add unit tests for landing overrides, claim consumption, preservation, and release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
