### PR TITLE
Decide offline resolution once per server instead of at every call site

### DIFF
--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/architecturemodelgenerator/extension/persist/PersistERModelGeneratorService.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/architecturemodelgenerator/extension/persist/PersistERModelGeneratorService.java
@@ -29,10 +29,8 @@ import io.ballerina.architecturemodelgenerator.core.diagnostics.DiagnosticUtils;
 import io.ballerina.architecturemodelgenerator.core.generators.entity.EntityModelGenerator;
 import io.ballerina.architecturemodelgenerator.core.model.entity.Entity;
 import io.ballerina.modelgenerator.commons.PackageUtil;
-import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.Project;
-import io.ballerina.projects.directory.SingleFileProject;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
@@ -70,11 +68,8 @@ public class PersistERModelGeneratorService implements ExtendedLanguageServerSer
             AtomicBoolean hasDiagnosticErrors = new AtomicBoolean(false);
             Map<String, Entity> entities = new HashMap<>();
             try {
-                // Persist model file should be loaded as a single file project. Tests (ls.test.offline) force offline
-                // resolution so compilation never pulls from Central; production keeps the default behaviour.
-                Project project = PackageUtil.isOffline()
-                        ? SingleFileProject.load(path, BuildOptions.builder().setOffline(true).build())
-                        : SingleFileProject.load(path);
+                // Persist model file should be loaded as a single file project
+                Project project = PackageUtil.loadSingleFileProject(path);
                 PackageCompilation currentPackageCompilation = project.currentPackage().getCompilation();
                 EntityModelGenerator entityModelGenerator =
                         new EntityModelGenerator(currentPackageCompilation,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/converters/utils/DataMappingModelConverterUtils.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/converters/utils/DataMappingModelConverterUtils.java
@@ -27,12 +27,9 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.UnionTypeDescriptorNode;
 import io.ballerina.modelgenerator.commons.PackageUtil;
-import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectException;
-import io.ballerina.projects.directory.BuildProject;
-import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.projects.util.ProjectUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
@@ -114,9 +111,7 @@ public final class DataMappingModelConverterUtils {
             Path projectRoot = ProjectUtils.findProjectRoot(filePath);
             if (projectRoot == null) {
                 // Since the project-root cannot be found, the provided file is considered as SingleFileProject.
-                project = PackageUtil.isOffline()
-                        ? SingleFileProject.load(filePath, BuildOptions.builder().setOffline(true).build())
-                        : SingleFileProject.load(filePath);
+                project = PackageUtil.loadSingleFileProject(filePath);
                 Package currentPackage = project.currentPackage();
                 moduleSymbols = PackageUtil.getCompilation(currentPackage)
                         .getSemanticModel(currentPackage.getDefaultModule().moduleId())
@@ -127,9 +122,7 @@ public final class DataMappingModelConverterUtils {
                     }
                 });
             } else {
-                project = PackageUtil.isOffline()
-                        ? BuildProject.load(projectRoot, BuildOptions.builder().setOffline(true).build())
-                        : BuildProject.load(projectRoot);
+                project = PackageUtil.loadBuildProject(projectRoot);
                 Package currentPackage = project.currentPackage();
                 moduleSymbols = PackageUtil.getCompilation(currentPackage)
                         .getSemanticModel(currentPackage.getDefaultModule().moduleId())

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ConfigEditorV2Service.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ConfigEditorV2Service.java
@@ -73,7 +73,6 @@ import io.ballerina.modelgenerator.commons.CommonUtils;
 import io.ballerina.modelgenerator.commons.ModuleInfo;
 import io.ballerina.modelgenerator.commons.PackageUtil;
 import io.ballerina.modelgenerator.commons.ParameterMemberTypeData;
-import io.ballerina.projects.CompilationOptions;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
@@ -752,14 +751,7 @@ public class ConfigEditorV2Service implements ExtendedLanguageServerService {
         try {
             Package packageInstance = module.packageInstance();
             if (packageInstance != null) {
-                // Resolve the dependency package offline ONLY during tests (ls.test.offline) so compiling it to read
-                // its config variables never pulls transitive dependencies from Central; compilation then reuses this
-                // cached resolution. In production we leave the package's own (inherited) resolution untouched, which
-                // matches the original behaviour exactly.
-                if (PackageUtil.isOffline()) {
-                    packageInstance.getResolution(
-                            CompilationOptions.builder().setOffline(true).build());
-                }
+                PackageUtil.preResolve(packageInstance);
                 if (packageInstance.getCompilation() != null) {
                     SemanticModel semanticModel = packageInstance.getCompilation()
                             .getSemanticModel(module.moduleId());
@@ -802,12 +794,8 @@ public class ConfigEditorV2Service implements ExtendedLanguageServerService {
             Package currentPkg, Collection<ModuleDependency> moduleDependencies,
             Toml configTomlValues) {
         Map<String, Map<String, List<FlowNode>>> pkgConfigs = new HashMap<>();
-        // Resolve the dependency graph offline ONLY during tests (ls.test.offline) so config extraction never pulls
-        // from Central; in production use the package's default (no-arg) resolution to match the original behaviour.
         // Resolve once and reuse.
-        PackageResolution resolution = PackageUtil.isOffline()
-                ? currentPkg.getResolution(CompilationOptions.builder().setOffline(true).build())
-                : currentPkg.getResolution();
+        PackageResolution resolution = PackageUtil.getResolution(currentPkg);
         if (resolution == null || resolution.dependencyGraph() == null) {
             return pkgConfigs;
         }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -22,6 +22,7 @@ import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.langserver.command.LSCommandExecutorProvidersHolder;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.ResolutionMode;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
@@ -94,6 +95,9 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
     private final TextDocumentService textService;
     private final WorkspaceService workspaceService;
     private final NotebookDocumentService notebookService;
+    // Seeded from the resolution mode so an unconfigured server is already correct; an embedder or a test that
+    // drives the server directly can override it before initialize() runs.
+    private boolean offlineResolution = ResolutionMode.isOffline();
     private int shutdown = 1;
 
     private static final String LS_ENABLE_SEMANTIC_HIGHLIGHTING = "enableSemanticHighlighting";
@@ -145,6 +149,7 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
                 experimentalClientCapabilities,
                 initializationOptions);
         this.serverContext.put(LSClientCapabilities.class, capabilities);
+        ResolutionMode.setOffline(this.offlineResolution);
 
         //Checks for instances in which the LS needs to be initiated in lightweight mode
         if (capabilities.getInitializationOptions().isEnableLightWeightMode()) {
@@ -222,6 +227,16 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
         ((BallerinaTextDocumentService) textService).setClientCapabilities(capabilities);
         ((BallerinaWorkspaceService) workspaceService).setClientCapabilities(capabilities);
         return CompletableFuture.supplyAsync(() -> res);
+    }
+
+    /**
+     * Runs this server without Ballerina Central access, resolving only from its Ballerina home. Must be called before
+     * {@link #initialize} to take effect.
+     *
+     * @param offline {@code true} to resolve offline.
+     */
+    public void setOfflineResolution(boolean offline) {
+        this.offlineResolution = offline;
     }
 
     @Override

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/CentralPackageDescriptorLoader.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/CentralPackageDescriptorLoader.java
@@ -17,16 +17,15 @@ package org.ballerinalang.langserver;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
-import io.ballerina.projects.Settings;
-import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.central.client.CentralAPIClient;
-import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.CentralClientProvider;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -71,14 +70,12 @@ public class CentralPackageDescriptorLoader {
     }
 
     private List<LSPackageLoader.ModuleInfo> getCentralGraphQLPackages() {
-        // Tests (ls.test.offline) never contact Central; completions resolve from local/distribution packages only.
-        if (CommonUtil.TEST_OFFLINE) {
+        Optional<CentralAPIClient> client = CentralClientProvider.graphQlClient();
+        if (client.isEmpty()) {
             return Collections.emptyList();
         }
         try {
-            Settings settings = RepoUtils.readSettings();
-            CentralAPIClient centralAPIClient = new CentralAPIClient(RepoUtils.getRemoteRepoGraphQLURL(),
-                    ProjectUtils.initializeProxy(settings.getProxy()), ProjectUtils.getAccessTokenOfCLI(settings));
+            CentralAPIClient centralAPIClient = client.get();
             String query = String.format(GET_PACKAGES_QUERY, "ballerinax", 800);
             JsonElement allPackagesResponse = centralAPIClient.getCentralPackagesUsingGraphQL(query, "any",
                     RepoUtils.getBallerinaVersion());

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -34,8 +34,8 @@ import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.codeaction.providers.imports.PullModuleCodeAction;
 import org.ballerinalang.langserver.command.CommandUtil;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
-import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.PathUtil;
+import org.ballerinalang.langserver.common.utils.ResolutionMode;
 import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.ExecuteCommandContext;
@@ -191,7 +191,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
                     CompilationOptions.CompilationOptionsBuilder optionsBuilder = CompilationOptions.builder();
                     // Production resolves online so missing modules are pulled from Central; tests
                     // (ls.test.offline) resolve only from the build-provisioned Ballerina home.
-                    optionsBuilder.setOffline(CommonUtil.TEST_OFFLINE).setSticky(sticky);
+                    optionsBuilder.setOffline(ResolutionMode.isOffline()).setSticky(sticky);
                     CompilationOptions options = optionsBuilder.build();
 
                     // For workspace projects, currentPackage() returns only the first member package.

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CentralClientProvider.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CentralClientProvider.java
@@ -77,6 +77,6 @@ public final class CentralClientProvider {
      * @return {@code true} when Central may be contacted.
      */
     public static boolean isCentralAvailable() {
-        return !CommonUtil.TEST_OFFLINE;
+        return !ResolutionMode.isOffline();
     }
 }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CentralClientProvider.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CentralClientProvider.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.common.utils;
+
+import io.ballerina.projects.util.ProjectUtils;
+import org.ballerinalang.central.client.CentralAPIClient;
+import org.wso2.ballerinalang.util.RepoUtils;
+
+import java.util.Optional;
+
+/**
+ * Supplies Ballerina Central clients, or nothing when the language server runs without Central access.
+ * <p>
+ * Callers ask for a client and skip their Central path when none is returned; they never inspect how that decision was
+ * made. This is the counterpart of {@code RemoteCentral.getInstance()} returning an offline implementation, and keeps
+ * the "is Central reachable" question out of the services that use it.
+ *
+ * @since 1.7.0
+ */
+public final class CentralClientProvider {
+
+    private CentralClientProvider() {
+    }
+
+    /**
+     * A client for the Central REST API, or empty when Central is not reachable.
+     *
+     * @return An {@link Optional} holding the client.
+     */
+    public static Optional<CentralAPIClient> restClient() {
+        if (!isCentralAvailable()) {
+            return Optional.empty();
+        }
+        var settings = RepoUtils.readSettings();
+        return Optional.of(new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
+                ProjectUtils.initializeProxy(settings.getProxy()), settings.getProxy().username(),
+                settings.getProxy().password(), ProjectUtils.getAccessTokenOfCLI(settings),
+                settings.getCentral().getConnectTimeout(), settings.getCentral().getReadTimeout(),
+                settings.getCentral().getWriteTimeout(), settings.getCentral().getCallTimeout(),
+                settings.getCentral().getMaxRetries()));
+    }
+
+    /**
+     * A client for the Central GraphQL API, or empty when Central is not reachable.
+     *
+     * @return An {@link Optional} holding the client.
+     */
+    public static Optional<CentralAPIClient> graphQlClient() {
+        if (!isCentralAvailable()) {
+            return Optional.empty();
+        }
+        var settings = RepoUtils.readSettings();
+        return Optional.of(new CentralAPIClient(RepoUtils.getRemoteRepoGraphQLURL(),
+                ProjectUtils.initializeProxy(settings.getProxy()), ProjectUtils.getAccessTokenOfCLI(settings)));
+    }
+
+    /**
+     * Whether the language server may reach Ballerina Central at all. False for test runs, which resolve only from the
+     * build-provisioned Ballerina home.
+     *
+     * @return {@code true} when Central may be contacted.
+     */
+    public static boolean isCentralAvailable() {
+        return !CommonUtil.TEST_OFFLINE;
+    }
+}

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -101,11 +101,6 @@ public final class CommonUtil {
 
     public static final boolean COMPILE_OFFLINE;
 
-    // Set by the Gradle test tasks (-Dls.test.offline=true). When enabled, every site that would contact Ballerina
-    // Central is forced offline so tests resolve only from the build-provisioned Ballerina home. Defaults to false, so
-    // production behaviour is unchanged. Single flag for everything that can see langserver-core;
-    public static final boolean TEST_OFFLINE = Boolean.getBoolean("ls.test.offline");
-
     public static final String BALLERINA_CMD;
 
     public static final String URI_SCHEME_BALA = "bala";

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/ResolutionMode.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/ResolutionMode.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.common.utils;
+
+/**
+ * Whether this language server may reach Ballerina Central, decided once for the whole server.
+ * <p>
+ * An offline server resolves only from the Ballerina home it was given. Test runs get one by setting
+ * {@code -Dls.test.offline=true}, which is the default source of this value, so nothing has to be initialised for it to
+ * be correct. {@link #setOffline(boolean)} lets an embedder override it explicitly.
+ * <p>
+ * Code that resolves packages should ask {@link #isOffline()} rather than reading a system property, so that adding a
+ * resolution path does not mean remembering the test setup.
+ *
+ * @since 1.7.0
+ */
+public final class ResolutionMode {
+
+    // Seeded from the system property so the value is right before anyone calls the setter. Volatile because an
+    // embedder may override it after request threads have started.
+    private static volatile boolean offline = Boolean.getBoolean("ls.test.offline");
+
+    private ResolutionMode() {
+    }
+
+    /**
+     * Whether package resolution must avoid Ballerina Central.
+     *
+     * @return {@code true} when the server resolves offline.
+     */
+    public static boolean isOffline() {
+        return offline;
+    }
+
+    /**
+     * Overrides the mode for this server. Intended for the server bootstrap and for tests that drive the server
+     * directly; the system property covers the ordinary case.
+     *
+     * @param value {@code true} to resolve without contacting Ballerina Central.
+     */
+    public static void setOffline(boolean value) {
+        offline = value;
+    }
+}

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
@@ -33,7 +33,6 @@ import io.ballerina.projects.PackageOrg;
 import io.ballerina.projects.PackageVersion;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
-import io.ballerina.projects.Settings;
 import io.ballerina.projects.environment.Environment;
 import io.ballerina.projects.environment.EnvironmentBuilder;
 import io.ballerina.projects.environment.PackageResolver;
@@ -48,6 +47,7 @@ import org.ballerinalang.diagramutil.DiagramUtil;
 import org.ballerinalang.diagramutil.connector.generator.ConnectorGenerator;
 import org.ballerinalang.diagramutil.connector.models.connector.Connector;
 import org.ballerinalang.langserver.LSClientLogger;
+import org.ballerinalang.langserver.common.utils.CentralClientProvider;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
@@ -71,8 +71,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static io.ballerina.projects.util.ProjectUtils.getAccessTokenOfCLI;
-import static io.ballerina.projects.util.ProjectUtils.initializeProxy;
 
 /**
  * Implementation of the BallerinaConnectorService.
@@ -106,17 +104,9 @@ public class BallerinaConnectorService implements ExtendedLanguageServerService 
         return CompletableFuture.supplyAsync(() -> {
             BallerinaConnectorListResponse connectorList = new BallerinaConnectorListResponse();
             try {
-                // Tests (ls.test.offline) never contact Central; only local project connectors are returned.
-                if (!CommonUtil.TEST_OFFLINE) {
-                    Settings settings = RepoUtils.readSettings();
-                    CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
-                            initializeProxy(settings.getProxy()), settings.getProxy().username(),
-                            settings.getProxy().password(), getAccessTokenOfCLI(settings),
-                            settings.getCentral().getConnectTimeout(),
-                            settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
-                            settings.getCentral().getCallTimeout(), settings.getCentral().getMaxRetries());
-
-                    JsonElement connectorSearchResult = client.getConnectors(request.getQueryMap(),
+                Optional<CentralAPIClient> centralClient = CentralClientProvider.restClient();
+                if (centralClient.isPresent()) {
+                    JsonElement connectorSearchResult = centralClient.get().getConnectors(request.getQueryMap(),
                             "any", RepoUtils.getBallerinaVersion());
                     CentralConnectorListResult centralConnectorListResult = new Gson().fromJson(
                             connectorSearchResult.getAsString(), CentralConnectorListResult.class);
@@ -195,20 +185,13 @@ public class BallerinaConnectorService implements ExtendedLanguageServerService 
     }
 
     private Optional<JsonObject> getConnectorFromCentral(BallerinaConnectorRequest request) {
-        // Tests (ls.test.offline) never contact Central; fall through to local resolution.
-        if (CommonUtil.TEST_OFFLINE) {
+        Optional<CentralAPIClient> centralClient = CentralClientProvider.restClient();
+        if (centralClient.isEmpty()) {
             return Optional.empty();
         }
         JsonObject connector;
         try {
-            Settings settings = RepoUtils.readSettings();
-            CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
-                    initializeProxy(settings.getProxy()), settings.getProxy().username(),
-                    settings.getProxy().password(),
-                    getAccessTokenOfCLI(settings),
-                    settings.getCentral().getConnectTimeout(),
-                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
-                    settings.getCentral().getCallTimeout(), settings.getCentral().getMaxRetries());
+            CentralAPIClient client = centralClient.get();
             if (request.getConnectorId() != null) {
                 // Fetch connector by connector Id.
                 connector = client.getConnector(request.getConnectorId(), "any", RepoUtils.getBallerinaVersion());

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
@@ -48,7 +48,7 @@ import org.ballerinalang.diagramutil.connector.generator.ConnectorGenerator;
 import org.ballerinalang.diagramutil.connector.models.connector.Connector;
 import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.common.utils.CentralClientProvider;
-import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.ResolutionMode;
 import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
@@ -155,7 +155,7 @@ public class BallerinaConnectorService implements ExtendedLanguageServerService 
         PackageResolver packageResolver = environment.getService(PackageResolver.class);
         Collection<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(
                 Collections.singletonList(resolutionRequest),
-                ResolutionOptions.builder().setOffline(CommonUtil.TEST_OFFLINE).build());
+                ResolutionOptions.builder().setOffline(ResolutionMode.isOffline()).build());
         ResolutionResponse resolutionResponse = resolutionResponses.stream().findFirst().orElse(null);
 
         if (resolutionResponse != null && resolutionResponse.resolutionStatus().equals(

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/version/BallerinaBaseCompilerApi.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/version/BallerinaBaseCompilerApi.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.ResolutionMode;
 import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 
@@ -115,9 +116,8 @@ public class BallerinaBaseCompilerApi extends BallerinaCompilerApi {
 
     @Override
     public Project loadProject(Path path) {
-        // Tests (ls.test.offline) force offline resolution so this load never pulls from Central; production keeps the
-        // default (online) behaviour.
-        if (CommonUtil.TEST_OFFLINE) {
+        // An offline server never pulls from Central; an online one keeps the default behaviour.
+        if (ResolutionMode.isOffline()) {
             return createProject(path, BuildOptions.builder().setOffline(true).build());
         }
         return ProjectLoader.loadProject(path);

--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -22,6 +22,7 @@ import io.ballerina.centralconnector.CentralAPI;
 import io.ballerina.centralconnector.RemoteCentral;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.projects.BuildOptions;
+import io.ballerina.projects.CompilationOptions;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.ModuleName;
@@ -30,11 +31,13 @@ import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.PackageDescriptor;
 import io.ballerina.projects.PackageName;
 import io.ballerina.projects.PackageOrg;
+import io.ballerina.projects.PackageResolution;
 import io.ballerina.projects.PackageVersion;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.bala.BalaProject;
 import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.projects.environment.PackageMetadataResponse;
 import io.ballerina.projects.environment.PackageResolver;
 import io.ballerina.projects.environment.ResolutionOptions;
@@ -85,6 +88,57 @@ public class PackageUtil {
     // Owned by BallerinaCompilerApi so this stays loadable on distributions that predate PackageLockingMode.
     private static BuildOptions balaBuildOptions() {
         return BallerinaCompilerApi.getInstance().getBalaBuildOptions(CommonUtil.TEST_OFFLINE);
+    }
+
+    /**
+     * Loads a standalone {@code .bal} file as a single file project. Callers get offline resolution automatically when
+     * the language server runs offline, so they never have to branch on it themselves.
+     *
+     * @param path Path to the standalone Ballerina file.
+     * @return The loaded project.
+     */
+    public static Project loadSingleFileProject(Path path) {
+        return CommonUtil.TEST_OFFLINE
+                ? SingleFileProject.load(path, BuildOptions.builder().setOffline(true).build())
+                : SingleFileProject.load(path);
+    }
+
+    /**
+     * Loads a package directory as a build project. Offline counterpart of
+     * {@link #loadSingleFileProject(Path)}.
+     *
+     * @param projectRoot Path to the package root.
+     * @return The loaded project.
+     */
+    public static Project loadBuildProject(Path projectRoot) {
+        return CommonUtil.TEST_OFFLINE
+                ? BuildProject.load(projectRoot, BuildOptions.builder().setOffline(true).build())
+                : BuildProject.load(projectRoot);
+    }
+
+    /**
+     * Resolves a package's dependency graph, offline when the language server runs offline.
+     *
+     * @param pkg The package to resolve.
+     * @return The package resolution.
+     */
+    public static PackageResolution getResolution(Package pkg) {
+        return CommonUtil.TEST_OFFLINE
+                ? pkg.getResolution(CompilationOptions.builder().setOffline(true).build())
+                : pkg.getResolution();
+    }
+
+    /**
+     * Pre-resolves a package so a subsequent compilation reuses that resolution instead of resolving again. A no-op
+     * unless the language server runs offline, where it pins the resolution offline so compiling the package never
+     * reaches Ballerina Central. Production behaviour is unchanged.
+     *
+     * @param pkg The package to pre-resolve.
+     */
+    public static void preResolve(Package pkg) {
+        if (CommonUtil.TEST_OFFLINE) {
+            pkg.getResolution(CompilationOptions.builder().setOffline(true).build());
+        }
     }
 
     private static final BuildProject SAMPLE_PROJECT = getSampleProject();

--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -46,7 +46,7 @@ import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.projects.repos.TempDirCompilationCache;
 import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.langserver.LSClientLogger;
-import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.ResolutionMode;
 import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
 import org.ballerinalang.langserver.commons.eventsync.exceptions.EventSyncException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
@@ -82,12 +82,12 @@ public class PackageUtil {
      * @return {@code true} if offline resolution is forced; {@code false} in production.
      */
     public static boolean isOffline() {
-        return CommonUtil.TEST_OFFLINE;
+        return ResolutionMode.isOffline();
     }
 
     // Owned by BallerinaCompilerApi so this stays loadable on distributions that predate PackageLockingMode.
     private static BuildOptions balaBuildOptions() {
-        return BallerinaCompilerApi.getInstance().getBalaBuildOptions(CommonUtil.TEST_OFFLINE);
+        return BallerinaCompilerApi.getInstance().getBalaBuildOptions(ResolutionMode.isOffline());
     }
 
     /**
@@ -98,7 +98,7 @@ public class PackageUtil {
      * @return The loaded project.
      */
     public static Project loadSingleFileProject(Path path) {
-        return CommonUtil.TEST_OFFLINE
+        return ResolutionMode.isOffline()
                 ? SingleFileProject.load(path, BuildOptions.builder().setOffline(true).build())
                 : SingleFileProject.load(path);
     }
@@ -111,7 +111,7 @@ public class PackageUtil {
      * @return The loaded project.
      */
     public static Project loadBuildProject(Path projectRoot) {
-        return CommonUtil.TEST_OFFLINE
+        return ResolutionMode.isOffline()
                 ? BuildProject.load(projectRoot, BuildOptions.builder().setOffline(true).build())
                 : BuildProject.load(projectRoot);
     }
@@ -123,7 +123,7 @@ public class PackageUtil {
      * @return The package resolution.
      */
     public static PackageResolution getResolution(Package pkg) {
-        return CommonUtil.TEST_OFFLINE
+        return ResolutionMode.isOffline()
                 ? pkg.getResolution(CompilationOptions.builder().setOffline(true).build())
                 : pkg.getResolution();
     }
@@ -136,7 +136,7 @@ public class PackageUtil {
      * @param pkg The package to pre-resolve.
      */
     public static void preResolve(Package pkg) {
-        if (CommonUtil.TEST_OFFLINE) {
+        if (ResolutionMode.isOffline()) {
             pkg.getResolution(CompilationOptions.builder().setOffline(true).build());
         }
     }
@@ -268,7 +268,7 @@ public class PackageUtil {
         PackageResolver packageResolver = buildProject.projectEnvironmentContext().getService(PackageResolver.class);
 
         Optional<ResolutionResponse> resolutionResponse =
-                resolveResponse(packageResolver, ResolutionRequest.from(packageDescriptor), CommonUtil.TEST_OFFLINE);
+                resolveResponse(packageResolver, ResolutionRequest.from(packageDescriptor), ResolutionMode.isOffline());
         if (resolutionResponse.isEmpty()) {
             return Optional.empty();
         }
@@ -309,7 +309,7 @@ public class PackageUtil {
         PackageDescriptor packageDescriptor;
         if (pkgMetadata.isEmpty() ||
                 pkgMetadata.get().resolutionStatus() == ResolutionResponse.ResolutionStatus.UNRESOLVED) {
-            if (CommonUtil.TEST_OFFLINE) {
+            if (ResolutionMode.isOffline()) {
                 // Not in the local repositories and network fallback is disabled.
                 return Optional.empty();
             }
@@ -324,7 +324,7 @@ public class PackageUtil {
 
         Collection<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(
                 Collections.singletonList(ResolutionRequest.from(packageDescriptor)),
-                ResolutionOptions.builder().setOffline(CommonUtil.TEST_OFFLINE).build());
+                ResolutionOptions.builder().setOffline(ResolutionMode.isOffline()).build());
         Optional<ResolutionResponse> resolutionResponse = resolutionResponses.stream().findFirst();
         if (resolutionResponse.isEmpty() || resolutionResponse.get().resolvedPackage() == null) {
             // Offline and the package could not be resolved from the local repositories.
@@ -560,13 +560,13 @@ public class PackageUtil {
 
     public static ModuleInfo fetchVersionIfNotExists(ModuleInfo moduleInfo) {
         if (moduleInfo.version() == null) {
-            String version = CommonUtil.TEST_OFFLINE
+            String version = ResolutionMode.isOffline()
                     ? cachedVersion(moduleInfo.org(), moduleInfo.packageName())
                     : RemoteCentral.getInstance().latestPackageVersion(moduleInfo.org(), moduleInfo.packageName());
-            // Under TEST_OFFLINE a null version means the package was never provisioned into the build-owned
-            // cache. Fail loudly (matching the TEST_OFFLINE contract above) so a missing lock entry is
+            // When offline a null version means the package was never provisioned into the build-owned
+            // cache. Fail loudly (matching the offline contract above) so a missing lock entry is
             // self-diagnosing, rather than silently degrading into an empty model downstream.
-            if (CommonUtil.TEST_OFFLINE && version == null) {
+            if (ResolutionMode.isOffline() && version == null) {
                 throw new IllegalStateException(String.format(
                         "Package '%s/%s' is not provisioned in the offline test cache. Add it to "
                         + "build-config/ballerina_dependencies (Ballerina.toml) " + "and regenerate Dependencies.toml.",


### PR DESCRIPTION
## Purpose

Addresses [review comment 5](https://github.com/ballerina-platform/ballerina-vscode/pull/666#discussion_r3663233132) on #666: production code should not read a test flag and take a different path.

> **Stacked on #841.** The base branch is `address-pr-666-deferred-comments`, so the diff here is only this change.
>
> When #841 merges, GitHub retargets this PR to `main` automatically. If #841 is merged with a merge commit (as PRs in this repo normally are) its commits keep their SHAs, they become ancestors of this branch, and the diff stays correct with nothing to do. If #841 is **squash**-merged, the squashed commit has a new SHA and this diff will re-show #841's changes, which needs:
>
> ```
> git rebase --onto main address-pr-666-deferred-comments packageutil-offline-seams
> ```

## Problem

#666 made the LS tests hermetic by adding a global `ls.test.offline` flag and then, in 17 places in production code, branching on it:

```java
if (PackageUtil.isOffline()) {
    return SingleFileProject.load(path, offlineOptions);
}
return SingleFileProject.load(path);
```

Users run the second line, tests run the first, so the tests were not exercising the shipped path. Anyone adding a resolution path also had to remember the test setup.

## Approach

The offline decision is made once for the server and everything else asks for it, instead of each call site asking whether it is under test. `RemoteCentral.getInstance()` returning `OfflineCentral` was already the right shape in #666; this extends the same idea to project loading, Central client creation and package resolution.

**`ResolutionMode`** (new, `langserver-core`) owns the answer. It is seeded from the system property, so an unconfigured server is already correct and there is no initialise-before-use hazard. `BallerinaLanguageServer` exposes `setOfflineResolution()` for an embedder or a test that drives the server directly.

**`CentralClientProvider`** (new, `langserver-core`) supplies a `CentralAPIClient`, or nothing when Central is unreachable. Callers skip their Central path when they get nothing; they never ask why. This also removes the duplicated 10-argument client construction from two call sites.

**`PackageUtil`** gains `loadSingleFileProject`, `loadBuildProject`, `getResolution` and `preResolve`, so callers that used to pick between an offline and an online load now make one unconditional call.

## Result

| | before | after |
|---|---|---|
| production sites reading the test flag | 17 | 0 |
| places the system property is read | 3 | 2 |
| `CommonUtil.TEST_OFFLINE` | present | removed |

`CommonUtil.java` is now byte-identical to its pre-#666 state.

Where an offline question survives, it is `ResolutionMode.isOffline()` — "is this server configured without Central access", which is a real deployment mode rather than test scaffolding. No shipped behaviour changes: every site receives the same value it did before.

## Testing

Full suite on a wiped Ballerina home and wiped module distributions: **5074 tests, 0 failures**.

Also verified no package in the provisioned home ends up with more than one version (82 packages, one version each). That matters because the home is provisioned from a lock file with exactly one version per package, so a second version can only arrive from a Central pull during the run. Before this series the suite was pulling `ballerina/http` 2.13.2 and 2.14.0 mid-run.

## Not included

- `PackageUtil`'s own 11 offline branches are still branches rather than two selected implementations (`OfflinePackageResolver` / `RemotePackageResolver`). That needs `PackageUtil` moved into `langserver-core`, which needs `ModuleInfo` moved with it to avoid a dependency cycle.
- `service-model-generator .../Utils.java` still has `if (PackageUtil.isOffline()) { return; }`. It guards whether to attempt a Central pull rather than how to resolve, and routing it through `fetchVersionIfNotExists` would change offline behaviour.
- `RemoteCentral.OFFLINE` still reads the property directly; `flow-model-central-client` cannot depend on `langserver-core`.

Tracked in https://github.com/wso2-enterprise/integration-engineering/issues/2141.
