### PR TITLE
Fix intermittent empty diffs in review mode across LS, extension, and UI

### DIFF
--- a/packages/ballerina-core/src/interfaces/extended-lang-client.ts
+++ b/packages/ballerina-core/src/interfaces/extended-lang-client.ts
@@ -854,6 +854,8 @@ export interface ProjectDiagnosticsRequest {
 
 export interface ProjectDiagnosticsResponse {
     errorDiagnosticMap?: Map<string, Diagnostic[]>;
+    /** Why diagnostics could not be produced (e.g. the package failed to compile). */
+    errorMsg?: string;
 }
 
 export interface MainFunctionParamsRequest {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -416,6 +416,20 @@ export interface EnsureAiBaselineResponse {
     errorMsg?: string;
 }
 
+/**
+ * Request to warm the LS module-package caches for a package's direct dependencies,
+ * so the first review-diff flow-model fetch does not pay the one-time dependency
+ * resolution/compilation cost interactively. Fired in the background at run start.
+ */
+export interface PrewarmDependenciesRequest {
+    projectPath: string;
+}
+
+export interface PrewarmDependenciesResponse {
+    warmedDependencyCount?: number;
+    errorMsg?: string;
+}
+
 // Numeric enum values from the API
 export enum ChangeTypeEnum {
     ADDITION = 0,

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -425,6 +425,14 @@ export interface SemanticDiff {
 export interface SemanticDiffResponse {
     loadDesignDiagrams: boolean;
     semanticDiffs: SemanticDiff[];
+    /** Set when diff computation failed entirely; semanticDiffs is absent in that case. */
+    errorMsg?: string;
+    /**
+     * Set when the syntax-level diffs succeeded but the package failed to compile
+     * (design-model comparison). The diffs are still usable, but flow diagrams
+     * will likely be unavailable for the same reason.
+     */
+    compilationError?: string;
 }
 
 export interface RevertGenerationRequest {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -393,6 +393,29 @@ export interface SemanticDiffRequest {
     projectPath: string;
 }
 
+/** One file's frozen baseline content, relative to the package root. */
+export interface AiBaselineFile {
+    filePath: string;
+    content: string;
+}
+
+/**
+ * Request to (re)establish a package's ai:// frozen baseline from explicit file contents.
+ * Unlike the didOpen/didChange notification protocol, the LS applies everything before
+ * responding, so callers can await the baseline being in place.
+ */
+export interface EnsureAiBaselineRequest {
+    projectPath: string;
+    files: AiBaselineFile[];
+}
+
+export interface EnsureAiBaselineResponse {
+    seededFileCount: number;
+    /** Files whose baseline content could not be applied; the rest are in place. */
+    failedFiles?: string[];
+    errorMsg?: string;
+}
+
 // Numeric enum values from the API
 export enum ChangeTypeEnum {
     ADDITION = 0,
@@ -401,10 +424,34 @@ export enum ChangeTypeEnum {
 
 }
 
+/**
+ * Mirrors the LS NodeKind wire ordinals
+ * (io.ballerina.copilotagent.core.models.NodeKind) — the single TS copy.
+ */
+export enum NodeKindEnum {
+    MODULE_FUNCTION = 0,
+    OBJECT_FUNCTION = 1,
+    TYPE_DEFINITION = 2,
+    DATA_MAPPING_FUNCTION = 3,
+    MODULE_VARIABLE = 4,
+    CONSTANT = 5,
+    LISTENER = 6,
+    CLASS_DEFINITION = 7,
+    ENUM_DECLARATION = 8,
+    IMPORT_DECLARATION = 9,
+}
+
 export type ChangeType = "ADDITION" | "MODIFICATION" | "DELETION";
 
 export interface IdentifierMetadata {
     name: string;
+    /**
+     * Before/after source text, present on construct kinds the review UI renders as
+     * source blocks (module vars, constants, listeners, classes, enums, imports).
+     * Either side is absent for a pure addition/deletion.
+     */
+    oldSource?: string;
+    newSource?: string;
 }
 
 export interface ResourceMetadata {

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -257,6 +257,8 @@ export interface ReviewModeData {
     modifiedFiles?: string[];
     tempProjectPath?: string;
     isWorkspace?: boolean;
+    /** Compile/diff failure to surface in the review UI instead of a silent empty review. */
+    semanticDiffError?: string;
 }
 
 // --- Evalset Trace Types ---
@@ -852,6 +854,8 @@ export interface GenerationReviewState {
         semanticDiffs: object[];
         loadDesignDiagrams: boolean;
         isWorkspace: boolean;
+        /** Compile/diff failure to surface in the review UI instead of a silent empty review. */
+        semanticDiffError?: string;
     };
 }
 

--- a/packages/ballerina-extension/src/core/extended-language-client.ts
+++ b/packages/ballerina-extension/src/core/extended-language-client.ts
@@ -292,6 +292,8 @@ import {
     ClausePositionRequest,
     SemanticDiffRequest,
     SemanticDiffResponse,
+    EnsureAiBaselineRequest,
+    EnsureAiBaselineResponse,
     ConvertExpressionRequest,
     ConvertExpressionResponse,
     IntrospectDatabaseRequest,
@@ -499,6 +501,7 @@ enum EXTENDED_APIS {
     BI_AI_GEN_AGENT_DEFINITION = 'agentManager/genAgentDefinition',
     BI_AI_GET_PACKAGE_VERSION = 'agentManager/getPackageVersion',
     BI_GET_SEMANTIC_DIFF = 'copilotAgentService/getSemanticDiff',
+    BI_ENSURE_AI_BASELINE = 'copilotAgentService/ensureAiBaseline',
     BI_IS_ICP_ENABLED = 'icpService/isIcpEnabled',
     BI_ADD_ICP = 'icpService/addICP',
     BI_DISABLE_ICP = 'icpService/disableICP',
@@ -1619,6 +1622,10 @@ export class ExtendedLangClient extends LanguageClient implements ExtendedLangCl
 
     async getSemanticDiff(params: SemanticDiffRequest): Promise<SemanticDiffResponse> {
         return this.sendRequest<SemanticDiffResponse>(EXTENDED_APIS.BI_GET_SEMANTIC_DIFF, params);
+    }
+
+    async ensureAiBaseline(params: EnsureAiBaselineRequest): Promise<EnsureAiBaselineResponse> {
+        return this.sendRequest<EnsureAiBaselineResponse>(EXTENDED_APIS.BI_ENSURE_AI_BASELINE, params);
     }
 
     // <------------ BI APIS END --------------->

--- a/packages/ballerina-extension/src/core/extended-language-client.ts
+++ b/packages/ballerina-extension/src/core/extended-language-client.ts
@@ -294,6 +294,8 @@ import {
     SemanticDiffResponse,
     EnsureAiBaselineRequest,
     EnsureAiBaselineResponse,
+    PrewarmDependenciesRequest,
+    PrewarmDependenciesResponse,
     ConvertExpressionRequest,
     ConvertExpressionResponse,
     IntrospectDatabaseRequest,
@@ -502,6 +504,7 @@ enum EXTENDED_APIS {
     BI_AI_GET_PACKAGE_VERSION = 'agentManager/getPackageVersion',
     BI_GET_SEMANTIC_DIFF = 'copilotAgentService/getSemanticDiff',
     BI_ENSURE_AI_BASELINE = 'copilotAgentService/ensureAiBaseline',
+    BI_PREWARM_DEPENDENCIES = 'copilotAgentService/prewarmDependencies',
     BI_IS_ICP_ENABLED = 'icpService/isIcpEnabled',
     BI_ADD_ICP = 'icpService/addICP',
     BI_DISABLE_ICP = 'icpService/disableICP',
@@ -1626,6 +1629,10 @@ export class ExtendedLangClient extends LanguageClient implements ExtendedLangCl
 
     async ensureAiBaseline(params: EnsureAiBaselineRequest): Promise<EnsureAiBaselineResponse> {
         return this.sendRequest<EnsureAiBaselineResponse>(EXTENDED_APIS.BI_ENSURE_AI_BASELINE, params);
+    }
+
+    async prewarmDependencies(params: PrewarmDependenciesRequest): Promise<PrewarmDependenciesResponse> {
+        return this.sendRequest<PrewarmDependenciesResponse>(EXTENDED_APIS.BI_PREWARM_DEPENDENCIES, params);
     }
 
     // <------------ BI APIS END --------------->

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -23,6 +23,7 @@ import { ModelMessage, stepCountIs, streamText, TextStreamPart } from 'ai';
 import { getAnthropicClient, getProviderCacheControl, getProviderModelOptions, addCacheControlToMessages, ANTHROPIC_SONNET } from '../utils/ai-client';
 import { populateHistoryForAgent, getErrorMessage, getErrorCode, buildChatError } from '../utils/ai-utils';
 import { seedAiBaselines } from '../utils/project/ls-schema-notifications';
+import { mapWithConcurrency } from '../utils/concurrency';
 import { getSystemPrompt, getUserPrompt } from './prompts';
 import { FollowupSituation, startFollowupSuggestions } from './followups';
 import { prepareAgentsMdForTurn } from './agents-md';
@@ -307,6 +308,18 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                 await seedAiBaselines(tempProjectPath, projects);
             } else {
                 console.log(`[AgentExecutor] Skipping ai:// baseline seed (skipFreshProjectSetup)`);
+            }
+
+            // Fire-and-forget: warm the LS module-package caches for each package's
+            // dependencies while the generation streams, so the first review-diff diagram
+            // does not pay the one-time dependency resolution/compilation cost (seconds)
+            // interactively. Failures are irrelevant — the fetch path pays the cost lazily.
+            for (const project of projects) {
+                const pkgRoot = project.packagePath
+                    ? path.join(tempProjectPath, project.packagePath)
+                    : tempProjectPath;
+                StateMachine.langClient().prewarmDependencies({ projectPath: pkgRoot })
+                    .catch(() => { /* best-effort warm-up only */ });
             }
 
             const workspaceId = this.config.executionContext.workspacePath || this.config.executionContext.projectPath;
@@ -1073,9 +1086,15 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
             const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
             let semanticDiffError: string | undefined;
             let diffedPackageCount = 0;
-            for (const pkg of affectedPackages) {
+            // Each package's diff is an independent LS request against its own project root,
+            // so fetch them concurrently; results are folded back in affectedPackages order
+            // below to keep diffPackageMap/semanticDiffs alignment and error-message order
+            // deterministic. Bounded, because each request can trigger two full package
+            // compilations and migration turns can touch many packages at once.
+            const diffPackages = affectedPackages.filter(
                 // Skip workspace root — it only contains Ballerina.toml, not a real package
-                if (isWorkspace && pkg === workingProjectPath) { continue; }
+                pkg => !(isWorkspace && pkg === workingProjectPath));
+            const packageResults = await mapWithConcurrency(diffPackages, 3, async pkg => {
                 const pkgName = path.basename(pkg);
                 try {
                     const res = await langClient.getSemanticDiff({ projectPath: pkg });
@@ -1085,23 +1104,29 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                     if (res?.errorMsg) {
                         throw new Error(res.errorMsg);
                     }
-                    if (res) {
-                        diffedPackageCount++;
-                        diffPackageMap.push(...Array(res.semanticDiffs.length).fill(pkgName));
-                        semanticDiffs.push(...res.semanticDiffs);
-                        loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
-                        // Partial success: diffs are valid but the package failed to compile,
-                        // so flow diagrams will likely be unavailable. Keep the diffs and
-                        // surface the reason as a warning.
-                        semanticDiffError = semanticDiffError ?? res.compilationError ?? undefined;
-                    }
+                    return { pkgName, res, error: undefined as string | undefined };
                 } catch (err) {
-                    // One package failing must not discard the diffs already collected for
-                    // its siblings — keep going and report the failure alongside them.
+                    // One package failing must not discard the diffs collected for its
+                    // siblings — record the failure and report it alongside them.
                     console.error(`[AgentExecutor] getSemanticDiff failed for package ${pkg}; keeping other packages' diffs`, err);
                     const message = err instanceof Error ? err.message : String(err);
-                    const packageError = isWorkspace ? `${pkgName}: ${message}` : message;
-                    semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${packageError}` : packageError;
+                    return { pkgName, res: undefined, error: isWorkspace ? `${pkgName}: ${message}` : message };
+                }
+            });
+            for (const { pkgName, res, error } of packageResults) {
+                if (error !== undefined) {
+                    semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${error}` : error;
+                    continue;
+                }
+                if (res) {
+                    diffedPackageCount++;
+                    diffPackageMap.push(...Array(res.semanticDiffs.length).fill(pkgName));
+                    semanticDiffs.push(...res.semanticDiffs);
+                    loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
+                    // Partial success: diffs are valid but the package failed to compile,
+                    // so flow diagrams will likely be unavailable. Keep the diffs and
+                    // surface the reason as a warning.
+                    semanticDiffError = semanticDiffError ?? res.compilationError ?? undefined;
                 }
             }
 

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -1040,22 +1040,34 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                 ? cachedAffectedPackages
                 : await determineAffectedPackages(accumulatedModifiedFiles, context.projects, context.ctx, workingProjectPath);
             const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
+            let semanticDiffError: string | undefined;
             for (const pkg of affectedPackages) {
                 // Skip workspace root — it only contains Ballerina.toml, not a real package
                 if (isWorkspace && pkg === workingProjectPath) { continue; }
                 const pkgName = path.basename(pkg);
                 try {
                     const res = await langClient.getSemanticDiff({ projectPath: pkg });
+                    // errorMsg means the LS could not compute diffs at all (e.g. the package
+                    // fails to compile) — semanticDiffs is absent, so treat it as a failure
+                    // instead of reading past it.
+                    if (res?.errorMsg) {
+                        throw new Error(res.errorMsg);
+                    }
                     if (res) {
                         diffPackageMap.push(...Array(res.semanticDiffs.length).fill(pkgName));
                         semanticDiffs.push(...res.semanticDiffs);
                         loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
+                        // Partial success: diffs are valid but the package failed to compile,
+                        // so flow diagrams will likely be unavailable. Keep the diffs and
+                        // surface the reason as a warning.
+                        semanticDiffError = semanticDiffError ?? res.compilationError ?? undefined;
                     }
                 } catch (err) {
                     console.error(`[AgentExecutor] getSemanticDiff failed for package ${pkg}, falling back to plain modifiedFiles`, err);
                     semanticDiffs.length = 0;
                     diffPackageMap.length = 0;
                     loadDesignDiagrams = false;
+                    semanticDiffError = err instanceof Error ? err.message : String(err);
                     break;
                 }
             }
@@ -1070,6 +1082,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                 modifiedFiles: accumulatedModifiedFiles,
                 tempProjectPath: workingProjectPath,
                 isWorkspace,
+                semanticDiffError,
             };
 
             approvalViewManager.openReviewMode(context.messageId, reviewData, false);
@@ -1082,7 +1095,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                 tempProjectPath: workingProjectPath,
                 modifiedFiles: accumulatedModifiedFiles,
                 affectedPackagePaths: affectedPackages,
-                reviewView: { semanticDiffs, loadDesignDiagrams, isWorkspace },
+                reviewView: { semanticDiffs, loadDesignDiagrams, isWorkspace, semanticDiffError },
             });
 
             context.eventHandler({

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -22,7 +22,7 @@ import { StateMachine } from '../../../stateMachine';
 import { ModelMessage, stepCountIs, streamText, TextStreamPart } from 'ai';
 import { getAnthropicClient, getProviderCacheControl, getProviderModelOptions, addCacheControlToMessages, ANTHROPIC_SONNET } from '../utils/ai-client';
 import { populateHistoryForAgent, getErrorMessage, getErrorCode, buildChatError } from '../utils/ai-utils';
-import { sendAgentDidOpenForFreshProjects } from '../utils/project/ls-schema-notifications';
+import { seedAiBaselines } from '../utils/project/ls-schema-notifications';
 import { getSystemPrompt, getUserPrompt } from './prompts';
 import { FollowupSituation, startFollowupSuggestions } from './followups';
 import { prepareAgentsMdForTurn } from './agents-md';
@@ -147,6 +147,18 @@ function computeTokenBreakdown(
 }
 
 /**
+ * Normalizes a relative path for package-membership comparison: trims, collapses `.`
+ * segments, converts backslashes, and strips leading `./` and trailing slashes. The two
+ * sides being compared come from different authors (the workspace toml's `packages` list
+ * vs the LLM's verbatim tool `file_path` args), so raw string comparison misses trivially
+ * equivalent forms like `./orders` vs `orders/main.bal`.
+ */
+export function normalizeRelativePath(p: string): string {
+    const normalized = path.normalize(p.trim()).replace(/\\/g, '/').replace(/\/+$/, '');
+    return normalized === '.' ? '' : normalized;
+}
+
+/**
  * Determines which packages have been affected by analyzing modified files
  * Returns temp directory package paths for use with Language Server semantic diff API
  * @param modifiedFiles Array of relative file paths that were modified
@@ -173,18 +185,23 @@ async function determineAffectedPackages(
         return Array.from(affectedPackages);
     }
 
-    // Re-read workspace Ballerina.toml from temp to get the current package list
-    // (the agent may have added new packages during the session)
+    // Union of the current workspace Ballerina.toml package list (re-read so packages the
+    // agent added mid-run are present) and the generation-start ProjectSource packages.
+    // An empty toml `packages` array must fall back too — `??` alone doesn't cover it.
     const workspaceToml = await getWorkspaceTomlValues(tempProjectPath);
-    const packagePaths: string[] = workspaceToml?.workspace?.packages ?? projects.map(p => p.packagePath).filter(p => p !== "");
+    const tomlPackages = (workspaceToml?.workspace?.packages ?? []).map(normalizeRelativePath);
+    const sourcePackages = projects.map(p => normalizeRelativePath(p.packagePath ?? ''));
+    const packagePaths: string[] = Array.from(new Set([...tomlPackages, ...sourcePackages])).filter(p => p !== '');
 
     // For workspace scenario with multiple packages
     // We need to map modified files to their temp package paths
+    const unmatchedFiles: string[] = [];
     for (const modifiedFile of modifiedFiles) {
+        const normalizedFile = normalizeRelativePath(modifiedFile);
         let matched = false;
 
         for (const pkgPath of packagePaths) {
-            if (modifiedFile.startsWith(pkgPath + '/') || modifiedFile === pkgPath) {
+            if (normalizedFile.startsWith(pkgPath + '/') || normalizedFile === pkgPath) {
                 const tempPackagePath = path.join(tempProjectPath, pkgPath);
                 affectedPackages.add(tempPackagePath);
                 matched = true;
@@ -196,8 +213,19 @@ async function determineAffectedPackages(
         if (!matched) {
             // File at workspace root (e.g. root Ballerina.toml)
             affectedPackages.add(tempProjectPath);
+            unmatchedFiles.push(modifiedFile);
             console.log(`[determineAffectedPackages] File '${modifiedFile}' is at workspace root (temp): ${tempProjectPath}`);
         }
+    }
+
+    // Unmatched .bal files are a red flag: the workspace root holds no sources, so their
+    // package's diff would silently never be computed. Loud log so this is diagnosable.
+    const unmatchedBalFiles = unmatchedFiles.filter(f => f.endsWith('.bal'));
+    if (unmatchedBalFiles.length > 0) {
+        console.error(
+            `[determineAffectedPackages] ${unmatchedBalFiles.length} modified .bal file(s) matched no workspace package — their diffs will be missing.`,
+            { unmatchedBalFiles, packagePaths }
+        );
     }
 
     const result = Array.from(affectedPackages);
@@ -271,9 +299,12 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
             );
 
             // 2. Seed the ai:// baseline, unless the caller explicitly asked to skip it
-            // (migration reusing the same directory across sequential stages).
+            // (migration reusing the same directory across sequential stages). Awaited so
+            // the baseline is guaranteed in place before the first edit can touch disk —
+            // the LS-side ensureAiBaseline request applies the pre-edit contents before
+            // responding, unlike the old fire-and-forget didOpen seed.
             if (!this.config.lifecycle?.skipFreshProjectSetup) {
-                sendAgentDidOpenForFreshProjects(tempProjectPath, projects);
+                await seedAiBaselines(tempProjectPath, projects);
             } else {
                 console.log(`[AgentExecutor] Skipping ai:// baseline seed (skipFreshProjectSetup)`);
             }
@@ -1041,6 +1072,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                 : await determineAffectedPackages(accumulatedModifiedFiles, context.projects, context.ctx, workingProjectPath);
             const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
             let semanticDiffError: string | undefined;
+            let diffedPackageCount = 0;
             for (const pkg of affectedPackages) {
                 // Skip workspace root — it only contains Ballerina.toml, not a real package
                 if (isWorkspace && pkg === workingProjectPath) { continue; }
@@ -1054,6 +1086,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                         throw new Error(res.errorMsg);
                     }
                     if (res) {
+                        diffedPackageCount++;
                         diffPackageMap.push(...Array(res.semanticDiffs.length).fill(pkgName));
                         semanticDiffs.push(...res.semanticDiffs);
                         loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
@@ -1063,13 +1096,30 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                         semanticDiffError = semanticDiffError ?? res.compilationError ?? undefined;
                     }
                 } catch (err) {
-                    console.error(`[AgentExecutor] getSemanticDiff failed for package ${pkg}, falling back to plain modifiedFiles`, err);
-                    semanticDiffs.length = 0;
-                    diffPackageMap.length = 0;
-                    loadDesignDiagrams = false;
-                    semanticDiffError = err instanceof Error ? err.message : String(err);
-                    break;
+                    // One package failing must not discard the diffs already collected for
+                    // its siblings — keep going and report the failure alongside them.
+                    console.error(`[AgentExecutor] getSemanticDiff failed for package ${pkg}; keeping other packages' diffs`, err);
+                    const message = err instanceof Error ? err.message : String(err);
+                    const packageError = isWorkspace ? `${pkgName}: ${message}` : message;
+                    semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${packageError}` : packageError;
                 }
+            }
+
+            // Diagnosability guard: files were modified, yet no package produced (or was
+            // even asked for) a diff and no error was recorded. Without this, a mapping
+            // failure is indistinguishable from a genuine no-op turn.
+            // (diffedPackageCount === 0 implies semanticDiffs is empty — diffs are only
+            // pushed in the branch that increments it.)
+            const modifiedBalFiles = accumulatedModifiedFiles.filter(f => f.endsWith('.bal'));
+            if (!semanticDiffError && modifiedBalFiles.length > 0 && diffedPackageCount === 0) {
+                semanticDiffError =
+                    `The review diff could not be computed: none of the ${modifiedBalFiles.length} modified .bal file(s) ` +
+                    `mapped to a reviewable package. The changes are already applied to your files.`;
+                console.error('[AgentExecutor] Review diff silently empty — modified files mapped to no package.', {
+                    modifiedFiles: accumulatedModifiedFiles,
+                    affectedPackages,
+                    workingProjectPath,
+                });
             }
 
             const reviewData: ReviewModeData = {

--- a/packages/ballerina-extension/src/features/ai/agent/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/index.ts
@@ -31,7 +31,7 @@ import { getProjectMetrics } from "../../telemetry/common/project-metrics";
 import { getHashedProjectId } from "../../telemetry/common/project-id";
 import { runEventStore } from "../utils/run-event-store";
 import { sendSaveChatNotification } from "../utils/ai-utils";
-import { finalizeRevertibleGeneration } from "../utils/generation-response";
+import { finalizeRevertibleGeneration, finalizeRevertibleGenerationsAllThreads } from "../utils/generation-response";
 
 // ==================================
 // Agent Generation Functions
@@ -127,10 +127,14 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
             throw new Error('A generation is already in progress. Please wait for it to finish before starting a new one.');
         }
 
-        // Moving on to a new generation implicitly accepts a still-open previous one.
-        // Nothing to clean up: edits already land directly in the real workspace, and there's
-        // no separate temp copy anymore (see existingTempPath below).
-        finalizeLastGeneration(projectRootPath, threadId);
+        // Moving on to a new generation implicitly accepts a still-open previous one —
+        // on EVERY thread of the project, not just this one: the upcoming ai:// baseline
+        // reseed is a per-package LS slot shared by all threads, so any other thread's
+        // still-open review would be silently invalidated (and its decline would restore
+        // stale content over this run's edits). Nothing to clean up beyond that: edits
+        // already land directly in the real workspace, and there's no separate temp copy
+        // anymore (see existingTempPath below).
+        finalizeRevertibleGenerationsAllThreads(projectRootPath);
 
         // Create config using factory function. existingTempPath makes the agent operate
         // directly on the real project root instead of AICommandExecutor creating a

--- a/packages/ballerina-extension/src/features/ai/agent/tools/diagnostics-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/diagnostics-utils.ts
@@ -1,5 +1,5 @@
 import { DiagnosticEntry, Diagnostics } from '@wso2/ballerina-core';
-import { checkProjectDiagnostics, isModuleNotFoundDiagsExist as resolveModuleNotFoundDiagnostics } from '../../../../rpc-managers/ai-panel/repair-utils';
+import { checkProjectDiagnostics, isModuleNotFoundDiagsExist as resolveModuleNotFoundDiagnostics, PACKAGE_COMPILATION_FAILED_PREFIX } from '../../../../rpc-managers/ai-panel/repair-utils';
 import { StateMachine } from '../../../../stateMachine';
 import * as path from 'path';
 import { Uri } from 'vscode';
@@ -162,12 +162,25 @@ export async function checkCompilationErrors(
         };
     } catch (error) {
         console.error("[DiagnosticsUtils] Error checking compilation errors:", error);
+        const reason = error instanceof Error ? error.message : 'Unknown error';
+        if (reason.startsWith(PACKAGE_COMPILATION_FAILED_PREFIX)) {
+            // The package itself cannot compile (e.g. an unresolvable dependency mix from a
+            // stale sticky Dependencies.toml) — distinct from an LS malfunction. Tell the
+            // agent the real cause so it can inform the user instead of silently finishing.
+            return {
+                diagnostics: [{ message: reason }],
+                message: `<CRITICAL_ERROR> The Ballerina package failed to compile, so diagnostics could not be produced.
+Reason: ${reason}
+This is an environment/dependency problem, not something to fix with code edits. Do not attempt further code changes for it. Inform the user that the project currently fails to compile with the reason above, and suggest running 'bal build' in the project to refresh its dependency resolution (Dependencies.toml) if the reason mentions a module or dependency.
+</CRITICAL_ERROR>`,
+            };
+        }
         return {
             diagnostics: [{
                 message: "Internal error occurred while checking compilation errors."
             }],
             message: `<CRITICAL_ERROR> Failed to check compilation errors due to an internal error. Avoid try to resolve this with code changes. Acknowledge the failure, consider the task is done.
-Reason: ${error instanceof Error ? error.message : 'Unknown error'}
+Reason: ${reason}
 </CRITICAL_ERROR>`,
         };
     }

--- a/packages/ballerina-extension/src/features/ai/agent/tools/text-editor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/text-editor.ts
@@ -24,6 +24,7 @@ import { normalizeInvisibleChars } from "../../utils/string-utils";
 import { normalizeToLf, readAndNormalize, restoreEol } from "../../utils/eol-utils";
 import { addToIntegration } from "../../../../rpc-managers/ai-panel/utils";
 import { recordAiTouchedFile } from "../../../../rpc-managers/diagram-validity";
+import { seedNewPackageBaseline } from "../../utils/project/ls-schema-notifications";
 
 /**
  * Persists a tool's computed content directly into the real workspace file via VS Code's
@@ -45,10 +46,27 @@ async function persistLiveEdit(
     return;
   }
   const workspaceRoot = ctx.workspacePath || ctx.projectPath;
+  const absolutePath = path.join(workspaceRoot, file_path);
+  // A Ballerina.toml that doesn't exist yet means the agent is creating a whole new
+  // package mid-run — its ai:// baseline must be frozen NOW, before more files land,
+  // or the review diff loads the baseline from post-edit disk and shows no changes.
+  const isNewPackageToml = path.basename(file_path) === 'Ballerina.toml' && !fs.existsSync(absolutePath);
   try {
     await addToIntegration(workspaceRoot, [{ filePath: file_path, content }]);
-    recordAiTouchedFile(path.join(workspaceRoot, file_path));
+    recordAiTouchedFile(absolutePath);
     allModifiedFiles?.add(file_path);
+    if (isNewPackageToml) {
+      const packageRoot = path.dirname(absolutePath);
+      // .bal files this generation already wrote into the new package: freeze them as
+      // empty in the baseline so they still register as additions in the review.
+      const alreadyWritten = new Set([...(modifiedFiles ?? []), ...(allModifiedFiles ?? [])]);
+      const preexistingBalFiles = [...alreadyWritten]
+        .filter(f => f.endsWith('.bal'))
+        .map(f => path.resolve(workspaceRoot, f))
+        .filter(abs => abs.startsWith(packageRoot + path.sep))
+        .map(abs => path.relative(packageRoot, abs));
+      await seedNewPackageBaseline(packageRoot, content, preexistingBalFiles);
+    }
   } catch (error) {
     console.error("[TextEditorTool] Live persist failed:", error);
   }

--- a/packages/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
@@ -77,7 +77,7 @@ export interface AICommandConfig<TParams = any> {
          */
         existingTempPath?: string;
         /**
-         * Skip sendAgentDidOpenForFreshProjects (the ai:// baseline seed). Set by callers
+         * Skip seedAiBaselines (the ai:// baseline seed). Set by callers
          * that reuse the same existingTempPath across multiple executions of the same
          * directory (migration's per-stage runs), where the LS already has it open from
          * an earlier execution and re-seeding would overwrite the baseline with
@@ -418,7 +418,13 @@ export abstract class AICommandExecutor<TParams = any> {
         );
     }
 
-    /** Implicitly accepts whichever generation is still in the revertible 'done' window. */
+    /**
+     * Implicitly accepts whichever generation is still in the revertible 'done' window.
+     * Per-thread on purpose: executors on this path (typecreator, data mapper) work in
+     * their own temp copies and do NOT reseed the shared ai:// diff baseline, so another
+     * thread's open review stays valid. The agent entry point (generateAgent) finalizes
+     * ALL threads instead, because its baseline reseed invalidates every open review.
+     */
     protected finalizePreviousGeneration(): void {
         if (!this.config.chatStorage) {
             return;

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -573,12 +573,24 @@ export class ApprovalViewManager {
         }
 
         const tempProjectPath = review.tempProjectPath ?? projectRootPath;
-        sendReviewRestoreDidOpenBatch(
+        const { restoredCount, skippedCount } = sendReviewRestoreDidOpenBatch(
             tempProjectPath,
             review.modifiedFiles,
             undefined,
             generation.checkpoint?.workspaceSnapshot
         );
+
+        // Without original content (no checkpoint — disabled or size-capped), the ai://
+        // baseline could not be re-established, so the "old" side of every diagram is
+        // gone. Surface that instead of silently degrading to New-only views.
+        let semanticDiffError = review.reviewView.semanticDiffError;
+        if (restoredCount === 0 && skippedCount > 0) {
+            const restoreWarning =
+                'The original (pre-change) version of the files could not be restored after the window reload ' +
+                '(no checkpoint snapshot exists for this generation), so only the New view is available.';
+            semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${restoreWarning}` : restoreWarning;
+            console.error(`[ApprovalViewManager] Review restore had no original content for ${generationId} — ${skippedCount} file(s) skipped.`);
+        }
 
         return {
             views: [],
@@ -591,7 +603,7 @@ export class ApprovalViewManager {
             modifiedFiles: review.modifiedFiles,
             tempProjectPath,
             isWorkspace: review.reviewView.isWorkspace,
-            semanticDiffError: review.reviewView.semanticDiffError,
+            semanticDiffError,
         };
     }
 

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -591,6 +591,7 @@ export class ApprovalViewManager {
             modifiedFiles: review.modifiedFiles,
             tempProjectPath,
             isWorkspace: review.reviewView.isWorkspace,
+            semanticDiffError: review.reviewView.semanticDiffError,
         };
     }
 

--- a/packages/ballerina-extension/src/features/ai/utils/concurrency.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/concurrency.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Maps items through an async function with at most `limit` invocations in flight,
+ * preserving input order in the result. A flat Promise.all over a workspace-sized
+ * collection can fire dozens of concurrent LS compilations or file reads at once;
+ * this keeps the parallelism win while bounding the fan-out.
+ *
+ * Rejections propagate like Promise.all: the first rejection rejects the whole call.
+ * Callers that need per-item error isolation should catch inside `fn`.
+ */
+export async function mapWithConcurrency<T, R>(
+    items: readonly T[],
+    limit: number,
+    fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+    const results = new Array<R>(items.length);
+    let nextIndex = 0;
+    const workers = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+        while (true) {
+            const index = nextIndex++;
+            if (index >= items.length) {
+                return;
+            }
+            results[index] = await fn(items[index], index);
+        }
+    });
+    await Promise.all(workers);
+    return results;
+}

--- a/packages/ballerina-extension/src/features/ai/utils/generation-response.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/generation-response.ts
@@ -52,6 +52,23 @@ export function finalizeRevertibleGeneration(projectRootPath: string, threadId: 
 }
 
 /**
+ * Finalizes revertible generations across EVERY thread of the project, not just the one
+ * about to run. The ai:// diff baseline is a single per-package slot in the Language
+ * Server — reseeding it at generation start silently invalidates any other thread's
+ * still-open review, whose decline would then restore stale content over the new run's
+ * edits. Same policy as the same-thread implicit accept, applied project-wide.
+ *
+ * @returns true if any generation was finalized
+ */
+export function finalizeRevertibleGenerationsAllThreads(projectRootPath: string): boolean {
+    let finalizedAny = false;
+    for (const thread of chatStateStorage.listThreadsSummary(projectRootPath)) {
+        finalizedAny = finalizeRevertibleGeneration(projectRootPath, thread.id) || finalizedAny;
+    }
+    return finalizedAny;
+}
+
+/**
  * Sends a telemetry event when the user keeps an AI-generated response.
  *
  * @param messageId - The message identifier for the kept generation

--- a/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
@@ -19,6 +19,7 @@ import * as path from 'path';
 import { Uri } from 'vscode';
 import { StateMachine } from "../../../../stateMachine";
 import { ProjectSource, PROJECT_KIND } from "@wso2/ballerina-core";
+import { mapWithConcurrency } from "../concurrency";
 
 /**
  * How the ai:// baseline works, and the Language Server behaviours every caller here depends
@@ -162,7 +163,11 @@ export async function seedAiBaselines(tempProjectPath: string, projects: Project
     }
   }
 
-  for (const project of projects) {
+  // Packages are independent project roots on the LS side (per-project locks), so seed
+  // them concurrently — only the workspace-root toml above must land first. Bounded,
+  // because this runs every turn over every package in the workspace and each request
+  // rebuilds that package's ai:// project.
+  await mapWithConcurrency(projects, 4, async project => {
     const pkgPath = project.packagePath || '';
     const packageRoot = pkgPath ? path.join(tempProjectPath, pkgPath) : tempProjectPath;
     const files = collectBaselineFiles(project);
@@ -181,7 +186,7 @@ export async function seedAiBaselines(tempProjectPath: string, projects: Project
       const tomlRel = pkgPath ? path.join(pkgPath, 'Ballerina.toml') : 'Ballerina.toml';
       seedAiBaseline(tempProjectPath, tomlRel);
     }
-  }
+  });
 }
 
 /**

--- a/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
@@ -106,60 +106,117 @@ function seedAiBaseline(tempProjectPath: string, filePath: string): void {
   }
 }
 
+/** The baseline payload for one package: every .bal/toml file with its pre-edit content. */
+function collectBaselineFiles(project: ProjectSource): { filePath: string; content: string }[] {
+  const files: { filePath: string; content: string }[] = [];
+
+  project.sourceFiles.forEach(f => {
+    if (f.filePath.endsWith('.bal') || f.filePath.endsWith('.toml')) {
+      files.push({ filePath: f.filePath, content: f.content ?? '' });
+    }
+  });
+  project.projectModules?.forEach(module => {
+    module.sourceFiles.forEach(f => {
+      if (f.filePath.endsWith('.bal')) {
+        files.push({
+          filePath: path.join('modules', module.moduleName, f.filePath),
+          content: f.content ?? '',
+        });
+      }
+    });
+  });
+  project.projectTests?.forEach(f => {
+    if (f.filePath.endsWith('.bal')) {
+      files.push({ filePath: path.join('tests', f.filePath), content: f.content ?? '' });
+    }
+  });
+  return files;
+}
+
 /**
- * Seeds the ai:// baseline for every package in the project at generation start, via each
- * package's Ballerina.toml (one seedAiBaseline call per package is enough: dropping and
- * re-opening any of a package's documents makes the LS re-scan the whole package from disk
- * and cache it under ai://).
+ * Establishes the ai:// frozen baseline for every package from the in-hand pre-edit
+ * contents (ProjectSource), via the LS ensureAiBaseline request. Unlike the notification
+ * protocol, the LS applies everything before responding — awaiting this call guarantees
+ * the baseline is in place before the first edit can land, killing the seed↔edit race.
+ * Falls back to the legacy notification seed for a package if the request fails.
  * @param tempProjectPath The root path of the project (the real workspace/project root)
  * @param projects Array of project sources containing source files, modules, and tests
  */
-export function sendAgentDidOpenForFreshProjects(tempProjectPath: string, projects: ProjectSource[]): void {
-  const allFiles: string[] = [];
-
-  // For workspace projects, open the workspace root Ballerina.toml first so the LSP
-  // can resolve cross-package dependencies when checking diagnostics per-package.
+export async function seedAiBaselines(tempProjectPath: string, projects: ProjectSource[]): Promise<void> {
   const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
+
+  // Workspace root first, so the LS can resolve cross-package dependencies.
   if (isWorkspace) {
     const workspaceTomlPath = path.join(tempProjectPath, 'Ballerina.toml');
     if (fs.existsSync(workspaceTomlPath)) {
-      allFiles.push('Ballerina.toml');
+      try {
+        const content = fs.readFileSync(workspaceTomlPath, 'utf-8');
+        await StateMachine.langClient().ensureAiBaseline({
+          projectPath: tempProjectPath,
+          files: [{ filePath: 'Ballerina.toml', content }],
+        });
+      } catch (error) {
+        console.error('[AgentNotification] ensureAiBaseline failed for workspace root, falling back:', error);
+        seedAiBaseline(tempProjectPath, 'Ballerina.toml');
+      }
     }
   }
 
-  projects.forEach(project => {
-    const pkgPath = project.packagePath || ""; // Empty for single package, relative path for workspace
-
-    // Add root-level source files
-    project.sourceFiles.forEach(f => {
-      const relativePath = pkgPath ? path.join(pkgPath, f.filePath) : f.filePath;
-      allFiles.push(relativePath);
-    });
-
-    // Add module files
-    project.projectModules?.forEach(module => {
-      module.sourceFiles.forEach(f => {
-        const relativePath = pkgPath
-          ? path.join(pkgPath, 'modules', module.moduleName, f.filePath)
-          : path.join('modules', module.moduleName, f.filePath);
-        allFiles.push(relativePath);
-      });
-    });
-
-    // Add test files
-    if (project.projectTests) {
-      project.projectTests.forEach(f => {
-        const relativePath = pkgPath
-          ? path.join(pkgPath, 'tests', f.filePath)
-          : path.join('tests', f.filePath);
-        allFiles.push(relativePath);
-      });
+  for (const project of projects) {
+    const pkgPath = project.packagePath || '';
+    const packageRoot = pkgPath ? path.join(tempProjectPath, pkgPath) : tempProjectPath;
+    const files = collectBaselineFiles(project);
+    try {
+      const res = await StateMachine.langClient().ensureAiBaseline({ projectPath: packageRoot, files });
+      if (res?.errorMsg) {
+        throw new Error(res.errorMsg);
+      }
+      if (res?.failedFiles?.length) {
+        console.warn(`[AgentNotification] ensureAiBaseline could not seed ${res.failedFiles.length} file(s) in ${packageRoot}:`, res.failedFiles);
+      }
+      console.log(`[AgentNotification] Seeded ai:// baseline (${res?.seededFileCount ?? 0} files) for: ${packageRoot}`);
+    } catch (error) {
+      // Older LS or request failure: fall back to the racy-but-working notification seed.
+      console.error(`[AgentNotification] ensureAiBaseline failed for ${packageRoot}, falling back to didOpen seed:`, error);
+      const tomlRel = pkgPath ? path.join(pkgPath, 'Ballerina.toml') : 'Ballerina.toml';
+      seedAiBaseline(tempProjectPath, tomlRel);
     }
-  });
+  }
+}
 
-  const tomlFiles = allFiles.filter(f => f.endsWith('Ballerina.toml'));
-  console.log(`[AgentNotification] Sending didOpen for ${tomlFiles.length} Ballerina.toml(s) across ${projects.length} project(s)`);
-  tomlFiles.forEach(file => seedAiBaseline(tempProjectPath, file));
+/**
+ * Freezes the ai:// baseline for a package the agent just created mid-run (it wrote a new
+ * Ballerina.toml). Without this, the package has no cached ai:// project, so the first
+ * getSemanticDiff loads the baseline from post-edit disk and the whole package diffs
+ * against itself as "no changes". The baseline is the just-written toml plus explicit
+ * empty content for any .bal files this generation already wrote into the package —
+ * everything the run adds afterwards then registers as an addition.
+ * @param packageRoot Absolute path of the new package
+ * @param tomlContent The Ballerina.toml content just written
+ * @param preexistingBalFiles Package-relative .bal paths this generation already created
+ */
+export async function seedNewPackageBaseline(
+  packageRoot: string,
+  tomlContent: string,
+  preexistingBalFiles: string[]
+): Promise<void> {
+  const files = [
+    { filePath: 'Ballerina.toml', content: tomlContent },
+    ...preexistingBalFiles.map(filePath => ({ filePath, content: '' })),
+  ];
+  try {
+    const res = await StateMachine.langClient().ensureAiBaseline({ projectPath: packageRoot, files });
+    if (res?.errorMsg) {
+      throw new Error(res.errorMsg);
+    }
+    console.log(`[AgentNotification] Seeded ai:// baseline for new package: ${packageRoot}`);
+  } catch (error) {
+    // Same policy as seedAiBaselines: fall back to the notification seed. Right after the
+    // toml write the disk state is still close to the intended baseline, so a racy seed
+    // beats no baseline at all (which would make the whole package diff as unchanged).
+    console.error(`[AgentNotification] ensureAiBaseline failed for new package ${packageRoot}, falling back to didOpen seed:`, error);
+    seedAiBaseline(packageRoot, 'Ballerina.toml');
+  }
 }
 
 /**
@@ -217,9 +274,10 @@ export function sendReviewRestoreDidOpenBatch(
   modifiedFiles: string[],
   baselineProjectPath: string | undefined,
   fallbackOriginalContents?: Record<string, string>
-): void {
+): { restoredCount: number; skippedCount: number } {
   const normalizedTempRoot = path.resolve(tempProjectPath);
   const baselineAvailable = !!baselineProjectPath && fs.existsSync(baselineProjectPath);
+  let skippedCount = 0;
   const restored: { filePath: string; aiUri: string; originalContent: string }[] = [];
 
   for (const filePath of modifiedFiles) {
@@ -248,13 +306,20 @@ export function sendReviewRestoreDidOpenBatch(
       } else if (baselineAvailable) {
         // The baseline is authoritative: absence means the generation created this file.
         originalContent = '';
+      } else if (fallbackOriginalContents !== undefined) {
+        // A checkpoint snapshot exists but has no entry for this file — it did not exist
+        // when the snapshot was captured, i.e. the generation created it. An empty
+        // original makes it read as an addition, matching the live-run behavior.
+        originalContent = '';
       } else {
         console.warn(`[AgentNotification] Original content unavailable, skipping review restore: ${filePath}`);
+        skippedCount++;
         continue;
       }
 
       if (!tempFileExists && !baselineFileExists && !hasFallbackOriginal) {
         console.warn(`[AgentNotification] File is absent from both review versions, skipping: ${filePath}`);
+        skippedCount++;
         continue;
       }
 
@@ -271,6 +336,9 @@ export function sendReviewRestoreDidOpenBatch(
       evictAiBaseline(tempFileFullPath);
       restored.push({ filePath, aiUri, originalContent });
     } catch (error) {
+      // Counts as skipped: without it a total failure through this path would return
+      // {restoredCount: 0, skippedCount: 0} and read as "nothing needed restoring".
+      skippedCount++;
       console.error(`[AgentNotification] Failed to restore review schemas for ${filePath}:`, error);
     }
   }
@@ -290,4 +358,6 @@ export function sendReviewRestoreDidOpenBatch(
       console.error(`[AgentNotification] Failed to restore the ai:// baseline for ${filePath}:`, error);
     }
   }
+
+  return { restoredCount: restored.length, skippedCount };
 }

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/repair-utils.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/repair-utils.ts
@@ -23,6 +23,9 @@ import { TextDocumentEdit } from "vscode-languageserver-types";
 import { fileURLToPath } from "url";
 import { writeBallerinaFileDidOpenTemp } from "../../utils/modification";
 
+/** Marks errors whose cause is the package failing to compile, not an LS malfunction. */
+export const PACKAGE_COMPILATION_FAILED_PREFIX = "Package compilation failed: ";
+
 export async function attemptRepairProject(langClient: ExtendedLangClient, tempDir: string): Promise<Diagnostics[]> {
     // check project diagnostics
     let projectDiags: Diagnostics[] = await checkProjectDiagnostics(langClient, tempDir);
@@ -58,8 +61,12 @@ export async function checkProjectDiagnostics(langClient: ExtendedLangClient, te
     });
     const _diagDurationMs = Date.now() - _diagStartMs;
     if (!response.errorDiagnosticMap) {
-        console.log(`[DiagTiming] getProjectDiagnostics END — ${_diagDurationMs}ms — no errorDiagnosticMap (internal error)`);
-        throw new Error("Internal error while getting diagnostics from language server");
+        console.log(`[DiagTiming] getProjectDiagnostics END — ${_diagDurationMs}ms — no errorDiagnosticMap (${response.errorMsg ?? "internal error"})`);
+        // errorMsg carries the language server's reason — typically a package-compilation
+        // failure (e.g. unresolvable dependencies), which callers surface to the user.
+        throw new Error(response.errorMsg
+            ? `${PACKAGE_COMPILATION_FAILED_PREFIX}${response.errorMsg}`
+            : "Internal error while getting diagnostics from language server");
     }
     const _fileCount = Object.keys(response.errorDiagnosticMap).length;
     console.log(`[DiagTiming] getProjectDiagnostics END — ${_diagDurationMs}ms, ${_fileCount} files with errors`);

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -551,13 +551,18 @@ export class AiPanelRpcManager implements AIPanelAPI {
 
             console.log(`[Review Actions] Reverting generation ${doneGeneration.id}`);
 
-            // Restore workspace to state before this generation ran
+            // Restore workspace to state before this generation ran. Without a checkpoint
+            // (checkpoints disabled, or the workspace exceeded the snapshot size cap)
+            // nothing can be restored — that must fail loudly rather than mark the
+            // generation reverted and tell the model files were restored when they weren't.
             const checkpoint = doneGeneration.checkpoint;
-            if (checkpoint) {
-                await restoreWorkspaceSnapshot(checkpoint, true);
-            } else {
-                console.warn("[Review Actions] No checkpoint found for generation — workspace changes will not be reverted");
+            if (!checkpoint) {
+                const reason = "No checkpoint exists for this generation (checkpoints may be disabled, or the workspace exceeded the snapshot size limit), so the changes cannot be reverted automatically. Use source control to undo them if needed.";
+                console.error(`[Review Actions] Revert refused for ${doneGeneration.id}: ${reason}`);
+                window.showErrorMessage(`Could not revert the Copilot changes: ${reason}`);
+                throw new Error(reason);
             }
+            await restoreWorkspaceSnapshot(checkpoint, true);
 
             // Append revert notification to model messages so the LLM knows changes were reverted
             const existingMessages = doneGeneration.modelMessages || [];
@@ -575,6 +580,10 @@ User reverted the last made changes. The files have been restored to the state b
 
             chatStateStorage.revertLastGeneration(projectRootPath, threadId);
             console.log(`[Review Actions] Reverted generation: ${doneGeneration.id}`);
+
+            // Drop the manager's cached review for this generation so a queued/late
+            // navigation cannot reopen the just-reverted diff.
+            approvalViewManager.clearReviewData(doneGeneration.id);
 
             sendGenerationDiscardTelemetry(doneGeneration.id);
 

--- a/packages/ballerina-extension/src/test-support/emitReviewActions.test.ts
+++ b/packages/ballerina-extension/src/test-support/emitReviewActions.test.ts
@@ -67,7 +67,7 @@ for (const m of [
 
 jest.mock('../features/ai/executors/base/AICommandExecutor', () => ({ AICommandExecutor: class { } }));
 
-import { AgentExecutor } from '../features/ai/agent/AgentExecutor';
+import { AgentExecutor, normalizeRelativePath } from '../features/ai/agent/AgentExecutor';
 import { chatStateStorage } from '../views/ai-panel/chatStateStorage';
 
 const ROOT = '/ws';
@@ -160,7 +160,7 @@ describe('emitReviewActions', () => {
         expect(review.data.modifiedFiles).toEqual(['main.bal']);
     });
 
-    it('EDGE: a partial failure discards the diffs already collected', async () => {
+    it('EDGE: a partial failure keeps the diffs already collected and reports the error', async () => {
         seedGeneration('gen-1', ['a.bal', 'b.bal'], [PKG_A, PKG_B]);
         getSemanticDiff
             .mockResolvedValueOnce({ semanticDiffs: [{ a: 1 }], loadDesignDiagrams: true })
@@ -170,9 +170,13 @@ describe('emitReviewActions', () => {
 
         await executor.emitReviewActions(context);
 
-        // Mixing one package's diffs with another's absence would misattribute them.
-        expect(reviewEvent(events).data.semanticDiffs).toEqual([]);
-        expect(reviewEvent(events).data.loadDesignDiagrams).toBe(false);
+        // One package failing must not cost the sibling package its valid diffs; the
+        // failure is surfaced alongside them instead (openReviewMode's reviewData).
+        expect(reviewEvent(events).data.semanticDiffs).toEqual([{ a: 1 }]);
+        expect(reviewEvent(events).data.diffPackageMap).toEqual(['pkg-a']);
+        expect(reviewEvent(events).data.loadDesignDiagrams).toBe(true);
+        const reviewData = openReviewMode.mock.calls[0][1];
+        expect(reviewData.semanticDiffError).toContain('LS died');
     });
 
     it('EDGE: skips the workspace root, which holds no package to diff', async () => {
@@ -217,5 +221,24 @@ describe('emitReviewActions', () => {
         expect(stored?.reviewState.reviewView).toEqual({
             semanticDiffs: [{ a: 1 }], loadDesignDiagrams: true, isWorkspace: false,
         });
+    });
+});
+
+describe('normalizeRelativePath', () => {
+    // The two sides of the package-membership match come from different authors: the
+    // workspace toml's `packages` entries vs the LLM's verbatim tool file_path args.
+    it.each([
+        ['./orders', 'orders'],
+        ['orders/', 'orders'],
+        ['./orders/', 'orders'],
+        ['orders', 'orders'],
+        ['orders\\main.bal', 'orders/main.bal'],
+        ['./orders/main.bal', 'orders/main.bal'],
+        ['orders//main.bal', 'orders/main.bal'],
+        [' orders ', 'orders'],
+        ['.', ''],
+        ['./', ''],
+    ])('normalizes %s to %s', (input, expected) => {
+        expect(normalizeRelativePath(input)).toBe(expected);
     });
 });

--- a/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -54,27 +54,39 @@ export async function captureWorkspaceSnapshot(messageId: string): Promise<Check
     try {
         const allFiles = await getAllWorkspaceFiles(workspaceRoot, config.ignorePatterns);
 
-        for (const fileUri of allFiles) {
-            try {
-                const fileContent = await vscode.workspace.fs.readFile(fileUri);
-                const content = Buffer.from(fileContent).toString('utf8');
-                const relativePath = path.relative(workspaceRoot.fsPath, fileUri.fsPath).split(path.sep).join('/');
-
-                workspaceSnapshot[relativePath] = content;
-                fileList.push(relativePath);
-                totalSize += content.length;
-
-                if (totalSize > config.maxSnapshotSize) {
-                    // Fail closed rather than save a partial checkpoint that silently leaves
-                    // later-scanned files unrevertible on restore.
-                    console.warn(`[Checkpoint] Snapshot size exceeded max limit (${totalSize} bytes) — aborting capture, no partial checkpoint will be saved`);
-                    vscode.window.showWarningMessage(
-                        `Workspace is too large to checkpoint (exceeds ${Math.round(config.maxSnapshotSize / 1024 / 1024)}MB). This generation will not be revertible.`
-                    );
+        // Read in bounded-concurrency chunks: one-at-a-time reads dominate run-start
+        // latency on large workspaces, while unbounded Promise.all can exhaust file
+        // handles. Chunks keep fileList in findFiles order and let the size cap abort
+        // between chunks.
+        const READ_CONCURRENCY = 32;
+        for (let i = 0; i < allFiles.length; i += READ_CONCURRENCY) {
+            const chunk = allFiles.slice(i, i + READ_CONCURRENCY);
+            const chunkContents = await Promise.all(chunk.map(async fileUri => {
+                try {
+                    const fileContent = await vscode.workspace.fs.readFile(fileUri);
+                    return { fileUri, content: Buffer.from(fileContent).toString('utf8') };
+                } catch (error) {
+                    console.error(`[Checkpoint] Failed to read file ${fileUri.fsPath}:`, error);
                     return null;
                 }
-            } catch (error) {
-                console.error(`[Checkpoint] Failed to read file ${fileUri.fsPath}:`, error);
+            }));
+
+            for (const entry of chunkContents) {
+                if (!entry) { continue; }
+                const relativePath = path.relative(workspaceRoot.fsPath, entry.fileUri.fsPath).split(path.sep).join('/');
+                workspaceSnapshot[relativePath] = entry.content;
+                fileList.push(relativePath);
+                totalSize += entry.content.length;
+            }
+
+            if (totalSize > config.maxSnapshotSize) {
+                // Fail closed rather than save a partial checkpoint that silently leaves
+                // later-scanned files unrevertible on restore.
+                console.warn(`[Checkpoint] Snapshot size exceeded max limit (${totalSize} bytes) — aborting capture, no partial checkpoint will be saved`);
+                vscode.window.showWarningMessage(
+                    `Workspace is too large to checkpoint (exceeds ${Math.round(config.maxSnapshotSize / 1024 / 1024)}MB). This generation will not be revertible.`
+                );
+                return null;
             }
         }
 

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/NodeRefExtractor.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/NodeRefExtractor.java
@@ -18,7 +18,11 @@
 
 package io.ballerina.copilotagent.core;
 
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
+import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
@@ -47,6 +51,7 @@ public class NodeRefExtractor extends NodeVisitor {
 
     @Override
     public void visit(ModulePartNode modulePartNode) {
+        modulePartNode.imports().forEach(importNode -> importNode.accept(this));
         modulePartNode.members().forEach(member -> member.accept(this));
     }
 
@@ -80,6 +85,42 @@ public class NodeRefExtractor extends NodeVisitor {
         String key = CommonUtils.getVariableName(
                 moduleVariableDeclarationNode.typedBindingPattern().bindingPattern());
         this.nodeRefMap.putModuleVarNode(key, moduleVariableDeclarationNode);
+    }
+
+    @Override
+    public void visit(ConstantDeclarationNode constantDeclarationNode) {
+        String key = constantDeclarationNode.variableName().text().trim();
+        this.nodeRefMap.putConstantNode(key, constantDeclarationNode);
+    }
+
+    @Override
+    public void visit(EnumDeclarationNode enumDeclarationNode) {
+        String key = enumDeclarationNode.identifier().text().trim();
+        this.nodeRefMap.putEnumNode(key, enumDeclarationNode);
+    }
+
+    @Override
+    public void visit(ClassDefinitionNode classDefinitionNode) {
+        String key = classDefinitionNode.className().text().trim();
+        this.nodeRefMap.putClassNode(key, classDefinitionNode);
+    }
+
+    @Override
+    public void visit(ImportDeclarationNode importDeclarationNode) {
+        // Key by the imported module identity plus alias: the same module may legally be
+        // imported more than once under different prefixes, and identity-only keys would
+        // silently overwrite one of them. An alias-only change therefore reads as a
+        // deletion+addition pair rather than a modification — an acceptable trade for
+        // never dropping an import from the diff.
+        String orgName = importDeclarationNode.orgName().map(org -> org.orgName().text() + "/").orElse("");
+        String moduleName = importDeclarationNode.moduleName().stream()
+                .map(identifier -> identifier.text().trim())
+                .collect(Collectors.joining("."));
+        // " as <prefix>" keeps the key readable, since it doubles as the diff's display name.
+        String prefix = importDeclarationNode.prefix()
+                .map(p -> " as " + p.prefix().text().trim())
+                .orElse("");
+        this.nodeRefMap.putImportNode(orgName + moduleName + prefix, importDeclarationNode);
     }
 
     private static String getPath(NodeList<Node> paths) {

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -65,6 +65,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
 /**
@@ -130,11 +131,32 @@ public class SemanticDiffComputer {
         computeTypeDefDiffs(originalNodeRefMap.getTypeDefNodeMap(), modifiedNodeRefMap.getTypeDefNodeMap());
         computeModuleVarDiffs(originalNodeRefMap.getModuleVarNodeMap(), modifiedNodeRefMap.getModuleVarNodeMap());
 
+        String compilationError = null;
         if (!loadDesignDiagrams) {
-            compareUsingDesignDiagrams();
+            try {
+                compareUsingDesignDiagrams();
+            } catch (Throwable t) {
+                // The design-model comparison is the only step that needs a full package
+                // compilation, which can fail for reasons unrelated to the edit (e.g. an
+                // unresolvable dependency). The syntax-level diffs above are still valid,
+                // so report the failure instead of discarding them.
+                compilationError = rootCauseMessage(t);
+            }
         }
 
-        return new Result(loadDesignDiagrams, this.semanticDiffs);
+        return new Result(loadDesignDiagrams, this.semanticDiffs, compilationError);
+    }
+
+    // Unwraps only async plumbing (CompletionException from join()); the first real
+    // exception's message already carries the full context (e.g. which module failed).
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause instanceof CompletionException
+                && cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        String message = cause.getMessage();
+        return message == null || message.isBlank() ? cause.getClass().getName() : message;
     }
 
     /**

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -19,6 +19,7 @@
 package io.ballerina.copilotagent.core;
 
 import io.ballerina.compiler.syntax.tree.BlockStatementNode;
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
 import io.ballerina.compiler.syntax.tree.DoStatementNode;
 import io.ballerina.compiler.syntax.tree.ExpressionFunctionBodyNode;
 import io.ballerina.compiler.syntax.tree.ForEachStatementNode;
@@ -27,11 +28,9 @@ import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.FunctionBodyNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.IfElseStatementNode;
-import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.LockStatementNode;
 import io.ballerina.compiler.syntax.tree.MatchClauseNode;
 import io.ballerina.compiler.syntax.tree.MatchStatementNode;
-import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.NamedWorkerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeList;
@@ -53,6 +52,7 @@ import io.ballerina.designmodelgenerator.core.model.Connection;
 import io.ballerina.designmodelgenerator.core.model.DesignModel;
 import io.ballerina.designmodelgenerator.core.model.Listener;
 import io.ballerina.projects.Document;
+import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LineRange;
 
@@ -60,10 +60,12 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
@@ -79,6 +81,10 @@ public class SemanticDiffComputer {
     private final Project modifiedProject;
     private final List<SemanticDiff> semanticDiffs = new ArrayList<>();
     private final String rootProjectPath;
+    // Document-name → absolute path for the module currently being diffed. LineRange only
+    // carries the document name, which for module/test documents does not resolve against
+    // the project root; this map recovers the real on-disk path. Rebuilt per module.
+    private final Map<String, Path> currentModuleFilePaths = new HashMap<>();
     private boolean loadDesignDiagrams = false;
 
     public SemanticDiffComputer(Project originalProject,
@@ -91,8 +97,64 @@ public class SemanticDiffComputer {
 
     public Result computeSemanticDiffs() {
 
-        Map<String, Document> originalDocumentMap = collectDocumentMap(originalProject);
-        Map<String, Document> modifiedDocumentMap = collectDocumentMap(modifiedProject);
+        // Diff module by module: name-keyed construct maps are only unique within a module
+        // (the same function name may legally exist in two modules), and per-module passes
+        // keep document names unambiguous. The union covers added/removed modules.
+        Map<String, Module> originalModules = collectModules(originalProject);
+        Map<String, Module> modifiedModules = collectModules(modifiedProject);
+        Set<String> allModuleNames = new LinkedHashSet<>();
+        allModuleNames.addAll(originalModules.keySet());
+        allModuleNames.addAll(modifiedModules.keySet());
+
+        for (String moduleName : allModuleNames) {
+            computeModuleSemanticDiffs(originalModules.get(moduleName), modifiedModules.get(moduleName));
+        }
+
+        String compilationError = null;
+        if (!loadDesignDiagrams) {
+            try {
+                compareUsingDesignDiagrams();
+            } catch (Throwable t) {
+                // The design-model comparison is the only step that needs a full package
+                // compilation, which can fail for reasons unrelated to the edit (e.g. an
+                // unresolvable dependency). The syntax-level diffs above are still valid,
+                // so report the failure instead of discarding them.
+                compilationError = rootCauseMessage(t);
+            }
+        }
+
+        return new Result(loadDesignDiagrams, this.semanticDiffs, compilationError);
+    }
+
+    // Unwraps only async plumbing (CompletionException from join()); the first real
+    // exception's message already carries the full context (e.g. which module failed).
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause instanceof CompletionException
+                && cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        String message = cause.getMessage();
+        return message == null || message.isBlank() ? cause.getClass().getName() : message;
+    }
+
+    private static Map<String, Module> collectModules(Project project) {
+        Map<String, Module> modules = new LinkedHashMap<>();
+        project.currentPackage().modules().forEach(module ->
+                modules.put(module.moduleName().toString(), module));
+        return modules;
+    }
+
+    /**
+     * Computes the semantic diffs contributed by one module. Either side may be null when the
+     * module itself was added or removed; the corresponding document map is then empty, so
+     * every construct on the other side registers as an addition/deletion.
+     */
+    private void computeModuleSemanticDiffs(Module originalModule, Module modifiedModule) {
+
+        this.currentModuleFilePaths.clear();
+        Map<String, Document> originalDocumentMap = collectDocumentMap(originalModule);
+        Map<String, Document> modifiedDocumentMap = collectDocumentMap(modifiedModule);
 
         STNodeRefMap originalNodeRefMap = new STNodeRefMap();
         STNodeRefMap modifiedNodeRefMap = new STNodeRefMap();
@@ -125,119 +187,136 @@ public class SemanticDiffComputer {
             modifiedDoc.syntaxTree().rootNode().accept(modifiedNodeRefExtractor);
         }
 
-        computeListenerDiffs(originalNodeRefMap.getListenerNodeMap(), modifiedNodeRefMap.getListenerNodeMap());
+        // Listeners and module variables (connections) shape the design diagram; the rest don't.
+        computeSourceDiffs(originalNodeRefMap.getListenerNodeMap(), modifiedNodeRefMap.getListenerNodeMap(),
+                NodeKind.LISTENER, true);
         computeServiceDiffs(originalNodeRefMap.getServiceNodeMap(), modifiedNodeRefMap.getServiceNodeMap());
         computeFunctionDiffs(originalNodeRefMap.getFunctionNodeMap(), modifiedNodeRefMap.getFunctionNodeMap());
         computeTypeDefDiffs(originalNodeRefMap.getTypeDefNodeMap(), modifiedNodeRefMap.getTypeDefNodeMap());
-        computeModuleVarDiffs(originalNodeRefMap.getModuleVarNodeMap(), modifiedNodeRefMap.getModuleVarNodeMap());
-
-        String compilationError = null;
-        if (!loadDesignDiagrams) {
-            try {
-                compareUsingDesignDiagrams();
-            } catch (Throwable t) {
-                // The design-model comparison is the only step that needs a full package
-                // compilation, which can fail for reasons unrelated to the edit (e.g. an
-                // unresolvable dependency). The syntax-level diffs above are still valid,
-                // so report the failure instead of discarding them.
-                compilationError = rootCauseMessage(t);
-            }
-        }
-
-        return new Result(loadDesignDiagrams, this.semanticDiffs, compilationError);
-    }
-
-    // Unwraps only async plumbing (CompletionException from join()); the first real
-    // exception's message already carries the full context (e.g. which module failed).
-    private static String rootCauseMessage(Throwable throwable) {
-        Throwable cause = throwable;
-        while (cause instanceof CompletionException
-                && cause.getCause() != null && cause.getCause() != cause) {
-            cause = cause.getCause();
-        }
-        String message = cause.getMessage();
-        return message == null || message.isBlank() ? cause.getClass().getName() : message;
+        computeSourceDiffs(originalNodeRefMap.getModuleVarNodeMap(), modifiedNodeRefMap.getModuleVarNodeMap(),
+                NodeKind.MODULE_VARIABLE, true);
+        computeSourceDiffs(originalNodeRefMap.getConstantNodeMap(), modifiedNodeRefMap.getConstantNodeMap(),
+                NodeKind.CONSTANT, false);
+        computeSourceDiffs(originalNodeRefMap.getEnumNodeMap(), modifiedNodeRefMap.getEnumNodeMap(),
+                NodeKind.ENUM_DECLARATION, false);
+        computeClassDiffs(originalNodeRefMap.getClassNodeMap(), modifiedNodeRefMap.getClassNodeMap());
+        computeSourceDiffs(originalNodeRefMap.getImportNodeMap(), modifiedNodeRefMap.getImportNodeMap(),
+                NodeKind.IMPORT_DECLARATION, false);
     }
 
     /**
-     * Computes listener differences between original and modified projects to determine
-     * if design diagrams need to be reloaded.
+     * Computes diffs for a construct kind whose changes are reviewed as source text:
+     * name-keyed nodes compared by their source, producing addition/deletion/modification
+     * entries carrying that source in the metadata.
      *
-     * <p>This method performs a shallow comparison of listener declarations to detect
-     * structural changes such as listener additions or removals. It sets the
-     * {@code loadDesignDiagrams} flag if any differences are found, which indicates
-     * that the architecture diagram should be regenerated.
-     *
-     * <p>Note: This method does not analyze the expression content of listeners since
-     * only structural changes affect the design diagram. The comparison terminates
-     * early if a difference is already detected to optimize performance.
-     *
-     * @param originalListenerMap map of listener names to their declaration nodes
-     *                            from the original project
-     * @param modifiedListenerMap map of listener names to their declaration nodes
-     *                            from the modified project
+     * @param originalMap   original map of construct names to their declaration nodes
+     * @param modifiedMap   modified map of construct names to their declaration nodes
+     * @param kind          the NodeKind reported on the diffs
+     * @param affectsDesign whether a change to this kind reshapes the design diagram
+     *                      (listeners and module vars/connections do)
      */
-    private void computeListenerDiffs(Map<String, ListenerDeclarationNode> originalListenerMap,
-                                      Map<String, ListenerDeclarationNode> modifiedListenerMap) {
+    private <T extends Node> void computeSourceDiffs(Map<String, T> originalMap, Map<String, T> modifiedMap,
+                                                     NodeKind kind, boolean affectsDesign) {
 
-        if (loadDesignDiagrams) {
-            return;
+        for (Map.Entry<String, T> entry : originalMap.entrySet()) {
+            String name = entry.getKey();
+            T originalNode = entry.getValue();
+            if (!modifiedMap.containsKey(name)) {
+                loadDesignDiagrams |= affectsDesign;
+                addDeletionDiff(kind, originalNode.lineRange(),
+                        buildSourceMetadata(name, originalNode.toSourceCode(), null));
+                continue;
+            }
+            T modifiedNode = modifiedMap.remove(name);
+            String originalSource = originalNode.toSourceCode();
+            String modifiedSource = modifiedNode.toSourceCode();
+            if (!originalSource.equals(modifiedSource)) {
+                loadDesignDiagrams |= affectsDesign;
+                addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(),
+                        buildSourceMetadata(name, originalSource, modifiedSource));
+            }
         }
 
-        for (Map.Entry<String, ListenerDeclarationNode> entry : originalListenerMap.entrySet()) {
-            String listenerName = entry.getKey();
-            if (!modifiedListenerMap.containsKey(listenerName)) {
-                loadDesignDiagrams = true;
-                return;
-            }
-            ListenerDeclarationNode originalListener = entry.getValue();
-            ListenerDeclarationNode modifiedListener = modifiedListenerMap.remove(listenerName);
-            if (!originalListener.toSourceCode().equals(modifiedListener.toSourceCode())) {
-                loadDesignDiagrams = true;
-                return;
-            }
-        }
-
-        if (!modifiedListenerMap.isEmpty()) {
-            loadDesignDiagrams = true;
+        for (Map.Entry<String, T> entry : modifiedMap.entrySet()) {
+            loadDesignDiagrams |= affectsDesign;
+            addAdditionDiff(kind, entry.getValue().lineRange(),
+                    buildSourceMetadata(entry.getKey(), null, entry.getValue().toSourceCode()));
         }
     }
 
     /**
-     * Computes module-level variable differences between original and modified projects to
-     * determine if design diagrams need to be reloaded.
-     *
-     * <p>Module-level variables include client/connection declarations. Changes to these
-     * variables (additions, removals, or modifications) affect the design diagram and
-     * should trigger a reload.
-     *
-     * @param originalVarMap original map of variable names to their declaration nodes
-     * @param modifiedVarMap modified map of variable names to their declaration nodes
+     * Computes class-definition differences. Method changes are reported individually as
+     * OBJECT_FUNCTION diffs (they have flow representations); changes to the remaining class
+     * members (fields, init expressions) are reported as a single CLASS_DEFINITION diff.
      */
-    private void computeModuleVarDiffs(Map<String, ModuleVariableDeclarationNode> originalVarMap,
-                                       Map<String, ModuleVariableDeclarationNode> modifiedVarMap) {
+    private void computeClassDiffs(Map<String, ClassDefinitionNode> originalClassMap,
+                                   Map<String, ClassDefinitionNode> modifiedClassMap) {
 
-        if (loadDesignDiagrams) {
-            return;
-        }
-
-        for (Map.Entry<String, ModuleVariableDeclarationNode> entry : originalVarMap.entrySet()) {
-            String varName = entry.getKey();
-            if (!modifiedVarMap.containsKey(varName)) {
-                loadDesignDiagrams = true;
-                return;
+        for (Map.Entry<String, ClassDefinitionNode> entry : originalClassMap.entrySet()) {
+            String className = entry.getKey();
+            ClassDefinitionNode originalClass = entry.getValue();
+            if (!modifiedClassMap.containsKey(className)) {
+                addDeletionDiff(NodeKind.CLASS_DEFINITION, originalClass.lineRange(),
+                        buildSourceMetadata(className, originalClass.toSourceCode(), null));
+                continue;
             }
-            ModuleVariableDeclarationNode originalVar = entry.getValue();
-            ModuleVariableDeclarationNode modifiedVar = modifiedVarMap.remove(varName);
-            if (!originalVar.toSourceCode().equals(modifiedVar.toSourceCode())) {
-                loadDesignDiagrams = true;
-                return;
+            ClassDefinitionNode modifiedClass = modifiedClassMap.remove(className);
+            String originalClassSource = originalClass.toSourceCode();
+            String modifiedClassSource = modifiedClass.toSourceCode();
+            if (originalClassSource.equals(modifiedClassSource)) {
+                continue;
+            }
+
+            Map<String, FunctionDefinitionNode> originalMethods = extractClassMethods(originalClass);
+            Map<String, FunctionDefinitionNode> modifiedMethods = extractClassMethods(modifiedClass);
+            for (Map.Entry<String, FunctionDefinitionNode> methodEntry : originalMethods.entrySet()) {
+                String methodKey = methodEntry.getKey();
+                FunctionDefinitionNode originalMethod = methodEntry.getValue();
+                Map<String, String> metadata = buildFunctionMetadata(className + "." + methodKey);
+                if (!modifiedMethods.containsKey(methodKey)) {
+                    addDeletionDiff(NodeKind.OBJECT_FUNCTION, originalMethod.lineRange(), metadata);
+                    continue;
+                }
+                compareFunctionBodies(originalMethod, modifiedMethods.remove(methodKey),
+                        NodeKind.OBJECT_FUNCTION, metadata);
+            }
+            for (Map.Entry<String, FunctionDefinitionNode> methodEntry : modifiedMethods.entrySet()) {
+                addAdditionDiff(NodeKind.OBJECT_FUNCTION, methodEntry.getValue().lineRange(),
+                        buildFunctionMetadata(className + "." + methodEntry.getKey()));
+            }
+
+            if (!nonMethodMembersSource(originalClass).equals(nonMethodMembersSource(modifiedClass))) {
+                addModificationDiff(NodeKind.CLASS_DEFINITION, modifiedClass.lineRange(),
+                        originalClass.lineRange(),
+                        buildSourceMetadata(className, originalClassSource, modifiedClassSource));
             }
         }
 
-        if (!modifiedVarMap.isEmpty()) {
-            loadDesignDiagrams = true;
+        for (Map.Entry<String, ClassDefinitionNode> entry : modifiedClassMap.entrySet()) {
+            addAdditionDiff(NodeKind.CLASS_DEFINITION, entry.getValue().lineRange(),
+                    buildSourceMetadata(entry.getKey(), null, entry.getValue().toSourceCode()));
         }
+    }
+
+    private static Map<String, FunctionDefinitionNode> extractClassMethods(ClassDefinitionNode classNode) {
+        Map<String, FunctionDefinitionNode> methods = new LinkedHashMap<>();
+        classNode.members().forEach(member -> {
+            if (member instanceof FunctionDefinitionNode method) {
+                String resourcePath = method.relativeResourcePath().stream()
+                        .map(node -> node.toSourceCode().trim())
+                        .collect(Collectors.joining(""));
+                methods.put(method.functionName().text().trim()
+                        + (resourcePath.isEmpty() ? "" : "#" + resourcePath), method);
+            }
+        });
+        return methods;
+    }
+
+    private static String nonMethodMembersSource(ClassDefinitionNode classNode) {
+        return classNode.members().stream()
+                .filter(member -> !(member instanceof FunctionDefinitionNode))
+                .map(Node::toSourceCode)
+                .collect(Collectors.joining());
     }
 
     /**
@@ -252,10 +331,12 @@ public class SemanticDiffComputer {
 
         for (Map.Entry<String, TypeDefinitionNode> entry : originalTypeDefMap.entrySet()) {
             String typeDefName = entry.getKey();
+            TypeDefinitionNode originalTypeDef = entry.getValue();
             if (!modifiedTypeDefMap.containsKey(typeDefName)) {
+                addDeletionDiff(NodeKind.TYPE_DEFINITION, originalTypeDef.lineRange(),
+                        buildTypeMetadata(typeDefName));
                 continue;
             }
-            TypeDefinitionNode originalTypeDef = entry.getValue();
             TypeDefinitionNode modifiedTypeDef = modifiedTypeDefMap.remove(typeDefName);
             if (originalTypeDef.toSourceCode().equals(modifiedTypeDef.toSourceCode())) {
                 continue;
@@ -412,43 +493,49 @@ public class SemanticDiffComputer {
             return;
         }
 
-        if (originalFunctionBody instanceof FunctionBodyBlockNode originalBodyNode
-                && modifiedFunctionBody instanceof FunctionBodyBlockNode modifiedBodyNode) {
-            if (originalBodyNode.statements().size() != modifiedBodyNode.statements().size()) {
+        if (!(originalFunctionBody instanceof FunctionBodyBlockNode originalBodyNode)
+                || !(modifiedFunctionBody instanceof FunctionBodyBlockNode modifiedBodyNode)) {
+            // Same body class but not a statement block (e.g. both `external` bodies): the
+            // sources already differ per the check above, so report the modification instead
+            // of falling through silently.
+            addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
+            return;
+        }
+
+        if (originalBodyNode.statements().size() != modifiedBodyNode.statements().size()) {
+            addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
+            return;
+        }
+
+        for (int i = 0; i < originalBodyNode.statements().size(); i++) {
+            StatementNode originalStmtNode = originalBodyNode.statements().get(i);
+            StatementNode modifiedStmtNode = modifiedBodyNode.statements().get(i);
+
+            if (originalStmtNode.toSourceCode().equals(modifiedStmtNode.toSourceCode())) {
+                continue;
+            }
+
+            List<Node> allOriginalStmtNodes = new ArrayList<>();
+            extractStatementNodes(originalStmtNode, allOriginalStmtNodes);
+            List<Node> allModifiedStmtNodes = new ArrayList<>();
+            extractStatementNodes(modifiedStmtNode, allModifiedStmtNodes);
+
+            if (allOriginalStmtNodes.size() != allModifiedStmtNodes.size()) {
                 addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
                 return;
             }
 
-            for (int i = 0; i < originalBodyNode.statements().size(); i++) {
-                StatementNode originalStmtNode = originalBodyNode.statements().get(i);
-                StatementNode modifiedStmtNode = modifiedBodyNode.statements().get(i);
-
-                if (originalStmtNode.toSourceCode().equals(modifiedStmtNode.toSourceCode())) {
-                    continue;
-                }
-
-                List<Node> allOriginalStmtNodes = new ArrayList<>();
-                extractStatementNodes(originalStmtNode, allOriginalStmtNodes);
-                List<Node> allModifiedStmtNodes = new ArrayList<>();
-                extractStatementNodes(modifiedStmtNode, allModifiedStmtNodes);
-
-                if (allOriginalStmtNodes.size() != allModifiedStmtNodes.size()) {
-                    addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
+            for (int j = 0; j < allOriginalStmtNodes.size(); j++) {
+                Node originalNode = allOriginalStmtNodes.get(j);
+                Node modifiedNode = allModifiedStmtNodes.get(j);
+                // need to change whether both nodes have the same type
+                if (!originalNode.getClass().equals(modifiedNode.getClass())) {
+                    addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(), metadata);
                     return;
                 }
-
-                for (int j = 0; j < allOriginalStmtNodes.size(); j++) {
-                    Node originalNode = allOriginalStmtNodes.get(j);
-                    Node modifiedNode = allModifiedStmtNodes.get(j);
-                    // need to change whether both nodes have the same type
-                    if (!originalNode.getClass().equals(modifiedNode.getClass())) {
-                        addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(), metadata);
-                        return;
-                    }
-                    if (!originalNode.toSourceCode().trim().equals(modifiedNode.toSourceCode().trim())) {
-                        addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(), metadata);
-                        return;
-                    }
+                if (!originalNode.toSourceCode().trim().equals(modifiedNode.toSourceCode().trim())) {
+                    addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(), metadata);
+                    return;
                 }
             }
         }
@@ -464,6 +551,34 @@ public class SemanticDiffComputer {
         SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, kind,
                 resolveUri(modifiedLineRange.fileName()), modifiedLineRange, originalLineRange, metadata);
         this.semanticDiffs.add(diff);
+    }
+
+    private void addAdditionDiff(NodeKind kind, LineRange lineRange, Map<String, String> metadata) {
+        this.semanticDiffs.add(new SemanticDiff(ChangeType.ADDITION, kind,
+                resolveUri(lineRange.fileName()), lineRange, metadata));
+    }
+
+    private void addDeletionDiff(NodeKind kind, LineRange originalLineRange, Map<String, String> metadata) {
+        this.semanticDiffs.add(new SemanticDiff(ChangeType.DELETION, kind,
+                resolveUri(originalLineRange.fileName()), originalLineRange, metadata));
+    }
+
+    /**
+     * Metadata for construct kinds the review UI renders as source text rather than a
+     * diagram (constants, module vars, listeners, imports, enums, classes): carries the
+     * construct's before/after source so the UI needs no extra content lookup. Either
+     * side may be null (pure addition/deletion).
+     */
+    private static Map<String, String> buildSourceMetadata(String name, String oldSource, String newSource) {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put("name", name);
+        if (oldSource != null) {
+            metadata.put("oldSource", oldSource.strip());
+        }
+        if (newSource != null) {
+            metadata.put("newSource", newSource.strip());
+        }
+        return metadata;
     }
 
     private void extractStatementNodes(Node statementNode, List<Node> nodes) {
@@ -735,21 +850,46 @@ public class SemanticDiffComputer {
     }
 
     /**
-     * Collects a map of document names to Document objects from the given project.
+     * Collects a map of document names to Document objects from the given module, covering
+     * both source and test documents so edits confined to tests still produce diffs. Also
+     * records each document's on-disk path for URI resolution.
      *
-     * @param project the Ballerina project to collect documents from
+     * @param module the module to collect documents from; null yields an empty map (module
+     *               absent on this side of the diff)
      * @return a map of document names to Document objects
      */
-    private Map<String, Document> collectDocumentMap(Project project) {
+    private Map<String, Document> collectDocumentMap(Module module) {
 
         Map<String, Document> documentMap = new HashMap<>();
-        project.currentPackage().getDefaultModule().documentIds().stream()
-                .map(project.currentPackage().getDefaultModule()::document)
+        if (module == null) {
+            return documentMap;
+        }
+        module.documentIds().stream()
+                .map(module::document)
                 .filter(Objects::nonNull)
                 .forEach(document -> {
                     documentMap.put(document.name(), document);
+                    registerDocumentPath(module, document);
+                });
+        module.testDocumentIds().stream()
+                .map(module::document)
+                .filter(Objects::nonNull)
+                .forEach(document -> {
+                    documentMap.put(document.name(), document);
+                    registerDocumentPath(module, document);
                 });
         return documentMap;
+    }
+
+    private void registerDocumentPath(Module module, Document document) {
+        Optional<Path> documentPath = module.project().documentPath(document.documentId());
+        // LineRange.fileName() reflects the syntax tree's file path (normally the document
+        // name); register both so either form resolves. Both sides of the diff share the
+        // same disk path, so a single map serves original and modified lookups.
+        documentPath.ifPresent(path -> {
+            this.currentModuleFilePaths.putIfAbsent(document.name(), path);
+            this.currentModuleFilePaths.putIfAbsent(document.syntaxTree().filePath(), path);
+        });
     }
 
     /**
@@ -764,7 +904,10 @@ public class SemanticDiffComputer {
         for (Map.Entry<String, ServiceDeclarationNode> entry : serviceMap.entrySet()) {
             String serviceName = entry.getKey();
             String basePath = serviceName.split("#")[0];
-            serviceBasePaths.put(basePath, serviceName);
+            // Two services may legally share a base path (different listeners). Keep the
+            // first instead of silently overwriting — the unmatched one then surfaces via
+            // the removed/added handling rather than being paired with the wrong service.
+            serviceBasePaths.putIfAbsent(basePath, serviceName);
         }
         return serviceBasePaths;
     }
@@ -933,7 +1076,10 @@ public class SemanticDiffComputer {
 
     private String resolveUri(String fileName) {
 
-        Path filePath = Path.of(rootProjectPath).resolve(fileName);
+        // Module and test documents don't live directly under the project root, so prefer
+        // the recorded document path; fall back to root-relative for robustness.
+        Path filePath = this.currentModuleFilePaths.getOrDefault(
+                fileName, Path.of(rootProjectPath).resolve(fileName));
         return "ai" + filePath.toUri().toString().substring(4);
     }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -28,6 +28,7 @@ import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.FunctionBodyNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.IfElseStatementNode;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.LockStatementNode;
 import io.ballerina.compiler.syntax.tree.MatchClauseNode;
 import io.ballerina.compiler.syntax.tree.MatchStatementNode;
@@ -200,8 +201,40 @@ public class SemanticDiffComputer {
         computeSourceDiffs(originalNodeRefMap.getEnumNodeMap(), modifiedNodeRefMap.getEnumNodeMap(),
                 NodeKind.ENUM_DECLARATION, false);
         computeClassDiffs(originalNodeRefMap.getClassNodeMap(), modifiedNodeRefMap.getClassNodeMap());
-        computeSourceDiffs(originalNodeRefMap.getImportNodeMap(), modifiedNodeRefMap.getImportNodeMap(),
-                NodeKind.IMPORT_DECLARATION, false);
+        computeImportDiffs(originalNodeRefMap.getImportNodeMap(), modifiedNodeRefMap.getImportNodeMap());
+    }
+
+    /**
+     * Computes import differences by key alone. An import's map key (org/module plus alias)
+     * already encodes everything semantic about the declaration, so two imports with the same
+     * key can only differ in surrounding trivia — e.g. a file-header comment that re-attached
+     * to a different import when one was inserted above it. Comparing source text here (as
+     * {@link #computeSourceDiffs} does) flagged such untouched imports as "modified", showing
+     * reviewers a comment shuffle. Only genuine additions and deletions are reported, and
+     * their displayed source is the canonical {@code import <key>;} form rather than
+     * {@code toSourceCode()}, which would drag any attached leading comment into the view.
+     */
+    private void computeImportDiffs(Map<String, ImportDeclarationNode> originalImportMap,
+                                    Map<String, ImportDeclarationNode> modifiedImportMap) {
+
+        for (Map.Entry<String, ImportDeclarationNode> entry : originalImportMap.entrySet()) {
+            String name = entry.getKey();
+            if (modifiedImportMap.containsKey(name)) {
+                modifiedImportMap.remove(name);
+                continue;
+            }
+            addDeletionDiff(NodeKind.IMPORT_DECLARATION, entry.getValue().lineRange(),
+                    buildSourceMetadata(name, canonicalImportSource(name), null));
+        }
+
+        for (Map.Entry<String, ImportDeclarationNode> entry : modifiedImportMap.entrySet()) {
+            addAdditionDiff(NodeKind.IMPORT_DECLARATION, entry.getValue().lineRange(),
+                    buildSourceMetadata(entry.getKey(), null, canonicalImportSource(entry.getKey())));
+        }
+    }
+
+    private static String canonicalImportSource(String importKey) {
+        return "import " + importKey + ";";
     }
 
     /**

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/NodeKind.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/NodeKind.java
@@ -27,5 +27,13 @@ public enum NodeKind {
     MODULE_FUNCTION,
     OBJECT_FUNCTION,
     TYPE_DEFINITION,
-    DATA_MAPPING_FUNCTION
+    DATA_MAPPING_FUNCTION,
+    // The kinds below have no diagram representation; the review UI renders them as
+    // source-level changes. Only append new constants — the wire format is the ordinal.
+    MODULE_VARIABLE,
+    CONSTANT,
+    LISTENER,
+    CLASS_DEFINITION,
+    ENUM_DECLARATION,
+    IMPORT_DECLARATION
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/Result.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/Result.java
@@ -25,8 +25,14 @@ import java.util.List;
  *
  * @param loadDesignDiagrams indicates whether design diagrams should be loaded
  * @param semanticDiffs   list of semantic differences identified
+ * @param compilationError message of a package-compilation failure hit while comparing design
+ *                         models, when the syntax-level diffs themselves are still valid
  *
  * @since 1.5.0
  */
-public record Result(boolean loadDesignDiagrams, List<SemanticDiff> semanticDiffs) {
+public record Result(boolean loadDesignDiagrams, List<SemanticDiff> semanticDiffs, String compilationError) {
+
+    public Result(boolean loadDesignDiagrams, List<SemanticDiff> semanticDiffs) {
+        this(loadDesignDiagrams, semanticDiffs, null);
+    }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/STNodeRefMap.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/STNodeRefMap.java
@@ -18,7 +18,11 @@
 
 package io.ballerina.copilotagent.core.models;
 
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
+import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
@@ -38,6 +42,10 @@ public class STNodeRefMap {
     private final Map<String, ServiceDeclarationNode> serviceNodeMap = new HashMap<>();
     private final Map<String, TypeDefinitionNode> typeDefNodeMap = new HashMap<>();
     private final Map<String, ModuleVariableDeclarationNode> moduleVarNodeMap = new HashMap<>();
+    private final Map<String, ConstantDeclarationNode> constantNodeMap = new HashMap<>();
+    private final Map<String, EnumDeclarationNode> enumNodeMap = new HashMap<>();
+    private final Map<String, ClassDefinitionNode> classNodeMap = new HashMap<>();
+    private final Map<String, ImportDeclarationNode> importNodeMap = new HashMap<>();
 
     public Map<String, ListenerDeclarationNode> getListenerNodeMap() {
         return this.listenerNodeMap;
@@ -59,6 +67,22 @@ public class STNodeRefMap {
         return this.moduleVarNodeMap;
     }
 
+    public Map<String, ConstantDeclarationNode> getConstantNodeMap() {
+        return this.constantNodeMap;
+    }
+
+    public Map<String, EnumDeclarationNode> getEnumNodeMap() {
+        return this.enumNodeMap;
+    }
+
+    public Map<String, ClassDefinitionNode> getClassNodeMap() {
+        return this.classNodeMap;
+    }
+
+    public Map<String, ImportDeclarationNode> getImportNodeMap() {
+        return this.importNodeMap;
+    }
+
     public void putListenerNode(String key, ListenerDeclarationNode node) {
         this.listenerNodeMap.put(key, node);
     }
@@ -77,5 +101,21 @@ public class STNodeRefMap {
 
     public void putModuleVarNode(String key, ModuleVariableDeclarationNode node) {
         this.moduleVarNodeMap.put(key, node);
+    }
+
+    public void putConstantNode(String key, ConstantDeclarationNode node) {
+        this.constantNodeMap.put(key, node);
+    }
+
+    public void putEnumNode(String key, EnumDeclarationNode node) {
+        this.enumNodeMap.put(key, node);
+    }
+
+    public void putClassNode(String key, ClassDefinitionNode node) {
+        this.classNodeMap.put(key, node);
+    }
+
+    public void putImportNode(String key, ImportDeclarationNode node) {
+        this.importNodeMap.put(key, node);
     }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
@@ -21,10 +21,17 @@ package io.ballerina.copilotagent.extension;
 import io.ballerina.copilotagent.core.SemanticDiffComputer;
 import io.ballerina.copilotagent.core.models.Result;
 import io.ballerina.copilotagent.extension.request.EnsureAiBaselineRequest;
+import io.ballerina.copilotagent.extension.request.PrewarmDependenciesRequest;
 import io.ballerina.copilotagent.extension.request.SemanticDiffRequest;
 import io.ballerina.copilotagent.extension.response.EnsureAiBaselineResponse;
+import io.ballerina.copilotagent.extension.response.PrewarmDependenciesResponse;
 import io.ballerina.copilotagent.extension.response.SemanticDiffResponse;
+import io.ballerina.modelgenerator.commons.PackageUtil;
+import io.ballerina.projects.DependencyGraph;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageDescriptor;
 import io.ballerina.projects.Project;
+import io.ballerina.projects.ResolvedPackageDependency;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.PathUtil;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
@@ -122,6 +129,57 @@ public class CopilotAgentService implements ExtendedLanguageServerService {
 
     private static String toAiUri(Path path) {
         return "ai" + path.toUri().toString().substring(4);
+    }
+
+    /**
+     * Warms the standalone module-package caches (see {@code PackageUtil}) for the package's
+     * direct dependencies. The flow-model generator resolves and compiles each dependency's
+     * standalone package the first time a diagram references it — a one-time-per-session cost
+     * of seconds that otherwise lands on the first review-diff click. Callers fire this in the
+     * background at generation start so the caches are hot by the time the review opens.
+     */
+    @JsonRequest
+    public CompletableFuture<PrewarmDependenciesResponse> prewarmDependencies(PrewarmDependenciesRequest request) {
+        return CompletableFuture.supplyAsync(() -> {
+            PrewarmDependenciesResponse response = new PrewarmDependenciesResponse();
+            try {
+                Path path = PathUtil.convertUriStringToPath(request.projectPath());
+                Project project = this.workspaceManager.loadProject(path);
+                Package currentPackage = project.currentPackage();
+                PackageDescriptor rootDescriptor = currentPackage.descriptor();
+                DependencyGraph<ResolvedPackageDependency> graph =
+                        currentPackage.getResolution().dependencyGraph();
+                // Only direct dependencies: the flow-model generator standalone-resolves the
+                // modules referenced from user code, which come from the package's own imports.
+                // Warming the transitive closure multiplies the background compile cost for
+                // packages the diagrams rarely touch.
+                ResolvedPackageDependency root = graph.getNodes().stream()
+                        .filter(node -> node.packageInstance().descriptor().equals(rootDescriptor))
+                        .findFirst().orElse(null);
+                if (root == null) {
+                    response.setWarmedDependencyCount(0);
+                    return response;
+                }
+                int warmed = 0;
+                for (ResolvedPackageDependency dependency : graph.getDirectDependencies(root)) {
+                    PackageDescriptor descriptor = dependency.packageInstance().descriptor();
+                    if (descriptor.equals(rootDescriptor) || descriptor.isLangLibPackage()
+                            || descriptor.isBuiltInPackage()) {
+                        continue;
+                    }
+                    PackageUtil.resolveModulePackage(descriptor.org().value(), descriptor.name().value(),
+                                    descriptor.version().value().toString())
+                            // The flow-model generator needs the dependency's own semantic model,
+                            // so pre-compile it too; memoized on the cached Package instance.
+                            .ifPresent(PackageUtil::getCompilation);
+                    warmed++;
+                }
+                response.setWarmedDependencyCount(warmed);
+            } catch (Exception e) {
+                response.setError(e);
+            }
+            return response;
+        });
     }
 
     @JsonRequest

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
@@ -20,20 +20,30 @@ package io.ballerina.copilotagent.extension;
 
 import io.ballerina.copilotagent.core.SemanticDiffComputer;
 import io.ballerina.copilotagent.core.models.Result;
+import io.ballerina.copilotagent.extension.request.EnsureAiBaselineRequest;
 import io.ballerina.copilotagent.extension.request.SemanticDiffRequest;
+import io.ballerina.copilotagent.extension.response.EnsureAiBaselineResponse;
 import io.ballerina.copilotagent.extension.response.SemanticDiffResponse;
 import io.ballerina.projects.Project;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.PathUtil;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManagerProxy;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @JavaSPIService("org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService")
@@ -54,6 +64,64 @@ public class CopilotAgentService implements ExtendedLanguageServerService {
     @Override
     public Class<?> getRemoteInterface() {
         return null;
+    }
+
+    /**
+     * (Re)establishes the ai:// frozen baseline of a package from explicit file contents,
+     * atomically from the caller's perspective: any cached ai:// project is evicted, the
+     * package is reloaded, and the provided contents are applied before the response
+     * resolves. This replaces the fire-and-forget didClose/didOpen notification protocol,
+     * whose disk-read timing raced against the caller's first workspace edit.
+     */
+    @JsonRequest
+    public CompletableFuture<EnsureAiBaselineResponse> ensureAiBaseline(EnsureAiBaselineRequest request) {
+        return CompletableFuture.supplyAsync(() -> {
+            EnsureAiBaselineResponse response = new EnsureAiBaselineResponse();
+            try {
+                Path projectRoot = PathUtil.convertUriStringToPath(request.projectPath());
+                // Evict via the package's Ballerina.toml — a concrete file the project
+                // lookup always resolves. Drops the whole cached ai:// project (no-op when
+                // absent), so the next document update rebuilds the package from disk
+                // before applying content.
+                Path evictionAnchor = projectRoot.resolve("Ballerina.toml");
+                this.aiWorkspaceManager.didClose(evictionAnchor,
+                        new DidCloseTextDocumentParams(new TextDocumentIdentifier(toAiUri(evictionAnchor))));
+
+                List<String> failedFiles = new ArrayList<>();
+                int seeded = 0;
+                List<EnsureAiBaselineRequest.BaselineFile> files =
+                        request.files() == null ? List.of() : request.files();
+                for (EnsureAiBaselineRequest.BaselineFile file : files) {
+                    Path filePath = projectRoot.resolve(file.filePath());
+                    try {
+                        // The first change rebuilds the package from disk and the rest update
+                        // documents in place — the same batch technique the extension's
+                        // restore path uses, minus the cross-process timing dependency.
+                        DidChangeTextDocumentParams params = new DidChangeTextDocumentParams(
+                                new VersionedTextDocumentIdentifier(toAiUri(filePath), 1),
+                                List.of(new TextDocumentContentChangeEvent(
+                                        file.content() == null ? "" : file.content())));
+                        this.aiWorkspaceManager.didChange(filePath, params);
+                        seeded++;
+                    } catch (WorkspaceDocumentException | RuntimeException e) {
+                        failedFiles.add(file.filePath());
+                    }
+                }
+                if (files.isEmpty()) {
+                    // No explicit contents: snapshot the package from disk as it stands now.
+                    this.aiWorkspaceManager.loadProject(projectRoot);
+                }
+                response.setSeededFileCount(seeded);
+                response.setFailedFiles(failedFiles);
+            } catch (Exception e) {
+                response.setError(e);
+            }
+            return response;
+        });
+    }
+
+    private static String toAiUri(Path path) {
+        return "ai" + path.toUri().toString().substring(4);
     }
 
     @JsonRequest

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
@@ -72,6 +72,7 @@ public class CopilotAgentService implements ExtendedLanguageServerService {
                 Result result = diffComputer.computeSemanticDiffs();
                 response.setLoadDesignDiagrams(result.loadDesignDiagrams());
                 response.setSemanticDiffs(result.semanticDiffs());
+                response.setCompilationError(result.compilationError());
             } catch (Exception e) {
                 response.setError(e);
             }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/EnsureAiBaselineRequest.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/EnsureAiBaselineRequest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.copilotagent.extension.request;
+
+import java.util.List;
+
+/**
+ * Request to (re)establish the ai:// frozen baseline of a package from explicit file
+ * contents. Evicts any cached ai:// project for the path, reloads it, and applies the
+ * given contents — all before the response resolves, so callers can rely on the baseline
+ * being in place (unlike the fire-and-forget didOpen/didChange notification protocol).
+ *
+ * @param projectPath the package root (URI or filesystem path)
+ * @param files       baseline contents to apply; paths are relative to projectPath.
+ *                    May be empty to snapshot the package purely from disk.
+ * @since 1.5.0
+ */
+public record EnsureAiBaselineRequest(String projectPath, List<BaselineFile> files) {
+
+    /**
+     * One file's frozen baseline content.
+     *
+     * @param filePath path relative to the package root
+     * @param content  the exact baseline text for the file
+     */
+    public record BaselineFile(String filePath, String content) {
+    }
+}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/PrewarmDependenciesRequest.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/PrewarmDependenciesRequest.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.copilotagent.extension.request;
+
+/**
+ * Request to warm the standalone module-package caches for a package's direct
+ * dependencies, so the first flow-model request of a review session does not pay the
+ * one-time dependency resolution/compilation cost interactively.
+ *
+ * @param projectPath the package root (URI or filesystem path)
+ * @since 1.5.0
+ */
+public record PrewarmDependenciesRequest(String projectPath) {
+}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/EnsureAiBaselineResponse.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/EnsureAiBaselineResponse.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.copilotagent.extension.response;
+
+import io.ballerina.designmodelgenerator.extension.response.AbstractResponse;
+
+import java.util.List;
+
+/**
+ * Response for the ensureAiBaseline request.
+ *
+ * @since 1.5.0
+ */
+public class EnsureAiBaselineResponse extends AbstractResponse {
+    private int seededFileCount;
+    // Files whose baseline content could not be applied (e.g. not part of the package).
+    // The rest of the baseline is still in place.
+    private List<String> failedFiles;
+
+    public int getSeededFileCount() {
+        return seededFileCount;
+    }
+
+    public void setSeededFileCount(int seededFileCount) {
+        this.seededFileCount = seededFileCount;
+    }
+
+    public List<String> getFailedFiles() {
+        return failedFiles;
+    }
+
+    public void setFailedFiles(List<String> failedFiles) {
+        this.failedFiles = failedFiles;
+    }
+}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/PrewarmDependenciesResponse.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/PrewarmDependenciesResponse.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.copilotagent.extension.response;
+
+import io.ballerina.designmodelgenerator.extension.response.AbstractResponse;
+
+/**
+ * Response for the prewarmDependencies request.
+ *
+ * @since 1.5.0
+ */
+public class PrewarmDependenciesResponse extends AbstractResponse {
+    private int warmedDependencyCount;
+
+    public int getWarmedDependencyCount() {
+        return warmedDependencyCount;
+    }
+
+    public void setWarmedDependencyCount(int warmedDependencyCount) {
+        this.warmedDependencyCount = warmedDependencyCount;
+    }
+}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/SemanticDiffResponse.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/SemanticDiffResponse.java
@@ -31,6 +31,17 @@ import java.util.List;
 public class SemanticDiffResponse extends AbstractResponse {
     private boolean loadDesignDiagrams;
     private List<SemanticDiff> semanticDiffs;
+    // Set when the syntax-level diffs succeeded but the package failed to compile
+    // (design-model comparison). Unlike errorMsg, the diffs are still usable.
+    private String compilationError;
+
+    public String getCompilationError() {
+        return compilationError;
+    }
+
+    public void setCompilationError(String compilationError) {
+        this.compilationError = compilationError;
+    }
 
     public boolean isLoadDesignDiagrams() {
         return loadDesignDiagrams;

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/java/io/ballerina/copilotagent/extension/SemanticDiffComputerTest.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/java/io/ballerina/copilotagent/extension/SemanticDiffComputerTest.java
@@ -93,7 +93,7 @@ public class SemanticDiffComputerTest extends AbstractLSTest {
         actualOutput = gson.fromJson(outputJsonStr, JsonElement.class);
         // assert the results
         if (!actualOutput.equals(testConfig.output())) {
-            TestConfig updatedConfig = new TestConfig(testConfig.description(), 
+            TestConfig updatedConfig = new TestConfig(testConfig.description(),
                     testConfig.projectPath(), actualOutput.getAsJsonObject());
 //            updateConfig(configJsonPath, updatedConfig);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config1.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config1.json
@@ -5,6 +5,26 @@
     "loadDesignDiagrams": true,
     "semanticDiffs": [
       {
+        "changeType": "ADDITION",
+        "nodeKind": "LISTENER",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 4,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 4,
+            "offset": 51
+          }
+        },
+        "metadata": {
+          "name": "unusedListener",
+          "newSource": "listener http:Listener unusedListener = new (8080);"
+        }
+      },
+      {
         "changeType": "DELETION",
         "nodeKind": "OBJECT_FUNCTION",
         "uri": "ai:///main.bal",
@@ -186,6 +206,86 @@
         },
         "metadata": {
           "name": "ErrorResponse"
+        }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "MODULE_VARIABLE",
+        "uri": "ai:///connections.bal",
+        "lineRange": {
+          "fileName": "connections.bal",
+          "startLine": {
+            "line": 3,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 3,
+            "offset": 70
+          }
+        },
+        "metadata": {
+          "name": "petStoreApiUrl",
+          "newSource": "// HTTP client configuration for external API calls\nconfigurable string petStoreApiUrl = \"https://petstore.swagger.io/v2\";"
+        }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "MODULE_VARIABLE",
+        "uri": "ai:///connections.bal",
+        "lineRange": {
+          "fileName": "connections.bal",
+          "startLine": {
+            "line": 6,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 6,
+            "offset": 69
+          }
+        },
+        "metadata": {
+          "name": "petStoreClient",
+          "newSource": "// HTTP client for making external API calls\npublic final http:Client petStoreClient = check new (petStoreApiUrl);"
+        }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "IMPORT_DECLARATION",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 1,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 1,
+            "offset": 22
+          }
+        },
+        "metadata": {
+          "name": "ballerina/uuid",
+          "newSource": "import ballerina/uuid;"
+        }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "IMPORT_DECLARATION",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 21
+          }
+        },
+        "metadata": {
+          "name": "ballerina/log",
+          "newSource": "import ballerina/log;"
         }
       }
     ]

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config10.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config10.json
@@ -3,6 +3,39 @@
   "projectPath": "connection_param_change",
   "output": {
     "loadDesignDiagrams": true,
-    "semanticDiffs": []
+    "semanticDiffs": [
+      {
+        "changeType": "MODIFICATION",
+        "nodeKind": "MODULE_VARIABLE",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 71
+          }
+        },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 68
+          }
+        },
+        "metadata": {
+          "name": "apiClient",
+          "oldSource": "final http:Client apiClient = check new (\"https://api.example.com\");",
+          "newSource": "final http:Client apiClient = check new (\"https://api.v2.example.com\");"
+        }
+      }
+    ]
   }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config2.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config2.json
@@ -37,6 +37,25 @@
         }
       },
       {
+        "changeType": "DELETION",
+        "nodeKind": "TYPE_DEFINITION",
+        "uri": "ai:///types.bal",
+        "lineRange": {
+          "fileName": "types.bal",
+          "startLine": {
+            "line": 0,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 11,
+            "offset": 3
+          }
+        },
+        "metadata": {
+          "name": "Patient"
+        }
+      },
+      {
         "changeType": "MODIFICATION",
         "nodeKind": "TYPE_DEFINITION",
         "uri": "ai:///types.bal",

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config3.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config3.json
@@ -188,6 +188,26 @@
         "metadata": {
           "name": "modulo"
         }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "IMPORT_DECLARATION",
+        "uri": "ai:///functions.bal",
+        "lineRange": {
+          "fileName": "functions.bal",
+          "startLine": {
+            "line": 0,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 0,
+            "offset": 21
+          }
+        },
+        "metadata": {
+          "name": "ballerina/log",
+          "newSource": "import ballerina/log;"
+        }
       }
     ]
   }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config5.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config5.json
@@ -3,6 +3,39 @@
   "projectPath": "listener_changes",
   "output": {
     "loadDesignDiagrams": true,
-    "semanticDiffs": []
+    "semanticDiffs": [
+      {
+        "changeType": "MODIFICATION",
+        "nodeKind": "LISTENER",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 49
+          }
+        },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 49
+          }
+        },
+        "metadata": {
+          "name": "httpListener",
+          "oldSource": "listener http:Listener httpListener = new (8080);",
+          "newSource": "listener http:Listener httpListener = new (9090);"
+        }
+      }
+    ]
   }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config8.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config8.json
@@ -35,6 +35,26 @@
           "servicePath": "/api",
           "resourcePath": "data"
         }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "MODULE_VARIABLE",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 68
+          }
+        },
+        "metadata": {
+          "name": "apiClient",
+          "newSource": "final http:Client apiClient = check new (\"https://api.example.com\");"
+        }
       }
     ]
   }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config9.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config9.json
@@ -35,6 +35,26 @@
           "servicePath": "/api",
           "resourcePath": "data"
         }
+      },
+      {
+        "changeType": "DELETION",
+        "nodeKind": "MODULE_VARIABLE",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 68
+          }
+        },
+        "metadata": {
+          "name": "apiClient",
+          "oldSource": "final http:Client apiClient = check new (\"https://api.example.com\");"
+        }
       }
     ]
   }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/publishers/ProjectUpdateEventPublisher.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/publishers/ProjectUpdateEventPublisher.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.langserver.eventsync.publishers;
 
 import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
@@ -46,6 +47,16 @@ public class ProjectUpdateEventPublisher extends AbstractEventPublisher {
     @Override
     public void publish(ExtendedLanguageClient client, LanguageServerContext serverContext,
                         DocumentServiceContext context) {
+        // The ai:// scheme is the AI copilot's frozen pre-edit baseline — a virtual clone the
+        // user never edits directly. No project-update reaction applies to it: its diagnostics
+        // have no consumer, and the pull-modules / compilation-error prompts would target a
+        // project the user cannot act on. Each subscriber forces a package compilation, so
+        // letting the baseline-seeding didOpen/didChange bursts through costs O(events) full
+        // compiles. Skip the whole fan-out here so every subscriber, present and future, is
+        // covered by a single check.
+        if (CommonUtil.AI_SCHEME.equals(context.workspace().uriScheme())) {
+            return;
+        }
         subscribers.parallelStream()
                 .forEach(subscriber -> subscriber.onEvent(client, context, serverContext));
     }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/runner/BallerinaRunnerService.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/runner/BallerinaRunnerService.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
  * Implementation of Ballerina runner extension for Language Server.
@@ -92,9 +93,25 @@ public class BallerinaRunnerService implements ExtendedLanguageServerService {
                 String msg = "Operation 'ballerinaRunner/diagnostics' failed!";
                 this.clientLogger.logError(RunnerContext.RUNNER_DIAGNOSTICS, msg, e, request.getProjectRootIdentifier(),
                         (Position) null);
+                // Tell the client why (e.g. a package-compilation failure) instead of an
+                // indistinguishable empty response.
+                ProjectDiagnosticsResponse errorResponse = new ProjectDiagnosticsResponse();
+                errorResponse.setErrorMsg(rootCauseMessage(e));
+                return errorResponse;
             }
-            return new ProjectDiagnosticsResponse();
         });
+    }
+
+    // Unwraps only async plumbing (CompletionException); the first real exception's
+    // message already carries the full context (e.g. which module failed to load).
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause instanceof CompletionException
+                && cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        String message = cause.getMessage();
+        return message == null || message.isBlank() ? cause.getClass().getName() : message;
     }
 
     /**

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/runner/ProjectDiagnosticsResponse.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/runner/ProjectDiagnosticsResponse.java
@@ -30,6 +30,9 @@ import java.util.Map;
 public class ProjectDiagnosticsResponse {
 
     private Map<String, List<Diagnostic>> errorDiagnosticMap;
+    // Why the diagnostics could not be produced (e.g. the package failed to compile).
+    // errorDiagnosticMap stays null in that case, which older clients already treat as failure.
+    private String errorMsg;
 
     public Map<String, List<Diagnostic>> getErrorDiagnosticMap() {
         return errorDiagnosticMap;
@@ -37,5 +40,13 @@ public class ProjectDiagnosticsResponse {
 
     public void setErrorDiagnosticMap(Map<String, List<Diagnostic>> errorDiagnosticMap) {
         this.errorDiagnosticMap = errorDiagnosticMap;
+    }
+
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+    public void setErrorMsg(String errorMsg) {
+        this.errorMsg = errorMsg;
     }
 }

--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -106,7 +106,7 @@ public class PackageUtil {
         return BuildOptions.builder().setSticky(true).build();
     }
 
-    private static final BuildProject SAMPLE_PROJECT = getSampleProject();
+    private static final BuildProject SAMPLE_PROJECT = createSampleProject();
 
     private static final String PULLING_THE_MODULE_MESSAGE = "Pulling the module '%s' from the central";
     private static final String MODULE_PULLING_FAILED_MESSAGE = "Failed to pull the module: %s";
@@ -114,6 +114,34 @@ public class PackageUtil {
 
     // Concurrent map to store locks for each project
     private static final ConcurrentHashMap<Path, ReentrantLock> PROJECT_LOCKS = new ConcurrentHashMap<>();
+
+    /**
+     * Session cache for sample-project module resolutions, keyed by
+     * {@code org:name:version:repository}. Resolving a module against the sample project is
+     * extremely expensive — non-sticky resolution contacts Ballerina Central over HTTP even for
+     * locally cached packages, and a missing package throws after a network round trip — and the
+     * flow-model generator triggers one such resolution per remote-call node on EVERY
+     * getFlowModel request. Before this cache, a single warm flow-model fetch took seconds of
+     * pure network time.
+     *
+     * A bala package is immutable per version, so positive entries never go stale. Negative
+     * entries (package absent — typically a generated/test package that will never exist on
+     * Central) are cached too: they are the hottest repeat offenders. The accepted trade-off is
+     * that a "latest version" lookup or a transient network failure sticks for the LS session.
+     */
+    private static final ConcurrentHashMap<String, Optional<Package>> SAMPLE_RESOLUTION_CACHE =
+            new ConcurrentHashMap<>();
+
+    /**
+     * Serializes cache-miss resolutions: before caching, every call built its own sample project
+     * (and resolver), so the shared resolver was never used concurrently. Keep that property.
+     */
+    private static final Object SAMPLE_RESOLUTION_LOCK = new Object();
+
+    private static String sampleResolutionKey(String org, String name, String version, String repository) {
+        return org + ":" + name + ":" + (version == null ? "<latest>" : version)
+                + ":" + (repository == null ? "" : repository);
+    }
 
     /**
      * Resolves the version of a package available in the local repositories (offline),
@@ -137,7 +165,17 @@ public class PackageUtil {
         return null;
     }
 
+    /**
+     * Returns the shared sample project used for resolving standalone module packages. Memoized:
+     * this used to build a fresh temp directory + BuildProject per call, which both leaked temp
+     * dirs and defeated every downstream cache (resolver, resolution results) on hot paths like
+     * flow-model generation.
+     */
     public static BuildProject getSampleProject() {
+        return SAMPLE_PROJECT;
+    }
+
+    private static BuildProject createSampleProject() {
         // Obtain the Ballerina distribution path
         String ballerinaHome = System.getProperty(BALLERINA_HOME_PROPERTY);
         if (ballerinaHome == null || ballerinaHome.isEmpty()) {
@@ -224,6 +262,30 @@ public class PackageUtil {
      */
     public static Optional<Package> getModulePackage(BuildProject buildProject, String org, String name,
                                                      String version, String repository) {
+        // Sample-project resolutions are descriptor-only (the project just supplies a resolver
+        // environment, and the returned bala is loaded with the default environment), so they
+        // are safe to memoize across requests. Resolutions against a caller's real project may
+        // depend on that project's state — leave them uncached.
+        if (buildProject == SAMPLE_PROJECT) {
+            return SAMPLE_RESOLUTION_CACHE.computeIfAbsent(sampleResolutionKey(org, name, version, repository),
+                    key -> {
+                        synchronized (SAMPLE_RESOLUTION_LOCK) {
+                            try {
+                                return resolveVersionedModulePackage(buildProject, org, name, version, repository);
+                            } catch (RuntimeException e) {
+                                // Cache the miss: a package that fails to resolve (typically a
+                                // generated/test package that does not exist on Central) would
+                                // otherwise re-pay the network round trip on every request.
+                                return Optional.empty();
+                            }
+                        }
+                    });
+        }
+        return resolveVersionedModulePackage(buildProject, org, name, version, repository);
+    }
+
+    private static Optional<Package> resolveVersionedModulePackage(BuildProject buildProject, String org, String name,
+                                                                   String version, String repository) {
         PackageOrg packageOrg = PackageOrg.from(org);
         PackageName packageName = PackageName.from(name);
         PackageVersion packageVersion = PackageVersion.from(version);
@@ -232,8 +294,15 @@ public class PackageUtil {
                 : PackageDescriptor.from(packageOrg, packageName, packageVersion, repository);
         PackageResolver packageResolver = buildProject.projectEnvironmentContext().getService(PackageResolver.class);
 
+        // Offline-first: an exact-version bala is immutable, so a local-cache hit is guaranteed
+        // to equal the remote answer — no reason to contact Central for it. Only a local miss
+        // falls back to online resolution (which can pull the package).
+        ResolutionRequest resolutionRequest = ResolutionRequest.from(packageDescriptor);
         Optional<ResolutionResponse> resolutionResponse =
-                resolveResponse(packageResolver, ResolutionRequest.from(packageDescriptor), false);
+                resolveResponse(packageResolver, resolutionRequest, true);
+        if (resolutionResponse.isEmpty() && !FORCE_OFFLINE) {
+            resolutionResponse = resolveResponse(packageResolver, resolutionRequest, false);
+        }
         if (resolutionResponse.isEmpty()) {
             return Optional.empty();
         }
@@ -264,6 +333,24 @@ public class PackageUtil {
     }
 
     public static Optional<Package> getModulePackage(BuildProject buildProject, String org, String name) {
+        // See the versioned overload for why sample-project resolutions are memoized. The
+        // "latest version" lookup below can itself hit Central, so caching matters just as much.
+        if (buildProject == SAMPLE_PROJECT) {
+            return SAMPLE_RESOLUTION_CACHE.computeIfAbsent(sampleResolutionKey(org, name, null, null),
+                    key -> {
+                        synchronized (SAMPLE_RESOLUTION_LOCK) {
+                            try {
+                                return resolveLatestModulePackage(buildProject, org, name);
+                            } catch (RuntimeException e) {
+                                return Optional.empty();
+                            }
+                        }
+                    });
+        }
+        return resolveLatestModulePackage(buildProject, org, name);
+    }
+
+    private static Optional<Package> resolveLatestModulePackage(BuildProject buildProject, String org, String name) {
         ResolutionRequest resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name)));
         PackageResolver packageResolver = buildProject.projectEnvironmentContext().getService(PackageResolver.class);
@@ -287,12 +374,23 @@ public class PackageUtil {
             packageDescriptor = pkgMetadata.get().resolvedDescriptor();
         }
 
+        // Offline-first: the descriptor now carries an exact version (from the local metadata
+        // or the remote latest-version lookup above), and an exact-version bala is immutable —
+        // resolve from the local cache when present, contact Central only on a local miss.
         Collection<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(
                 Collections.singletonList(ResolutionRequest.from(packageDescriptor)),
-                ResolutionOptions.builder().setOffline(FORCE_OFFLINE).build());
-        Optional<ResolutionResponse> resolutionResponse = resolutionResponses.stream().findFirst();
-        if (resolutionResponse.isEmpty() || resolutionResponse.get().resolvedPackage() == null) {
-            // Offline and the package could not be resolved from the local repositories.
+                ResolutionOptions.builder().setOffline(true).build());
+        Optional<ResolutionResponse> resolutionResponse = resolutionResponses.stream()
+                .filter(response -> response.resolvedPackage() != null).findFirst();
+        if (resolutionResponse.isEmpty() && !FORCE_OFFLINE) {
+            resolutionResponses = packageResolver.resolvePackages(
+                    Collections.singletonList(ResolutionRequest.from(packageDescriptor)),
+                    ResolutionOptions.builder().setOffline(false).build());
+            resolutionResponse = resolutionResponses.stream()
+                    .filter(response -> response.resolvedPackage() != null).findFirst();
+        }
+        if (resolutionResponse.isEmpty()) {
+            // The package could not be resolved from the local repositories or Central.
             return Optional.empty();
         }
 

--- a/packages/ballerina-language-server/spotbugs-exclude.xml
+++ b/packages/ballerina-language-server/spotbugs-exclude.xml
@@ -265,4 +265,11 @@
         <Class name="io.ballerina.projectservice.core.baltool.BalToolsUtil" />
         <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
     </Match>
+    <Match>
+        <!-- Returning the shared sample project is the point: it is a process-wide memoized
+             instance whose per-call re-creation defeated resolution caching (see PackageUtil). -->
+        <Class name="io.ballerina.modelgenerator.commons.PackageUtil" />
+        <Method name="getSampleProject" />
+        <Bug pattern="MS_EXPOSE_REP"/>
+    </Match>
 </FindBugsFilter>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
@@ -18,7 +18,8 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import styled from "@emotion/styled";
-import { SemanticDiff, ChangeTypeEnum, MACHINE_VIEW, VisualizerLocation } from "@wso2/ballerina-core";
+import { SemanticDiff, ChangeTypeEnum, NodeKindEnum, MACHINE_VIEW, VisualizerLocation } from "@wso2/ballerina-core";
+import { getNodeKindLabel } from "../../../ReviewMode/nodeKindLabels";
 import { getColorByMethod } from "../../../BI/ServiceDesigner/components/ResourceAccordion";
 
 const Container = styled.div<{ subtle?: boolean; expanded?: boolean }>`
@@ -259,10 +260,9 @@ const MethodBadge = styled.span<{ $color: string }>`
     flex-shrink: 0;
 `;
 
-// nodeKind === 2 is TYPE in semantic diffs
-const NODE_KIND_TYPE = 2;
-const NODE_KIND_RESOURCE = 1;
-const NODE_KIND_FUNCTION = 0;
+const NODE_KIND_FUNCTION = NodeKindEnum.MODULE_FUNCTION;
+const NODE_KIND_RESOURCE = NodeKindEnum.OBJECT_FUNCTION;
+const NODE_KIND_TYPE = NodeKindEnum.TYPE_DEFINITION;
 
 interface DiffEntry {
     symbol: string;
@@ -341,8 +341,10 @@ function getFileName(filePath: string): string {
 function getDiffLabel(diff: SemanticDiff): string {
     if (diff.metadata) {
         if (diff.nodeKind === NODE_KIND_RESOURCE) {
-            const m = diff.metadata as { accessor: string; servicePath: string; resourcePath: string };
-            return m.resourcePath;
+            // Class methods are OBJECT_FUNCTION diffs too but carry only `name` —
+            // fall through to it when there's no resource path.
+            const m = diff.metadata as { accessor?: string; servicePath?: string; resourcePath?: string };
+            if (m.resourcePath) return m.resourcePath;
         }
         const m = diff.metadata as { name?: string };
         if (m.name) return m.name;
@@ -364,9 +366,7 @@ function getDiffKindLabel(diff: SemanticDiff): string {
         const m = diff.metadata as { name?: string } | undefined;
         return m?.name === "main" ? "automation" : "function";
     }
-    if (diff.nodeKind === NODE_KIND_RESOURCE) return "resource";
-    if (diff.nodeKind === NODE_KIND_TYPE) return "type";
-    return "function";
+    return getNodeKindLabel(diff.nodeKind, diff.metadata);
 }
 
 function getChangeTypeLabel(changeType: number): string {
@@ -449,6 +449,8 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
     const serviceGroups: Record<string, DiffEntry[]> = {};
     const functionEntries: DiffEntry[] = [];
     const typeEntries: DiffEntry[] = [];
+    // Non-diagram construct kinds (constants, module vars, listeners, classes, enums, imports)
+    const declarationEntries: DiffEntry[] = [];
     let hasTypeView = false;
 
     for (const diff of semanticDiffs) {
@@ -456,12 +458,18 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
         if (isType && hasTypeView) continue;
         if (isType) hasTypeView = true;
 
+        // OBJECT_FUNCTION covers both service members and plain class methods; only the
+        // former carry a servicePath, and only they belong under a service group.
+        const servicePath = diff.nodeKind === NODE_KIND_RESOURCE
+            ? (diff.metadata as { servicePath?: string } | undefined)?.servicePath
+            : undefined;
+
         const entry: DiffEntry = {
             symbol: getSymbol(diff.changeType),
             changeType: diff.changeType,
             label: isType ? "Types" : getDiffLabel(diff),
-            accessor: diff.nodeKind === NODE_KIND_RESOURCE
-                ? (diff.metadata as { accessor: string } | undefined)?.accessor?.toUpperCase()
+            accessor: servicePath !== undefined
+                ? (diff.metadata as { accessor?: string } | undefined)?.accessor?.toUpperCase()
                 : undefined,
             kindLabel: getDiffKindLabel(diff),
             nodeKind: diff.nodeKind,
@@ -469,15 +477,17 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
         };
         viewIndex++;
 
-        if (diff.nodeKind === NODE_KIND_RESOURCE) {
-            const m = diff.metadata as { servicePath?: string } | undefined;
-            const svcPath = m?.servicePath || "/";
+        if (servicePath !== undefined) {
+            const svcPath = servicePath || "/";
             if (!serviceGroups[svcPath]) serviceGroups[svcPath] = [];
             serviceGroups[svcPath].push(entry);
-        } else if (diff.nodeKind === NODE_KIND_FUNCTION) {
+        } else if (diff.nodeKind === NODE_KIND_FUNCTION || diff.nodeKind === NODE_KIND_RESOURCE) {
+            // Plain functions, and class methods (OBJECT_FUNCTION without a service path)
             functionEntries.push(entry);
-        } else {
+        } else if (isType) {
             typeEntries.push(entry);
+        } else {
+            declarationEntries.push(entry);
         }
     }
 
@@ -491,6 +501,9 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
     }
     if (typeEntries.length > 0) {
         groups.push({ groupLabel: "types", entries: typeEntries });
+    }
+    if (declarationEntries.length > 0) {
+        groups.push({ groupLabel: "declarations", entries: declarationEntries });
     }
 
     return { groups, viewCount: viewIndex - startIndex };
@@ -761,8 +774,10 @@ export const ReviewBar: React.FC<ReviewBarProps> = ({
             await rpcClient.getAiPanelRpcClient().revertGeneration({ generationId });
             rpcClient.getVisualizerRpcClient().goBack();
         } catch (error) {
+            // Nothing was reverted (e.g. no checkpoint exists) — the backend already told
+            // the user via an error notification. Keep the bar so the review stays
+            // actionable; closing it here would make the failure look like a success.
             console.error("[ReviewBar] Error discarding changes:", error);
-            rpcClient.getVisualizerRpcClient().goBack();
         } finally {
             setIsProcessing(false);
         }

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyComponentDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyComponentDiagram.tsx
@@ -22,6 +22,7 @@ import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Diagram } from "@wso2/component-diagram";
 import { ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
+import { fetchDesignModel, ReviewModelCache } from "./reviewModelCache";
 
 const SpinnerContainer = styled.div`
     display: flex;
@@ -40,6 +41,8 @@ interface ReadonlyComponentDiagramProps {
     filePath: string;
     position: NodePosition;
     useFileSchema?: boolean;
+    /** Session-scoped model cache owned by ReviewMode — survives toggle/navigation remounts. */
+    modelCache: ReviewModelCache;
 }
 
 const EmptyMessage = styled.div`
@@ -59,7 +62,7 @@ function isDesignModelEmpty(model: CDModel): boolean {
 }
 
 export function ReadonlyComponentDiagram(props: ReadonlyComponentDiagramProps): JSX.Element {
-    const { projectPath, useFileSchema } = props;
+    const { projectPath, useFileSchema, modelCache } = props;
     const { rpcClient } = useRpcContext();
     const [project, setProject] = useState<CDModel | null>(null);
     const [isLoaded, setIsLoaded] = useState(false);
@@ -72,15 +75,13 @@ export function ReadonlyComponentDiagram(props: ReadonlyComponentDiagramProps): 
         // Stale-response guard: a slower earlier request (e.g. after toggling Old/New)
         // must not overwrite this render with the other version's model.
         let cancelled = false;
-        rpcClient
-            .getBIDiagramRpcClient()
-            .getDesignModel({ projectPath, useFileSchema })
-            .then((response) => {
+        fetchDesignModel(rpcClient, modelCache, projectPath, useFileSchema)
+            .then((designModel) => {
                 if (cancelled) {
                     return;
                 }
-                if (response?.designModel) {
-                    setProject(response.designModel);
+                if (designModel) {
+                    setProject(designModel);
                 } else {
                     setLoadFailed(true);
                 }
@@ -96,7 +97,7 @@ export function ReadonlyComponentDiagram(props: ReadonlyComponentDiagramProps): 
         return () => {
             cancelled = true;
         };
-    }, [projectPath, useFileSchema, rpcClient]);
+    }, [projectPath, useFileSchema, rpcClient, modelCache]);
 
     // No-op handlers for readonly mode
     const noOpHandler = () => {

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyComponentDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyComponentDiagram.tsx
@@ -63,28 +63,40 @@ export function ReadonlyComponentDiagram(props: ReadonlyComponentDiagramProps): 
     const { rpcClient } = useRpcContext();
     const [project, setProject] = useState<CDModel | null>(null);
     const [isLoaded, setIsLoaded] = useState(false);
+    const [loadFailed, setLoadFailed] = useState(false);
 
     useEffect(() => {
         setProject(null);
         setIsLoaded(false);
-        fetchProject();
-    }, [projectPath, useFileSchema]);
-
-    const fetchProject = () => {
+        setLoadFailed(false);
+        // Stale-response guard: a slower earlier request (e.g. after toggling Old/New)
+        // must not overwrite this render with the other version's model.
+        let cancelled = false;
         rpcClient
             .getBIDiagramRpcClient()
             .getDesignModel({ projectPath, useFileSchema })
             .then((response) => {
+                if (cancelled) {
+                    return;
+                }
                 if (response?.designModel) {
                     setProject(response.designModel);
+                } else {
+                    setLoadFailed(true);
                 }
                 setIsLoaded(true);
             })
             .catch((error) => {
                 console.error("Error getting design model", error);
-                setIsLoaded(true);
+                if (!cancelled) {
+                    setLoadFailed(true);
+                    setIsLoaded(true);
+                }
             });
-    };
+        return () => {
+            cancelled = true;
+        };
+    }, [projectPath, useFileSchema, rpcClient]);
 
     // No-op handlers for readonly mode
     const noOpHandler = () => {
@@ -99,10 +111,17 @@ export function ReadonlyComponentDiagram(props: ReadonlyComponentDiagramProps): 
         );
     }
 
+    // A load failure is not the same as a genuinely empty design — say which one it is,
+    // and name the version actually being shown.
+    const versionLabel = useFileSchema ? "previous" : "current";
+    if (loadFailed) {
+        return <EmptyMessage>The design diagram for the {versionLabel} version could not be loaded.</EmptyMessage>;
+    }
+
     if (!project || isDesignModelEmpty(project)) {
         return (
             <EmptyMessage>
-                No top-level constructs found in the previous version
+                No top-level constructs found in the {versionLabel} version
             </EmptyMessage>
         );
     }

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -44,6 +44,15 @@ const MessageContainer = styled.div`
     color: var(--vscode-descriptionForeground);
 `;
 
+const DiffNoticeBanner = styled.div`
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--vscode-inputValidation-warningForeground, var(--vscode-foreground));
+    background: var(--vscode-inputValidation-warningBackground, transparent);
+    border-bottom: 1px solid var(--vscode-inputValidation-warningBorder, var(--vscode-panel-border));
+    word-break: break-word;
+`;
+
 interface ItemMetadata {
     type: string;
     name: string;
@@ -156,6 +165,10 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
     const [flowModel, setFlowModel] = useState<Flow | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [unavailableMessage, setUnavailableMessage] = useState<string | null>(null);
+    // Why the unified diff degraded to the New-only view, when it did. Rendering the
+    // fallback silently made an old-side fetch failure indistinguishable from "nothing
+    // to highlight" — the single most confusing form of a broken diff.
+    const [diffNotice, setDiffNotice] = useState<string | null>(null);
     // Latest callbacks held in refs so the load effect can call them without listing them
     // as dependencies — the parent re-creates onModelLoaded on every render, which would
     // otherwise retrigger a full refetch each render.
@@ -171,6 +184,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         setIsLoading(true);
         setFlowModel(null);
         setUnavailableMessage(null);
+        setDiffNotice(null);
         let cancelled = false;
         loadFlowModel()
             .then((model) => {
@@ -290,10 +304,12 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         // them sequentially doubled the time-to-first-render for diff mode. Results are
         // cached per version, so the extra fetch on a metadata-mismatch fallback is free
         // if the user then toggles to New/Old.
+        let oldFetchError: unknown = null;
         const [newFlow, oldFlow] = await Promise.all([
             fetchFlowModelVersion(false),
             fetchFlowModelVersion(true).catch((error): Flow | null => {
                 console.error("[Reviewing Changes] Error fetching old flow model:", error);
+                oldFetchError = error;
                 return null;
             }),
         ]);
@@ -310,6 +326,11 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         }
         if (!oldFlow || !isSameExpectedFunction(oldFlow, newFlow, expectedMetadata)) {
             onDiffUnavailableRef.current?.();
+            setDiffNotice(
+                oldFetchError
+                    ? "The previous version of this diagram could not be loaded, so change highlighting is unavailable. Showing the new version."
+                    : "The previous version could not be matched to this change, so change highlighting is unavailable. Showing the new version."
+            );
             return newFlow;
         }
 
@@ -318,6 +339,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         } catch (error) {
             console.error("[Reviewing Changes] Error merging flow models for diff:", error);
             onDiffUnavailableRef.current?.();
+            setDiffNotice("The unified diff could not be built for this change. Showing the new version.");
             return newFlow;
         }
     };
@@ -336,6 +358,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
 
     return (
         <Container>
+            {viewMode === "diff" && diffNotice && <DiffNoticeBanner>⚠ {diffNotice}</DiffNoticeBanner>}
             <Diagram model={flowModel} readOnly={true} />
         </Container>
     );

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -17,12 +17,12 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { ChangeTypeEnum, Flow, NodePosition, ParentMetadata, SemanticDiff } from "@wso2/ballerina-core";
+import { Flow, NodePosition, ParentMetadata, SemanticDiff } from "@wso2/ballerina-core";
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
 import { Diagram, mergeFlowModelsForDiff, stampDiffState } from "@wso2/bi-diagram";
-import { getFlowLookupPosition } from "./position-utils";
+import { fetchFlowModelVersion, getVersionsForChangeType, ReviewModelCache } from "./reviewModelCache";
 
 const SpinnerContainer = styled.div`
     display: flex;
@@ -65,22 +65,6 @@ export type ExpectedFlowMetadata = Pick<SemanticDiff, "nodeKind" | "metadata">;
 const NODE_KIND_FUNCTION = 0;
 const NODE_KIND_RESOURCE = 1;
 
-/**
- * Which versions of a file structurally exist for a semantic-diff change type.
- * Single source of truth for the toggle availability (ReviewMode) and the
- * diff-mode fetch branching below.
- */
-export function getVersionsForChangeType(changeType: number): { old: boolean; new: boolean } {
-    switch (changeType) {
-        case ChangeTypeEnum.ADDITION:
-            return { old: false, new: true };
-        case ChangeTypeEnum.DELETION:
-            return { old: true, new: false };
-        default:
-            return { old: true, new: true };
-    }
-}
-
 interface ReadonlyFlowDiagramProps {
     projectPath: string;
     filePath: string;
@@ -91,6 +75,8 @@ interface ReadonlyFlowDiagramProps {
     changeType: number;
     expectedMetadata?: ExpectedFlowMetadata;
     onDiffUnavailable?: () => void;
+    /** Session-scoped model cache owned by ReviewMode — survives navigation remounts. */
+    modelCache: ReviewModelCache;
 }
 
 function getEventStartData(flow: Flow): ParentMetadata | undefined {
@@ -160,6 +146,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         changeType,
         expectedMetadata,
         onDiffUnavailable,
+        modelCache,
     } = props;
     const { rpcClient } = useRpcContext();
     const [flowModel, setFlowModel] = useState<Flow | null>(null);
@@ -176,9 +163,6 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
     const onDiffUnavailableRef = useRef(onDiffUnavailable);
     onModelLoadedRef.current = onModelLoaded;
     onDiffUnavailableRef.current = onDiffUnavailable;
-    // Review content is frozen while the review is open, so fetched versions are cached
-    // per view — toggling Diff/New/Old re-derives locally instead of re-querying the LS.
-    const flowCache = useRef<{ key: string; versions: Map<boolean, Flow | null> }>({ key: "", versions: new Map() });
 
     useEffect(() => {
         setIsLoading(true);
@@ -223,54 +207,16 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         };
     }, [filePath, position, oldPosition, viewMode, expectedMetadata, changeType, rpcClient]);
 
-    // Fetch one version of the enclosing function's flow model.
+    // Fetch one version of the enclosing function's flow model, through the session
+    // cache owned by ReviewMode — toggling Diff/New/Old or navigating back to this
+    // item re-derives locally instead of re-querying the LS.
     // useFileSchema=true reads the frozen original (ai://); false reads the live edits (file://).
-    const fetchFlowModelVersion = async (useFileSchema: boolean): Promise<Flow | null> => {
-        const lookupPosition = getFlowLookupPosition(position, oldPosition, useFileSchema);
-        const cacheKey = `${filePath}:${position.startLine}:${position.startColumn}:${position.endLine}:` +
-            `${position.endColumn}:${oldPosition?.startLine ?? ""}:${oldPosition?.startColumn ?? ""}:` +
-            `${oldPosition?.endLine ?? ""}:${oldPosition?.endColumn ?? ""}`;
-        if (flowCache.current.key !== cacheKey) {
-            flowCache.current = { key: cacheKey, versions: new Map() };
-        }
-        // capture the entry so a late response can't poison a newer view's cache
-        const cacheEntry = flowCache.current;
-        if (cacheEntry.versions.has(useFileSchema)) {
-            return cacheEntry.versions.get(useFileSchema);
-        }
-
-        // First resolve the full function range using getEnclosedFunction,
-        // since the position from semantic diff may only cover the changed statement
-        const enclosedFn = await rpcClient.getBIDiagramRpcClient().getEnclosedFunction({
-            filePath: filePath,
-            position: { line: lookupPosition.startLine, offset: lookupPosition.startColumn },
-            useFileSchema,
-        });
-        const startLine = enclosedFn?.startLine ?? {
-            line: lookupPosition.startLine,
-            offset: lookupPosition.startColumn,
-        };
-        const endLine = enclosedFn?.endLine ?? {
-            line: lookupPosition.endLine,
-            offset: lookupPosition.endColumn,
-        };
-
-        const response = await rpcClient.getBIDiagramRpcClient().getFlowModel({
-            filePath: filePath,
-            startLine,
-            endLine,
-            useFileSchema,
-        });
-        const flow = response?.flowModel ?? null;
-        if (flowCache.current === cacheEntry) {
-            cacheEntry.versions.set(useFileSchema, flow);
-        }
-        return flow;
-    };
+    const fetchVersion = (useFileSchema: boolean): Promise<Flow | null> =>
+        fetchFlowModelVersion(rpcClient, modelCache, { filePath, position, oldPosition, useFileSchema });
 
     const loadFlowModel = async (): Promise<Flow | null> => {
         if (viewMode === "old") {
-            const oldFlow = await fetchFlowModelVersion(true);
+            const oldFlow = await fetchVersion(true);
             if (oldFlow && !metadataMatchesExpected(oldFlow, expectedMetadata)) {
                 onDiffUnavailableRef.current?.();
                 return null;
@@ -278,7 +224,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
             return oldFlow;
         }
         if (viewMode === "new") {
-            const newFlow = await fetchFlowModelVersion(false);
+            const newFlow = await fetchVersion(false);
             if (newFlow && !metadataMatchesExpected(newFlow, expectedMetadata)) {
                 // Match the "old" branch: disable the diff toggle up front instead of
                 // waiting for the user to click Diff and discover it later.
@@ -291,11 +237,11 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         // unified diff mode
         const versions = getVersionsForChangeType(changeType);
         if (!versions.old) {
-            const newFlow = await fetchFlowModelVersion(false);
+            const newFlow = await fetchVersion(false);
             return newFlow ? stampDiffState(newFlow, "added") : null;
         }
         if (!versions.new) {
-            const oldFlow = await fetchFlowModelVersion(true);
+            const oldFlow = await fetchVersion(true);
             return oldFlow ? stampDiffState(oldFlow, "removed") : null;
         }
 
@@ -306,8 +252,8 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         // if the user then toggles to New/Old.
         let oldFetchError: unknown = null;
         const [newFlow, oldFlow] = await Promise.all([
-            fetchFlowModelVersion(false),
-            fetchFlowModelVersion(true).catch((error): Flow | null => {
+            fetchVersion(false),
+            fetchVersion(true).catch((error): Flow | null => {
                 console.error("[Reviewing Changes] Error fetching old flow model:", error);
                 oldFetchError = error;
                 return null;

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlySourceDiff.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlySourceDiff.tsx
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import styled from "@emotion/styled";
+import { ChangeTypeEnum } from "@wso2/ballerina-core";
+import { ReviewViewMode } from "./ReadonlyFlowDiagram";
+
+const Container = styled.div`
+    height: 100%;
+    overflow: auto;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    box-sizing: border-box;
+`;
+
+const PanelTitle = styled.div`
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--vscode-descriptionForeground);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+`;
+
+const SourceBlock = styled.pre<{ variant: "old" | "new" | "plain" }>`
+    margin: 0;
+    padding: 12px 16px;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: var(--vscode-editor-font-size, 13px);
+    white-space: pre-wrap;
+    word-break: break-word;
+    border-radius: 4px;
+    border: 1px solid
+        ${(props: { variant: "old" | "new" | "plain" }) =>
+            props.variant === "old"
+                ? "var(--vscode-inputValidation-errorBorder, #f85149)"
+                : props.variant === "new"
+                ? "var(--vscode-gitDecoration-addedResourceForeground, #2ea043)"
+                : "var(--vscode-panel-border)"};
+    background: var(--vscode-editor-background);
+    color: var(--vscode-editor-foreground);
+`;
+
+const EmptyNote = styled.div`
+    color: var(--vscode-descriptionForeground);
+    font-size: 13px;
+    font-style: italic;
+`;
+
+export interface ReadonlySourceDiffProps {
+    oldSource?: string;
+    newSource?: string;
+    changeType: number;
+    viewMode: ReviewViewMode;
+}
+
+/**
+ * Renders a construct change that has no diagram representation (constants, module
+ * variables, listeners, classes, enums, imports) as before/after source blocks. The
+ * before/after text travels inside the SemanticDiff metadata, so no extra fetch is
+ * needed — this view cannot fail asynchronously.
+ */
+export function ReadonlySourceDiff(props: ReadonlySourceDiffProps): JSX.Element {
+    const { oldSource, newSource, changeType, viewMode } = props;
+
+    const showOld = viewMode !== "new" && oldSource !== undefined;
+    const showNew = viewMode !== "old" && newSource !== undefined;
+
+    if (!showOld && !showNew) {
+        const missing =
+            viewMode === "old"
+                ? changeType === ChangeTypeEnum.ADDITION
+                    ? "This element was added — there is no previous version."
+                    : "The previous version of this element is unavailable."
+                : changeType === ChangeTypeEnum.DELETION
+                ? "This element was deleted — there is no new version."
+                : "The new version of this element is unavailable.";
+        return (
+            <Container>
+                <EmptyNote>{missing}</EmptyNote>
+            </Container>
+        );
+    }
+
+    return (
+        <Container>
+            {showOld && (
+                <div>
+                    <PanelTitle>{changeType === ChangeTypeEnum.DELETION ? "Removed" : "Before"}</PanelTitle>
+                    <SourceBlock variant={showNew ? "old" : "plain"}>{oldSource}</SourceBlock>
+                </div>
+            )}
+            {showNew && (
+                <div>
+                    <PanelTitle>{changeType === ChangeTypeEnum.ADDITION ? "Added" : "After"}</PanelTitle>
+                    <SourceBlock variant={showOld ? "new" : "plain"}>{newSource}</SourceBlock>
+                </div>
+            )}
+        </Container>
+    );
+}

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyTypeDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyTypeDiagram.tsx
@@ -35,6 +35,16 @@ const Container = styled.div`
     pointer-events: auto;
 `;
 
+const MessageContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    color: var(--vscode-descriptionForeground);
+    padding: 0 24px;
+    text-align: center;
+`;
+
 interface ItemMetadata {
     type: string;
     name: string;
@@ -52,17 +62,21 @@ export function ReadonlyTypeDiagram(props: ReadonlyTypeDiagramProps): JSX.Elemen
     const { filePath, onModelLoaded, useFileSchema } = props;
     const { rpcClient } = useRpcContext();
     const [typesModel, setTypesModel] = useState<Type[] | null>(null);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     useEffect(() => {
         setTypesModel(null);
-        fetchTypesModel();
-    }, [filePath, useFileSchema]);
-
-    const fetchTypesModel = () => {
+        setErrorMessage(null);
+        // Stale-response guard: a slower earlier request (e.g. after toggling Old/New)
+        // must not overwrite this render with the other version's model.
+        let cancelled = false;
         rpcClient
             .getBIDiagramRpcClient()
             .getTypes({ filePath: filePath, useFileSchema })
             .then((response) => {
+                if (cancelled) {
+                    return;
+                }
                 if (response?.types) {
                     setTypesModel(response.types);
 
@@ -84,17 +98,31 @@ export function ReadonlyTypeDiagram(props: ReadonlyTypeDiagramProps): JSX.Elemen
                             name: "No Types",
                         });
                     }
+                } else {
+                    // A resolved-but-empty response (e.g. the source is mid-edit and not
+                    // parseable) previously left the spinner up forever.
+                    setErrorMessage("The type diagram is unavailable for the selected version.");
                 }
             })
             .catch((error) => {
                 console.error("Error fetching types model:", error);
+                if (!cancelled) {
+                    setErrorMessage("The type diagram could not be loaded.");
+                }
             });
-    };
+        return () => {
+            cancelled = true;
+        };
+    }, [filePath, useFileSchema, rpcClient]);
 
     // No-op handlers for readonly mode
     const noOpHandler = () => {
         console.log("Diagram is in readonly mode");
     };
+
+    if (errorMessage) {
+        return <MessageContainer>{errorMessage}</MessageContainer>;
+    }
 
     if (!typesModel) {
         return (

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyTypeDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyTypeDiagram.tsx
@@ -22,6 +22,7 @@ import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
 import { TypeDiagram as TypeDesignDiagram } from "@wso2/type-diagram";
+import { fetchTypesModel, ReviewModelCache } from "./reviewModelCache";
 
 const SpinnerContainer = styled.div`
     display: flex;
@@ -56,10 +57,12 @@ interface ReadonlyTypeDiagramProps {
     filePath: string;
     onModelLoaded?: (metadata: ItemMetadata) => void;
     useFileSchema?: boolean;
+    /** Session-scoped model cache owned by ReviewMode — survives toggle/navigation remounts. */
+    modelCache: ReviewModelCache;
 }
 
 export function ReadonlyTypeDiagram(props: ReadonlyTypeDiagramProps): JSX.Element {
-    const { filePath, onModelLoaded, useFileSchema } = props;
+    const { filePath, onModelLoaded, useFileSchema, modelCache } = props;
     const { rpcClient } = useRpcContext();
     const [typesModel, setTypesModel] = useState<Type[] | null>(null);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -70,26 +73,24 @@ export function ReadonlyTypeDiagram(props: ReadonlyTypeDiagramProps): JSX.Elemen
         // Stale-response guard: a slower earlier request (e.g. after toggling Old/New)
         // must not overwrite this render with the other version's model.
         let cancelled = false;
-        rpcClient
-            .getBIDiagramRpcClient()
-            .getTypes({ filePath: filePath, useFileSchema })
-            .then((response) => {
+        fetchTypesModel(rpcClient, modelCache, filePath, useFileSchema)
+            .then((types) => {
                 if (cancelled) {
                     return;
                 }
-                if (response?.types) {
-                    setTypesModel(response.types);
+                if (types) {
+                    setTypesModel(types);
 
                     // Extract metadata from the types
-                    if (onModelLoaded && response.types.length > 0) {
+                    if (onModelLoaded && types.length > 0) {
                         // If there's a single type, use it; otherwise show "Types" as plural
-                        const firstType = response.types[0];
+                        const firstType = types[0];
                         onModelLoaded({
                             type: "Type",
                             name:
-                                response.types.length === 1
+                                types.length === 1
                                     ? firstType.name || "Unknown"
-                                    : `${response.types.length} Types`,
+                                    : `${types.length} Types`,
                         });
                     } else if (onModelLoaded) {
                         // No types found
@@ -113,7 +114,7 @@ export function ReadonlyTypeDiagram(props: ReadonlyTypeDiagramProps): JSX.Elemen
         return () => {
             cancelled = true;
         };
-    }, [filePath, useFileSchema, rpcClient]);
+    }, [filePath, useFileSchema, rpcClient, modelCache]);
 
     // No-op handlers for readonly mode
     const noOpHandler = () => {

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -117,6 +117,35 @@ const CloseButton = styled.button`
     }
 `;
 
+const CompileErrorMessage = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-width: 560px;
+    padding: 16px 20px;
+    color: var(--vscode-foreground);
+    border: 1px solid var(--vscode-inputValidation-warningBorder, ${ThemeColors.PRIMARY});
+    background: var(--vscode-inputValidation-warningBackground, transparent);
+    border-radius: 4px;
+    font-size: 13px;
+`;
+
+const ErrorDetail = styled.div`
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 12px;
+    color: var(--vscode-errorForeground);
+    word-break: break-word;
+`;
+
+const CompileWarningBanner = styled.div`
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--vscode-inputValidation-warningForeground, var(--vscode-foreground));
+    background: var(--vscode-inputValidation-warningBackground, transparent);
+    border-bottom: 1px solid var(--vscode-inputValidation-warningBorder, ${ThemeColors.PRIMARY});
+    word-break: break-word;
+`;
+
 enum DiagramType {
     COMPONENT = "component",
     FLOW = "flow",
@@ -244,6 +273,7 @@ export function ReviewMode(): JSX.Element {
     const [isLoading, setIsLoading] = useState(true);
     const [currentItemMetadata, setCurrentItemMetadata] = useState<ItemMetadata | null>(null);
     const [isWorkspace, setIsWorkspace] = useState(false);
+    const [semanticDiffError, setSemanticDiffError] = useState<string | null>(null);
     const [viewMode, setViewMode] = useState<ReviewViewMode>("diff");
     // View indices where the unified diff could not be built (old version missing/mismatched)
     const [diffUnavailableViews, setDiffUnavailableViews] = useState<Set<number>>(new Set());
@@ -274,6 +304,7 @@ export function ReviewMode(): JSX.Element {
 
             setProjectPath(tempDirPath);
             setIsWorkspace(isWorkspaceProject);
+            setSemanticDiffError(data.semanticDiffError ?? null);
             setSemanticDiffData({ semanticDiffs, loadDesignDiagrams });
 
             const packagesToReview = isWorkspaceProject ? affectedPackages : [tempDirPath];
@@ -499,7 +530,7 @@ export function ReviewMode(): JSX.Element {
         return (
             <ReviewContainer>
                 <TitleBar
-                    title="No Changes"
+                    title={semanticDiffError ? "Review Unavailable" : "No Changes"}
                     actions={
                         <>
                             <ReviewModeBadge>Reviewing Changes</ReviewModeBadge>
@@ -512,7 +543,19 @@ export function ReviewMode(): JSX.Element {
                     hideUndoRedo={true}
                 />
                 <DiagramContainer style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
-                    <div style={{ color: "var(--vscode-foreground)" }}>No changes to review</div>
+                    {semanticDiffError ? (
+                        <CompileErrorMessage>
+                            <strong>The changes could not be analyzed because the project fails to compile.</strong>
+                            <ErrorDetail>{semanticDiffError}</ErrorDetail>
+                            <div>
+                                The changes are already applied to your files. If the error mentions a
+                                dependency, running <code>bal build</code> in the project usually resolves it
+                                by refreshing <code>Dependencies.toml</code>.
+                            </div>
+                        </CompileErrorMessage>
+                    ) : (
+                        <div style={{ color: "var(--vscode-foreground)" }}>No changes to review</div>
+                    )}
                 </DiagramContainer>
             </ReviewContainer>
         );
@@ -584,6 +627,11 @@ export function ReviewMode(): JSX.Element {
                 hideBack={true}
                 hideUndoRedo={true}
             />
+            {semanticDiffError && (
+                <CompileWarningBanner title={semanticDiffError}>
+                    ⚠ The project fails to compile, so diagrams may be unavailable: {semanticDiffError}
+                </CompileWarningBanner>
+            )}
             <DiagramContainer>{renderDiagram()}</DiagramContainer>
             <ReviewNavigation
                 key={`nav-${currentIndex}-${views.length}`}

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -17,13 +17,15 @@
  */
 
 import React, { useEffect, useState, useCallback, useRef } from "react";
-import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum, NodePosition } from "@wso2/ballerina-core";
+import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum, NodeKindEnum, NodePosition } from "@wso2/ballerina-core";
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
 import { ExpectedFlowMetadata, ReadonlyFlowDiagram, ReviewViewMode, getVersionsForChangeType } from "./ReadonlyFlowDiagram";
 import { diffBelongsToPackage } from "./path-utils";
 import { ReadonlyTypeDiagram } from "./ReadonlyTypeDiagram";
+import { ReadonlySourceDiff } from "./ReadonlySourceDiff";
+import { getNodeKindLabel, SOURCE_VIEW_KINDS } from "./nodeKindLabels";
 import { ReviewNavigation } from "./ReviewNavigation";
 import { Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
 import { TitleBar } from "../../components/TitleBar";
@@ -150,6 +152,7 @@ enum DiagramType {
     COMPONENT = "component",
     FLOW = "flow",
     TYPE = "type",
+    SOURCE = "source",
 }
 
 interface ReviewView {
@@ -161,12 +164,8 @@ interface ReviewView {
     label?: string;
     changeType: number;
     expectedMetadata?: ExpectedFlowMetadata;
-}
-
-enum NodeKindEnum {
-    FUNCTION = 0,
-    RESOURCE_FUNCTION = 1,
-    TYPE = 2,
+    /** Construct name + before/after source, for SOURCE views (carried in diff metadata). */
+    sourceMeta?: { name?: string; oldSource?: string; newSource?: string };
 }
 
 // Map numeric changeType to string
@@ -183,23 +182,12 @@ function getChangeTypeString(changeType: number): string {
     }
 }
 
-// Map numeric nodeKind to string
-function getNodeKindString(nodeKind: number): string {
-    switch (nodeKind) {
-        case NodeKindEnum.FUNCTION:
-            return "function";
-        case NodeKindEnum.RESOURCE_FUNCTION:
-            return "resource";
-        case NodeKindEnum.TYPE:
-            return "type";
-        default:
-            return "component";
-    }
-}
-
 function getDiagramType(nodeKind: number): DiagramType {
-    if (nodeKind === NodeKindEnum.TYPE) {
+    if (nodeKind === NodeKindEnum.TYPE_DEFINITION) {
         return DiagramType.TYPE;
+    }
+    if (SOURCE_VIEW_KINDS.has(nodeKind)) {
+        return DiagramType.SOURCE;
     }
     return DiagramType.FLOW;
 }
@@ -208,15 +196,20 @@ function getDiagramType(nodeKind: number): DiagramType {
 function convertToReviewView(diff: SemanticDiff, projectPath: string, packageName?: string): ReviewView {
     const fileName = diff.uri.split("/").pop() || diff.uri;
     const changeTypeStr = getChangeTypeString(diff.changeType);
-    const nodeKindStr = getNodeKindString(diff.nodeKind);
+    const nodeKindStr = getNodeKindLabel(diff.nodeKind, diff.metadata);
+    const diagramType = getDiagramType(diff.nodeKind);
 
     // Include package name in label if provided (for multi-package scenarios)
     const changeLabel = packageName
         ? `${changeTypeStr}: ${nodeKindStr} in ${packageName}/${fileName}`
         : `${changeTypeStr}: ${nodeKindStr} in ${fileName}`;
 
+    const metadata = diff.metadata as
+        | { name?: string; oldSource?: string; newSource?: string }
+        | undefined;
+
     return {
-        type: getDiagramType(diff.nodeKind),
+        type: diagramType,
         filePath: diff.uri,
         position: {
             startLine: diff.lineRange.startLine.line,
@@ -239,6 +232,10 @@ function convertToReviewView(diff: SemanticDiff, projectPath: string, packageNam
             nodeKind: diff.nodeKind,
             metadata: diff.metadata,
         },
+        sourceMeta:
+            diagramType === DiagramType.SOURCE
+                ? { name: metadata?.name, oldSource: metadata?.oldSource, newSource: metadata?.newSource }
+                : undefined,
     };
 }
 
@@ -273,6 +270,7 @@ export function ReviewMode(): JSX.Element {
     const [isLoading, setIsLoading] = useState(true);
     const [currentItemMetadata, setCurrentItemMetadata] = useState<ItemMetadata | null>(null);
     const [isWorkspace, setIsWorkspace] = useState(false);
+    const [modifiedFiles, setModifiedFiles] = useState<string[]>([]);
     const [semanticDiffError, setSemanticDiffError] = useState<string | null>(null);
     const [viewMode, setViewMode] = useState<ReviewViewMode>("diff");
     // View indices where the unified diff could not be built (old version missing/mismatched)
@@ -304,6 +302,7 @@ export function ReviewMode(): JSX.Element {
 
             setProjectPath(tempDirPath);
             setIsWorkspace(isWorkspaceProject);
+            setModifiedFiles(data.modifiedFiles ?? []);
             setSemanticDiffError(data.semanticDiffError ?? null);
             setSemanticDiffData({ semanticDiffs, loadDesignDiagrams });
 
@@ -388,12 +387,19 @@ export function ReviewMode(): JSX.Element {
         });
     }, [rpcClient]);
 
-    // Set metadata for component diagram when view changes
+    // Set metadata for component/source views when view changes (they don't load a model
+    // that would report metadata back)
     useEffect(() => {
         if (currentView?.type === "component" && !currentItemMetadata) {
             setCurrentItemMetadata({
                 type: "Design",
                 name: "",
+            });
+        }
+        if (currentView?.type === "source" && !currentItemMetadata) {
+            setCurrentItemMetadata({
+                type: "Change",
+                name: currentView.sourceMeta?.name ?? "",
             });
         }
     }, [currentView, currentItemMetadata]);
@@ -445,6 +451,12 @@ export function ReviewMode(): JSX.Element {
         if (!currentView) {
             return { diff: false, new: true, old: false };
         }
+        if (currentView.type === DiagramType.SOURCE) {
+            // Source views carry their own before/after text; "diff" shows both blocks.
+            const hasOld = currentView.sourceMeta?.oldSource !== undefined;
+            const hasNew = currentView.sourceMeta?.newSource !== undefined;
+            return { diff: hasOld && hasNew, new: hasNew, old: hasOld };
+        }
         const versions = getVersionsForChangeType(currentView.changeType);
         const diff = currentView.type === DiagramType.FLOW && !diffUnavailableViews.has(currentIndex);
         return { diff, new: versions.new, old: versions.old };
@@ -465,8 +477,15 @@ export function ReviewMode(): JSX.Element {
             return <div>No view to display</div>;
         }
 
-        // Create a unique key for each diagram to force re-mount when switching views
-        const diagramKey = `${currentView.type}-${currentIndex}-${currentView.filePath}`;
+        // Create a unique key for each diagram to force re-mount when switching views.
+        // For type/design diagrams the Old/New toggle is part of the key: their fetch
+        // effects have no stale-response guard, so remounting on toggle prevents an
+        // out-of-order response from rendering the wrong version. Flow diagrams cache
+        // versions internally and derive the toggle locally, so their key excludes it.
+        const diagramKey =
+            currentView.type === "flow"
+                ? `${currentView.type}-${currentIndex}-${currentView.filePath}`
+                : `${currentView.type}-${currentIndex}-${currentView.filePath}-${effectiveViewMode}`;
 
         switch (currentView.type) {
             case "component":
@@ -503,6 +522,17 @@ export function ReviewMode(): JSX.Element {
                         filePath={currentView.filePath}
                         onModelLoaded={handleModelLoaded}
                         useFileSchema={effectiveViewMode === "old"}
+                    />
+                );
+            case "source":
+                // The construct's name is shown by the TitleBar (via currentItemMetadata).
+                return (
+                    <ReadonlySourceDiff
+                        key={diagramKey}
+                        oldSource={currentView.sourceMeta?.oldSource}
+                        newSource={currentView.sourceMeta?.newSource}
+                        changeType={currentView.changeType}
+                        viewMode={effectiveViewMode}
                     />
                 );
             default:
@@ -552,6 +582,22 @@ export function ReviewMode(): JSX.Element {
                                 dependency, running <code>bal build</code> in the project usually resolves it
                                 by refreshing <code>Dependencies.toml</code>.
                             </div>
+                        </CompileErrorMessage>
+                    ) : modifiedFiles.length > 0 ? (
+                        // Files changed but nothing produced a reviewable code diff (e.g. only
+                        // Config.toml / markdown / JSON edits). Say what changed instead of the
+                        // misleading "No changes to review".
+                        <CompileErrorMessage style={{ borderColor: "var(--vscode-panel-border)", background: "transparent" }}>
+                            <strong>No code changes to review as diagrams.</strong>
+                            <div>
+                                {modifiedFiles.length} file{modifiedFiles.length === 1 ? " was" : "s were"} changed
+                                and already applied to your project:
+                            </div>
+                            <ErrorDetail style={{ color: "var(--vscode-foreground)" }}>
+                                {modifiedFiles.map((f) => (
+                                    <div key={f}>{f}</div>
+                                ))}
+                            </ErrorDetail>
                         </CompileErrorMessage>
                     ) : (
                         <div style={{ color: "var(--vscode-foreground)" }}>No changes to review</div>

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -21,11 +21,12 @@ import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum, NodeKindEnum, NodeP
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
-import { ExpectedFlowMetadata, ReadonlyFlowDiagram, ReviewViewMode, getVersionsForChangeType } from "./ReadonlyFlowDiagram";
+import { ExpectedFlowMetadata, ReadonlyFlowDiagram, ReviewViewMode } from "./ReadonlyFlowDiagram";
 import { diffBelongsToPackage } from "./path-utils";
 import { ReadonlyTypeDiagram } from "./ReadonlyTypeDiagram";
 import { ReadonlySourceDiff } from "./ReadonlySourceDiff";
 import { getNodeKindLabel, SOURCE_VIEW_KINDS } from "./nodeKindLabels";
+import { getVersionsForChangeType, prefetchReviewView, ReviewModelCache } from "./reviewModelCache";
 import { ReviewNavigation } from "./ReviewNavigation";
 import { Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
 import { TitleBar } from "../../components/TitleBar";
@@ -277,6 +278,11 @@ export function ReviewMode(): JSX.Element {
     const [diffUnavailableViews, setDiffUnavailableViews] = useState<Set<number>>(new Set());
     const pendingIndexRef = useRef<number | null>(null);
     const viewsLengthRef = useRef<number>(0);
+    // Session-scoped LS model cache shared by all diagram components. The per-item
+    // components are remounted on navigation/toggle (their keys include currentIndex),
+    // so any cache they hold themselves dies with them — this one survives, making
+    // revisits and Old/New toggles cache hits instead of fresh LS round trips.
+    const modelCacheRef = useRef<ReviewModelCache>(new Map());
 
     useEffect(() => {
         viewsLengthRef.current = views.length;
@@ -293,6 +299,9 @@ export function ReviewMode(): JSX.Element {
             const location = await rpcClient.getVisualizerLocation();
             const data = location?.reviewData;
             if (!data?.semanticDiffs || !data?.tempProjectPath) return;
+
+            // New review payload — models cached for a previous generation are stale.
+            modelCacheRef.current = new Map();
 
             const tempDirPath = data.tempProjectPath;
             const isWorkspaceProject = data.isWorkspace ?? false;
@@ -386,6 +395,37 @@ export function ReviewMode(): JSX.Element {
             }
         });
     }, [rpcClient]);
+
+    // Warm the session cache for EVERY item once per review payload, ordered outward
+    // from the item the review opened on, so any chip click or prev/next lands on an
+    // already-fetched model. Two workers keep the sweep from starving the mounted
+    // component's own fetch (which the promise cache dedups against anyway); a failed
+    // prefetch evicts itself, so the visit-time fetch still gets a fresh attempt.
+    const prefetchedViewsRef = useRef<ReviewView[] | null>(null);
+    useEffect(() => {
+        if (views.length === 0 || prefetchedViewsRef.current === views) {
+            return;
+        }
+        prefetchedViewsRef.current = views;
+        const cache = modelCacheRef.current;
+        const order: ReviewView[] = [];
+        for (let distance = 0; order.length < views.length; distance++) {
+            const ahead = currentIndex + distance;
+            const behind = currentIndex - distance;
+            if (ahead < views.length) order.push(views[ahead]);
+            if (distance > 0 && behind >= 0) order.push(views[behind]);
+        }
+        let nextIndex = 0;
+        const worker = (): void => {
+            if (nextIndex >= order.length || modelCacheRef.current !== cache) {
+                // A new review payload replaced the cache — stop sweeping stale views.
+                return;
+            }
+            prefetchReviewView(rpcClient, cache, order[nextIndex++]).then(worker);
+        };
+        worker();
+        worker();
+    }, [views, currentIndex, rpcClient]);
 
     // Set metadata for component/source views when view changes (they don't load a model
     // that would report metadata back)
@@ -497,6 +537,7 @@ export function ReviewMode(): JSX.Element {
                         filePath={currentView.filePath}
                         position={currentView.position}
                         useFileSchema={effectiveViewMode === "old"}
+                        modelCache={modelCacheRef.current}
                     />
                 );
             case "flow":
@@ -512,6 +553,7 @@ export function ReviewMode(): JSX.Element {
                         changeType={currentView.changeType}
                         expectedMetadata={currentView.expectedMetadata}
                         onDiffUnavailable={handleDiffUnavailable}
+                        modelCache={modelCacheRef.current}
                     />
                 );
             case "type":
@@ -522,6 +564,7 @@ export function ReviewMode(): JSX.Element {
                         filePath={currentView.filePath}
                         onModelLoaded={handleModelLoaded}
                         useFileSchema={effectiveViewMode === "old"}
+                        modelCache={modelCacheRef.current}
                     />
                 );
             case "source":

--- a/packages/ballerina-visualizer/src/views/ReviewMode/nodeKindLabels.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/nodeKindLabels.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { NodeKindEnum, SemanticDiff } from "@wso2/ballerina-core";
+
+/**
+ * Shared nodeKind wording for the review surfaces (ReviewMode + ReviewBar) — a deliberate
+ * leaf module (no React/RPC) so both import one table instead of mirroring the LS enum twice.
+ */
+const NODE_KIND_LABELS: Record<number, string> = {
+    [NodeKindEnum.MODULE_FUNCTION]: "function",
+    [NodeKindEnum.OBJECT_FUNCTION]: "resource",
+    [NodeKindEnum.TYPE_DEFINITION]: "type",
+    [NodeKindEnum.DATA_MAPPING_FUNCTION]: "data mapping",
+    [NodeKindEnum.MODULE_VARIABLE]: "variable",
+    [NodeKindEnum.CONSTANT]: "constant",
+    [NodeKindEnum.LISTENER]: "listener",
+    [NodeKindEnum.CLASS_DEFINITION]: "class",
+    [NodeKindEnum.ENUM_DECLARATION]: "enum",
+    [NodeKindEnum.IMPORT_DECLARATION]: "import",
+};
+
+export function getNodeKindLabel(nodeKind: number, metadata?: SemanticDiff["metadata"]): string {
+    // OBJECT_FUNCTION covers both service resource/remote members and plain class
+    // methods; only the former carry resource metadata (accessor/servicePath).
+    if (nodeKind === NodeKindEnum.OBJECT_FUNCTION
+        && !(metadata as { accessor?: string } | undefined)?.accessor) {
+        return "method";
+    }
+    return NODE_KIND_LABELS[nodeKind] ?? "component";
+}
+
+/**
+ * Construct kinds with no diagram representation, rendered as before/after source blocks.
+ * Explicit membership on purpose: an ordinal-range check would silently misrender a future
+ * kind appended after these that DOES have a diagram.
+ */
+export const SOURCE_VIEW_KINDS: ReadonlySet<number> = new Set([
+    NodeKindEnum.MODULE_VARIABLE,
+    NodeKindEnum.CONSTANT,
+    NodeKindEnum.LISTENER,
+    NodeKindEnum.CLASS_DEFINITION,
+    NodeKindEnum.ENUM_DECLARATION,
+    NodeKindEnum.IMPORT_DECLARATION,
+]);

--- a/packages/ballerina-visualizer/src/views/ReviewMode/reviewModelCache.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/reviewModelCache.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CDModel, ChangeTypeEnum, Flow, NodePosition, Type } from "@wso2/ballerina-core";
+import { BallerinaRpcClient } from "@wso2/ballerina-rpc-client";
+import { getFlowLookupPosition } from "./position-utils";
+
+/**
+ * Review-session-scoped cache of LS model fetches, keyed by view identity + version.
+ *
+ * Review content is frozen while a review is open, so any model fetched once stays
+ * valid for the whole session. The cache lives in ReviewMode (not in the per-item
+ * diagram components, which are remounted on every prev/next navigation and on the
+ * Old/New toggle for type/design views) so that navigating back to an already-seen
+ * item, or flipping the toggle, never re-hits the LS.
+ *
+ * Promises (not resolved values) are cached so concurrent requests for the same
+ * model — e.g. a prefetch racing the mounted component's own fetch — collapse into
+ * one LS round trip. A rejected fetch evicts itself so an error never becomes sticky.
+ */
+export type ReviewModelCache = Map<string, Promise<unknown>>;
+
+export function getOrFetch<T>(cache: ReviewModelCache, key: string, fetch: () => Promise<T>): Promise<T> {
+    const existing = cache.get(key);
+    if (existing) {
+        return existing as Promise<T>;
+    }
+    const promise = fetch();
+    cache.set(key, promise);
+    promise.catch(() => {
+        if (cache.get(key) === promise) {
+            cache.delete(key);
+        }
+    });
+    return promise;
+}
+
+/**
+ * Which versions of a file structurally exist for a semantic-diff change type.
+ * Single source of truth for the toggle availability (ReviewMode), the diff-mode
+ * fetch branching (ReadonlyFlowDiagram), and prefetching below.
+ */
+export function getVersionsForChangeType(changeType: number): { old: boolean; new: boolean } {
+    switch (changeType) {
+        case ChangeTypeEnum.ADDITION:
+            return { old: false, new: true };
+        case ChangeTypeEnum.DELETION:
+            return { old: true, new: false };
+        default:
+            return { old: true, new: true };
+    }
+}
+
+export interface FlowVersionParams {
+    filePath: string;
+    position: NodePosition;
+    oldPosition?: NodePosition;
+    /** true reads the frozen original (ai://); false reads the live edits (file://). */
+    useFileSchema: boolean;
+}
+
+function positionKey(position?: NodePosition): string {
+    if (!position) {
+        return "";
+    }
+    return `${position.startLine}:${position.startColumn}:${position.endLine}:${position.endColumn}`;
+}
+
+/**
+ * Fetch one version of the enclosing function's flow model (enclosed-function lookup
+ * followed by the flow-model request), deduped through the session cache.
+ */
+export function fetchFlowModelVersion(
+    rpcClient: BallerinaRpcClient,
+    cache: ReviewModelCache,
+    params: FlowVersionParams
+): Promise<Flow | null> {
+    const { filePath, position, oldPosition, useFileSchema } = params;
+    const key = `flow:${filePath}:${positionKey(position)}:${positionKey(oldPosition)}:${useFileSchema}`;
+    return getOrFetch(cache, key, async () => {
+        const lookupPosition = getFlowLookupPosition(position, oldPosition, useFileSchema);
+
+        // First resolve the full function range using getEnclosedFunction,
+        // since the position from semantic diff may only cover the changed statement
+        const enclosedFn = await rpcClient.getBIDiagramRpcClient().getEnclosedFunction({
+            filePath,
+            position: { line: lookupPosition.startLine, offset: lookupPosition.startColumn },
+            useFileSchema,
+        });
+        const startLine = enclosedFn?.startLine ?? {
+            line: lookupPosition.startLine,
+            offset: lookupPosition.startColumn,
+        };
+        const endLine = enclosedFn?.endLine ?? {
+            line: lookupPosition.endLine,
+            offset: lookupPosition.endColumn,
+        };
+
+        const response = await rpcClient.getBIDiagramRpcClient().getFlowModel({
+            filePath,
+            startLine,
+            endLine,
+            useFileSchema,
+        });
+        return response?.flowModel ?? null;
+    });
+}
+
+/** Fetch the type-diagram model for one version, deduped through the session cache. */
+export function fetchTypesModel(
+    rpcClient: BallerinaRpcClient,
+    cache: ReviewModelCache,
+    filePath: string,
+    useFileSchema: boolean | undefined
+): Promise<Type[] | null> {
+    const key = `types:${filePath}:${useFileSchema === true}`;
+    return getOrFetch(cache, key, async () => {
+        const response = await rpcClient.getBIDiagramRpcClient().getTypes({ filePath, useFileSchema });
+        return response?.types ?? null;
+    });
+}
+
+/** Fetch the design/component model for one version, deduped through the session cache. */
+export function fetchDesignModel(
+    rpcClient: BallerinaRpcClient,
+    cache: ReviewModelCache,
+    projectPath: string,
+    useFileSchema: boolean | undefined
+): Promise<CDModel | null> {
+    const key = `design:${projectPath}:${useFileSchema === true}`;
+    return getOrFetch(cache, key, async () => {
+        const response = await rpcClient.getBIDiagramRpcClient().getDesignModel({ projectPath, useFileSchema });
+        return response?.designModel ?? null;
+    });
+}
+
+/** The structural subset of ReviewMode's ReviewView that prefetching needs. */
+export interface PrefetchableReviewView {
+    /** DiagramType value: "flow" | "type" | "component" | "source". */
+    type: string;
+    filePath: string;
+    position: NodePosition;
+    oldPosition?: NodePosition;
+    projectPath: string;
+    changeType: number;
+}
+
+/**
+ * Warms the session cache with what a view fetches when it first mounts, so navigating
+ * to it lands on an already-resolved model. Lives next to the fetchers on purpose: the
+ * per-view-kind fetch shape is this module's knowledge, not ReviewMode's.
+ *
+ * Only the versions shown by each view's initial mode are warmed — flow opens in diff
+ * mode (both versions per its change type); type/component open in "new" and fetch
+ * "old" on demand when toggled; source views carry their content in the diff metadata.
+ * A failed prefetch evicts itself from the cache (see getOrFetch). The returned promise
+ * settles when the view's fetches settle (never rejects) so callers can pace a sweep.
+ */
+export function prefetchReviewView(
+    rpcClient: BallerinaRpcClient,
+    cache: ReviewModelCache,
+    view: PrefetchableReviewView | undefined
+): Promise<void> {
+    if (!view) {
+        return Promise.resolve();
+    }
+    const fetches: Promise<unknown>[] = [];
+    switch (view.type) {
+        case "flow": {
+            const versions = getVersionsForChangeType(view.changeType);
+            const params = { filePath: view.filePath, position: view.position, oldPosition: view.oldPosition };
+            if (versions.new) {
+                fetches.push(fetchFlowModelVersion(rpcClient, cache, { ...params, useFileSchema: false }));
+            }
+            if (versions.old) {
+                fetches.push(fetchFlowModelVersion(rpcClient, cache, { ...params, useFileSchema: true }));
+            }
+            break;
+        }
+        case "type":
+            fetches.push(fetchTypesModel(rpcClient, cache, view.filePath, false));
+            break;
+        case "component":
+            fetches.push(fetchDesignModel(rpcClient, cache, view.projectPath, false));
+            break;
+        default:
+            break;
+    }
+    return Promise.allSettled(fetches).then((): void => undefined);
+}

--- a/packages/bi-diagram/src/components/Diagram.tsx
+++ b/packages/bi-diagram/src/components/Diagram.tsx
@@ -138,7 +138,9 @@ export function Diagram(props: DiagramProps) {
 
     const [showErrorFlow, setShowErrorFlow] = useState(false);
     const [nodeComments, setNodeComments] = useState<Map<string, FlowNode[]>>(new Map());
-    const [diagramEngine] = useState<DiagramEngine>(generateEngine());
+    // Lazy initializer: generateEngine() registers ~20 factories, and the non-lazy form
+    // would rebuild (and discard) an engine on every render of this component.
+    const [diagramEngine] = useState<DiagramEngine>(() => generateEngine());
     const [diagramModel, setDiagramModel] = useState<DiagramModel | null>(null);
     const [canvasVisible, setCanvasVisible] = useState(!(isAgentFocusView && embedded));
     const [showComponentPanel, setShowComponentPanel] = useState(false);


### PR DESCRIPTION
## Problem

The review-diff feature intermittently showed **"no diff available"** even though the agent had edited files. An independent investigation (driven by a 15-scenario LSP harness against the real language server) found failures at four layers, each able to produce an empty or misleading review on its own.

## Root causes and fixes

### 1. Language server: semantic diff was blind to most of the project
- Diffs were computed only for the **default module** — changes in other modules and in test sources were invisible.
- Only functions, services, types, and listeners were compared. Edits to **module variables, constants, enums, classes, and imports** produced no diff entries at all (several existing test fixtures encoded "expect zero diffs" for real changes).
- `SemanticDiffComputer` now walks the union of all modules on both sides (including test documents), and a generic construct differ covers the missing kinds. `NodeKind` gained six append-only constants (ordinals are wire format). Type deletions are now reported, and non-block function bodies no longer crash the body comparison.

### 2. Baseline lifecycle: the `ai://` baseline could be stale or missing
- Baseline seeding was fire-and-forget notifications — the agent could start editing before the LS had frozen the pre-edit copy, so the diff compared new against new (race confirmed empirically at 0 ms; dead after the fix).
- New `copilotAgentService/ensureAiBaseline` request: evicts the cached `ai://` project and re-seeds it per file, **acknowledged** so the extension awaits it before any edit lands. New packages created mid-run get their baseline seeded at `Ballerina.toml` creation time, with already-written `.bal` files seeded as empty (so they diff as additions).
- Review restore after a window reload treats files missing from the checkpoint snapshot as created files instead of skipping them.

### 3. Extension: package mapping and error isolation
- Changed-file → package attribution now normalizes paths (case, separators, trailing slashes) and unions `Ballerina.toml` discovery with `ProjectSource`, so files no longer fall out of the diff because their package wasn't matched.
- One package failing to diff no longer zeroes out the whole review — per-package errors are accumulated and surfaced while the remaining diffs render.
- Finalizing a previous generation now covers **all threads**, so a pending review from another thread can't leave a stale baseline behind.
- Reverting without a checkpoint now fails loudly instead of pretending the revert happened.

### 4. UI: silent degradation hid every failure above
- The review surfaces rendered nothing when a diff had no diagram representation. New source-view renderer (`ReadonlySourceDiff`) shows before/after code for variables, constants, listeners, classes, enums, and imports; shared `nodeKindLabels` module keeps ReviewMode and ReviewBar wording consistent.
- Flow/type/component diagrams no longer spin forever or silently fall back: fetch failures, metadata mismatches, and merge failures each show a distinct notice.
- The empty state now lists the changed files instead of claiming nothing changed, and a failed revert keeps the review bar open instead of navigating away.

## Verification

- LS: `gradle build pack` + full test suite green; 7 semantic-diff fixtures regenerated and hand-reviewed (they now encode the intended new coverage).
- Extension: `tsc` clean, 123/123 unit tests pass (new `it.each` suite for path normalization; partial-failure behavior asserted).
- Visualizer: build clean, 56/56 tests pass.
- `rush build --to ballerina`: SUCCESS.
- Empirical harness: all 15 scenarios (multi-module, tests, every construct kind, new-package creation, seed race at 0 ms) now produce correct diffs against the rebuilt LS.


---

## Follow-up: review-diff performance + import-diff noise (second commit series)

Profiling the review flow against a real project (jstack sampling of a live LS) showed the dominant cost was **not** package compilation: a *warm* `getFlowModel` took 2.5–3.4 s per call because `CodeAnalyzer`/`FunctionDataBuilder` resolved every remote-call node's dependency package through `PackageUtil` on every request — each call building a fresh temp "sample project" and running non-sticky resolution that performs an **HTTP round trip to Ballerina Central even for locally cached packages**. Diff mode fires two such calls per item.

### perf(ls): cache module-package resolution
- `PackageUtil`: memoized sample project; session cache for sample-project module resolutions (positive and negative — unresolvable generated/test packages were the hottest repeat offenders); exact-version descriptors resolve **offline-first**, contacting Central only on a local-cache miss.
- Measured on a real project: warm `getFlowModel` **~2,800 ms → ~30 ms**; cold first fetch halved; zero network for locally cached dependencies.
- New `copilotAgentService/prewarmDependencies`: resolves + pre-compiles a package's direct dependencies into those caches, fired by the extension in the background at generation start (~3.5 s for 7 deps, off the critical path).
- `ProjectUpdateEventPublisher` skips the `PROJECT_UPDATE` subscriber fan-out for `ai://` scheme events (no consumer for baseline diagnostics/prompts; each subscriber forces a compilation per seeding event).

### perf(extension): parallelize review-path work
- Per-package `getSemanticDiff` and `ensureAiBaseline` calls run concurrently (bounded via a new `mapWithConcurrency` helper), preserving result order and per-package error isolation.
- Checkpoint snapshots read files in 32-way chunks instead of one at a time.

### perf(review-ui): session cache + full prefetch
- New `reviewModelCache.ts`: a review-session promise cache shared by flow/type/component diagram components — prev/next navigation and Diff/New/Old toggles become cache hits instead of fresh LS round trips.
- All review items are prefetched once per review payload (two workers, ordered outward from the opening item), so any chip click lands on a resolved model.
- `bi-diagram`: lazy diagram-engine initialization (the non-lazy `useState` built and discarded an engine with ~20 factories on every render).

### fix(ls): trivia-only import "modifications"
An import's diff key already encodes its full semantics, but imports were compared by source text including leading trivia — inserting an import re-attached the file-header comment to a neighboring import and flagged it "modified", showing reviewers a comment shuffle. Imports now diff by key alone (add/delete/alias-change only), rendered in canonical `import <key>;` form.

### Verification (follow-up commits)
- LS: touched modules build (checkstyle + SpotBugs); `architecture-model-generator-ls-extension` suite green with `--rerun-tasks`; full jar rebuilt and re-measured with the LSP timing harness.
- Extension: `tsc` clean, 123/123 unit tests. Visualizer: build clean, 56/56 tests.
