### PR TITLE
Schedule sync branch with main

### DIFF
--- a/.github/workflows/sync-staging-to-main.yml
+++ b/.github/workflows/sync-staging-to-main.yml
@@ -71,7 +71,10 @@ jobs:
                 git checkout -B "$tempBranch" "origin/$stagingBranch"
               fi
 
-              if git diff --quiet "origin/main" "$tempBranch" --; then
+              # Ancestry, not just contents: main moving ahead on its own makes the trees
+              # differ while staging has nothing to sync, and gh pr create 422s on that.
+              if [ "$(git rev-list --count "origin/main..$tempBranch")" -eq 0 ] \
+                || git diff --quiet "origin/main" "$tempBranch" --; then
                 if [ -n "$existingPr" ]; then
                   gh pr close "$existingPr" --comment "Closing: \`$stagingBranch\` has no changes left to sync into \`main\`." || true
                   echo "::notice::$stagingBranch has nothing new for main; closed stale PR $existingPr."

--- a/.github/workflows/sync-staging-to-main.yml
+++ b/.github/workflows/sync-staging-to-main.yml
@@ -1,0 +1,108 @@
+name: Sync Staging Branches with Main
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: sync-staging-to-main
+  cancel-in-progress: false
+
+jobs:
+  sync-staging:
+    if: github.repository == 'ballerina-platform/ballerina-vscode'
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      # A deterministic temp branch per staging branch (no timestamp) is reused night
+      # over night: force-pushing it just updates the existing open PR's diff instead
+      # of a new PR piling up alongside yesterday's unmerged one.
+      - name: Sync each staging branch into main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          stagingBranches=$(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/staging/*' | sed 's|^origin/||')
+
+          if [ -z "$stagingBranches" ]; then
+            echo "::notice::No staging/* branches found; nothing to sync."
+            exit 0
+          fi
+
+          failed=0
+          for stagingBranch in $stagingBranches; do
+            set +e
+            (
+              set -euo pipefail
+
+              tempBranch="sync/main-${stagingBranch//\//-}"
+
+              echo "::group::Syncing $stagingBranch via $tempBranch"
+
+              existingPr=$(gh pr list -H "$tempBranch" -B main --state open --json url --jq '.[0].url // empty')
+
+              if [ -n "$existingPr" ] && git show-ref --verify --quiet "refs/remotes/origin/$tempBranch"; then
+                # Merge instead of reset so conflict-resolution work already pushed to the
+                # open sync PR survives, rather than being force-pushed away every run.
+                git checkout -B "$tempBranch" "origin/$tempBranch"
+                if ! git merge --no-edit "origin/$stagingBranch"; then
+                  git merge --abort || true
+                  # Self-heals even if the abort above failed, so a bad state can't survive into the next iteration.
+                  git reset --hard
+                  git clean -fd
+                  echo "::warning::Merge conflict syncing $stagingBranch into $tempBranch; skipping (resolve manually on the sync branch)."
+                  echo "::endgroup::"
+                  exit 0
+                fi
+              else
+                git checkout -B "$tempBranch" "origin/$stagingBranch"
+              fi
+
+              if git diff --quiet "origin/main" "$tempBranch" --; then
+                if [ -n "$existingPr" ]; then
+                  gh pr close "$existingPr" --comment "Closing: \`$stagingBranch\` has no changes left to sync into \`main\`." || true
+                  echo "::notice::$stagingBranch has nothing new for main; closed stale PR $existingPr."
+                else
+                  echo "::notice::$stagingBranch has nothing new for main; skipping."
+                fi
+                echo "::endgroup::"
+                exit 0
+              fi
+
+              git push --force-with-lease origin "$tempBranch"
+
+              if [ -n "$existingPr" ]; then
+                echo "::notice::Reusing existing sync PR: $existingPr"
+              else
+                pr=$(gh pr create -B main -H "$tempBranch" \
+                  --title "Sync ${stagingBranch} into main" \
+                  --body "Nightly sync of \`${stagingBranch}\` into \`main\`. Automated PR — updated in place each night this runs.")
+                echo "::notice::Opened sync PR: $pr"
+              fi
+
+              echo "::endgroup::"
+            )
+            status=$?
+            set -e
+            if [ "$status" -ne 0 ]; then
+              echo "::warning::Sync failed for $stagingBranch"
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Purpose

Release work lands on `staging/*` and has to flow back to `main`. Today that is done by hand, so `main` drifts behind the active staging branch and the eventual catch-up merge is large and conflict-prone.

## Goals

Keep `main` continuously up to date with the active staging branch, via one sync PR per staging branch that is updated in place each night rather than a new PR piling up alongside yesterday's unmerged one.

## Approach

Adds `.github/workflows/sync-staging-to-main.yml`, running on an 18:00 cron plus `workflow_dispatch`.

For each `staging/*` branch:

- A **deterministic** temp branch, `sync/main-<staging-branch>` — no timestamp. Re-pushing it updates the existing open PR's diff instead of opening a second PR.
- If an open sync PR already exists, `origin/$stagingBranch` is **merged into** the temp branch rather than the branch being reset to the staging head, so conflict resolution pushed to the sync branch survives the next run. On conflict the merge is aborted (with `reset --hard` / `clean -fd` as a self-heal) and the branch is skipped with a warning for a human to resolve.
- Branches with nothing ahead of `main` are skipped, and an open PR that has become empty is closed. This is an ancestry check (`git rev-list --count origin/main..$tempBranch`), not a content diff — once a sync PR is merged and `main` gains any further commit, the staging head is an ancestor of `main` while the trees still differ, and `gh pr create` rejects that with a 422.
- Pushes use `--force-with-lease`.
- Each branch is processed in its own subshell, so one failure does not abort the rest of the loop; the job fails at the end if any branch failed.

A `concurrency` group serializes a manual run against the scheduled one, since both would otherwise force-push the same temp branches.

## UI Component Development

N/A — CI-only change, no UI surface.

## User stories

N/A — internal release-engineering automation, no user-facing behaviour.

## Release note

N/A — no product change.

## Documentation

N/A — no product doc impact. The workflow's behaviour is documented in comments in the workflow file itself.

## Training

N/A — no product change.

## Certification

N/A — no product change, nothing certifiable.

## Marketing

N/A — internal automation.

## Automation tests

- Unit tests
  > N/A — a GitHub Actions workflow, not application code.
- Integration tests
  > Verified by `workflow_dispatch`. The nothing-to-sync guard was additionally verified against scratch repositories covering: staging fully merged with `main` ahead (skips), a genuinely new staging commit (proceeds), fully in sync (skips), and commits ahead with no net change (skips). The YAML parses and the extracted `run` block passes `bash -n`.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — no Java/application code in this change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

Additionally: the job uses the built-in `github.token` with `contents: write` and `pull-requests: write` only, and all actions are pinned by commit SHA.

## Samples

N/A.

## Related PRs

None. Note for reviewers: GitHub does not fire `pull_request` workflow triggers for PRs opened with the built-in `GITHUB_TOKEN`, so `pull-request.yml` (the build and tests) **does not run on the sync PRs this workflow creates** — an absent check list on those PRs is not a passing one. This matches the existing behaviour of `sync-main-with-releases.yml`; changing it would require a PAT or GitHub App token and is tracked separately.

## Migrations (if applicable)

N/A — no migration.

## Test environment

GitHub Actions `ubuntu-latest`. No JDK or OS matrix applies; the workflow only runs `git` and `gh`.

## Learning

Two behaviours drove the design: `gh pr create` rejects a head branch with no commits ahead of the base (HTTP 422), which is an ancestry question and not the same as a content diff; and `git for-each-ref` matches with `WM_PATHNAME`, so `staging/*` does not cross a `/` — fine under the current `staging/<version>` convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a scheduled and manual GitHub Actions workflow to synchronize `staging/*` branches with `main`.

The workflow creates or reuses deterministic temporary branches and pull requests. It skips branches with no changes, closes stale pull requests, and processes each staging branch independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
