### PR TITLE
Separate the suggested integration name with an underscore

### DIFF
--- a/packages/ballerina-extension/src/utils/bi.ts
+++ b/packages/ballerina-extension/src/utils/bi.ts
@@ -1421,7 +1421,7 @@ export async function getSuggestedProjectDefaults(isInProject: boolean): Promise
             for (let i = 2; ; i++) {
                 packageName = `${basePackageName}_${i}`;
                 if (packageName !== currentPackageName) {
-                    integrationName = `${BASE_INTEGRATION_NAME} ${i}`;
+                    integrationName = `${BASE_INTEGRATION_NAME}_${i}`;
                     break;
                 }
             }
@@ -1437,7 +1437,7 @@ export async function getSuggestedProjectDefaults(isInProject: boolean): Promise
         for (let i = 2; ; i++) {
             const packageName = `${basePackageName}_${i}`;
             if (!fs.existsSync(path.join(workspacePath, packageName))) {
-                return { projectName: BASE_PROJECT_NAME, projectHandle: BASE_PROJECT_NAME.toLowerCase(), integrationName: `${BASE_INTEGRATION_NAME} ${i}`, packageName };
+                return { projectName: BASE_PROJECT_NAME, projectHandle: BASE_PROJECT_NAME.toLowerCase(), integrationName: `${BASE_INTEGRATION_NAME}_${i}`, packageName };
             }
         }
     }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The two entry points that suggest a name for a new integration disagree on how to index it when the base name is taken.

| Entry point | Suggests |
|---|---|
| Create Integration wizard | `Untitled`, `Untitled_2`, `Untitled_3` |
| Add from the project overview | `Untitled`, `Untitled 2`, `Untitled 3` |

Both derive the same `untitled_2` package name; only the display title differs. The generators were written independently — one in the webview, one in the extension host — and neither is aware of the other.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

One suggested name for the same collision, whichever entry point the user came through.

## Approach
> Describe how you are implementing the solutions.

`getSuggestedProjectDefaults` (the extension-host generator, behind Add from the project overview) now indexes with an underscore, matching `resolveDefaultNameAndDirectory` in the webview.

Both forms pass `validateComponentName`, which permits spaces and underscores alike, so this is a consistency fix rather than a correctness one. The wizard's form was chosen as the one to keep: it leaves the title the user sees identical to the folder the integration lands in, and the Package Name field beside it already shows the identifier form.

The project name suggested alongside is deliberately untouched — it indexes as `Default 2` against a `default-2` handle, which is its own convention and not what was reported.

## UI Component Development
- [x] Added reusable UI components to the ui-toolkit — N/A, no new UI. This changes a suggested value, not a component.
- [x] Use ui-toolkit components wherever possible — N/A, as above.
- [x] Matches with the native VSCode look and feel — unchanged.

## User stories
> Summary of user stories addressed by this change

As a developer adding a second integration, I want the suggested name to look the same whichever way I started, so the two entry points do not appear to be different features.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

The integration name suggested when adding to a project now matches the Create Integration wizard, indexing as `Untitled_2` rather than `Untitled 2`.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR.

N/A — the suggested name is a pre-filled default the user can overwrite, and is not documented.

## Training
N/A

## Certification
N/A — no concept or workflow changes.

## Marketing
N/A

## Automation tests
 - Unit tests
   > None added. `getSuggestedProjectDefaults` probes the filesystem and reads the state machine's context, so covering the two suggested strings would mean mocking both for an assertion on a template literal. The existing 112 host tests pass unchanged.
 - Integration tests
   > None added. Labelled `Checks/Run Ballerina UI Tests` so the existing UI suite runs against it.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript only, no Java changed
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None. Independent of #847, which is about which view a create lands on.

## Migrations (if applicable)
N/A — affects only the value pre-filled into a form field. Integrations already created keep their names.

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested

macOS 15 (darwin 25.5.0), VS Code, Node 20.

## Learning
> Describe the research phase.

Worth recording that the two generators are on opposite sides of the RPC boundary — `resolveAvailableDirectoryName.ts` in the visualizer, `getSuggestedProjectDefaults` in the extension host — which is why they drifted without anything flagging it. A third entry point would drift the same way. Consolidating them is a larger change than this report warrants, but it is where the next divergence will come from.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates suggested integration names to use underscore separators for numeric suffixes, such as `Untitled_2`. This aligns project overview suggestions with the Create Integration wizard while preserving existing project name suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->