### PR TITLE
Fix the durable agent Attach Activity form and its code generation

### DIFF
--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -316,7 +316,8 @@ public class AiUtils {
                 originalProperty.defaultValue(),
                 originalProperty.comment(),
                 originalProperty.dynamicFormFields(),
-                originalProperty.itemOptions()
+                originalProperty.itemOptions(),
+                originalProperty.advanceProperties()
         );
     }
 
@@ -349,7 +350,8 @@ public class AiUtils {
                 original.defaultValue(),
                 original.comment(),
                 original.dynamicFormFields(),
-                original.itemOptions()
+                original.itemOptions(),
+                original.advanceProperties()
         );
     }
 
@@ -397,7 +399,8 @@ public class AiUtils {
                 original.defaultValue(),
                 original.comment(),
                 original.dynamicFormFields(),
-                original.itemOptions()
+                original.itemOptions(),
+                original.advanceProperties()
         );
     }
 
@@ -432,7 +435,8 @@ public class AiUtils {
                 original.defaultValue(),
                 original.comment(),
                 original.dynamicFormFields(),
-                original.itemOptions()
+                original.itemOptions(),
+                original.advanceProperties()
         );
     }
 
@@ -482,7 +486,8 @@ public class AiUtils {
                 property.defaultValue(),
                 property.comment(),
                 property.dynamicFormFields(),
-                property.itemOptions()
+                property.itemOptions(),
+                property.advanceProperties()
         );
         nodeBuilder.properties().build().put(key, copied);
     }
@@ -1978,7 +1983,8 @@ public class AiUtils {
                 property.defaultValue(),
                 property.comment(),
                 property.dynamicFormFields(),
-                property.itemOptions()
+                property.itemOptions(),
+                property.advanceProperties()
         );
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -150,6 +150,7 @@ import io.ballerina.flowmodelgenerator.core.model.node.ChunkerBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.ClassInitBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.DataLoaderBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.DataMapperBuilder;
+import io.ballerina.flowmodelgenerator.core.model.node.DurableAgentAddActivityBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.DurableAgentDataResultBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.DurableAgentResultBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.DurableAgentRunBuilder;
@@ -1541,6 +1542,35 @@ public class CodeAnalyzer extends NodeVisitor {
                     }
                     String fieldName = specificField.fieldName().toSourceCode().trim();
                     String rawValue = specificField.valueExpr().get().toSourceCode().trim();
+                    // Activity entries carry two composite fields the generic key mapping cannot
+                    // express, and both must hydrate or an edit-save regenerates the entry
+                    // without them. retryPolicy decomposes into the retry form's dropdown value
+                    // plus sub-fields; bindings explodes into the form's per-parameter selectors.
+                    if ("activity".equals(capabilityType) && "retryPolicy".equals(fieldName)) {
+                        RetryPolicyForm retryForm = normalizeRetryPolicy(rawValue);
+                        values.put(ActivityCallBuilder.RETRY_POLICY_PARAM, retryForm.dropdownValue());
+                        putIfNotBlank(values, ActivityCallBuilder.MAX_RETRIES_KEY, retryForm.maxRetries());
+                        putIfNotBlank(values, ActivityCallBuilder.RETRY_DELAY_KEY, retryForm.retryDelay());
+                        putIfNotBlank(values, ActivityCallBuilder.RETRY_BACKOFF_KEY, retryForm.retryBackoff());
+                        putIfNotBlank(values, ActivityCallBuilder.MAX_RETRY_DELAY_KEY,
+                                retryForm.maxRetryDelay());
+                        putIfNotBlank(values, ActivityCallBuilder.RETRY_USER_ROLES_KEY,
+                                retryForm.retryUserRoles());
+                        continue;
+                    }
+                    if ("activity".equals(capabilityType) && "bindings".equals(fieldName)
+                            && specificField.valueExpr().get().kind() == SyntaxKind.MAPPING_CONSTRUCTOR) {
+                        for (MappingFieldNode bindingField
+                                : ((MappingConstructorExpressionNode) specificField.valueExpr().get()).fields()) {
+                            if (bindingField instanceof SpecificFieldNode bindingSpecific
+                                    && bindingSpecific.valueExpr().isPresent()) {
+                                values.put(DurableAgentAddActivityBuilder.BINDING_KEY_PREFIX
+                                                + bindingSpecific.fieldName().toSourceCode().trim(),
+                                        bindingSpecific.valueExpr().get().toSourceCode().trim());
+                            }
+                        }
+                        continue;
+                    }
                     String propertyKey = fieldToPropertyKey.get(fieldName);
                     if (propertyKey != null) {
                         // The cardinality enum may be module-qualified in source (workflow:SINGLE_EVENT);
@@ -1574,6 +1604,12 @@ public class CodeAnalyzer extends NodeVisitor {
     // Capability declaration fields whose values render in text-mode form fields.
     private static final Set<String> TEXT_MODE_CAPABILITY_FIELDS =
             Set.of("name", "title", "description", "roles");
+
+    private static void putIfNotBlank(Map<String, String> values, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            values.put(key, value);
+        }
+    }
 
     private static String stripModulePrefix(String value) {
         int colon = value.lastIndexOf(':');
@@ -2155,6 +2191,19 @@ public class CodeAnalyzer extends NodeVisitor {
      * then adds them as root-level properties on the current nodeBuilder.
      */
     private void addNormalizedRetryPolicyProperties(String rawValue) {
+        RetryPolicyForm form = normalizeRetryPolicy(rawValue);
+        ActivityCallBuilder.addRetryPolicyFormProperties(nodeBuilder, form.dropdownValue(),
+                form.maxRetries(), form.retryDelay(), form.retryBackoff(), form.maxRetryDelay(),
+                form.retryUserRoles());
+    }
+
+    // The retry-policy form's decomposition of a raw retryPolicy source value: the dropdown
+    // selection plus its sub-field values.
+    private record RetryPolicyForm(String dropdownValue, String maxRetries, String retryDelay,
+                                   String retryBackoff, String maxRetryDelay, String retryUserRoles) {
+    }
+
+    private static RetryPolicyForm normalizeRetryPolicy(String rawValue) {
         String dropdownValue = ActivityCallBuilder.NO_RETRY_VALUE;
         String maxRetries = "", retryDelay = "", retryBackoff = "", maxRetryDelay = "";
         String retryUserRoles = "";
@@ -2186,9 +2235,8 @@ public class CodeAnalyzer extends NodeVisitor {
                 dropdownValue = trimmed;
             }
         }
-
-        ActivityCallBuilder.addRetryPolicyFormProperties(nodeBuilder, dropdownValue,
-                maxRetries, retryDelay, retryBackoff, maxRetryDelay, retryUserRoles);
+        return new RetryPolicyForm(dropdownValue, maxRetries, retryDelay, retryBackoff,
+                maxRetryDelay, retryUserRoles);
     }
 
     // Whether the retryPolicy source is a literal reviewer role (a string) or role list, the two

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/Constants.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/Constants.java
@@ -187,7 +187,7 @@ public class Constants {
         public static final String REGISTER_ACTIVITY_METHOD_NAME = "registerActivity";
         public static final String REGISTER_ACTIVITY_LABEL = "Register Activity";
         public static final String REGISTER_ACTIVITY_DESCRIPTION =
-                "Register a workflow activity as a durable agent tool";
+                "Register a workflow activity as a durable agent activity";
         public static final String REGISTER_HUMAN_TASK_METHOD_NAME = "registerHumanTask";
         public static final String REGISTER_HUMAN_TASK_LABEL = "Register HumanTask";
         public static final String REGISTER_HUMAN_TASK_DESCRIPTION =

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
@@ -80,13 +80,16 @@ import java.util.Set;
  * @param dynamicFormFields maps dropdown option values to their conditional sub-fields keyed by property name
  *                          (for DropdownChoiceForm)
  * @param itemOptions       dropdown item options for DROPDOWN_CHOICE fields (id, content, value)
+ * @param advanceProperties the child properties of a GROUP_SECTION property, keyed by property name; the UI
+ *                          renders them behind the group's Expand/Collapse toggle
  * @since 1.0.0
  */
 public record Property(Metadata metadata, List<PropertyType> types, Object value, Object oldValue,
                        String placeholder, boolean optional, boolean editable, boolean advanced, boolean hidden,
                        Boolean modified, Diagnostics diagnostics, PropertyCodedata codedata, Object advancedValue,
                        Map<String, String> imports, String defaultValue, CommentProperty comment,
-                       Map<String, Map<String, Property>> dynamicFormFields, List<ItemOption> itemOptions) {
+                       Map<String, Map<String, Property>> dynamicFormFields, List<ItemOption> itemOptions,
+                       Map<String, Property> advanceProperties) {
 
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
 
@@ -374,6 +377,11 @@ public record Property(Metadata metadata, List<PropertyType> types, Object value
         ADVANCE_PARAM_LIST,
         DROPDOWN_CHOICE,
         /**
+         * A property type that renders a labelled group with an Expand/Collapse toggle. The group's child
+         * properties are carried in {@link Property#advanceProperties()} and render behind that toggle.
+         */
+        GROUP_SECTION,
+        /**
          * A property type that renders a connection picker in the UI. The compatible
          * connection kinds are advertised through {@link PropertyCodedata#searchNodesKind()}.
          * The property value carries the picked connection variable name, or
@@ -411,6 +419,7 @@ public record Property(Metadata metadata, List<PropertyType> types, Object value
         private CommentProperty commentProperty;
         private Map<String, Map<String, Property>> dynamicFormFields;
         private List<ItemOption> itemOptions;
+        private Map<String, Property> advanceProperties;
 
         /**
          * Creates a builder pre-populated with all fields from an existing property.
@@ -453,6 +462,8 @@ public record Property(Metadata metadata, List<PropertyType> types, Object value
             }
             builder.itemOptions = original.itemOptions() != null
                     ? new ArrayList<>(original.itemOptions()) : null;
+            builder.advanceProperties = original.advanceProperties() != null
+                    ? new LinkedHashMap<>(original.advanceProperties()) : null;
             if (original.metadata() != null) {
                 builder.metadataBuilder = new Metadata.Builder<>(builder);
                 builder.metadataBuilder.label(original.metadata().label())
@@ -610,6 +621,11 @@ public record Property(Metadata metadata, List<PropertyType> types, Object value
 
         public Builder<T> itemOptions(List<ItemOption> itemOptions) {
             this.itemOptions = itemOptions;
+            return this;
+        }
+
+        public Builder<T> advanceProperties(Map<String, Property> advanceProperties) {
+            this.advanceProperties = advanceProperties;
             return this;
         }
 
@@ -1412,7 +1428,7 @@ public record Property(Metadata metadata, List<PropertyType> types, Object value
                     diagnosticsBuilder == null ? null : diagnosticsBuilder.build(),
                     codedataBuilder == null ? null : codedataBuilder.build(), advancedValue,
                     imports == null ? null : imports, defaultValue, commentProperty, dynamicFormFields,
-                    itemOptions);
+                    itemOptions, advanceProperties);
             this.metadataBuilder = null;
             this.types = new ArrayList<>();
             this.value = null;
@@ -1430,6 +1446,7 @@ public record Property(Metadata metadata, List<PropertyType> types, Object value
             this.imports = null;
             this.dynamicFormFields = null;
             this.itemOptions = null;
+            this.advanceProperties = null;
             return property;
         }
     }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ActivityCallBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ActivityCallBuilder.java
@@ -105,11 +105,9 @@ public class ActivityCallBuilder extends CallBuilder {
     public static final String RETRY_DELAY_KEY = "retryDelay";
     public static final String RETRY_BACKOFF_KEY = "retryBackoff";
     public static final String MAX_RETRY_DELAY_KEY = "maxRetryDelay";
-    // The workflow module's AutoRetry record defaults (types.bal); pre-filled in the form so
-    // choosing Auto Retry shows the values that would apply. maxRetryDelay has no default.
-    public static final String DEFAULT_MAX_RETRIES = "3";
-    public static final String DEFAULT_RETRY_DELAY = "1.0";
-    public static final String DEFAULT_RETRY_BACKOFF = "2.0";
+    // The AutoRetry branch's collapsible group; it holds the tuning fields, not a value of its own.
+    public static final String AUTO_RETRY_OPTIONS_KEY = "autoRetryOptions";
+    public static final String ADVANCED_RETRY_CONFIGURATIONS = "Advanced Configurations";
     // retryPolicy is excluded from ADVANCE_PARAM_LIST; it is added at root level as a DROPDOWN_CHOICE.
     public static final Set<String> EXCLUDED_CALL_ACTIVITY_PARAMS = Set.of("activityFunction", "args", "T",
             CHECK_ERROR_KEY, Property.CONNECTION_KEY, RETRY_POLICY_PARAM);
@@ -367,7 +365,9 @@ public class ActivityCallBuilder extends CallBuilder {
      * <p>Sub-properties inside {@code dynamicFormFields.AutoRetry} intentionally carry empty values.
      * The UI reads the actual value from the matching root hidden property (by key name) and writes
      * edits back there, exactly like the {@code method}/{@code message} pattern in
-     * {@link io.ballerina.flowmodelgenerator.core.model.node.builtin.RestActivityStrategy}.
+     * {@link io.ballerina.flowmodelgenerator.core.model.node.builtin.RestActivityStrategy}. The AutoRetry
+     * branch nests those sub-properties in a {@code GROUP_SECTION} ({@link #AUTO_RETRY_OPTIONS_KEY}) so they
+     * render as optional fields behind an Expand toggle rather than as required inputs.
      */
     public static void addRetryPolicyFormProperties(NodeBuilder nodeBuilder, String retryPolicyValue,
                                                     String maxRetries, String retryDelay,
@@ -382,18 +382,6 @@ public class ActivityCallBuilder extends CallBuilder {
                                                     String retryUserRoles) {
         String selectedValue = retryPolicyValue == null || retryPolicyValue.isBlank()
                 ? NO_RETRY_VALUE : retryPolicyValue;
-        // Blank Auto Retry sub-fields fall back to the module's AutoRetry record defaults, so
-        // selecting Auto Retry presents the values that would apply rather than an empty form.
-        // An entry saved with them emits the same behavior the record defaults give.
-        if (maxRetries == null || maxRetries.isBlank()) {
-            maxRetries = DEFAULT_MAX_RETRIES;
-        }
-        if (retryDelay == null || retryDelay.isBlank()) {
-            retryDelay = DEFAULT_RETRY_DELAY;
-        }
-        if (retryBackoff == null || retryBackoff.isBlank()) {
-            retryBackoff = DEFAULT_RETRY_BACKOFF;
-        }
         List<Option> options = new ArrayList<>(List.of(
                 new Option("No Automatic Retry", NO_RETRY_VALUE),
                 new Option("Auto Retry", AUTO_RETRY_VALUE),
@@ -406,15 +394,17 @@ public class ActivityCallBuilder extends CallBuilder {
         }
 
         // Sub-property definitions for the AutoRetry option. Empty values are intentional:
-        // the UI reads real values from the root hidden properties with matching keys.
+        // the UI reads real values from the root hidden properties with matching keys. Every
+        // sub-field is optional — a field left empty is omitted from the AutoRetry record, so
+        // the module's own record default applies.
         Property maxRetriesSubProp = buildRetrySubProperty("Max Retries",
-                "Maximum number of retry attempts", "int");
+                "Maximum number of retry attempts", "int", true);
         Property retryDelaySubProp = buildRetrySubProperty("Retry Delay",
-                "Initial delay between retries in seconds", "decimal");
+                "Initial delay between retries in seconds", "decimal", true);
         Property retryBackoffSubProp = buildRetrySubProperty("Retry Backoff",
-                "Exponential backoff multiplier (e.g. 2.0 doubles each delay)", "decimal");
+                "Exponential backoff multiplier (e.g. 2.0 doubles each delay)", "decimal", true);
         Property maxRetryDelaySubProp = buildRetrySubProperty("Max Retry Delay",
-                "Maximum delay cap in seconds", "decimal");
+                "Maximum delay cap in seconds", "decimal", true);
 
         // Insertion-ordered so the AutoRetry sub-fields always render in this sequence (Map.of does
         // not guarantee iteration order).
@@ -426,11 +416,15 @@ public class ActivityCallBuilder extends CallBuilder {
 
         Map<String, Map<String, Property>> dynamicFields = new LinkedHashMap<>();
         dynamicFields.put(NO_RETRY_VALUE, Map.of());
-        dynamicFields.put(AUTO_RETRY_VALUE, autoRetryFields);
+        // The tuning fields sit behind the AutoRetry branch's collapsible group instead of being
+        // presented up front: none of them has to be filled in, and every one left empty falls back
+        // to the AutoRetry record's own default.
+        dynamicFields.put(AUTO_RETRY_VALUE, Map.of(AUTO_RETRY_OPTIONS_KEY,
+                buildAutoRetryOptionsGroup(autoRetryFields)));
         Map<String, Property> manualRetryFields = new LinkedHashMap<>();
         manualRetryFields.put(RETRY_USER_ROLES_KEY, buildRetrySubProperty("Reviewer Roles",
                 "Role(s) permitted to decide the human review, e.g. \"manager\" or "
-                        + "[\"finance\", \"manager\"]. Leave empty to allow any role.", "string|string[]"));
+                        + "[\"finance\", \"manager\"]. Leave empty to allow any role.", "string|string[]", false));
         dynamicFields.put(MANUAL_RETRY_VALUE, manualRetryFields);
         if (opaquePolicy) {
             dynamicFields.put(selectedValue, Map.of());
@@ -468,7 +462,8 @@ public class ActivityCallBuilder extends CallBuilder {
                 "Max Retry Delay", "Maximum delay cap in seconds", "decimal", maxRetryDelay);
     }
 
-    private static Property buildRetrySubProperty(String label, String description, String ballerinaType) {
+    private static Property buildRetrySubProperty(String label, String description, String ballerinaType,
+                                                  boolean optional) {
         return new Property.Builder<Void>(null)
                 .metadata()
                     .label(label)
@@ -478,6 +473,29 @@ public class ActivityCallBuilder extends CallBuilder {
                     .ballerinaType(ballerinaType).selected(true).stepOut()
                 .value("")
                 .editable(true)
+                .optional(optional)
+                .build();
+    }
+
+    /**
+     * The collapsible group that holds the AutoRetry tuning fields. A DROPDOWN_CHOICE branch renders its
+     * plain fields inline but hides everything optional, so the fields are carried as the group's
+     * {@code advanceProperties} — the UI shows them behind the group's Expand toggle, where being optional
+     * only means they carry no required marker.
+     */
+    private static Property buildAutoRetryOptionsGroup(Map<String, Property> autoRetryFields) {
+        return new Property.Builder<Void>(null)
+                .metadata()
+                    .label(ADVANCED_RETRY_CONFIGURATIONS)
+                    .description("Optional tuning for the automatic retries. A field left empty uses the "
+                            + "engine default: 3 attempts, a 1.0 second initial delay doubling on each "
+                            + "retry, and no cap on the delay.")
+                    .stepOut()
+                .type().fieldType(Property.ValueType.GROUP_SECTION).selected(true).stepOut()
+                .value("")
+                .editable(true)
+                .optional(true)
+                .advanceProperties(autoRetryFields)
                 .build();
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ActivityCallBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ActivityCallBuilder.java
@@ -105,6 +105,11 @@ public class ActivityCallBuilder extends CallBuilder {
     public static final String RETRY_DELAY_KEY = "retryDelay";
     public static final String RETRY_BACKOFF_KEY = "retryBackoff";
     public static final String MAX_RETRY_DELAY_KEY = "maxRetryDelay";
+    // The workflow module's AutoRetry record defaults (types.bal); pre-filled in the form so
+    // choosing Auto Retry shows the values that would apply. maxRetryDelay has no default.
+    public static final String DEFAULT_MAX_RETRIES = "3";
+    public static final String DEFAULT_RETRY_DELAY = "1.0";
+    public static final String DEFAULT_RETRY_BACKOFF = "2.0";
     // retryPolicy is excluded from ADVANCE_PARAM_LIST; it is added at root level as a DROPDOWN_CHOICE.
     public static final Set<String> EXCLUDED_CALL_ACTIVITY_PARAMS = Set.of("activityFunction", "args", "T",
             CHECK_ERROR_KEY, Property.CONNECTION_KEY, RETRY_POLICY_PARAM);
@@ -377,6 +382,18 @@ public class ActivityCallBuilder extends CallBuilder {
                                                     String retryUserRoles) {
         String selectedValue = retryPolicyValue == null || retryPolicyValue.isBlank()
                 ? NO_RETRY_VALUE : retryPolicyValue;
+        // Blank Auto Retry sub-fields fall back to the module's AutoRetry record defaults, so
+        // selecting Auto Retry presents the values that would apply rather than an empty form.
+        // An entry saved with them emits the same behavior the record defaults give.
+        if (maxRetries == null || maxRetries.isBlank()) {
+            maxRetries = DEFAULT_MAX_RETRIES;
+        }
+        if (retryDelay == null || retryDelay.isBlank()) {
+            retryDelay = DEFAULT_RETRY_DELAY;
+        }
+        if (retryBackoff == null || retryBackoff.isBlank()) {
+            retryBackoff = DEFAULT_RETRY_BACKOFF;
+        }
         List<Option> options = new ArrayList<>(List.of(
                 new Option("No Automatic Retry", NO_RETRY_VALUE),
                 new Option("Auto Retry", AUTO_RETRY_VALUE),

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DurableAgentAddActivityBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DurableAgentAddActivityBuilder.java
@@ -51,7 +51,7 @@ import static io.ballerina.flowmodelgenerator.core.Constants.Workflow.WORKFLOW_M
 import static io.ballerina.flowmodelgenerator.core.Constants.Workflow.WORKFLOW_ORG;
 
 /**
- * Registers a workflow activity as a durable agent tool. Generates
+ * Registers a workflow activity as a durable agent activity. Generates
  * {@code check durableAgentContext.registerActivity(<activity>);}.
  *
  * <p>Built-in activities (Call REST API, Call SOAP API, Send Email) are registered as-is — no wrapper
@@ -123,6 +123,8 @@ public class DurableAgentAddActivityBuilder extends CallBuilder {
             preSelected = contextSymbol;
         }
 
+        // A pre-selected activity is the form's subject, not a choice: the selector is hidden and
+        // the value only travels for source generation.
         properties().custom()
                 .metadata()
                     .label(ACTIVITY_LABEL)
@@ -138,6 +140,7 @@ public class DurableAgentAddActivityBuilder extends CallBuilder {
                     .stepOut()
                 .value(preSelected)
                 .editable(true)
+                .hidden(!preSelected.isEmpty())
                 .stepOut()
                 .addProperty(ACTIVITY_KEY);
         addBindingProperties(context, preSelected);
@@ -221,8 +224,9 @@ public class DurableAgentAddActivityBuilder extends CallBuilder {
         return options;
     }
 
-    // The name/description advertised to the model, mirroring the workflow activity form's
-    // identity fields; both default to the function's own name and doc comment.
+    // Hidden carriers for the declaration's optional name/description fields: the form does not
+    // present them (the activity's own identity is enough), but an entry declared with them in
+    // source must round-trip through an edit-save without losing them.
     private void addToolIdentityProperties() {
         properties().custom()
                 .metadata()
@@ -237,7 +241,7 @@ public class DurableAgentAddActivityBuilder extends CallBuilder {
                 .value("")
                 .editable(true)
                 .optional(true)
-                .advanced(true)
+                .hidden(true)
                 .stepOut()
                 .addProperty(TOOL_NAME_KEY);
         properties().custom()
@@ -253,7 +257,7 @@ public class DurableAgentAddActivityBuilder extends CallBuilder {
                 .value("")
                 .editable(true)
                 .optional(true)
-                .advanced(true)
+                .hidden(true)
                 .stepOut()
                 .addProperty(TOOL_DESCRIPTION_KEY);
     }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_activity_and_wait.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_activity_and_wait.json
@@ -319,7 +319,7 @@
                 "selected": true
               }
             ],
-            "value": "",
+            "value": "3",
             "optional": true,
             "editable": true,
             "advanced": false,
@@ -337,7 +337,7 @@
                 "selected": true
               }
             ],
-            "value": "",
+            "value": "1.0",
             "optional": true,
             "editable": true,
             "advanced": false,
@@ -373,7 +373,7 @@
                 "selected": true
               }
             ],
-            "value": "",
+            "value": "2.0",
             "optional": true,
             "editable": true,
             "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_activity_and_wait.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_activity_and_wait.json
@@ -195,77 +195,96 @@
             "dynamicFormFields": {
               "NoRetry": {},
               "AutoRetry": {
-                "maxRetries": {
+                "autoRetryOptions": {
                   "metadata": {
-                    "label": "Max Retries",
-                    "description": "Maximum number of retry attempts"
+                    "label": "Advanced Configurations",
+                    "description": "Optional tuning for the automatic retries. A field left empty uses the engine default: 3 attempts, a 1.0 second initial delay doubling on each retry, and no cap on the delay."
                   },
                   "types": [
                     {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "int",
+                      "fieldType": "GROUP_SECTION",
                       "selected": true
                     }
                   ],
                   "value": "",
-                  "optional": false,
+                  "optional": true,
                   "editable": true,
                   "advanced": false,
-                  "hidden": false
-                },
-                "retryDelay": {
-                  "metadata": {
-                    "label": "Retry Delay",
-                    "description": "Initial delay between retries in seconds"
-                  },
-                  "types": [
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "decimal",
-                      "selected": true
+                  "hidden": false,
+                  "advanceProperties": {
+                    "maxRetries": {
+                      "metadata": {
+                        "label": "Max Retries",
+                        "description": "Maximum number of retry attempts"
+                      },
+                      "types": [
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "int",
+                          "selected": true
+                        }
+                      ],
+                      "value": "",
+                      "optional": true,
+                      "editable": true,
+                      "advanced": false,
+                      "hidden": false
+                    },
+                    "retryDelay": {
+                      "metadata": {
+                        "label": "Retry Delay",
+                        "description": "Initial delay between retries in seconds"
+                      },
+                      "types": [
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "decimal",
+                          "selected": true
+                        }
+                      ],
+                      "value": "",
+                      "optional": true,
+                      "editable": true,
+                      "advanced": false,
+                      "hidden": false
+                    },
+                    "retryBackoff": {
+                      "metadata": {
+                        "label": "Retry Backoff",
+                        "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
+                      },
+                      "types": [
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "decimal",
+                          "selected": true
+                        }
+                      ],
+                      "value": "",
+                      "optional": true,
+                      "editable": true,
+                      "advanced": false,
+                      "hidden": false
+                    },
+                    "maxRetryDelay": {
+                      "metadata": {
+                        "label": "Max Retry Delay",
+                        "description": "Maximum delay cap in seconds"
+                      },
+                      "types": [
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "decimal",
+                          "selected": true
+                        }
+                      ],
+                      "value": "",
+                      "optional": true,
+                      "editable": true,
+                      "advanced": false,
+                      "hidden": false
                     }
-                  ],
-                  "value": "",
-                  "optional": false,
-                  "editable": true,
-                  "advanced": false,
-                  "hidden": false
-                },
-                "retryBackoff": {
-                  "metadata": {
-                    "label": "Retry Backoff",
-                    "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
-                  },
-                  "types": [
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "decimal",
-                      "selected": true
-                    }
-                  ],
-                  "value": "",
-                  "optional": false,
-                  "editable": true,
-                  "advanced": false,
-                  "hidden": false
-                },
-                "maxRetryDelay": {
-                  "metadata": {
-                    "label": "Max Retry Delay",
-                    "description": "Maximum delay cap in seconds"
-                  },
-                  "types": [
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "decimal",
-                      "selected": true
-                    }
-                  ],
-                  "value": "",
-                  "optional": false,
-                  "editable": true,
-                  "advanced": false,
-                  "hidden": false
+                  }
                 }
               },
               "ManualRetry": {
@@ -319,7 +338,7 @@
                 "selected": true
               }
             ],
-            "value": "3",
+            "value": "",
             "optional": true,
             "editable": true,
             "advanced": false,
@@ -337,7 +356,7 @@
                 "selected": true
               }
             ],
-            "value": "1.0",
+            "value": "",
             "optional": true,
             "editable": true,
             "advanced": false,
@@ -373,7 +392,7 @@
                 "selected": true
               }
             ],
-            "value": "2.0",
+            "value": "",
             "optional": true,
             "editable": true,
             "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_connection_activity_call.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_connection_activity_call.json
@@ -189,77 +189,96 @@
             "dynamicFormFields": {
               "NoRetry": {},
               "AutoRetry": {
-                "maxRetries": {
+                "autoRetryOptions": {
                   "metadata": {
-                    "label": "Max Retries",
-                    "description": "Maximum number of retry attempts"
+                    "label": "Advanced Configurations",
+                    "description": "Optional tuning for the automatic retries. A field left empty uses the engine default: 3 attempts, a 1.0 second initial delay doubling on each retry, and no cap on the delay."
                   },
                   "types": [
                     {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "int",
+                      "fieldType": "GROUP_SECTION",
                       "selected": true
                     }
                   ],
                   "value": "",
-                  "optional": false,
+                  "optional": true,
                   "editable": true,
                   "advanced": false,
-                  "hidden": false
-                },
-                "retryDelay": {
-                  "metadata": {
-                    "label": "Retry Delay",
-                    "description": "Initial delay between retries in seconds"
-                  },
-                  "types": [
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "decimal",
-                      "selected": true
+                  "hidden": false,
+                  "advanceProperties": {
+                    "maxRetries": {
+                      "metadata": {
+                        "label": "Max Retries",
+                        "description": "Maximum number of retry attempts"
+                      },
+                      "types": [
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "int",
+                          "selected": true
+                        }
+                      ],
+                      "value": "",
+                      "optional": true,
+                      "editable": true,
+                      "advanced": false,
+                      "hidden": false
+                    },
+                    "retryDelay": {
+                      "metadata": {
+                        "label": "Retry Delay",
+                        "description": "Initial delay between retries in seconds"
+                      },
+                      "types": [
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "decimal",
+                          "selected": true
+                        }
+                      ],
+                      "value": "",
+                      "optional": true,
+                      "editable": true,
+                      "advanced": false,
+                      "hidden": false
+                    },
+                    "retryBackoff": {
+                      "metadata": {
+                        "label": "Retry Backoff",
+                        "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
+                      },
+                      "types": [
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "decimal",
+                          "selected": true
+                        }
+                      ],
+                      "value": "",
+                      "optional": true,
+                      "editable": true,
+                      "advanced": false,
+                      "hidden": false
+                    },
+                    "maxRetryDelay": {
+                      "metadata": {
+                        "label": "Max Retry Delay",
+                        "description": "Maximum delay cap in seconds"
+                      },
+                      "types": [
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "decimal",
+                          "selected": true
+                        }
+                      ],
+                      "value": "",
+                      "optional": true,
+                      "editable": true,
+                      "advanced": false,
+                      "hidden": false
                     }
-                  ],
-                  "value": "",
-                  "optional": false,
-                  "editable": true,
-                  "advanced": false,
-                  "hidden": false
-                },
-                "retryBackoff": {
-                  "metadata": {
-                    "label": "Retry Backoff",
-                    "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
-                  },
-                  "types": [
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "decimal",
-                      "selected": true
-                    }
-                  ],
-                  "value": "",
-                  "optional": false,
-                  "editable": true,
-                  "advanced": false,
-                  "hidden": false
-                },
-                "maxRetryDelay": {
-                  "metadata": {
-                    "label": "Max Retry Delay",
-                    "description": "Maximum delay cap in seconds"
-                  },
-                  "types": [
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "decimal",
-                      "selected": true
-                    }
-                  ],
-                  "value": "",
-                  "optional": false,
-                  "editable": true,
-                  "advanced": false,
-                  "hidden": false
+                  }
                 }
               },
               "ManualRetry": {
@@ -313,7 +332,7 @@
                 "selected": true
               }
             ],
-            "value": "3",
+            "value": "",
             "optional": true,
             "editable": true,
             "advanced": false,
@@ -331,7 +350,7 @@
                 "selected": true
               }
             ],
-            "value": "1.0",
+            "value": "",
             "optional": true,
             "editable": true,
             "advanced": false,
@@ -367,7 +386,7 @@
                 "selected": true
               }
             ],
-            "value": "2.0",
+            "value": "",
             "optional": true,
             "editable": true,
             "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_connection_activity_call.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_connection_activity_call.json
@@ -313,7 +313,7 @@
                 "selected": true
               }
             ],
-            "value": "",
+            "value": "3",
             "optional": true,
             "editable": true,
             "advanced": false,
@@ -331,7 +331,7 @@
                 "selected": true
               }
             ],
-            "value": "",
+            "value": "1.0",
             "optional": true,
             "editable": true,
             "advanced": false,
@@ -367,7 +367,7 @@
                 "selected": true
               }
             ],
-            "value": "",
+            "value": "2.0",
             "optional": true,
             "editable": true,
             "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/builtin_activity_email.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/builtin_activity_email.json
@@ -321,77 +321,96 @@
         "dynamicFormFields": {
           "NoRetry": {},
           "AutoRetry": {
-            "maxRetries": {
+            "autoRetryOptions": {
               "metadata": {
-                "label": "Max Retries",
-                "description": "Maximum number of retry attempts"
+                "label": "Advanced Configurations",
+                "description": "Optional tuning for the automatic retries. A field left empty uses the engine default: 3 attempts, a 1.0 second initial delay doubling on each retry, and no cap on the delay."
               },
               "types": [
                 {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "int",
+                  "fieldType": "GROUP_SECTION",
                   "selected": true
                 }
               ],
               "value": "",
-              "optional": false,
+              "optional": true,
               "editable": true,
               "advanced": false,
-              "hidden": false
-            },
-            "retryDelay": {
-              "metadata": {
-                "label": "Retry Delay",
-                "description": "Initial delay between retries in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
+              "hidden": false,
+              "advanceProperties": {
+                "maxRetries": {
+                  "metadata": {
+                    "label": "Max Retries",
+                    "description": "Maximum number of retry attempts"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "int",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryDelay": {
+                  "metadata": {
+                    "label": "Retry Delay",
+                    "description": "Initial delay between retries in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryBackoff": {
+                  "metadata": {
+                    "label": "Retry Backoff",
+                    "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "maxRetryDelay": {
+                  "metadata": {
+                    "label": "Max Retry Delay",
+                    "description": "Maximum delay cap in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
                 }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "retryBackoff": {
-              "metadata": {
-                "label": "Retry Backoff",
-                "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "maxRetryDelay": {
-              "metadata": {
-                "label": "Max Retry Delay",
-                "description": "Maximum delay cap in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
+              }
             }
           },
           "ManualRetry": {
@@ -445,7 +464,7 @@
             "selected": true
           }
         ],
-        "value": "3",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -463,7 +482,7 @@
             "selected": true
           }
         ],
-        "value": "1.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -499,7 +518,7 @@
             "selected": true
           }
         ],
-        "value": "2.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/builtin_activity_rest.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/builtin_activity_rest.json
@@ -345,77 +345,96 @@
         "dynamicFormFields": {
           "NoRetry": {},
           "AutoRetry": {
-            "maxRetries": {
+            "autoRetryOptions": {
               "metadata": {
-                "label": "Max Retries",
-                "description": "Maximum number of retry attempts"
+                "label": "Advanced Configurations",
+                "description": "Optional tuning for the automatic retries. A field left empty uses the engine default: 3 attempts, a 1.0 second initial delay doubling on each retry, and no cap on the delay."
               },
               "types": [
                 {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "int",
+                  "fieldType": "GROUP_SECTION",
                   "selected": true
                 }
               ],
               "value": "",
-              "optional": false,
+              "optional": true,
               "editable": true,
               "advanced": false,
-              "hidden": false
-            },
-            "retryDelay": {
-              "metadata": {
-                "label": "Retry Delay",
-                "description": "Initial delay between retries in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
+              "hidden": false,
+              "advanceProperties": {
+                "maxRetries": {
+                  "metadata": {
+                    "label": "Max Retries",
+                    "description": "Maximum number of retry attempts"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "int",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryDelay": {
+                  "metadata": {
+                    "label": "Retry Delay",
+                    "description": "Initial delay between retries in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryBackoff": {
+                  "metadata": {
+                    "label": "Retry Backoff",
+                    "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "maxRetryDelay": {
+                  "metadata": {
+                    "label": "Max Retry Delay",
+                    "description": "Maximum delay cap in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
                 }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "retryBackoff": {
-              "metadata": {
-                "label": "Retry Backoff",
-                "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "maxRetryDelay": {
-              "metadata": {
-                "label": "Max Retry Delay",
-                "description": "Maximum delay cap in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
+              }
             }
           },
           "ManualRetry": {
@@ -469,7 +488,7 @@
             "selected": true
           }
         ],
-        "value": "3",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -487,7 +506,7 @@
             "selected": true
           }
         ],
-        "value": "1.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -523,7 +542,7 @@
             "selected": true
           }
         ],
-        "value": "2.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/builtin_activity_rest.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/builtin_activity_rest.json
@@ -469,7 +469,7 @@
             "selected": true
           }
         ],
-        "value": "",
+        "value": "3",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -487,7 +487,7 @@
             "selected": true
           }
         ],
-        "value": "",
+        "value": "1.0",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -523,7 +523,7 @@
             "selected": true
           }
         ],
-        "value": "",
+        "value": "2.0",
         "optional": true,
         "editable": true,
         "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/builtin_activity_soap.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/builtin_activity_soap.json
@@ -225,77 +225,96 @@
         "dynamicFormFields": {
           "NoRetry": {},
           "AutoRetry": {
-            "maxRetries": {
+            "autoRetryOptions": {
               "metadata": {
-                "label": "Max Retries",
-                "description": "Maximum number of retry attempts"
+                "label": "Advanced Configurations",
+                "description": "Optional tuning for the automatic retries. A field left empty uses the engine default: 3 attempts, a 1.0 second initial delay doubling on each retry, and no cap on the delay."
               },
               "types": [
                 {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "int",
+                  "fieldType": "GROUP_SECTION",
                   "selected": true
                 }
               ],
               "value": "",
-              "optional": false,
+              "optional": true,
               "editable": true,
               "advanced": false,
-              "hidden": false
-            },
-            "retryDelay": {
-              "metadata": {
-                "label": "Retry Delay",
-                "description": "Initial delay between retries in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
+              "hidden": false,
+              "advanceProperties": {
+                "maxRetries": {
+                  "metadata": {
+                    "label": "Max Retries",
+                    "description": "Maximum number of retry attempts"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "int",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryDelay": {
+                  "metadata": {
+                    "label": "Retry Delay",
+                    "description": "Initial delay between retries in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryBackoff": {
+                  "metadata": {
+                    "label": "Retry Backoff",
+                    "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "maxRetryDelay": {
+                  "metadata": {
+                    "label": "Max Retry Delay",
+                    "description": "Maximum delay cap in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
                 }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "retryBackoff": {
-              "metadata": {
-                "label": "Retry Backoff",
-                "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "maxRetryDelay": {
-              "metadata": {
-                "label": "Max Retry Delay",
-                "description": "Maximum delay cap in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
+              }
             }
           },
           "ManualRetry": {
@@ -349,7 +368,7 @@
             "selected": true
           }
         ],
-        "value": "3",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -367,7 +386,7 @@
             "selected": true
           }
         ],
-        "value": "1.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -403,7 +422,7 @@
             "selected": true
           }
         ],
-        "value": "2.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/builtin_activity_soap.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/builtin_activity_soap.json
@@ -349,7 +349,7 @@
             "selected": true
           }
         ],
-        "value": "",
+        "value": "3",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -367,7 +367,7 @@
             "selected": true
           }
         ],
-        "value": "",
+        "value": "1.0",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -403,7 +403,7 @@
             "selected": true
           }
         ],
-        "value": "",
+        "value": "2.0",
         "optional": true,
         "editable": true,
         "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_add_activity.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_add_activity.json
@@ -161,77 +161,96 @@
         "dynamicFormFields": {
           "NoRetry": {},
           "AutoRetry": {
-            "maxRetries": {
+            "autoRetryOptions": {
               "metadata": {
-                "label": "Max Retries",
-                "description": "Maximum number of retry attempts"
+                "label": "Advanced Configurations",
+                "description": "Optional tuning for the automatic retries. A field left empty uses the engine default: 3 attempts, a 1.0 second initial delay doubling on each retry, and no cap on the delay."
               },
               "types": [
                 {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "int",
+                  "fieldType": "GROUP_SECTION",
                   "selected": true
                 }
               ],
               "value": "",
-              "optional": false,
+              "optional": true,
               "editable": true,
               "advanced": false,
-              "hidden": false
-            },
-            "retryDelay": {
-              "metadata": {
-                "label": "Retry Delay",
-                "description": "Initial delay between retries in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
+              "hidden": false,
+              "advanceProperties": {
+                "maxRetries": {
+                  "metadata": {
+                    "label": "Max Retries",
+                    "description": "Maximum number of retry attempts"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "int",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryDelay": {
+                  "metadata": {
+                    "label": "Retry Delay",
+                    "description": "Initial delay between retries in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryBackoff": {
+                  "metadata": {
+                    "label": "Retry Backoff",
+                    "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "maxRetryDelay": {
+                  "metadata": {
+                    "label": "Max Retry Delay",
+                    "description": "Maximum delay cap in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
                 }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "retryBackoff": {
-              "metadata": {
-                "label": "Retry Backoff",
-                "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "maxRetryDelay": {
-              "metadata": {
-                "label": "Max Retry Delay",
-                "description": "Maximum delay cap in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
+              }
             }
           },
           "ManualRetry": {
@@ -285,7 +304,7 @@
             "selected": true
           }
         ],
-        "value": "3",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -303,7 +322,7 @@
             "selected": true
           }
         ],
-        "value": "1.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -339,7 +358,7 @@
             "selected": true
           }
         ],
-        "value": "2.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_add_activity.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_add_activity.json
@@ -1,74 +1,49 @@
 {
-  "source": "builtin_activity/functions.bal",
+  "source": "durable_agent_activities.bal",
   "position": {
-    "line": 5,
+    "line": 27,
     "offset": 0
   },
-  "description": "Builtin activity - Send Email (SMTP) node template",
+  "description": "Register Activity template from the palette: the activity selector is visible, tool identity fields are hidden, auto-retry sub-fields carry the module defaults",
   "codedata": {
-    "node": "BUILTIN_ACTIVITY",
+    "node": "DURABLE_AGENT_ADD_ACTIVITY",
     "org": "ballerina",
-    "module": "workflow.activity",
-    "symbol": "sendEmail"
+    "module": "workflow"
   },
   "output": {
     "id": "31",
     "metadata": {
-      "label": "Send Email",
-      "description": "Send a plain-text email as a workflow activity using a configured email:SmtpClient connection."
+      "label": "Register Activity",
+      "description": "Register a workflow activity as a durable agent activity"
     },
     "codedata": {
-      "node": "CONNECTION_ACTIVITY_CALL",
+      "node": "DURABLE_AGENT_ADD_ACTIVITY",
       "org": "ballerina",
-      "module": "workflow.activity",
-      "symbol": "sendEmail",
+      "module": "workflow",
+      "object": "AgenticWorkflowContext",
+      "symbol": "registerActivity",
       "isNew": true
     },
     "returning": false,
     "properties": {
-      "connection": {
+      "activity": {
         "metadata": {
-          "label": "Connection",
-          "description": "Connection to use",
-          "connectors": [
-            {
-              "codedata": {
-                "node": "NEW_CONNECTION",
-                "org": "ballerina",
-                "module": "email",
-                "packageName": "email",
-                "object": "SmtpClient",
-                "symbol": "init"
+          "label": "Activity",
+          "description": "The @workflow:Activity function to expose as an agent tool"
+        },
+        "types": [
+          {
+            "fieldType": "SINGLE_SELECT",
+            "options": [
+              {
+                "label": "lookupBill",
+                "value": "lookupBill"
               },
-              "addNewConnectionLabel": "Add new SMTP connection"
-            }
-          ]
-        },
-        "types": [
-          {
-            "fieldType": "CONNECTION",
-            "selected": true
-          }
-        ],
-        "value": "NEW_CONNECTION",
-        "placeholder": "NEW_CONNECTION",
-        "optional": false,
-        "editable": true,
-        "advanced": false,
-        "hidden": false,
-        "codedata": {
-          "searchNodesKind": "EMAIL"
-        }
-      },
-      "to": {
-        "metadata": {
-          "label": "To",
-          "description": "Recipient email address (or list of addresses)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string|string[]",
+              {
+                "label": "recordPayment",
+                "value": "recordPayment"
+              }
+            ],
             "selected": true
           }
         ],
@@ -81,199 +56,46 @@
           "kind": "REQUIRED"
         }
       },
-      "subject": {
+      "name": {
         "metadata": {
-          "label": "Subject",
-          "description": "Email subject line"
+          "label": "Tool Name",
+          "description": "The tool name advertised to the model. Defaults to the function name"
         },
         "types": [
           {
-            "fieldType": "EXPRESSION",
+            "fieldType": "TEXT",
             "ballerinaType": "string",
             "selected": true
           }
         ],
         "value": "",
-        "optional": false,
+        "optional": true,
         "editable": true,
         "advanced": false,
-        "hidden": false,
-        "codedata": {
-          "kind": "REQUIRED"
-        }
+        "hidden": true
       },
-      "body": {
+      "description": {
         "metadata": {
-          "label": "Body",
-          "description": "Plain-text body of the email"
+          "label": "Description",
+          "description": "Tells the model what this tool does and when to use it"
         },
         "types": [
           {
-            "fieldType": "EXPRESSION",
+            "fieldType": "DOC_TEXT",
             "ballerinaType": "string",
             "selected": true
           }
         ],
         "value": "",
-        "optional": false,
+        "optional": true,
         "editable": true,
         "advanced": false,
-        "hidden": false,
-        "codedata": {
-          "kind": "REQUIRED"
-        }
+        "hidden": true
       },
-      "from": {
+      "requiresApproval": {
         "metadata": {
-          "label": "From",
-          "description": "Sender address"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": false,
-        "editable": true,
-        "advanced": false,
-        "hidden": false,
-        "codedata": {
-          "kind": "REQUIRED"
-        }
-      },
-      "cc": {
-        "metadata": {
-          "label": "CC",
-          "description": "Optional CC recipient(s)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string|string[]?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "bcc": {
-        "metadata": {
-          "label": "BCC",
-          "description": "Optional BCC recipient(s)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string|string[]?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "htmlBody": {
-        "metadata": {
-          "label": "HTML Body",
-          "description": "Optional HTML body (sent alongside the plain-text body)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "contentType": {
-        "metadata": {
-          "label": "Content Type",
-          "description": "MIME content type override (e.g., \"text/plain\")"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "emailHeaders": {
-        "metadata": {
-          "label": "Email Headers",
-          "description": "Additional mail headers as map<string>"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "map<string>?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "replyTo": {
-        "metadata": {
-          "label": "Reply To",
-          "description": "Optional Reply-To address(es)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string|string[]?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "sender": {
-        "metadata": {
-          "label": "Sender",
-          "description": "Sender address (used when the envelope sender differs from From)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "checkError": {
-        "metadata": {
-          "label": "Check Error",
-          "description": "Add 'check' to propagate errors. Uncheck to handle errors manually."
+          "label": "Requires Approval",
+          "description": "Gate this tool: before the agent runs it, a review activity is created and the agent suspends durably until a reviewer proceeds (optionally editing the arguments) or rejects."
         },
         "types": [
           {
@@ -282,10 +104,28 @@
             "selected": true
           }
         ],
-        "value": "true",
+        "value": "false",
         "optional": true,
         "editable": true,
-        "advanced": false,
+        "advanced": true,
+        "hidden": false
+      },
+      "userRoles": {
+        "metadata": {
+          "label": "Reviewer Roles",
+          "description": "Role(s) permitted to decide the approval review of this activity, e.g. \"support-lead\" or [\"finance\", \"manager\"]."
+        },
+        "types": [
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "string|string[]",
+            "selected": true
+          }
+        ],
+        "placeholder": "",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
         "hidden": false
       },
       "retryPolicy": {
@@ -523,22 +363,22 @@
         "advanced": false,
         "hidden": true
       },
-      "advanced": {
+      "checkError": {
         "metadata": {
-          "label": "Activity call configurations",
-          "description": "Activity call configurations"
+          "label": "Check Error",
+          "description": "Trigger error flow"
         },
         "types": [
           {
-            "fieldType": "ADVANCE_PARAM_LIST",
-            "selected": false
+            "fieldType": "FLAG",
+            "selected": true
           }
         ],
-        "value": {},
+        "value": true,
         "optional": false,
-        "editable": false,
-        "advanced": false,
-        "hidden": false
+        "editable": true,
+        "advanced": true,
+        "hidden": true
       }
     },
     "flags": 0

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_add_activity_preselected.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_add_activity_preselected.json
@@ -1,74 +1,77 @@
 {
-  "source": "builtin_activity/functions.bal",
+  "source": "durable_agent_activities.bal",
   "position": {
-    "line": 5,
+    "line": 27,
     "offset": 0
   },
-  "description": "Builtin activity - Send Email (SMTP) node template",
+  "description": "Register Activity template for a chosen activity: the selector is pre-selected and hidden, and a binding selector is offered for the client parameter",
   "codedata": {
-    "node": "BUILTIN_ACTIVITY",
+    "node": "DURABLE_AGENT_ADD_ACTIVITY",
     "org": "ballerina",
-    "module": "workflow.activity",
-    "symbol": "sendEmail"
+    "module": "workflow",
+    "symbol": "lookupBill"
   },
   "output": {
     "id": "31",
     "metadata": {
-      "label": "Send Email",
-      "description": "Send a plain-text email as a workflow activity using a configured email:SmtpClient connection."
+      "label": "Register Activity",
+      "description": "Register a workflow activity as a durable agent activity"
     },
     "codedata": {
-      "node": "CONNECTION_ACTIVITY_CALL",
+      "node": "DURABLE_AGENT_ADD_ACTIVITY",
       "org": "ballerina",
-      "module": "workflow.activity",
-      "symbol": "sendEmail",
+      "module": "workflow",
+      "object": "AgenticWorkflowContext",
+      "symbol": "registerActivity",
       "isNew": true
     },
     "returning": false,
     "properties": {
-      "connection": {
+      "activity": {
         "metadata": {
-          "label": "Connection",
-          "description": "Connection to use",
-          "connectors": [
-            {
-              "codedata": {
-                "node": "NEW_CONNECTION",
-                "org": "ballerina",
-                "module": "email",
-                "packageName": "email",
-                "object": "SmtpClient",
-                "symbol": "init"
+          "label": "Activity",
+          "description": "The @workflow:Activity function to expose as an agent tool"
+        },
+        "types": [
+          {
+            "fieldType": "SINGLE_SELECT",
+            "options": [
+              {
+                "label": "lookupBill",
+                "value": "lookupBill"
               },
-              "addNewConnectionLabel": "Add new SMTP connection"
-            }
-          ]
-        },
-        "types": [
-          {
-            "fieldType": "CONNECTION",
+              {
+                "label": "recordPayment",
+                "value": "recordPayment"
+              }
+            ],
             "selected": true
           }
         ],
-        "value": "NEW_CONNECTION",
-        "placeholder": "NEW_CONNECTION",
+        "value": "lookupBill",
         "optional": false,
         "editable": true,
         "advanced": false,
-        "hidden": false,
+        "hidden": true,
         "codedata": {
-          "searchNodesKind": "EMAIL"
+          "kind": "REQUIRED"
         }
       },
-      "to": {
+      "bindings.api": {
         "metadata": {
-          "label": "To",
-          "description": "Recipient email address (or list of addresses)"
+          "label": "Api",
+          "description": "Fixed at registration and hidden from the model: the agent cannot supply a 'ballerina/http:2.16.6:Client'"
         },
         "types": [
           {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string|string[]",
+            "fieldType": "SINGLE_SELECT",
+            "ballerinaType": "ballerina/http:2.16.6:Client",
+            "options": [
+              {
+                "label": "billingApi",
+                "value": "billingApi"
+              }
+            ],
             "selected": true
           }
         ],
@@ -81,199 +84,46 @@
           "kind": "REQUIRED"
         }
       },
-      "subject": {
+      "name": {
         "metadata": {
-          "label": "Subject",
-          "description": "Email subject line"
+          "label": "Tool Name",
+          "description": "The tool name advertised to the model. Defaults to the function name"
         },
         "types": [
           {
-            "fieldType": "EXPRESSION",
+            "fieldType": "TEXT",
             "ballerinaType": "string",
             "selected": true
           }
         ],
         "value": "",
-        "optional": false,
+        "optional": true,
         "editable": true,
         "advanced": false,
-        "hidden": false,
-        "codedata": {
-          "kind": "REQUIRED"
-        }
+        "hidden": true
       },
-      "body": {
+      "description": {
         "metadata": {
-          "label": "Body",
-          "description": "Plain-text body of the email"
+          "label": "Description",
+          "description": "Tells the model what this tool does and when to use it"
         },
         "types": [
           {
-            "fieldType": "EXPRESSION",
+            "fieldType": "DOC_TEXT",
             "ballerinaType": "string",
             "selected": true
           }
         ],
         "value": "",
-        "optional": false,
+        "optional": true,
         "editable": true,
         "advanced": false,
-        "hidden": false,
-        "codedata": {
-          "kind": "REQUIRED"
-        }
+        "hidden": true
       },
-      "from": {
+      "requiresApproval": {
         "metadata": {
-          "label": "From",
-          "description": "Sender address"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": false,
-        "editable": true,
-        "advanced": false,
-        "hidden": false,
-        "codedata": {
-          "kind": "REQUIRED"
-        }
-      },
-      "cc": {
-        "metadata": {
-          "label": "CC",
-          "description": "Optional CC recipient(s)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string|string[]?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "bcc": {
-        "metadata": {
-          "label": "BCC",
-          "description": "Optional BCC recipient(s)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string|string[]?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "htmlBody": {
-        "metadata": {
-          "label": "HTML Body",
-          "description": "Optional HTML body (sent alongside the plain-text body)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "contentType": {
-        "metadata": {
-          "label": "Content Type",
-          "description": "MIME content type override (e.g., \"text/plain\")"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "emailHeaders": {
-        "metadata": {
-          "label": "Email Headers",
-          "description": "Additional mail headers as map<string>"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "map<string>?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "replyTo": {
-        "metadata": {
-          "label": "Reply To",
-          "description": "Optional Reply-To address(es)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string|string[]?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "sender": {
-        "metadata": {
-          "label": "Sender",
-          "description": "Sender address (used when the envelope sender differs from From)"
-        },
-        "types": [
-          {
-            "fieldType": "EXPRESSION",
-            "ballerinaType": "string?",
-            "selected": true
-          }
-        ],
-        "value": "",
-        "optional": true,
-        "editable": true,
-        "advanced": true,
-        "hidden": false
-      },
-      "checkError": {
-        "metadata": {
-          "label": "Check Error",
-          "description": "Add 'check' to propagate errors. Uncheck to handle errors manually."
+          "label": "Requires Approval",
+          "description": "Gate this tool: before the agent runs it, a review activity is created and the agent suspends durably until a reviewer proceeds (optionally editing the arguments) or rejects."
         },
         "types": [
           {
@@ -282,10 +132,28 @@
             "selected": true
           }
         ],
-        "value": "true",
+        "value": "false",
         "optional": true,
         "editable": true,
-        "advanced": false,
+        "advanced": true,
+        "hidden": false
+      },
+      "userRoles": {
+        "metadata": {
+          "label": "Reviewer Roles",
+          "description": "Role(s) permitted to decide the approval review of this activity, e.g. \"support-lead\" or [\"finance\", \"manager\"]."
+        },
+        "types": [
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "string|string[]",
+            "selected": true
+          }
+        ],
+        "placeholder": "",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
         "hidden": false
       },
       "retryPolicy": {
@@ -523,22 +391,22 @@
         "advanced": false,
         "hidden": true
       },
-      "advanced": {
+      "checkError": {
         "metadata": {
-          "label": "Activity call configurations",
-          "description": "Activity call configurations"
+          "label": "Check Error",
+          "description": "Trigger error flow"
         },
         "types": [
           {
-            "fieldType": "ADVANCE_PARAM_LIST",
-            "selected": false
+            "fieldType": "FLAG",
+            "selected": true
           }
         ],
-        "value": {},
+        "value": true,
         "optional": false,
-        "editable": false,
-        "advanced": false,
-        "hidden": false
+        "editable": true,
+        "advanced": true,
+        "hidden": true
       }
     },
     "flags": 0

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_add_activity_preselected.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_add_activity_preselected.json
@@ -189,77 +189,96 @@
         "dynamicFormFields": {
           "NoRetry": {},
           "AutoRetry": {
-            "maxRetries": {
+            "autoRetryOptions": {
               "metadata": {
-                "label": "Max Retries",
-                "description": "Maximum number of retry attempts"
+                "label": "Advanced Configurations",
+                "description": "Optional tuning for the automatic retries. A field left empty uses the engine default: 3 attempts, a 1.0 second initial delay doubling on each retry, and no cap on the delay."
               },
               "types": [
                 {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "int",
+                  "fieldType": "GROUP_SECTION",
                   "selected": true
                 }
               ],
               "value": "",
-              "optional": false,
+              "optional": true,
               "editable": true,
               "advanced": false,
-              "hidden": false
-            },
-            "retryDelay": {
-              "metadata": {
-                "label": "Retry Delay",
-                "description": "Initial delay between retries in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
+              "hidden": false,
+              "advanceProperties": {
+                "maxRetries": {
+                  "metadata": {
+                    "label": "Max Retries",
+                    "description": "Maximum number of retry attempts"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "int",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryDelay": {
+                  "metadata": {
+                    "label": "Retry Delay",
+                    "description": "Initial delay between retries in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryBackoff": {
+                  "metadata": {
+                    "label": "Retry Backoff",
+                    "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "maxRetryDelay": {
+                  "metadata": {
+                    "label": "Max Retry Delay",
+                    "description": "Maximum delay cap in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
                 }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "retryBackoff": {
-              "metadata": {
-                "label": "Retry Backoff",
-                "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "maxRetryDelay": {
-              "metadata": {
-                "label": "Max Retry Delay",
-                "description": "Maximum delay cap in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
+              }
             }
           },
           "ManualRetry": {
@@ -313,7 +332,7 @@
             "selected": true
           }
         ],
-        "value": "3",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -331,7 +350,7 @@
             "selected": true
           }
         ],
-        "value": "1.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -367,7 +386,7 @@
             "selected": true
           }
         ],
-        "value": "2.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_register_tool_preselected.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_register_tool_preselected.json
@@ -1,0 +1,112 @@
+{
+  "source": "durable_agent_activities.bal",
+  "position": {
+    "line": 27,
+    "offset": 0
+  },
+  "description": "Register Tool template for a chosen @ai:AgentTool function: no name/description fields, only the tool reference and ToolDecl gating",
+  "codedata": {
+    "node": "DURABLE_AGENT_REGISTER_TOOL",
+    "org": "ballerina",
+    "module": "workflow",
+    "symbol": "searchBillingDocs"
+  },
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Register AgentTool",
+      "description": "Register an AI tool the agent can invoke"
+    },
+    "codedata": {
+      "node": "DURABLE_AGENT_REGISTER_TOOL",
+      "org": "ballerina",
+      "module": "workflow",
+      "object": "AgenticWorkflowContext",
+      "symbol": "registerAgentTool",
+      "isNew": true
+    },
+    "returning": false,
+    "properties": {
+      "tool": {
+        "metadata": {
+          "label": "Tool",
+          "description": "The @ai:AgentTool function to register with the agent"
+        },
+        "types": [
+          {
+            "fieldType": "SINGLE_SELECT",
+            "options": [
+              {
+                "label": "searchBillingDocs",
+                "value": "searchBillingDocs"
+              }
+            ],
+            "selected": true
+          }
+        ],
+        "value": "searchBillingDocs",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {
+          "kind": "REQUIRED"
+        }
+      },
+      "requiresApproval": {
+        "metadata": {
+          "label": "Requires Approval",
+          "description": "Gate this tool: before the agent runs it, a review activity is created and the agent suspends durably until a reviewer proceeds (optionally editing the arguments) or rejects."
+        },
+        "types": [
+          {
+            "fieldType": "FLAG",
+            "ballerinaType": "boolean",
+            "selected": true
+          }
+        ],
+        "value": "false",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false
+      },
+      "userRoles": {
+        "metadata": {
+          "label": "Reviewer Roles",
+          "description": "Role(s) permitted to decide the approval review of this tool, e.g. \"support-lead\" or [\"finance\", \"manager\"]."
+        },
+        "types": [
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "string|string[]",
+            "selected": true
+          }
+        ],
+        "placeholder": "",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false
+      },
+      "checkError": {
+        "metadata": {
+          "label": "Check Error",
+          "description": "Trigger error flow"
+        },
+        "types": [
+          {
+            "fieldType": "FLAG",
+            "selected": true
+          }
+        ],
+        "value": true,
+        "optional": false,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      }
+    },
+    "flags": 0
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/source/durable_agent_activities.bal
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/source/durable_agent_activities.bal
@@ -27,3 +27,9 @@ final workflow:DurableAgent billingAgent = check new ({
 function interactWithBillingAgent() returns error? {
 
 }
+
+# Search the billing knowledge base
+@ai:AgentTool
+isolated function searchBillingDocs(string query) returns string|error {
+    return "results for " + query;
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/source/durable_agent_activities.bal
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/source/durable_agent_activities.bal
@@ -1,0 +1,29 @@
+import ballerina/ai;
+import ballerina/http;
+import ballerina/workflow;
+
+final ai:Wso2ModelProvider triageModel = check new ("http://localhost:9099", "test-token");
+
+final http:Client billingApi = check new ("http://localhost:9090");
+
+# Look up a bill activity
+@workflow:Activity
+function lookupBill(http:Client api, string billId) returns json|error {
+    return api->get("/bills/" + billId);
+}
+
+# Record a payment activity
+@workflow:Activity
+function recordPayment(string billId, decimal amount) returns string|error {
+    return "paid: " + billId + " " + amount.toString();
+}
+
+# Billing durable agentic workflow
+final workflow:DurableAgent billingAgent = check new ({
+    systemPrompt: {role: "Billing assistant", instructions: "Handle customer bills."},
+    model: triageModel
+});
+
+function interactWithBillingAgent() returns error? {
+
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/activities/durable_agent_activity_search.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/activities/durable_agent_activity_search.json
@@ -1,0 +1,100 @@
+{
+  "description": "Durable agent Add Activity list: project activities carry the agent registration kind",
+  "kind": "ACTIVITY_CALL",
+  "source": "workflow_proj/main.bal",
+  "position": {
+    "startLine": {
+      "line": 40,
+      "offset": 0
+    },
+    "endLine": {
+      "line": 42,
+      "offset": 1
+    }
+  },
+  "queryMap": {
+    "q": "",
+    "excludeBuiltins": "true",
+    "nodeKind": "DURABLE_AGENT_ADD_ACTIVITY"
+  },
+  "categories": [
+    {
+      "metadata": {
+        "label": "Activities",
+        "description": "Activities defined within the current integration",
+        "keywords": [
+          "Project",
+          "Local",
+          "Activity"
+        ]
+      },
+      "items": [
+        {
+          "metadata": {
+            "label": "sendNotification",
+            "description": "Workflow activity function",
+            "icon": "bi-task"
+          },
+          "codedata": {
+            "node": "DURABLE_AGENT_ADD_ACTIVITY",
+            "org": "test",
+            "module": "workflow_proj",
+            "symbol": "sendNotification",
+            "version": "0.1.0"
+          },
+          "enabled": true
+        },
+        {
+          "metadata": {
+            "label": "sendEmail",
+            "description": "Workflow activity function",
+            "icon": "bi-task"
+          },
+          "codedata": {
+            "node": "DURABLE_AGENT_ADD_ACTIVITY",
+            "org": "test",
+            "module": "workflow_proj",
+            "symbol": "sendEmail",
+            "version": "0.1.0"
+          },
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "label": "MCP Tools",
+        "description": "MCP servers exposing tools to the durable agent",
+        "keywords": [
+          "MCP",
+          "Tool",
+          "Agent"
+        ]
+      },
+      "items": [
+        {
+          "metadata": {
+            "label": "Use MCP Server",
+            "description": "Connect to an MCP server and expose its tools to the agent",
+            "icon": "bi-plus"
+          },
+          "codedata": {
+            "node": "MCP_TOOL_KIT"
+          },
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "label": "Tools",
+        "description": "AI tools usable by the durable agent",
+        "keywords": [
+          "Tool",
+          "Agent"
+        ]
+      },
+      "items": []
+    }
+  ]
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/activities/durable_agent_activity_search_empty.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/activities/durable_agent_activity_search_empty.json
@@ -1,0 +1,69 @@
+{
+  "description": "Durable agent Add Activity list on a project with no activities: empty category for the create-new CTA",
+  "kind": "ACTIVITY_CALL",
+  "source": "empty.bal",
+  "position": {
+    "startLine": {
+      "line": 1,
+      "offset": 1
+    },
+    "endLine": {
+      "line": 1,
+      "offset": 1
+    }
+  },
+  "queryMap": {
+    "q": "",
+    "excludeBuiltins": "true",
+    "nodeKind": "DURABLE_AGENT_ADD_ACTIVITY"
+  },
+  "categories": [
+    {
+      "metadata": {
+        "label": "Activities",
+        "description": "Activities defined within the current integration",
+        "keywords": [
+          "Project",
+          "Local",
+          "Activity"
+        ]
+      },
+      "items": []
+    },
+    {
+      "metadata": {
+        "label": "MCP Tools",
+        "description": "MCP servers exposing tools to the durable agent",
+        "keywords": [
+          "MCP",
+          "Tool",
+          "Agent"
+        ]
+      },
+      "items": [
+        {
+          "metadata": {
+            "label": "Use MCP Server",
+            "description": "Connect to an MCP server and expose its tools to the agent",
+            "icon": "bi-plus"
+          },
+          "codedata": {
+            "node": "MCP_TOOL_KIT"
+          },
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "label": "Tools",
+        "description": "AI tools usable by the durable agent",
+        "keywords": [
+          "Tool",
+          "Agent"
+        ]
+      },
+      "items": []
+    }
+  ]
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/durable_agent_add_activity_to_source.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/durable_agent_add_activity_to_source.json
@@ -1,0 +1,162 @@
+{
+  "source": "workflow_function/agent.bal",
+  "description": "Append an activity entry (auto-retry defaults + connection binding) to the agent declaration",
+  "diagram": {
+    "id": "1",
+    "metadata": {
+      "label": "fetchClaim",
+      "description": "Register a workflow activity as a durable agent activity"
+    },
+    "codedata": {
+      "node": "DURABLE_AGENT_ADD_ACTIVITY",
+      "org": "ballerina",
+      "module": "workflow",
+      "object": "DurableAgent",
+      "symbol": "registerActivity",
+      "parentSymbol": "claimAgent",
+      "lineRange": {
+        "fileName": "agent.bal",
+        "startLine": {
+          "line": 21,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 21,
+          "offset": 0
+        }
+      },
+      "isNew": true
+    },
+    "returning": false,
+    "properties": {
+      "activity": {
+        "metadata": {
+          "label": "Activity"
+        },
+        "valueType": "SINGLE_SELECT",
+        "value": "fetchClaim",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": true
+      },
+      "bindings.api": {
+        "metadata": {
+          "label": "Api"
+        },
+        "valueType": "SINGLE_SELECT",
+        "value": "claimApi",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "name": {
+        "metadata": {
+          "label": "Tool Name"
+        },
+        "valueType": "TEXT",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": true
+      },
+      "description": {
+        "metadata": {
+          "label": "Description"
+        },
+        "valueType": "DOC_TEXT",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": true
+      },
+      "requiresApproval": {
+        "metadata": {
+          "label": "Requires Approval"
+        },
+        "valueType": "FLAG",
+        "value": "false",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false
+      },
+      "retryPolicy": {
+        "metadata": {
+          "label": "Retry Policy"
+        },
+        "valueType": "DROPDOWN_CHOICE",
+        "value": "AutoRetry",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "maxRetries": {
+        "metadata": {
+          "label": "Max Retries"
+        },
+        "valueType": "EXPRESSION",
+        "value": "3",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      },
+      "retryDelay": {
+        "metadata": {
+          "label": "Retry Delay"
+        },
+        "valueType": "EXPRESSION",
+        "value": "1.0",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      },
+      "retryBackoff": {
+        "metadata": {
+          "label": "Retry Backoff"
+        },
+        "valueType": "EXPRESSION",
+        "value": "2.0",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      },
+      "maxRetryDelay": {
+        "metadata": {
+          "label": "Max Retry Delay"
+        },
+        "valueType": "EXPRESSION",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "workflow_function/agent.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 20,
+            "character": 4
+          },
+          "end": {
+            "line": 20,
+            "character": 4
+          }
+        },
+        "newText": "\n, {activity: fetchClaim, retryPolicy: {maxRetries: 3, retryDelay: 1.0, retryBackoff: 2.0}, bindings: {api: claimApi}}"
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/durable_agent_edit_activity_to_source.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/durable_agent_edit_activity_to_source.json
@@ -1,0 +1,151 @@
+{
+  "source": "workflow_function/agent.bal",
+  "description": "Rewrite an existing activity entry at its own range inside the declaration's activities list",
+  "diagram": {
+    "id": "1",
+    "metadata": {
+      "label": "myActivity",
+      "description": "Register a workflow activity as a durable agent activity"
+    },
+    "codedata": {
+      "node": "DURABLE_AGENT_ADD_ACTIVITY",
+      "org": "ballerina",
+      "module": "workflow",
+      "object": "DurableAgent",
+      "symbol": "registerActivity",
+      "parentSymbol": "claimAgent",
+      "lineRange": {
+        "fileName": "agent.bal",
+        "startLine": {
+          "line": 19,
+          "offset": 8
+        },
+        "endLine": {
+          "line": 19,
+          "offset": 18
+        }
+      },
+      "isNew": false
+    },
+    "returning": false,
+    "properties": {
+      "activity": {
+        "metadata": {
+          "label": "Activity"
+        },
+        "valueType": "SINGLE_SELECT",
+        "value": "myActivity",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": true
+      },
+      "name": {
+        "metadata": {
+          "label": "Tool Name"
+        },
+        "valueType": "TEXT",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": true
+      },
+      "description": {
+        "metadata": {
+          "label": "Description"
+        },
+        "valueType": "DOC_TEXT",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": true
+      },
+      "requiresApproval": {
+        "metadata": {
+          "label": "Requires Approval"
+        },
+        "valueType": "FLAG",
+        "value": "true",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false
+      },
+      "retryPolicy": {
+        "metadata": {
+          "label": "Retry Policy"
+        },
+        "valueType": "DROPDOWN_CHOICE",
+        "value": "NoRetry",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "maxRetries": {
+        "metadata": {
+          "label": "Max Retries"
+        },
+        "valueType": "EXPRESSION",
+        "value": "3",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      },
+      "retryDelay": {
+        "metadata": {
+          "label": "Retry Delay"
+        },
+        "valueType": "EXPRESSION",
+        "value": "1.0",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      },
+      "retryBackoff": {
+        "metadata": {
+          "label": "Retry Backoff"
+        },
+        "valueType": "EXPRESSION",
+        "value": "2.0",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      },
+      "maxRetryDelay": {
+        "metadata": {
+          "label": "Max Retry Delay"
+        },
+        "valueType": "EXPRESSION",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "workflow_function/agent.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 19,
+            "character": 8
+          },
+          "end": {
+            "line": 19,
+            "character": 18
+          }
+        },
+        "newText": "{activity: myActivity, requiresApproval: true}"
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/durable_agent_register_tool_gated_to_source.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/durable_agent_register_tool_gated_to_source.json
@@ -1,0 +1,85 @@
+{
+  "source": "workflow_function/agent.bal",
+  "description": "Register a gated tool: approval and reviewer roles emit a ToolDecl mapping entry",
+  "diagram": {
+    "id": "1",
+    "metadata": {
+      "label": "searchClaimDocs",
+      "description": "Register an AI tool the agent can call"
+    },
+    "codedata": {
+      "node": "DURABLE_AGENT_REGISTER_TOOL",
+      "org": "ballerina",
+      "module": "workflow",
+      "object": "DurableAgent",
+      "symbol": "registerAgentTool",
+      "parentSymbol": "claimAgent",
+      "lineRange": {
+        "fileName": "agent.bal",
+        "startLine": {
+          "line": 21,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 21,
+          "offset": 0
+        }
+      },
+      "isNew": true
+    },
+    "returning": false,
+    "properties": {
+      "tool": {
+        "metadata": {
+          "label": "Tool"
+        },
+        "valueType": "SINGLE_SELECT",
+        "value": "searchClaimDocs",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "requiresApproval": {
+        "metadata": {
+          "label": "Requires Approval"
+        },
+        "valueType": "FLAG",
+        "value": "true",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false
+      },
+      "userRoles": {
+        "metadata": {
+          "label": "Reviewer Roles"
+        },
+        "valueType": "EXPRESSION",
+        "value": "finance",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "workflow_function/agent.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 21,
+            "character": 0
+          },
+          "end": {
+            "line": 21,
+            "character": 0
+          }
+        },
+        "newText": "\n, tools: [{tool: searchClaimDocs, requiresApproval: true, userRoles: \"finance\"}]"
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/durable_agent_register_tool_to_source.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/durable_agent_register_tool_to_source.json
@@ -1,0 +1,85 @@
+{
+  "source": "workflow_function/agent.bal",
+  "description": "Register an @ai:AgentTool function on the agent declaration as a bare tools entry",
+  "diagram": {
+    "id": "1",
+    "metadata": {
+      "label": "searchClaimDocs",
+      "description": "Register an AI tool the agent can call"
+    },
+    "codedata": {
+      "node": "DURABLE_AGENT_REGISTER_TOOL",
+      "org": "ballerina",
+      "module": "workflow",
+      "object": "DurableAgent",
+      "symbol": "registerAgentTool",
+      "parentSymbol": "claimAgent",
+      "lineRange": {
+        "fileName": "agent.bal",
+        "startLine": {
+          "line": 21,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 21,
+          "offset": 0
+        }
+      },
+      "isNew": true
+    },
+    "returning": false,
+    "properties": {
+      "tool": {
+        "metadata": {
+          "label": "Tool"
+        },
+        "valueType": "SINGLE_SELECT",
+        "value": "searchClaimDocs",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "requiresApproval": {
+        "metadata": {
+          "label": "Requires Approval"
+        },
+        "valueType": "FLAG",
+        "value": "false",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false
+      },
+      "userRoles": {
+        "metadata": {
+          "label": "Reviewer Roles"
+        },
+        "valueType": "EXPRESSION",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "workflow_function/agent.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 21,
+            "character": 0
+          },
+          "end": {
+            "line": 21,
+            "character": 0
+          }
+        },
+        "newText": "\n, tools: [searchClaimDocs]"
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/durable_agent_register_toolkit_to_source.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/durable_agent_register_toolkit_to_source.json
@@ -1,0 +1,85 @@
+{
+  "source": "workflow_function/agent.bal",
+  "description": "Register an ai toolkit variable (the MCP server flow's final write) on the agent's tools list",
+  "diagram": {
+    "id": "1",
+    "metadata": {
+      "label": "claimMcp",
+      "description": "Register an AI tool the agent can call"
+    },
+    "codedata": {
+      "node": "DURABLE_AGENT_REGISTER_TOOL",
+      "org": "ballerina",
+      "module": "workflow",
+      "object": "DurableAgent",
+      "symbol": "registerAgentTool",
+      "parentSymbol": "claimAgent",
+      "lineRange": {
+        "fileName": "agent.bal",
+        "startLine": {
+          "line": 21,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 21,
+          "offset": 0
+        }
+      },
+      "isNew": true
+    },
+    "returning": false,
+    "properties": {
+      "tool": {
+        "metadata": {
+          "label": "Tool"
+        },
+        "valueType": "SINGLE_SELECT",
+        "value": "claimMcp",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "requiresApproval": {
+        "metadata": {
+          "label": "Requires Approval"
+        },
+        "valueType": "FLAG",
+        "value": "false",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false
+      },
+      "userRoles": {
+        "metadata": {
+          "label": "Reviewer Roles"
+        },
+        "valueType": "EXPRESSION",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "workflow_function/agent.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 21,
+            "character": 0
+          },
+          "end": {
+            "line": 21,
+            "character": 0
+          }
+        },
+        "newText": "\n, tools: [claimMcp]"
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/workflow_function/agent.bal
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/workflow_function/agent.bal
@@ -20,3 +20,11 @@ final workflow:DurableAgent claimAgent = check new ({
         myActivity
     ]
 });
+
+# Search the claims knowledge base
+@ai:AgentTool
+isolated function searchClaimDocs(string query) returns string|error {
+    return "results for " + query;
+}
+
+final ai:McpToolKit claimMcp = check new ("http://localhost:9092/mcp");

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/workflow_function/agent.bal
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/workflow_function/agent.bal
@@ -1,0 +1,22 @@
+import ballerina/ai;
+import ballerina/http;
+import ballerina/workflow;
+
+final ai:Wso2ModelProvider claimModel = check new ("http://localhost:9099", "test-token");
+
+final http:Client claimApi = check new ("http://localhost:9090");
+
+# Fetch claim details activity
+@workflow:Activity
+function fetchClaim(http:Client api, string claimId) returns json|error {
+    return api->get("/claims/" + claimId);
+}
+
+# Expense claim durable agentic workflow
+final workflow:DurableAgent claimAgent = check new ({
+    systemPrompt: {role: "Expense claim assistant", instructions: "Process expense claims."},
+    model: claimModel,
+    activities: [
+        myActivity
+    ]
+});

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_call.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_call.json
@@ -176,77 +176,96 @@
         "dynamicFormFields": {
           "NoRetry": {},
           "AutoRetry": {
-            "maxRetries": {
+            "autoRetryOptions": {
               "metadata": {
-                "label": "Max Retries",
-                "description": "Maximum number of retry attempts"
+                "label": "Advanced Configurations",
+                "description": "Optional tuning for the automatic retries. A field left empty uses the engine default: 3 attempts, a 1.0 second initial delay doubling on each retry, and no cap on the delay."
               },
               "types": [
                 {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "int",
+                  "fieldType": "GROUP_SECTION",
                   "selected": true
                 }
               ],
               "value": "",
-              "optional": false,
+              "optional": true,
               "editable": true,
               "advanced": false,
-              "hidden": false
-            },
-            "retryDelay": {
-              "metadata": {
-                "label": "Retry Delay",
-                "description": "Initial delay between retries in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
+              "hidden": false,
+              "advanceProperties": {
+                "maxRetries": {
+                  "metadata": {
+                    "label": "Max Retries",
+                    "description": "Maximum number of retry attempts"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "int",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryDelay": {
+                  "metadata": {
+                    "label": "Retry Delay",
+                    "description": "Initial delay between retries in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "retryBackoff": {
+                  "metadata": {
+                    "label": "Retry Backoff",
+                    "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "maxRetryDelay": {
+                  "metadata": {
+                    "label": "Max Retry Delay",
+                    "description": "Maximum delay cap in seconds"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "decimal",
+                      "selected": true
+                    }
+                  ],
+                  "value": "",
+                  "optional": true,
+                  "editable": true,
+                  "advanced": false,
+                  "hidden": false
                 }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "retryBackoff": {
-              "metadata": {
-                "label": "Retry Backoff",
-                "description": "Exponential backoff multiplier (e.g. 2.0 doubles each delay)"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
-            },
-            "maxRetryDelay": {
-              "metadata": {
-                "label": "Max Retry Delay",
-                "description": "Maximum delay cap in seconds"
-              },
-              "types": [
-                {
-                  "fieldType": "EXPRESSION",
-                  "ballerinaType": "decimal",
-                  "selected": true
-                }
-              ],
-              "value": "",
-              "optional": false,
-              "editable": true,
-              "advanced": false,
-              "hidden": false
+              }
             }
           },
           "ManualRetry": {
@@ -300,7 +319,7 @@
             "selected": true
           }
         ],
-        "value": "3",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -318,7 +337,7 @@
             "selected": true
           }
         ],
-        "value": "1.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -354,7 +373,7 @@
             "selected": true
           }
         ],
-        "value": "2.0",
+        "value": "",
         "optional": true,
         "editable": true,
         "advanced": false,

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_call.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_call.json
@@ -300,7 +300,7 @@
             "selected": true
           }
         ],
-        "value": "",
+        "value": "3",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -318,7 +318,7 @@
             "selected": true
           }
         ],
-        "value": "",
+        "value": "1.0",
         "optional": true,
         "editable": true,
         "advanced": false,
@@ -354,7 +354,7 @@
             "selected": true
           }
         ],
-        "value": "",
+        "value": "2.0",
         "optional": true,
         "editable": true,
         "advanced": false,

--- a/packages/ballerina-side-panel/src/test/DropdownChoiceForm.test.tsx
+++ b/packages/ballerina-side-panel/src/test/DropdownChoiceForm.test.tsx
@@ -22,6 +22,7 @@
 
 import React from "react";
 import type { FormField } from "../components/Form/types";
+import { fireEvent } from "@testing-library/react";
 import { renderWithForm } from "./formHarness";
 import { DropdownChoiceForm } from "../components/editors/DropdownChoiceForm";
 
@@ -56,5 +57,94 @@ describe("DropdownChoiceForm", () => {
             defaultValues: { kind: "TCP" },
         });
         expect(getForm().getValues("kind")).toBe("TCP");
+    });
+});
+
+// The retry policy declares its Auto Retry tuning fields inside a group of the AutoRetry branch, while
+// their values live in root properties of the same key - which is what source generation reads. The
+// group's children must therefore render under their own keys, or an edit has nowhere to land.
+const groupBranchField = (): FormField =>
+    ({
+        key: "retryPolicy",
+        label: "Retry Policy",
+        type: "SINGLE_SELECT",
+        items: ["NoRetry", "AutoRetry"],
+        value: "AutoRetry",
+        optional: false,
+        editable: true,
+        enabled: true,
+        documentation: "",
+        dynamicFormFields: {
+            NoRetry: [],
+            AutoRetry: [
+                {
+                    key: "autoRetryOptions",
+                    label: "Advanced Configurations",
+                    type: "GROUP_SECTION",
+                    types: [{ fieldType: "GROUP_SECTION", selected: true }],
+                    value: "",
+                    optional: true,
+                    editable: true,
+                    enabled: true,
+                    documentation: "",
+                    advanceProps: [
+                        {
+                            key: "maxRetries",
+                            label: "Max Retries",
+                            type: "STRING",
+                            types: [{ fieldType: "STRING", selected: true }],
+                            value: "",
+                            optional: true,
+                            editable: true,
+                            enabled: true,
+                            documentation: "Maximum number of retry attempts",
+                        },
+                    ],
+                } as unknown as FormField,
+            ],
+        },
+    } as unknown as FormField);
+
+describe("DropdownChoiceForm group branch", () => {
+    it("renders the group of the selected branch", () => {
+        const { container } = renderWithForm(<DropdownChoiceForm field={groupBranchField()} />, {
+            defaultValues: { retryPolicy: "AutoRetry" },
+        });
+        expect(container.textContent ?? "").toContain("Advanced Configurations");
+    });
+
+    it("renders the group's child under its own key once expanded, so its edit reaches the root property", () => {
+        const { container, getForm } = renderWithForm(<DropdownChoiceForm field={groupBranchField()} />, {
+            defaultValues: { retryPolicy: "AutoRetry" },
+        });
+
+        // The toggle is a link button nested in a container that carries the same text, so clicking
+        // every element whose text is exactly "Expand" reaches the one holding the handler.
+        const expandTargets = Array.from(container.querySelectorAll("*")).filter(
+            (element) => element.textContent?.trim() === "Expand"
+        );
+        expect(expandTargets.length).toBeGreaterThan(0);
+        expandTargets.forEach((target) => fireEvent.click(target));
+
+        expect(container.textContent ?? "").toContain("Max Retries");
+        getForm().setValue("maxRetries", "5");
+        expect(getForm().getValues("maxRetries")).toBe("5");
+    });
+});
+
+// Editing an existing node: the value lives in the root property and the branch declares the field
+// with an empty value. Rendering the branch must not overwrite what was loaded.
+describe("DropdownChoiceForm group branch on an existing node", () => {
+    it("keeps the loaded value when the group is expanded", () => {
+        const { container, getForm } = renderWithForm(<DropdownChoiceForm field={groupBranchField()} />, {
+            defaultValues: { retryPolicy: "AutoRetry", maxRetries: "5" },
+        });
+
+        Array.from(container.querySelectorAll("*"))
+            .filter((element) => element.textContent?.trim() === "Expand")
+            .forEach((target) => fireEvent.click(target));
+
+        expect(container.textContent ?? "").toContain("Max Retries");
+        expect(getForm().getValues("maxRetries")).toBe("5");
     });
 });

--- a/packages/ballerina-side-panel/src/test/DropdownChoiceForm.test.tsx
+++ b/packages/ballerina-side-panel/src/test/DropdownChoiceForm.test.tsx
@@ -127,7 +127,13 @@ describe("DropdownChoiceForm group branch", () => {
         expandTargets.forEach((target) => fireEvent.click(target));
 
         expect(container.textContent ?? "").toContain("Max Retries");
-        getForm().setValue("maxRetries", "5");
+
+        // The control the group renders is registered under the leaf key, so typing into it is what
+        // puts the value where the root property - and therefore source generation - reads it.
+        const control = container.querySelector('[name="maxRetries"]');
+        expect(control).toBeTruthy();
+        fireEvent.input(control!, { target: { value: "5" } });
+
         expect(getForm().getValues("maxRetries")).toBe("5");
     });
 });

--- a/packages/ballerina-visualizer/src/utils/bi.test.ts
+++ b/packages/ballerina-visualizer/src/utils/bi.test.ts
@@ -174,6 +174,24 @@ describe('convertNodePropertiesToFormFields', () => {
             expect(fields.map((f) => f.key).sort()).toEqual(['options__retryOptions', 'variable'].sort());
         });
     });
+
+    describe('GROUP_SECTION children', () => {
+        it('becomes a form field under its own key, which is the key its value is stored under', () => {
+            const fields = convertNodePropertiesToFormFields({
+                autoRetryOptions: makeProperty({
+                    fieldType: 'GROUP_SECTION',
+                    metadata: { label: 'Advanced Configurations', description: '' },
+                    advanceProperties: {
+                        maxRetries: makeProperty({ fieldType: 'EXPRESSION', optional: true }),
+                        retryDelay: makeProperty({ fieldType: 'EXPRESSION', optional: true }),
+                    },
+                } as any),
+            } as NodeProperties);
+
+            const group = fields.find((f) => f.key === 'autoRetryOptions');
+            expect(group?.advanceProps?.map((f) => f.key)).toEqual(['maxRetries', 'retryDelay']);
+        });
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -181,6 +199,60 @@ describe('convertNodePropertiesToFormFields', () => {
 // ---------------------------------------------------------------------------
 
 describe('updateNodeProperties', () => {
+    // The Auto Retry tuning fields are declared inside the retry policy's AutoRetry branch, but their
+    // values live in root properties of the same key - which is what source generation reads. The form
+    // registers each field under its own key, so submitting carries the edit to the root property.
+    describe('retry policy group fields', () => {
+        const retryNodeProperties = (): NodeProperties => {
+            const child = (fieldType: string) => makeProperty({ fieldType, value: '', optional: true });
+            return {
+                retryPolicy: makeProperty({
+                    fieldType: 'DROPDOWN_CHOICE',
+                    value: 'NoRetry',
+                    dynamicFormFields: {
+                        NoRetry: {},
+                        AutoRetry: {
+                            autoRetryOptions: makeProperty({
+                                fieldType: 'GROUP_SECTION',
+                                value: '',
+                                optional: true,
+                                advanceProperties: {
+                                    maxRetries: child('EXPRESSION'),
+                                    retryDelay: child('EXPRESSION'),
+                                },
+                            } as any),
+                        },
+                    },
+                } as any),
+                maxRetries: makeProperty({ fieldType: 'EXPRESSION', value: '', hidden: true, optional: true }),
+                retryDelay: makeProperty({ fieldType: 'EXPRESSION', value: '', hidden: true, optional: true }),
+            } as NodeProperties;
+        };
+
+        it('carries an edited group field to the root property source generation reads', () => {
+            const updated = updateNodeProperties(
+                { retryPolicy: 'AutoRetry', maxRetries: '5', retryDelay: '2.5' },
+                retryNodeProperties(),
+                {}
+            );
+
+            expect(updated.retryPolicy!.value).toBe('AutoRetry');
+            expect((updated as any).maxRetries.value).toBe('5');
+            expect((updated as any).retryDelay.value).toBe('2.5');
+        });
+
+        it('leaves a root field untouched when its group field was not edited', () => {
+            const updated = updateNodeProperties(
+                { retryPolicy: 'AutoRetry', maxRetries: '5' },
+                retryNodeProperties(),
+                {}
+            );
+
+            expect((updated as any).maxRetries.value).toBe('5');
+            expect((updated as any).retryDelay.value).toBe('');
+        });
+    });
+
     describe('ADVANCE_PARAM_LIST re-nesting', () => {
         it('writes form values back into the correct sub-property', () => {
             const subOptionsProp = makeProperty({

--- a/packages/ballerina-visualizer/src/utils/bi.test.ts
+++ b/packages/ballerina-visualizer/src/utils/bi.test.ts
@@ -40,6 +40,11 @@ import { convertNodePropertiesToFormFields, updateNodeProperties } from './node-
 // Helpers
 // ---------------------------------------------------------------------------
 
+// NodePropertyKey does not list every key the product uses (options, retryPolicy, maxRetries, ...),
+// so property maps are read as a record of Property rather than through `any`.
+const rootProperty = (properties: NodeProperties, key: string): Property =>
+    (properties as Record<string, Property>)[key];
+
 function makeProperty(overrides: Partial<Property> & { fieldType: string }): Property {
     const { fieldType, metadata: metaOverride, ...rest } = overrides;
     return {
@@ -225,7 +230,7 @@ describe('updateNodeProperties', () => {
                     },
                 } as any),
                 maxRetries: makeProperty({ fieldType: 'EXPRESSION', value: '', hidden: true, optional: true }),
-                retryDelay: makeProperty({ fieldType: 'EXPRESSION', value: '', hidden: true, optional: true }),
+                retryDelay: makeProperty({ fieldType: 'EXPRESSION', value: '1.5', hidden: true, optional: true }),
             } as NodeProperties;
         };
 
@@ -236,20 +241,21 @@ describe('updateNodeProperties', () => {
                 {}
             );
 
-            expect(updated.retryPolicy!.value).toBe('AutoRetry');
-            expect((updated as any).maxRetries.value).toBe('5');
-            expect((updated as any).retryDelay.value).toBe('2.5');
+            expect(rootProperty(updated, 'retryPolicy').value).toBe('AutoRetry');
+            expect(rootProperty(updated, 'maxRetries').value).toBe('5');
+            expect(rootProperty(updated, 'retryDelay').value).toBe('2.5');
         });
 
-        it('leaves a root field untouched when its group field was not edited', () => {
+        it('keeps a root field that the submitted form did not carry', () => {
             const updated = updateNodeProperties(
                 { retryPolicy: 'AutoRetry', maxRetries: '5' },
                 retryNodeProperties(),
                 {}
             );
 
-            expect((updated as any).maxRetries.value).toBe('5');
-            expect((updated as any).retryDelay.value).toBe('');
+            expect(rootProperty(updated, 'maxRetries').value).toBe('5');
+            // Seeded with a value, so this asserts the field was preserved rather than merely empty.
+            expect(rootProperty(updated, 'retryDelay').value).toBe('1.5');
         });
     });
 

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -131,6 +131,17 @@ type NodePromptLaunchOptions = {
 
 const SIDE_PANEL_DEFAULT_ERROR_MESSAGE = "Error while performing the action.";
 
+// The form node kind behind each capability of the durable agent box. A capability type with
+// no entry here has no form, and is refused rather than routed to whichever branch happened
+// to be last.
+const DURABLE_CAPABILITY_NODE_KINDS: Record<string, string> = {
+    activity: "DURABLE_AGENT_ADD_ACTIVITY",
+    event: "DURABLE_AGENT_REGISTER_EVENT",
+    tool: "DURABLE_AGENT_REGISTER_TOOL",
+    humanTask: "DURABLE_AGENT_HUMAN_TASK",
+    peer: "DURABLE_AGENT_PEER",
+};
+
 // AI component pickers resolve templates from Central, so selecting one shows a full-panel loader.
 const AI_COMPONENT_PICKER_VIEWS: SidePanelView[] = [
     SidePanelView.MODEL_PROVIDERS,
@@ -1958,9 +1969,8 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     break;
                 }
 
-                // Selecting a project activity from the list is a complete choice — append it to
-                // the agent declaration's activities list directly (no intermediate form),
-                // unless it needs a binding.
+                // Selecting a project activity from the list opens its registration form
+                // (retry policy, approval gating, bindings) before anything is written.
                 setShowProgressIndicator(true);
                 addActivityToDurableAgent(node.codedata, fileName)
                     .catch((error) => {
@@ -2256,6 +2266,20 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 updatedNode.codedata.lineRange = selectedLineRange;
             }
             hasRenameOperation.current = false;
+        }
+
+        // A durable-agent capability edit writes back to the entry's own range inside the
+        // declaration's config literal, but the form re-stamps the submitted node with
+        // targetLineRange — the expression-editor probe position at the declaration START
+        // (see probeRangeForCapability). Submitting that range would splice the entry text
+        // into the declaration line, so restore the entry range stamped on the selected node
+        // by handleOnEditDurableCapability.
+        if (
+            updatedNode.codedata?.isNew === false &&
+            Object.values(DURABLE_CAPABILITY_NODE_KINDS).includes(updatedNode.codedata.node) &&
+            selectedNodeRef.current?.codedata?.lineRange
+        ) {
+            updatedNode.codedata.lineRange = selectedNodeRef.current.codedata.lineRange;
         }
 
         setShowProgressIndicator(true);
@@ -3437,11 +3461,11 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         return node;
     };
 
-    // Appends a project activity to the agent declaration's activities. An activity that takes
-    // something the model cannot supply — the client of a connection-based activity, say — comes
-    // back with a binding selector per such parameter: those open the register form so the
-    // connection is picked, because an entry registered without it could never be invoked.
-    // Everything else is a complete choice and is written straight to the declaration.
+    // Opens the registration form for a project activity picked from the agent's activity list.
+    // The activity itself is already chosen (its selector arrives pre-selected and hidden), so
+    // the form presents the registration config: retry policy, approval gating, and a binding
+    // selector for every parameter the model cannot supply — the client of a connection-based
+    // activity, say. Saving appends the entry to the agent declaration's activities.
     const addActivityToDurableAgent = async (activityCodedata: AvailableNode["codedata"], fileName?: string) => {
         const response = await rpcClient.getBIDiagramRpcClient().getNodeTemplate({
             position: targetRef.current.startLine,
@@ -3457,20 +3481,16 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             startLine: targetRef.current.startLine,
             endLine: targetRef.current.startLine,
         } as any;
-        if (Object.keys(activityNode.properties ?? {}).some((key) => key.startsWith("bindings."))) {
-            selectedNodeRef.current = activityNode;
-            nodeTemplateRef.current = activityNode;
-            showEditForm.current = false;
-            setSidePanelView(SidePanelView.FORM);
-            setShowSidePanel(true);
-            return;
-        }
-        await rpcClient.getBIDiagramRpcClient().getSourceCode({
-            filePath: model.fileName,
-            flowNode: activityNode,
-        });
-        durableAgentActivityListRef.current = false;
-        finishCapabilityOpAfterRefresh();
+        // Title the form with the chosen activity, like the edit path does.
+        activityNode.metadata = {
+            ...activityNode.metadata,
+            label: activityCodedata?.symbol || activityNode.metadata?.label,
+        } as any;
+        selectedNodeRef.current = activityNode;
+        nodeTemplateRef.current = activityNode;
+        showEditForm.current = false;
+        setSidePanelView(SidePanelView.FORM);
+        setShowSidePanel(true);
     };
 
     // Adds a workflow activity to the durable agent: the registerActivities statement is
@@ -3608,13 +3628,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     // The form behind each capability of the agent box. A kind with no entry here has no form,
     // and is refused rather than routed to whichever branch happened to be last.
     const durableCapabilityNodeKind = (type?: string): string | undefined =>
-        ({
-            activity: "DURABLE_AGENT_ADD_ACTIVITY",
-            event: "DURABLE_AGENT_REGISTER_EVENT",
-            tool: "DURABLE_AGENT_REGISTER_TOOL",
-            humanTask: "DURABLE_AGENT_HUMAN_TASK",
-            peer: "DURABLE_AGENT_PEER",
-        } as Record<string, string>)[type ?? ""];
+        DURABLE_CAPABILITY_NODE_KINDS[type ?? ""];
 
     const handleOnEditDurableCapability = async (runNode: FlowNode, capability: any) => {
         const superseded = beginPanelNav();
@@ -3648,10 +3662,16 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         setTargetLineRange(probeRange);
         setShowProgressIndicator(true);
         try {
+            // An activity capability's template is requested with the activity function as the
+            // symbol: the selector arrives pre-selected (and hidden — the entry's activity is its
+            // identity, not a choice) and the template carries the binding selector properties,
+            // without which a declared `bindings` field could not round-trip through the form.
+            const activityRef =
+                capability?.type === "activity" ? (capability?.values as any)?.activity : undefined;
             const response = await rpcClient.getBIDiagramRpcClient().getNodeTemplate({
                 position: lineRange.startLine,
                 filePath: model?.fileName,
-                id: { node: nodeKind } as any,
+                id: (activityRef ? { node: nodeKind, symbol: activityRef } : { node: nodeKind }) as any,
             });
             const node = response.flowNode;
             // Seed the form with the existing statement's values and point it at that statement.


### PR DESCRIPTION
Fixes the durable agent **Attach Activity** form and its code generation, covering all six problems reported in wso2/product-integrator#2094.

## Fixes

1. **Selecting an activity now always opens the registration form** (retry policy, approval gating, connection bindings) instead of appending the entry with defaults. Previously the form only appeared when the activity needed a binding; configuring anything else required re-opening the attached activity. The form is titled with the chosen activity, like the edit path.
2. **Form description corrected** to `Register a workflow activity as a durable agent activity`.
3. **The activity selector is hidden when the activity is already chosen** (both the add-from-list and edit paths) — the entry's activity is its identity, not a choice. The edit path now passes the activity symbol in the template request.
4. **Selecting Auto Retry does not make retry configurations mandetory
5. **Tool Name / Description are no longer presented.** They mirrored the module `ActivityDecl`'s optional `name`/`description` fields from when activities registered as agent tools. They remain as hidden carriers so entries declared with them in source round-trip through an edit unchanged. (The Register Tool form never had them — `ToolDecl` has no such fields.)
6. **Saving the form no longer generates invalid code.** Two defects:
   - `FlowNodeForm` re-stamps the submitted node's `lineRange` from `targetLineRange`, which for capability edits is the expression-editor probe range at the *declaration start* — the LS capability replace then spliced the entry text into the declaration line (`validateClaimfinal workflow:DurableAgent ...`). The entry's own range is now restored on submit for every durable capability kind.
   - Declared `retryPolicy` and `bindings` fields were not hydrated into the edit form, so an edit-save silently dropped both from the regenerated entry. `CodeAnalyzer.collectDeclaredCapabilities` now decomposes `retryPolicy` into the retry form's values and explodes `bindings` into the per-parameter selectors.

## Tests

New goldens covering the agent capability flows:
- `node_template`: Register Activity from the palette and pre-selected (hidden selector, hidden identity fields, retry defaults, binding selector for a client parameter); Register Tool pre-selected (tool reference + ToolDecl gating only).
- `to_source`: activities-list append (retry record + bindings emitted) and rewrite at the entry's own range (the regression guard for the invalid code-gen); tools-list bare entry, gated `ToolDecl` mapping, and an ai toolkit variable registration (the MCP server flow's final write).
- `search`: the Add Activity list for a project with activities and for an empty project (empty category behind the create-new CTA), both with the Use MCP Server entry.

Existing goldens (builtin activities, Call Activity, diagram) regenerated for the Auto Retry defaults — each changes exactly the three hidden sub-field values.

`NodeTemplateTest`, `SourceGeneratorTest`, `SearchTest`, `ModelGeneratorTest`, `WorkflowNodeTemplateTest` and checkstyle are green locally; `rush build --to ballerina-visualizer` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed durable agent activity selection and registration flows.
- Corrected the activity form description and hid selectors for preselected activities.
- Made `AutoRetry` settings optional and added grouped form fields.
- Preserved retry values, bindings, and source ranges during edits and code generation.
- Hid tool name and description fields while preserving source round-tripping.
- Added support for grouped properties and expanded test coverage for retry configuration and registration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->