### PR TITLE
Fix durable agent creation config, form wording, and workflow import suggestions

### DIFF
--- a/packages/ballerina-extension/src/features/bi/pending-artifact.ts
+++ b/packages/ballerina-extension/src/features/bi/pending-artifact.ts
@@ -31,6 +31,8 @@ import {
 import { openView, StateMachine } from "../../stateMachine";
 import { ServiceDesignerRpcManager } from "../../rpc-managers/service-designer/rpc-manager";
 import { BiDiagramRpcManager } from "../../rpc-managers/bi-diagram/rpc-manager";
+import { extension } from "../../BalExtensionContext";
+import { addConfigFile, getConfigFilePath } from "../ai/utils";
 import {
     clearPendingIntegrationPointer,
     isPendingPointerFresh,
@@ -309,6 +311,9 @@ async function generatePendingArtifact(
                 flowNode: payload.flowNode,
                 isFunctionNodeUpdate: true,
             });
+            if (payload.flowNode.codedata?.node === "DURABLE_AGENT") {
+                await configureDurableAgentModelProvider(projectRoot);
+            }
             if (landOnPackageOverview) {
                 openPackageOverview(projectRoot);
             }
@@ -326,6 +331,25 @@ async function generatePendingArtifact(
         }
         default:
             throw new Error(`Unsupported artifact kind: ${(payload as PendingIntegrationArtifactPayload).kind}`);
+    }
+}
+
+/**
+ * Writes the WSO2 default model provider's Config.toml entry for a durable agent generated
+ * into a fresh package. The generation itself declares the `wso2ModelProvider` variable, but
+ * without the `[ballerina.ai.wso2ProviderConfig]` values the agent fails at startup. The
+ * package root is already known here, so the config file is targeted directly (no project
+ * quick-pick). Failures are non-fatal: the agent exists and the provider can be configured
+ * from the agent's model circle.
+ */
+async function configureDurableAgentModelProvider(projectRoot: string): Promise<void> {
+    try {
+        const configPath = await getConfigFilePath(extension.ballerinaExtInstance, projectRoot);
+        if (configPath) {
+            await addConfigFile(configPath, "model");
+        }
+    } catch (error) {
+        console.error("[IntegrationWizard] Failed to configure the default model provider:", error);
     }
 }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DurableAgentBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DurableAgentBuilder.java
@@ -63,6 +63,12 @@ public class DurableAgentBuilder extends FunctionDefinitionBuilder {
     // created here and one created from the AI chat agent wizard converge on the same variable.
     private static final String DEFAULT_MODEL_PROVIDER_VAR = "wso2ModelProvider";
 
+    // The name identifies the agent (used to reference it in management and execution), not a
+    // function — the generic "Name of the function" doc would be wrong here.
+    public static final String NAME_DOC =
+            "Unique name of the Durable Agentic Workflow, used to reference it in workflow "
+                    + "management and execution.";
+
     @Override
     public void setConcreteConstData() {
         metadata().label(LABEL).description(DESCRIPTION);
@@ -78,7 +84,8 @@ public class DurableAgentBuilder extends FunctionDefinitionBuilder {
         PackageUtil.pullModuleAndNotify(context.lsClientLogger(), workflowModuleInfo);
         // The creation form asks only for a name; the input is always a json payload
         // named "input".
-        properties().functionNameTemplate("durableAgenticWorkflow", context.getAllVisibleSymbolNames());
+        properties().functionNameTemplate("durableAgenticWorkflow", context.getAllVisibleSymbolNames(),
+                FunctionDefinitionBuilder.FUNCTION_NAME_LABEL, NAME_DOC);
         WorkflowBuilder.setMandatoryProperties(this, RETURN_TYPE, "", "");
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_creation.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/durable_agent_creation.json
@@ -1,0 +1,116 @@
+{
+  "source": "durable_agent_module.bal",
+  "position": {
+    "line": 17,
+    "offset": 0
+  },
+  "description": "Durable Agentic Workflow creation template: the Name field describes the agent identifier, not a function",
+  "codedata": {
+    "node": "DURABLE_AGENT",
+    "org": "ballerina",
+    "module": "workflow"
+  },
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Durable Agentic Workflow",
+      "description": "Define a durable workflow driven by an agentic model"
+    },
+    "codedata": {
+      "node": "DURABLE_AGENT",
+      "org": "ballerina",
+      "module": "workflow",
+      "isNew": true
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Name",
+          "description": "Unique name of the Durable Agentic Workflow, used to reference it in workflow management and execution."
+        },
+        "types": [
+          {
+            "fieldType": "IDENTIFIER",
+            "scope": "Global",
+            "selected": true
+          }
+        ],
+        "value": "durableAgenticWorkflow",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "functionNameDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the function"
+        },
+        "types": [
+          {
+            "fieldType": "DOC_TEXT",
+            "selected": true
+          }
+        ],
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "types": [
+          {
+            "fieldType": "TYPE",
+            "selected": true
+          }
+        ],
+        "value": "error?",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "typeDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the return value"
+        },
+        "types": [
+          {
+            "fieldType": "DOC_TEXT",
+            "selected": true
+          }
+        ],
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "isPublic": {
+        "metadata": {
+          "label": "public",
+          "description": "Make visible across the project"
+        },
+        "types": [
+          {
+            "fieldType": "FLAG",
+            "selected": true
+          }
+        ],
+        "value": "false",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
@@ -160,6 +160,24 @@ public class LSPackageLoader {
 
                 this.getDistributionRepoModules().forEach(packageInfo ->
                         packagesList.put(packageInfo.packageIdentifier(), packageInfo));
+
+                // The user-home repositories hold the centrally-pulled and locally-published
+                // packages that do NOT ship inside the distribution (ballerina/workflow, for
+                // one). Without loading them here, the "import module" code action and
+                // unimported-module completions only ever offer distribution packages — a
+                // module the project itself pulled would still get no import suggestion.
+                // The empty listener map skips the listener-metadata compilation pass.
+                lsClientLogger.logTrace("Loading packages from the Ballerina user home repositories");
+                BallerinaUserHome ballerinaUserHome = BallerinaUserHome.from(environment);
+                this.remoteRepoPackages.addAll(checkAndResolvePackagesFromRepository(
+                        ballerinaUserHome.remotePackageRepository(), Collections.emptyMap(),
+                        Collections.emptyList(), packagesList.keySet()));
+                this.getRemoteRepoModules().forEach(packageInfo ->
+                        packagesList.putIfAbsent(packageInfo.packageIdentifier(), packageInfo));
+                this.localRepoPackages.addAll(checkAndResolvePackagesFromRepository(
+                        ballerinaUserHome.localPackageRepository(), Collections.emptyMap(),
+                        Collections.emptyList(), packagesList.keySet()));
+
                 List<ModuleInfo> repoPackages = new ArrayList<>(this.getLocalRepoModules());
                 repoPackages.stream().filter(packageInfo -> !packagesList.containsKey(packageInfo.packageIdentifier()))
                         .forEach(packageInfo -> packagesList.put(packageInfo.packageIdentifier(), packageInfo));

--- a/packages/ballerina-visualizer/src/views/BI/FunctionForm/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FunctionForm/index.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import { CodeData, FunctionNode, LineRange, NodeKind, NodeProperties, NodePropertyKey, DIRECTORY_MAP, EVENT_TYPE, getPrimaryInputType, isTemplateType, RecordTypeField } from "@wso2/ballerina-core";
+import { FunctionNode, LineRange, NodeKind, NodeProperties, NodePropertyKey, DIRECTORY_MAP, EVENT_TYPE, getPrimaryInputType, isTemplateType, RecordTypeField } from "@wso2/ballerina-core";
 import { Button, Codicon, Typography, View, ViewContent } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
@@ -27,21 +27,8 @@ import { TitleBar } from "../../../components/TitleBar";
 import { TopNavigationBar } from "../../../components/TopNavigationBar";
 import { FormHeader } from "../../../components/FormHeader";
 import { convertConfig, getImportsForProperty } from "../../../utils/bi";
-import { getNodeTemplate } from "../AIChatAgent/utils";
 import { BodyText, LoadingContainer, TopBar } from "../../styles";
 import { LoadingRing } from "../../../components/Loader";
-
-
-// Durable agents run their LLM calls through a module-level `ai:ModelProvider`. Creating a
-// durable agent ensures the shared WSO2 default provider exists (mirrors AIChatAgentWizard).
-const WSO2_MODEL_PROVIDER_CODEDATA: CodeData = {
-    node: "MODEL_PROVIDER",
-    org: "ballerina",
-    module: "ai",
-    packageName: "ai",
-    symbol: "getDefaultModelProvider",
-};
-const WSO2_MODEL_PROVIDER_VAR = "wso2ModelProvider";
 
 // Default (auto-numbered) name offered by the Durable Agentic Workflow creation form.
 const DURABLE_AGENT_DEFAULT_NAME = "durableAgenticWorkflow";
@@ -379,37 +366,34 @@ export function FunctionForm(props: FunctionFormProps) {
         console.log("Existing Function Node: ", flowNode);
     }
 
-    // Ensure the project has a model provider for the new durable agent. If ANY provider
-    // already exists, reuse it and create nothing (the generated run call references the
-    // existing provider). Only when the project has no provider at all do we create the
-    // shared WSO2 default provider and write its Config.toml entry. Failures are non-fatal:
-    // the agent function is already created and a provider can be configured from the model
-    // circle. */
-    const ensureWso2ModelProvider = async () => {
+    // Whether the project already declares a model provider. For a durable agent this MUST be
+    // probed BEFORE the agent is generated: the agent's own source generation declares the
+    // shared WSO2 default provider when the project has none, so probing afterwards always
+    // finds one — the Config.toml write was then skipped and running the agent failed with
+    // "ballerina.ai.wso2ProviderConfig is not configured correctly".
+    const projectHasModelProvider = async (): Promise<boolean> => {
         try {
             const existingModelProviders = await rpcClient.getBIDiagramRpcClient().searchNodes({
                 filePath: projectPath,
                 query: { kind: "MODEL_PROVIDER" as NodeKind }
             });
-            const hasAnyProvider = (existingModelProviders?.output?.length ?? 0) > 0;
-            if (hasAnyProvider) {
-                // A provider already exists — the agent's run call references it; nothing to create.
-                return;
-            }
-            const modelNodeTemplate = await getNodeTemplate(rpcClient, WSO2_MODEL_PROVIDER_CODEDATA, projectPath);
-            modelNodeTemplate.properties.variable.value = WSO2_MODEL_PROVIDER_VAR;
-            const response = await rpcClient
-                .getBIDiagramRpcClient()
-                .getSourceCode({ filePath: projectPath, flowNode: modelNodeTemplate });
-            if (response?.error) {
-                // `getSourceCode` reports LS failures as `{ artifacts: [], error }` rather than
-                // rejecting; the provider was never written, so don't configure it.
-                console.error("Failed to create the default model provider:", response.error);
-                return;
-            }
+            return (existingModelProviders?.output?.length ?? 0) > 0;
+        } catch (error) {
+            // Same failure mode as before the probe existed: skip the config write rather
+            // than prompting for sign-in on an unknown project state.
+            console.error("Failed to probe for model providers:", error);
+            return true;
+        }
+    };
+
+    // Writes the WSO2 default provider's Config.toml entry (service URL + token) after an
+    // agent creation that declared the provider. Failures are non-fatal: the agent is already
+    // created and the provider can be configured from the agent's model circle.
+    const configureWso2ModelProvider = async () => {
+        try {
             await rpcClient.getAIAgentRpcClient().configureDefaultModelProvider("model");
         } catch (error) {
-            console.error("Failed to ensure a default model provider:", error);
+            console.error("Failed to configure the default model provider:", error);
         }
     };
 
@@ -518,6 +502,9 @@ export function FunctionForm(props: FunctionFormProps) {
         }
 
         console.log("Updated function node: ", functionNodeCopy);
+        // Probed before generation on purpose — the durable agent's source generation declares
+        // the default provider itself, so an after-the-fact probe always finds one.
+        const hadModelProviderBeforeSave = isDurableAgent ? await projectHasModelProvider() : true;
         const sourceCode = await rpcClient
             .getBIDiagramRpcClient()
             .getSourceCode({ filePath, flowNode: functionNodeCopy, isFunctionNodeUpdate: true });
@@ -528,8 +515,8 @@ export function FunctionForm(props: FunctionFormProps) {
         } else {
             const newArtifact = sourceCode.artifacts.find(res => res.isNew);
             if (newArtifact) {
-                if (isDurableAgent) {
-                    await ensureWso2ModelProvider();
+                if (isDurableAgent && !hadModelProviderBeforeSave) {
+                    await configureWso2ModelProvider();
                 }
                 if (isPopup) {
                     handleClosePopup(functionNodeCopy.properties.functionName.value as string);


### PR DESCRIPTION
Fixes three of the alpha-testing issues reported for the Durable Agentic Workflow experience. Independent commits, one per issue.

## Fixes

**wso2/product-integrator#2090 — Create form's Name field description.** The field carried the generic "Name of the function" doc; it now reads "Unique name of the Durable Agentic Workflow, used to reference it in workflow management and execution", following the workflow creation form's wording. Locked with a creation-template golden.

**wso2/product-integrator#2099 — `wso2ProviderConfig` not configured when creating a Durable Agentic Workflow.** The agent's source generation declares the WSO2 default provider variable, but its Config.toml values were never written, on either creation path:
- *Artifacts panel*: the "does a provider exist?" probe ran **after** generation — and the generation itself declares the provider — so the probe always found one and `configureDefaultModelProvider` was unreachable. The probe now runs before generation, and the now-redundant webview-side provider creation is removed.
- *Create Integration wizard*: the pending-artifact generation path had no configuration call at all. A `DURABLE_AGENT` node now writes the `[ballerina.ai.wso2ProviderConfig]` entry directly against the known package root (avoiding the multi-package quick-pick), non-fatally on failure — matching the AI chat agent behavior.

**wso2/product-integrator#2097 — no import code action / completion for `ballerina/workflow`.** Import suggestions draw from `LSPackageLoader.getAllVisiblePackages()`, but only the distribution repository was loaded at startup: the remote (Central cache) list was appended only after an explicit Pull Modules action, and the local-repo list was never populated anywhere. Any package not bundled in the distribution — `ballerina/workflow` included — got no import suggestion even after the project had pulled it. The loader now also reads the user-home remote and local repositories at startup (deduplicated against distribution packages, with the empty listener map so no compilation cost is incurred).

Closes https://github.com/wso2/product-integrator/issues/2090
Closes https://github.com/wso2/product-integrator/issues/2097
Closes https://github.com/wso2/product-integrator/issues/2099

## Tests

- #2090: new `node_template` golden (`durable_agent_creation.json`) asserts the description.
- #2097/#2099: verified by build + code-path analysis; both depend on machine state (the user-home Central cache, Devant/BI-Intel tokens) that the LS/webview test fixtures can't express — manual VSIX verification recommended. `NodeTemplateTest`, langserver-core compile + checkstyle, and `rush build --to ballerina` are green locally.

Note for #2097: a deeper pre-existing gap remains — the shipped `moduleInfo.json` (central package seed) is serialized in a legacy shape the current `ModuleInfo` deserializer reads as all-nulls, so org/name-based central suggestions for never-pulled packages are silently broken. That is untouched here and worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Clarified the Durable Agentic Workflow creation form description for the workflow name.
- Configured `wso2ProviderConfig` during durable agent creation when no provider exists.
- Loaded user-home remote and local repositories at startup to restore import actions and completion suggestions.
- Added a creation-template golden test for the updated form wording.
- Build, compilation, checkstyle, and related tests pass locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->