### PR TITLE
Add scheduled E2E workflow with flakiness reporting

### DIFF
--- a/.github/actions/resolve-source-branch/action.yml
+++ b/.github/actions/resolve-source-branch/action.yml
@@ -2,6 +2,8 @@ name: 'Resolve source branch'
 description: >-
   Resolve the branch a nightly-style pipeline should run against: an explicit
   override if given, otherwise the latest staging/* branch if one exists, else main.
+  Runs 'git ls-remote --heads origin', so the calling job must check out the
+  repository (any ref) before this step, to have the 'origin' remote configured.
 inputs:
   sourceBranch:
     description: 'Explicit branch to use. Leave blank to auto-select.'

--- a/.github/actions/resolve-source-branch/action.yml
+++ b/.github/actions/resolve-source-branch/action.yml
@@ -1,0 +1,38 @@
+name: 'Resolve source branch'
+description: >-
+  Resolve the branch a nightly-style pipeline should run against: an explicit
+  override if given, otherwise the latest staging/* branch if one exists, else main.
+inputs:
+  sourceBranch:
+    description: 'Explicit branch to use. Leave blank to auto-select.'
+    required: false
+    default: ''
+outputs:
+  branch:
+    description: 'The resolved branch name'
+    value: ${{ steps.resolve.outputs.branch }}
+runs:
+  using: "composite"
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        INPUT_SOURCE_BRANCH: ${{ inputs.sourceBranch }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "${INPUT_SOURCE_BRANCH}" ]; then
+          SOURCE_BRANCH="${INPUT_SOURCE_BRANCH}"
+        else
+          # No explicit source given: prefer the latest staging/* branch (e.g.
+          # staging/5.14.0) if one exists, so callers follow the active release
+          # staging branch without a workflow edit each time one is cut. Falls
+          # back to main once no staging/* branch remains.
+          latest_staging=$(git ls-remote --heads origin \
+            | awk -F'refs/heads/' '/refs\/heads\/staging\// { print $2 }' \
+            | sort -t/ -k2 -V | tail -n 1)
+          SOURCE_BRANCH="${latest_staging:-main}"
+        fi
+
+        SOURCE_BRANCH="$(git check-ref-format --branch "${SOURCE_BRANCH}")"
+        echo "branch=${SOURCE_BRANCH}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/run-e2e-group/action.yml
+++ b/.github/actions/run-e2e-group/action.yml
@@ -1,0 +1,97 @@
+name: 'Run E2E test group'
+description: >-
+  Runs one matrix group of the Ballerina e2e Playwright suite (first attempt, then a
+  --last-failed re-run if needed) and uploads its results/recordings/project-data
+  artifacts. Shared by reusable-build.yml's BalE2ETest job and e2e-scheduled.yml's E2E
+  job, which differ only in how they prepare the workspace beforehand (a full
+  ExtBuild restore vs installing the nightly VSIX) — this action starts from the
+  assumption that workspace is already prepared (deps installed, Ballerina
+  distribution installed) in the calling job.
+inputs:
+  group:
+    description: 'Matrix group name, e.g. group1'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Check for previous test results
+      shell: bash
+      if: github.run_attempt > 1
+      run: |
+        PREVIOUS_ATTEMPT=$((${{ github.run_attempt }} - 1))
+        echo "PREVIOUS_ATTEMPT=$PREVIOUS_ATTEMPT" >> $GITHUB_ENV
+
+    - name: Download previous test results
+      id: check-results
+      if: github.run_attempt > 1
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      continue-on-error: true
+      with:
+        name: Ballerina-e2e-test-results-linux-${{ inputs.group }}-${{ env.PREVIOUS_ATTEMPT }}
+        path: packages/ballerina-extension/test-results
+
+    - name: Install packages
+      shell: bash
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y xvfb ffmpeg gnome-keyring libsecret-1.0 dbus-x11
+        cd packages/ballerina-extension && npx playwright install
+
+    - name: Run Ballerina e2e Test (First Attempt)
+      shell: bash
+      id: run-tests-first
+      if: github.run_attempt == 1 || steps.check-results.outcome == 'failure'
+      continue-on-error: true
+      env:
+        # A distinct filename from the re-run's report below: both are full Playwright
+        # JSON reports written by separate CLI invocations, so a shared name would let
+        # the re-run silently overwrite the first attempt's results instead of adding
+        # to them — aggregate-e2e-results.js merges both by matching this prefix.
+        PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-first.json
+      run: |
+        export $(dbus-launch)
+        export DISPLAY=:98.0
+        cd packages/ballerina-extension
+        xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ inputs.group }}"
+
+    - name: Run Failed Ballerina e2e Test (Re-run)
+      shell: bash
+      if: steps.run-tests-first.outcome == 'failure' || steps.check-results.outcome == 'success'
+      env:
+        PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-rerun.json
+      run: |
+        rm -rf packages/ballerina-extension/e2e-test/data/new-project
+        export $(dbus-launch)
+        export DISPLAY=:98.0
+        cd packages/ballerina-extension
+        xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ inputs.group }} --last-failed"
+
+    - name: Upload Ballerina e2e Test results
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      if: always()
+      with:
+        name: Ballerina-e2e-test-results-linux-${{ inputs.group }}-${{ github.run_attempt }}
+        path: packages/ballerina-extension/test-results/**
+        retention-days: 5
+        include-hidden-files: true
+
+    - name: Upload Ballerina e2e Test recordings
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      if: always()
+      with:
+        name: Ballerina-e2e-test-recording-linux-${{ inputs.group }}-${{ github.run_attempt }}
+        path: |
+          packages/ballerina-extension/e2e-test/test-resources/videos/**
+          packages/ballerina-extension/e2e-test/test-resources/screenshots/**
+          packages/ballerina-extension/e2e-test/test-resources/snapshots/**
+          packages/ballerina-extension/record.mp4
+        retention-days: 5
+
+    - name: Upload Ballerina e2e Test project data
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      if: always()
+      with:
+        name: Ballerina-e2e-test-project-linux-${{ inputs.group }}-${{ github.run_attempt }}
+        path: |
+          packages/ballerina-extension/e2e-test/data/new-project/**
+        retention-days: 5

--- a/.github/actions/run-e2e-group/action.yml
+++ b/.github/actions/run-e2e-group/action.yml
@@ -3,10 +3,9 @@ description: >-
   Runs one matrix group of the Ballerina e2e Playwright suite (first attempt, then a
   --last-failed re-run if needed) and uploads its results/recordings/project-data
   artifacts. Shared by reusable-build.yml's BalE2ETest job and e2e-scheduled.yml's E2E
-  job, which differ only in how they prepare the workspace beforehand (a full
-  ExtBuild restore vs installing the nightly VSIX) — this action starts from the
-  assumption that workspace is already prepared (deps installed, Ballerina
-  distribution installed) in the calling job.
+  job — see "Scheduled E2E testing" in .github/workflows/README.md for the design
+  rationale. Assumes the workspace is already prepared (deps installed, Ballerina
+  distribution installed) by the calling job.
 inputs:
   group:
     description: 'Matrix group name, e.g. group1'
@@ -28,20 +27,7 @@ runs:
       continue-on-error: true
       with:
         name: Ballerina-e2e-test-results-linux-${{ inputs.group }}-${{ env.PREVIOUS_ATTEMPT }}
-        # Extracts to packages/ballerina-extension, not straight into test-results/: the
-        # upload step below now spans two path roots (test-results/ and e2e-reports/), so
-        # upload-artifact roots the artifact at their common ancestor instead of flattening
-        # test-results/'s own contents to the artifact root.
-        # e2e-reports/ from a restored previous attempt is kept, deliberately, not
-        # discarded: a GitHub-level "re-run failed jobs" is a continuation of the same
-        # logical test run, so a test's full attempt history across that continuation
-        # (attempt N-1's failures plus attempt N's retry) is the correct thing to
-        # record — the same principle the first-attempt/re-run merge within one
-        # attempt already relies on. Discarding it instead (tried once, reverted) means
-        # the Report job — which only downloads the highest-numbered artifact per
-        # group — sees *only* the small --last-failed subset from the latest attempt,
-        # silently losing every test that already passed earlier and erasing the
-        # failed-then-passed history for exactly the flaky tests this exists to catch.
+        # Restored e2e-reports/ is deliberately kept, not discarded — see README.
         path: packages/ballerina-extension
 
     - name: Install packages
@@ -57,11 +43,7 @@ runs:
       if: github.run_attempt == 1 || steps.check-results.outcome == 'failure'
       continue-on-error: true
       env:
-        # Not under test-results/: that's Playwright's own outputDir, which the re-run
-        # below wipes at its own startup — a report placed there would be deleted before
-        # ever being read, regardless of filename (verified locally). e2e-reports/ is
-        # never touched by that cleanup. The distinct filename from the re-run's report
-        # lets aggregate-e2e-results.js merge both instead of one replacing the other.
+        # Not under test-results/ (Playwright's outputDir, wiped every invocation).
         PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-first.json
       run: |
         export $(dbus-launch)
@@ -73,7 +55,8 @@ runs:
       shell: bash
       if: steps.run-tests-first.outcome == 'failure' || steps.check-results.outcome == 'success'
       env:
-        PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-rerun.json
+        # run_attempt-suffixed so a second re-run doesn't overwrite the first's report.
+        PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-rerun-${{ github.run_attempt }}.json
       run: |
         rm -rf packages/ballerina-extension/e2e-test/data/new-project
         export $(dbus-launch)

--- a/.github/actions/run-e2e-group/action.yml
+++ b/.github/actions/run-e2e-group/action.yml
@@ -28,7 +28,11 @@ runs:
       continue-on-error: true
       with:
         name: Ballerina-e2e-test-results-linux-${{ inputs.group }}-${{ env.PREVIOUS_ATTEMPT }}
-        path: packages/ballerina-extension/test-results
+        # Extracts to packages/ballerina-extension, not straight into test-results/: the
+        # upload step below now spans two path roots (test-results/ and e2e-reports/), so
+        # upload-artifact roots the artifact at their common ancestor instead of flattening
+        # test-results/'s own contents to the artifact root.
+        path: packages/ballerina-extension
 
     - name: Install packages
       shell: bash
@@ -43,11 +47,12 @@ runs:
       if: github.run_attempt == 1 || steps.check-results.outcome == 'failure'
       continue-on-error: true
       env:
-        # A distinct filename from the re-run's report below: both are full Playwright
-        # JSON reports written by separate CLI invocations, so a shared name would let
-        # the re-run silently overwrite the first attempt's results instead of adding
-        # to them — aggregate-e2e-results.js merges both by matching this prefix.
-        PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-first.json
+        # Not under test-results/: that's Playwright's own outputDir, which the re-run
+        # below wipes at its own startup — a report placed there would be deleted before
+        # ever being read, regardless of filename (verified locally). e2e-reports/ is
+        # never touched by that cleanup. The distinct filename from the re-run's report
+        # lets aggregate-e2e-results.js merge both instead of one replacing the other.
+        PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-first.json
       run: |
         export $(dbus-launch)
         export DISPLAY=:98.0
@@ -58,7 +63,7 @@ runs:
       shell: bash
       if: steps.run-tests-first.outcome == 'failure' || steps.check-results.outcome == 'success'
       env:
-        PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-rerun.json
+        PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-rerun.json
       run: |
         rm -rf packages/ballerina-extension/e2e-test/data/new-project
         export $(dbus-launch)
@@ -71,7 +76,9 @@ runs:
       if: always()
       with:
         name: Ballerina-e2e-test-results-linux-${{ inputs.group }}-${{ github.run_attempt }}
-        path: packages/ballerina-extension/test-results/**
+        path: |
+          packages/ballerina-extension/test-results/**
+          packages/ballerina-extension/e2e-reports/**
         retention-days: 5
         include-hidden-files: true
 

--- a/.github/actions/run-e2e-group/action.yml
+++ b/.github/actions/run-e2e-group/action.yml
@@ -32,6 +32,16 @@ runs:
         # upload step below now spans two path roots (test-results/ and e2e-reports/), so
         # upload-artifact roots the artifact at their common ancestor instead of flattening
         # test-results/'s own contents to the artifact root.
+        # e2e-reports/ from a restored previous attempt is kept, deliberately, not
+        # discarded: a GitHub-level "re-run failed jobs" is a continuation of the same
+        # logical test run, so a test's full attempt history across that continuation
+        # (attempt N-1's failures plus attempt N's retry) is the correct thing to
+        # record — the same principle the first-attempt/re-run merge within one
+        # attempt already relies on. Discarding it instead (tried once, reverted) means
+        # the Report job — which only downloads the highest-numbered artifact per
+        # group — sees *only* the small --last-failed subset from the latest attempt,
+        # silently losing every test that already passed earlier and erasing the
+        # failed-then-passed history for exactly the flaky tests this exists to catch.
         path: packages/ballerina-extension
 
     - name: Install packages

--- a/.github/actions/setup-ballerina/action.yml
+++ b/.github/actions/setup-ballerina/action.yml
@@ -1,5 +1,15 @@
 name: Set up Ballerina
 description: Install the Ballerina distribution required by the language-server build
+inputs:
+  gradlePropertiesRef:
+    description: >-
+      Git tag to read packages/ballerina-language-server/gradle.properties from,
+      instead of the checked-out working tree. Use this when the thing under test
+      (e.g. a VSIX built from that tag) may be older than the current checkout, so the
+      installed Ballerina distribution stays pinned to what was actually built rather
+      than drifting with the checkout. Leave blank to read from the working tree.
+    required: false
+    default: ''
 outputs:
   version:
     description: The Ballerina distribution version from the LS Gradle properties
@@ -12,10 +22,16 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        properties="${{ github.workspace }}/packages/ballerina-language-server/gradle.properties"
-        version=$(sed -n 's/^ballerinaLangVersion=//p' "${properties}")
+        if [ -n "${{ inputs.gradlePropertiesRef }}" ]; then
+          git fetch --quiet --depth 1 origin "refs/tags/${{ inputs.gradlePropertiesRef }}"
+          properties_content=$(git show FETCH_HEAD:packages/ballerina-language-server/gradle.properties)
+          version=$(sed -n 's/^ballerinaLangVersion=//p' <<< "${properties_content}")
+        else
+          properties="${{ github.workspace }}/packages/ballerina-language-server/gradle.properties"
+          version=$(sed -n 's/^ballerinaLangVersion=//p' "${properties}")
+        fi
         if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "::error::Invalid or missing ballerinaLangVersion in packages/ballerina-language-server/gradle.properties"
+          echo "::error::Invalid or missing ballerinaLangVersion in packages/ballerina-language-server/gradle.properties${{ inputs.gradlePropertiesRef && format(' at tag {0}', inputs.gradlePropertiesRef) || '' }}"
           exit 1
         fi
         echo "version=${version}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-ballerina/action.yml
+++ b/.github/actions/setup-ballerina/action.yml
@@ -20,10 +20,23 @@ runs:
     - name: Resolve Ballerina distribution version
       id: version
       shell: bash
+      env:
+        # Passed through env, not interpolated directly into the script below: this
+        # input could in principle carry attacker-controlled text from a future caller,
+        # and raw `${{ }}` interpolation into a run: block would execute it as script
+        # rather than data (the same pattern resolve-source-branch/action.yml uses).
+        GRADLE_PROPERTIES_REF: ${{ inputs.gradlePropertiesRef }}
       run: |
         set -euo pipefail
-        if [ -n "${{ inputs.gradlePropertiesRef }}" ]; then
-          git fetch --quiet --depth 1 origin "refs/tags/${{ inputs.gradlePropertiesRef }}"
+        if [ -n "${GRADLE_PROPERTIES_REF}" ]; then
+          source "${{ github.workspace }}/.github/scripts/retry.sh"
+          # Same race the 'nightly' release accesses in e2e-scheduled.yml retry for, and
+          # like the VSIX download there (not the metadata-only sourceSha lookup),
+          # exhausting retries here fails the whole calling job — same generous budget.
+          if ! retry 6 10 git fetch --quiet --depth 1 origin "refs/tags/${GRADLE_PROPERTIES_REF}"; then
+            echo "::error::Failed to fetch tag ${GRADLE_PROPERTIES_REF} after 6 attempts."
+            exit 1
+          fi
           properties_content=$(git show FETCH_HEAD:packages/ballerina-language-server/gradle.properties)
           version=$(sed -n 's/^ballerinaLangVersion=//p' <<< "${properties_content}")
         else
@@ -31,7 +44,7 @@ runs:
           version=$(sed -n 's/^ballerinaLangVersion=//p' "${properties}")
         fi
         if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "::error::Invalid or missing ballerinaLangVersion in packages/ballerina-language-server/gradle.properties${{ inputs.gradlePropertiesRef && format(' at tag {0}', inputs.gradlePropertiesRef) || '' }}"
+          echo "::error::Invalid or missing ballerinaLangVersion in packages/ballerina-language-server/gradle.properties${GRADLE_PROPERTIES_REF:+ at tag ${GRADLE_PROPERTIES_REF}}"
           exit 1
         fi
         echo "version=${version}" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -166,7 +166,7 @@ function toNdjson(allTests) {
   const timestamp = new Date().toISOString();
   const runId = process.env.GITHUB_RUN_ID || '';
   const runAttempt = process.env.GITHUB_RUN_ATTEMPT || '';
-  const sourceBranch = process.env.E2E_SOURCE_BRANCH || '';
+  const sourceTag = process.env.E2E_SOURCE_TAG || '';
 
   return allTests
     .map((t) =>
@@ -174,7 +174,7 @@ function toNdjson(allTests) {
         timestamp,
         runId,
         runAttempt,
-        sourceBranch,
+        sourceTag,
         ...t,
       })
     )

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// Aggregates Playwright JSON-reporter output (one file per matrix group, downloaded
+// into per-artifact subfolders) into a Markdown summary: attempt counts per test and
+// the error line for any failed attempt. Exits non-zero if any test's final status
+// is not 'passed'/'skipped', so callers can gate a failure notification on it.
+//
+// When given a second argument, also writes one NDJSON line per test (including
+// clean single-attempt passes) so a caller can append it to a cross-run history file.
+
+const fs = require('fs');
+const path = require('path');
+
+function findResultFiles(rootDir) {
+  const found = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name === 'e2e-results.json') {
+        found.push(full);
+      }
+    }
+  };
+  if (fs.existsSync(rootDir)) walk(rootDir);
+  return found;
+}
+
+// A group name is derived from the artifact subfolder Playwright's JSON landed in,
+// e.g. Ballerina-e2e-test-results-linux-group2-1/test-results/e2e-results.json -> group2.
+function groupNameFromPath(filePath, rootDir) {
+  const rel = path.relative(rootDir, filePath);
+  const match = rel.match(/-(group\d+)-\d+[\\/]/);
+  return match ? match[1] : rel.split(path.sep)[0];
+}
+
+function collectSpecs(suite, out) {
+  for (const spec of suite.specs || []) out.push(spec);
+  for (const child of suite.suites || []) collectSpecs(child, out);
+}
+
+function firstErrorLine(result) {
+  const error = result.error || (result.errors && result.errors[0]);
+  if (!error) return null;
+  const message = (error.message || '').split('\n')[0].trim();
+  const stackLine = (error.stack || '')
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => /\.(ts|js):\d+/.test(l));
+  return [message, stackLine].filter(Boolean).join(' — ');
+}
+
+function aggregate(rootDir) {
+  const files = findResultFiles(rootDir);
+  const rows = [];
+  const allTests = [];
+  let total = 0;
+  let passed = 0;
+  let failed = 0;
+  let flaky = 0;
+
+  for (const file of files) {
+    const group = groupNameFromPath(file, rootDir);
+    const report = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const specs = [];
+    for (const suite of report.suites || []) collectSpecs(suite, specs);
+
+    for (const spec of specs) {
+      for (const test of spec.tests || []) {
+        total += 1;
+        const attempts = test.results ? test.results.length : 0;
+        const finalResult = test.results && test.results[test.results.length - 1];
+        const finalStatus = finalResult ? finalResult.status : test.status;
+        const isPassed = finalStatus === 'passed';
+        const isSkipped = finalStatus === 'skipped';
+
+        if (isPassed) passed += 1;
+        else if (!isSkipped) failed += 1;
+        if (isPassed && attempts > 1) flaky += 1;
+
+        const errorLines = (test.results || [])
+          .map((r, i) => {
+            const line = firstErrorLine(r);
+            return line ? `attempt ${i + 1}: ${line}` : null;
+          })
+          .filter(Boolean);
+
+        allTests.push({
+          group,
+          title: spec.title,
+          file: spec.file,
+          attempts,
+          finalStatus,
+          error: errorLines.length ? errorLines[errorLines.length - 1] : null,
+        });
+
+        if (attempts > 1 || (!isPassed && !isSkipped)) {
+          rows.push({ group, title: spec.title, file: spec.file, attempts, finalStatus, errorLines });
+        }
+      }
+    }
+  }
+
+  return { rows, allTests, total, passed, failed, flaky, groupCount: files.length };
+}
+
+function toNdjson(allTests) {
+  const timestamp = new Date().toISOString();
+  const runId = process.env.GITHUB_RUN_ID || '';
+  const runAttempt = process.env.GITHUB_RUN_ATTEMPT || '';
+  const sourceBranch = process.env.E2E_SOURCE_BRANCH || '';
+
+  return allTests
+    .map((t) =>
+      JSON.stringify({
+        timestamp,
+        runId,
+        runAttempt,
+        sourceBranch,
+        ...t,
+      })
+    )
+    .join('\n');
+}
+
+function toMarkdown({ rows, total, passed, failed, flaky, groupCount }) {
+  const lines = [];
+  lines.push('## E2E flakiness report');
+  lines.push('');
+  lines.push(
+    `Groups reported: ${groupCount} · Total: ${total} · Passed: ${passed} · Failed: ${failed} · Flaky (passed after retry): ${flaky}`
+  );
+  lines.push('');
+
+  if (rows.length === 0) {
+    lines.push('No retries or failures — every test passed on the first attempt.');
+    return lines.join('\n');
+  }
+
+  lines.push('| Group | Test | Attempts | Final status | Errors |');
+  lines.push('|---|---|---|---|---|');
+  for (const row of rows.sort((a, b) => b.attempts - a.attempts)) {
+    const errors = row.errorLines.length ? row.errorLines.join('<br>') : '';
+    lines.push(
+      `| ${row.group} | ${row.title} (${row.file}) | ${row.attempts} | ${row.finalStatus} | ${errors} |`
+    );
+  }
+  return lines.join('\n');
+}
+
+function main() {
+  const rootDir = process.argv[2];
+  const ndjsonOutPath = process.argv[3];
+  if (!rootDir) {
+    console.error('Usage: aggregate-e2e-results.js <downloaded-artifacts-dir> [ndjson-output-path]');
+    process.exit(2);
+  }
+
+  const summary = aggregate(rootDir);
+  console.log(toMarkdown(summary));
+
+  if (ndjsonOutPath && summary.allTests.length > 0) {
+    fs.writeFileSync(ndjsonOutPath, toNdjson(summary.allTests) + '\n');
+  }
+
+  if (summary.failed > 0) process.exit(1);
+}
+
+main();

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -33,12 +33,16 @@ function findResultFiles(rootDir) {
   return found;
 }
 
-// A group name is derived from the artifact subfolder Playwright's JSON landed in,
-// e.g. Ballerina-e2e-test-results-linux-group2-1/test-results/e2e-results.json -> group2.
+// The caller downloads each matrix group's artifact into its own explicitly-named
+// subfolder (e2e-results/group1, e2e-results/group2, ...) rather than one pattern-based
+// download across all groups — so the group name is simply the first path segment
+// under rootDir. (A pattern-based download only nests per-artifact when more than one
+// artifact matches; with exactly one surviving group it flattens to the root, which a
+// folder-name regex here couldn't recover from — controlling the download layout
+// avoids that ambiguity entirely instead of guessing around it.)
 function groupNameFromPath(filePath, rootDir) {
   const rel = path.relative(rootDir, filePath);
-  const match = rel.match(/-(group\d+)-\d+[\\/]/);
-  return match ? match[1] : rel.split(path.sep)[0];
+  return rel.split(path.sep)[0];
 }
 
 function collectSpecs(suite, out) {

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -1,8 +1,15 @@
 #!/usr/bin/env node
-// Aggregates Playwright JSON-reporter output (one file per matrix group, downloaded
-// into per-artifact subfolders) into a Markdown summary: attempt counts per test and
-// the error line for any failed attempt. Exits non-zero if any test's final status
-// is not 'passed'/'skipped', so callers can gate a failure notification on it.
+// Aggregates Playwright JSON-reporter output (one or more files per matrix group,
+// downloaded into per-artifact subfolders) into a Markdown summary: attempt counts per
+// test and the error line for any failed attempt. Exits non-zero if any test's final
+// status is not 'passed'/'skipped', or if no readable report was found at all, so
+// callers can gate a failure notification on it.
+//
+// A group can produce more than one report file: reusable-build.yml runs a first
+// attempt, then re-runs just the failed subset (`--last-failed`) into a second file
+// (see PLAYWRIGHT_JSON_OUTPUT_FILE in reusable-build.yml). Both are full Playwright JSON
+// reports, so per-test results across the group's files are merged here rather than
+// letting the later file silently replace the earlier one.
 //
 // When given a second argument, also writes one NDJSON line per test (including
 // clean single-attempt passes) so a caller can append it to a cross-run history file.
@@ -17,7 +24,7 @@ function findResultFiles(rootDir) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(full);
-      } else if (entry.isFile() && entry.name === 'e2e-results.json') {
+      } else if (entry.isFile() && /^e2e-results.*\.json$/.test(entry.name)) {
         found.push(full);
       }
     }
@@ -50,58 +57,105 @@ function firstErrorLine(result) {
   return [message, stackLine].filter(Boolean).join(' — ');
 }
 
+// Merges every report file belonging to one matrix group into a single per-test view,
+// keyed by (file, title). Files are merged in filename order — 'e2e-results-first.json'
+// before 'e2e-results-rerun.json' — so a test's results carry the first attempt's
+// history followed by the re-run's, giving a true attempt count and final outcome even
+// when the group needed a re-run.
+function mergeGroupReports(files, onUnreadable) {
+  const merged = new Map();
+  for (const file of [...files].sort()) {
+    let report;
+    try {
+      report = JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch (err) {
+      onUnreadable(file, err);
+      continue;
+    }
+    const specs = [];
+    for (const suite of report.suites || []) collectSpecs(suite, specs);
+
+    for (const spec of specs) {
+      for (const test of spec.tests || []) {
+        const key = `${spec.file}::${spec.title}`;
+        const results = test.results || [];
+        const existing = merged.get(key);
+        if (existing) {
+          existing.results.push(...results);
+        } else {
+          merged.set(key, { title: spec.title, file: spec.file, results: [...results] });
+        }
+      }
+    }
+  }
+  return [...merged.values()];
+}
+
 function aggregate(rootDir) {
   const files = findResultFiles(rootDir);
+  const byGroup = new Map();
+  for (const file of files) {
+    const group = groupNameFromPath(file, rootDir);
+    if (!byGroup.has(group)) byGroup.set(group, []);
+    byGroup.get(group).push(file);
+  }
+
   const rows = [];
   const allTests = [];
   let total = 0;
   let passed = 0;
   let failed = 0;
   let flaky = 0;
+  let unreadableCount = 0;
 
-  for (const file of files) {
-    const group = groupNameFromPath(file, rootDir);
-    const report = JSON.parse(fs.readFileSync(file, 'utf8'));
-    const specs = [];
-    for (const suite of report.suites || []) collectSpecs(suite, specs);
+  for (const [group, groupFiles] of byGroup) {
+    const mergedTests = mergeGroupReports(groupFiles, (file, err) => {
+      console.error(`Skipping unreadable report ${file}: ${err.message}`);
+      unreadableCount += 1;
+    });
 
-    for (const spec of specs) {
-      for (const test of spec.tests || []) {
-        total += 1;
-        const attempts = test.results ? test.results.length : 0;
-        const finalResult = test.results && test.results[test.results.length - 1];
-        const finalStatus = finalResult ? finalResult.status : test.status;
-        const isPassed = finalStatus === 'passed';
-        const isSkipped = finalStatus === 'skipped';
+    for (const test of mergedTests) {
+      total += 1;
+      const attempts = test.results.length;
+      const finalResult = test.results[test.results.length - 1];
+      const finalStatus = finalResult ? finalResult.status : 'skipped';
+      const isPassed = finalStatus === 'passed';
+      const isSkipped = attempts === 0 || finalStatus === 'skipped';
 
-        if (isPassed) passed += 1;
-        else if (!isSkipped) failed += 1;
-        if (isPassed && attempts > 1) flaky += 1;
+      if (isPassed) passed += 1;
+      else if (!isSkipped) failed += 1;
+      // Flakiness is derived from the merged attempt history rather than either report
+      // file's own test.status: a test re-run via --last-failed spans two separate
+      // Playwright invocations, so no single file's status reflects the merged outcome.
+      if (isPassed && attempts > 1) flaky += 1;
 
-        const errorLines = (test.results || [])
-          .map((r, i) => {
-            const line = firstErrorLine(r);
-            return line ? `attempt ${i + 1}: ${line}` : null;
-          })
-          .filter(Boolean);
+      const errorLines = test.results
+        .map((r, i) => {
+          const line = firstErrorLine(r);
+          return line ? `attempt ${i + 1}: ${line}` : null;
+        })
+        .filter(Boolean);
 
-        allTests.push({
-          group,
-          title: spec.title,
-          file: spec.file,
-          attempts,
-          finalStatus,
-          error: errorLines.length ? errorLines[errorLines.length - 1] : null,
-        });
+      allTests.push({
+        group,
+        title: test.title,
+        file: test.file,
+        attempts,
+        finalStatus,
+        error: errorLines.length ? errorLines[errorLines.length - 1] : null,
+      });
 
-        if (attempts > 1 || (!isPassed && !isSkipped)) {
-          rows.push({ group, title: spec.title, file: spec.file, attempts, finalStatus, errorLines });
-        }
+      if (attempts > 1 || (!isPassed && !isSkipped)) {
+        rows.push({ group, title: test.title, file: test.file, attempts, finalStatus, errorLines });
       }
     }
   }
 
-  return { rows, allTests, total, passed, failed, flaky, groupCount: files.length };
+  // A malformed report is a lost test, not a passed one — count it toward 'failed' so
+  // it isn't reported as a clean run, and note it separately so the cause is visible.
+  failed += unreadableCount;
+
+  return { rows, allTests, total, passed, failed, flaky, unreadableCount, groupCount: byGroup.size };
 }
 
 function toNdjson(allTests) {
@@ -123,13 +177,25 @@ function toNdjson(allTests) {
     .join('\n');
 }
 
-function toMarkdown({ rows, total, passed, failed, flaky, groupCount }) {
+// eslint-disable-next-line no-control-regex
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
+
+// Markdown table cells break on a bare '|' and render garbage on raw ANSI escapes —
+// both show up routinely in Playwright assertion/diff output.
+function cell(value) {
+  return String(value ?? '').replace(ANSI_PATTERN, '').replace(/\|/g, '\\|');
+}
+
+function toMarkdown({ rows, total, passed, failed, flaky, unreadableCount, groupCount }) {
   const lines = [];
   lines.push('## E2E flakiness report');
   lines.push('');
   lines.push(
     `Groups reported: ${groupCount} · Total: ${total} · Passed: ${passed} · Failed: ${failed} · Flaky (passed after retry): ${flaky}`
   );
+  if (unreadableCount > 0) {
+    lines.push(`⚠️ ${unreadableCount} report file(s) could not be parsed and were counted as failed.`);
+  }
   lines.push('');
 
   if (rows.length === 0) {
@@ -140,9 +206,9 @@ function toMarkdown({ rows, total, passed, failed, flaky, groupCount }) {
   lines.push('| Group | Test | Attempts | Final status | Errors |');
   lines.push('|---|---|---|---|---|');
   for (const row of rows.sort((a, b) => b.attempts - a.attempts)) {
-    const errors = row.errorLines.length ? row.errorLines.join('<br>') : '';
+    const errors = row.errorLines.map(cell).join('<br>');
     lines.push(
-      `| ${row.group} | ${row.title} (${row.file}) | ${row.attempts} | ${row.finalStatus} | ${errors} |`
+      `| ${cell(row.group)} | ${cell(row.title)} (${cell(row.file)}) | ${row.attempts} | ${cell(row.finalStatus)} | ${errors} |`
     );
   }
   return lines.join('\n');
@@ -161,6 +227,11 @@ function main() {
 
   if (ndjsonOutPath && summary.allTests.length > 0) {
     fs.writeFileSync(ndjsonOutPath, toNdjson(summary.allTests) + '\n');
+  }
+
+  if (summary.groupCount === 0) {
+    console.error(`No e2e-results*.json found under ${rootDir}; the artifact contract is broken.`);
+    process.exit(1);
   }
 
   if (summary.failed > 0) process.exit(1);

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -2,14 +2,17 @@
 // Aggregates Playwright JSON-reporter output (one or more files per matrix group,
 // downloaded into per-artifact subfolders) into a Markdown summary: attempt counts per
 // test and the error line for any failed attempt. Exits non-zero if any test's final
-// status is not 'passed'/'skipped', or if no readable report was found at all, so
-// callers can gate a failure notification on it.
+// status is not 'passed'/'skipped', if a report file couldn't be parsed, or if no
+// readable report was found at all, so callers can gate a failure notification on it.
+// A malformed report is tracked separately (unreadableCount) rather than folded into
+// the test-level 'failed' count, since it isn't a test outcome and a report full of
+// unreadable files would otherwise produce nonsensical totals like "Total: 0 · Failed: 2".
 //
-// A group can produce more than one report file: reusable-build.yml runs a first
-// attempt, then re-runs just the failed subset (`--last-failed`) into a second file
-// (see PLAYWRIGHT_JSON_OUTPUT_FILE in reusable-build.yml). Both are full Playwright JSON
-// reports, so per-test results across the group's files are merged here rather than
-// letting the later file silently replace the earlier one.
+// A group can produce more than one report file: run-e2e-group runs a first attempt,
+// then re-runs just the failed subset (`--last-failed`) into a second file (see
+// PLAYWRIGHT_JSON_OUTPUT_FILE in .github/actions/run-e2e-group/action.yml). Both are
+// full Playwright JSON reports, so per-test results across the group's files are merged
+// here rather than letting the later file silently replace the earlier one.
 //
 // When given a second argument, also writes one NDJSON line per test (including
 // clean single-attempt passes) so a caller can append it to a cross-run history file.
@@ -155,10 +158,6 @@ function aggregate(rootDir) {
     }
   }
 
-  // A malformed report is a lost test, not a passed one — count it toward 'failed' so
-  // it isn't reported as a clean run, and note it separately so the cause is visible.
-  failed += unreadableCount;
-
   return { rows, allTests, total, passed, failed, flaky, unreadableCount, groupCount: byGroup.size };
 }
 
@@ -198,12 +197,15 @@ function toMarkdown({ rows, total, passed, failed, flaky, unreadableCount, group
     `Groups reported: ${groupCount} · Total: ${total} · Passed: ${passed} · Failed: ${failed} · Flaky (passed after retry): ${flaky}`
   );
   if (unreadableCount > 0) {
-    lines.push(`⚠️ ${unreadableCount} report file(s) could not be parsed and were counted as failed.`);
+    lines.push(`⚠️ ${unreadableCount} report file(s) could not be parsed — this run is marked failed.`);
   }
   lines.push('');
 
-  if (rows.length === 0) {
+  if (rows.length === 0 && unreadableCount === 0) {
     lines.push('No retries or failures — every test passed on the first attempt.');
+    return lines.join('\n');
+  }
+  if (rows.length === 0) {
     return lines.join('\n');
   }
 
@@ -238,7 +240,7 @@ function main() {
     process.exit(1);
   }
 
-  if (summary.failed > 0) process.exit(1);
+  if (summary.failed > 0 || summary.unreadableCount > 0) process.exit(1);
 }
 
 main();

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -65,7 +65,11 @@ function firstErrorLine(result) {
 }
 
 // Merges every report file belonging to one matrix group into a single per-test view,
-// keyed by (file, title). Files are merged in filename order — 'e2e-results-first.json'
+// keyed by spec.id (falling back to file::title only if a report predates that field)
+// plus the test's project name. spec.id is unique per spec location, unlike spec.title
+// alone, which collides when two describe blocks reuse the same inner test title;
+// the project name further distinguishes the same spec run under more than one
+// Playwright project. Files are merged in filename order — 'e2e-results-first.json'
 // before 'e2e-results-rerun.json' — so a test's results carry the first attempt's
 // history followed by the re-run's, giving a true attempt count and final outcome even
 // when the group needed a re-run.
@@ -84,7 +88,8 @@ function mergeGroupReports(files, onUnreadable) {
 
     for (const spec of specs) {
       for (const test of spec.tests || []) {
-        const key = `${spec.file}::${spec.title}`;
+        const specKey = spec.id || `${spec.file}::${spec.title}`;
+        const key = `${specKey}::${test.projectName || ''}`;
         const results = test.results || [];
         const existing = merged.get(key);
         if (existing) {
@@ -98,7 +103,7 @@ function mergeGroupReports(files, onUnreadable) {
   return [...merged.values()];
 }
 
-function aggregate(rootDir) {
+function aggregate(rootDir, expectedGroups) {
   const files = findResultFiles(rootDir);
   const byGroup = new Map();
   for (const file of files) {
@@ -107,11 +112,17 @@ function aggregate(rootDir) {
     byGroup.get(group).push(file);
   }
 
+  // A group killed outright (e.g. the 60-minute job timeout) never uploads any report
+  // file, so it never gets a byGroup entry at all — groupCount === 0 only catches total
+  // loss across every group, not one group silently vanishing while the rest look clean.
+  const missingGroups = (expectedGroups || []).filter((g) => !byGroup.has(g));
+
   const rows = [];
   const allTests = [];
   let total = 0;
   let passed = 0;
   let failed = 0;
+  let skipped = 0;
   let flaky = 0;
   let unreadableCount = 0;
 
@@ -130,7 +141,8 @@ function aggregate(rootDir) {
       const isSkipped = attempts === 0 || finalStatus === 'skipped';
 
       if (isPassed) passed += 1;
-      else if (!isSkipped) failed += 1;
+      else if (isSkipped) skipped += 1;
+      else failed += 1;
       // Flakiness is derived from the merged attempt history rather than either report
       // file's own test.status: a test re-run via --last-failed spans two separate
       // Playwright invocations, so no single file's status reflects the merged outcome.
@@ -158,7 +170,7 @@ function aggregate(rootDir) {
     }
   }
 
-  return { rows, allTests, total, passed, failed, flaky, unreadableCount, groupCount: byGroup.size };
+  return { rows, allTests, total, passed, failed, skipped, flaky, unreadableCount, missingGroups, groupCount: byGroup.size };
 }
 
 function toNdjson(allTests) {
@@ -189,19 +201,25 @@ function cell(value) {
   return String(value ?? '').replace(ANSI_PATTERN, '').replace(/\|/g, '\\|');
 }
 
-function toMarkdown({ rows, total, passed, failed, flaky, unreadableCount, groupCount }) {
+function toMarkdown({ rows, total, passed, failed, skipped, flaky, unreadableCount, missingGroups, groupCount }) {
   const lines = [];
   lines.push('## E2E flakiness report');
   lines.push('');
   lines.push(
-    `Groups reported: ${groupCount} · Total: ${total} · Passed: ${passed} · Failed: ${failed} · Flaky (passed after retry): ${flaky}`
+    `Groups reported: ${groupCount} · Total: ${total} · Passed: ${passed} · Failed: ${failed} · Skipped: ${skipped} · Flaky (passed after retry): ${flaky}`
   );
   if (unreadableCount > 0) {
     lines.push(`⚠️ ${unreadableCount} report file(s) could not be parsed — this run is marked failed.`);
   }
+  if (missingGroups && missingGroups.length > 0) {
+    lines.push(
+      `⚠️ No report at all from: ${missingGroups.join(', ')} (killed before uploading, e.g. by the job timeout) — this run is marked failed.`
+    );
+  }
   lines.push('');
 
-  if (rows.length === 0 && unreadableCount === 0) {
+  const clean = rows.length === 0 && unreadableCount === 0 && (!missingGroups || missingGroups.length === 0);
+  if (clean) {
     lines.push('No retries or failures — every test passed on the first attempt.');
     return lines.join('\n');
   }
@@ -228,7 +246,21 @@ function main() {
     process.exit(2);
   }
 
-  const summary = aggregate(rootDir);
+  let expectedGroups = [];
+  if (process.env.EXPECTED_GROUPS_JSON) {
+    try {
+      const parsed = JSON.parse(process.env.EXPECTED_GROUPS_JSON);
+      if (Array.isArray(parsed)) {
+        expectedGroups = parsed;
+      } else {
+        console.error('EXPECTED_GROUPS_JSON is not an array; ignoring.');
+      }
+    } catch (err) {
+      console.error(`Failed to parse EXPECTED_GROUPS_JSON: ${err.message}; ignoring.`);
+    }
+  }
+
+  const summary = aggregate(rootDir, expectedGroups);
   console.log(toMarkdown(summary));
 
   if (ndjsonOutPath && summary.allTests.length > 0) {
@@ -240,7 +272,7 @@ function main() {
     process.exit(1);
   }
 
-  if (summary.failed > 0 || summary.unreadableCount > 0) process.exit(1);
+  if (summary.failed > 0 || summary.unreadableCount > 0 || summary.missingGroups.length > 0) process.exit(1);
 }
 
 main();

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -64,18 +64,26 @@ function firstErrorLine(result) {
   return [message, stackLine].filter(Boolean).join(' — ');
 }
 
+// Plain string sort puts 'e2e-results-rerun-10.json' before 'e2e-results-rerun-2.json'
+// ('1' < '2' as the first differing character), so a group re-run past attempt 9 would
+// merge chronologically out of order. localeCompare's numeric mode compares embedded
+// digit runs by value instead of character-by-character.
+function naturalFileOrder(a, b) {
+  return path.basename(a).localeCompare(path.basename(b), undefined, { numeric: true });
+}
+
 // Merges every report file belonging to one matrix group into a single per-test view,
 // keyed by spec.id (falling back to file::title only if a report predates that field)
 // plus the test's project name. spec.id is unique per spec location, unlike spec.title
 // alone, which collides when two describe blocks reuse the same inner test title;
 // the project name further distinguishes the same spec run under more than one
 // Playwright project. Files are merged in filename order — 'e2e-results-first.json'
-// before 'e2e-results-rerun.json' — so a test's results carry the first attempt's
-// history followed by the re-run's, giving a true attempt count and final outcome even
-// when the group needed a re-run.
-function mergeGroupReports(files, onUnreadable) {
+// before 'e2e-results-rerun-1.json', 'e2e-results-rerun-2.json', ... — so a test's
+// results carry the first attempt's history followed by each re-run's, giving a true
+// attempt count and final outcome even across repeated re-runs.
+function mergeGroupReports(files, onUnreadable, onTruncated) {
   const merged = new Map();
-  for (const file of [...files].sort()) {
+  for (const file of [...files].sort(naturalFileOrder)) {
     let report;
     try {
       report = JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -83,19 +91,49 @@ function mergeGroupReports(files, onUnreadable) {
       onUnreadable(file, err);
       continue;
     }
+
     const specs = [];
     for (const suite of report.suites || []) collectSpecs(suite, specs);
+
+    // maxFailures (playwright.config.js) aborts the run once that many tests have
+    // failed — remaining tests never execute. Detecting that reliably needs two
+    // independent signals together, since neither alone is precise:
+    //  - Playwright emits a top-level error with this exact wording only when the cap
+    //    is actually hit — but it fires even if the cap lands on the suite's last test
+    //    with nothing left to run, so it alone would flag a run that in fact finished.
+    //  - Remaining tests show up with status 'skipped', same as an intentional
+    //    test.skip()/test.fixme() (annotated) or a test skipped because a beforeAll/
+    //    beforeEach hook threw (also unannotated) — so an unannotated skip alone
+    //    doesn't prove maxFailures was the cause.
+    // Requiring both rules out a suite that legitimately finished on its Nth failure
+    // (no unannotated skip exists) and a hook failure that coincidentally also has
+    // stats.unexpected reach the cap (hook failures don't emit this top-level error).
+    const stoppedEarly = (report.errors || []).some(
+      (e) => typeof e.message === 'string' && /maximum allowed failures/i.test(e.message)
+    );
+    const hasInvoluntarySkip = specs.some((spec) =>
+      (spec.tests || []).some(
+        (t) =>
+          t.status === 'skipped' &&
+          !(t.annotations || []).some((a) => a.type === 'skip' || a.type === 'fixme')
+      )
+    );
+    if (stoppedEarly && hasInvoluntarySkip) {
+      onTruncated(file);
+    }
 
     for (const spec of specs) {
       for (const test of spec.tests || []) {
         const specKey = spec.id || `${spec.file}::${spec.title}`;
         const key = `${specKey}::${test.projectName || ''}`;
         const results = test.results || [];
+        const hasSkipAnnotation = (test.annotations || []).some((a) => a.type === 'skip' || a.type === 'fixme');
         const existing = merged.get(key);
         if (existing) {
           existing.results.push(...results);
+          existing.hasSkipAnnotation = existing.hasSkipAnnotation || hasSkipAnnotation;
         } else {
-          merged.set(key, { title: spec.title, file: spec.file, results: [...results] });
+          merged.set(key, { title: spec.title, file: spec.file, results: [...results], hasSkipAnnotation });
         }
       }
     }
@@ -125,12 +163,17 @@ function aggregate(rootDir, expectedGroups) {
   let skipped = 0;
   let flaky = 0;
   let unreadableCount = 0;
+  const truncatedGroups = new Set();
 
   for (const [group, groupFiles] of byGroup) {
-    const mergedTests = mergeGroupReports(groupFiles, (file, err) => {
-      console.error(`Skipping unreadable report ${file}: ${err.message}`);
-      unreadableCount += 1;
-    });
+    const mergedTests = mergeGroupReports(
+      groupFiles,
+      (file, err) => {
+        console.error(`Skipping unreadable report ${file}: ${err.message}`);
+        unreadableCount += 1;
+      },
+      () => truncatedGroups.add(group)
+    );
 
     for (const test of mergedTests) {
       total += 1;
@@ -155,12 +198,18 @@ function aggregate(rootDir, expectedGroups) {
         })
         .filter(Boolean);
 
+      // Distinguishes, for history/trend analysis, a test that never ran because a
+      // group hit maxFailures from one intentionally skipped via test.skip()/fixme() —
+      // both otherwise show up identically as finalStatus 'skipped'.
+      const skipCause = !isSkipped ? null : test.hasSkipAnnotation ? 'intentional' : 'involuntary';
+
       allTests.push({
         group,
         title: test.title,
         file: test.file,
         attempts,
         finalStatus,
+        skipCause,
         error: errorLines.length ? errorLines[errorLines.length - 1] : null,
       });
 
@@ -170,7 +219,19 @@ function aggregate(rootDir, expectedGroups) {
     }
   }
 
-  return { rows, allTests, total, passed, failed, skipped, flaky, unreadableCount, missingGroups, groupCount: byGroup.size };
+  return {
+    rows,
+    allTests,
+    total,
+    passed,
+    failed,
+    skipped,
+    flaky,
+    unreadableCount,
+    missingGroups,
+    truncatedGroups: [...truncatedGroups],
+    groupCount: byGroup.size,
+  };
 }
 
 function toNdjson(allTests) {
@@ -178,6 +239,7 @@ function toNdjson(allTests) {
   const runId = process.env.GITHUB_RUN_ID || '';
   const runAttempt = process.env.GITHUB_RUN_ATTEMPT || '';
   const sourceTag = process.env.E2E_SOURCE_TAG || '';
+  const sourceSha = process.env.E2E_SOURCE_SHA || '';
 
   return allTests
     .map((t) =>
@@ -186,6 +248,7 @@ function toNdjson(allTests) {
         runId,
         runAttempt,
         sourceTag,
+        sourceSha,
         ...t,
       })
     )
@@ -201,7 +264,18 @@ function cell(value) {
   return String(value ?? '').replace(ANSI_PATTERN, '').replace(/\|/g, '\\|');
 }
 
-function toMarkdown({ rows, total, passed, failed, skipped, flaky, unreadableCount, missingGroups, groupCount }) {
+function toMarkdown({
+  rows,
+  total,
+  passed,
+  failed,
+  skipped,
+  flaky,
+  unreadableCount,
+  missingGroups,
+  truncatedGroups,
+  groupCount,
+}) {
   const lines = [];
   lines.push('## E2E flakiness report');
   lines.push('');
@@ -216,14 +290,17 @@ function toMarkdown({ rows, total, passed, failed, skipped, flaky, unreadableCou
       `⚠️ No report at all from: ${missingGroups.join(', ')} (killed before uploading, e.g. by the job timeout) — this run is marked failed.`
     );
   }
+  if (truncatedGroups && truncatedGroups.length > 0) {
+    lines.push(
+      `⚠️ Hit maxFailures and stopped early in: ${truncatedGroups.join(', ')} — remaining tests in that group never ran and are counted as skipped, not as a smaller suite. This run is marked failed.`
+    );
+  }
   lines.push('');
 
-  const clean = rows.length === 0 && unreadableCount === 0 && (!missingGroups || missingGroups.length === 0);
-  if (clean) {
-    lines.push('No retries or failures — every test passed on the first attempt.');
-    return lines.join('\n');
-  }
   if (rows.length === 0) {
+    if (unreadableCount === 0 && (!missingGroups || missingGroups.length === 0) && (!truncatedGroups || truncatedGroups.length === 0)) {
+      lines.push('No retries or failures — every test passed on the first attempt.');
+    }
     return lines.join('\n');
   }
 
@@ -272,7 +349,13 @@ function main() {
     process.exit(1);
   }
 
-  if (summary.failed > 0 || summary.unreadableCount > 0 || summary.missingGroups.length > 0) process.exit(1);
+  if (
+    summary.failed > 0 ||
+    summary.unreadableCount > 0 ||
+    summary.missingGroups.length > 0 ||
+    summary.truncatedGroups.length > 0
+  )
+    process.exit(1);
 }
 
 main();

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Sourced by e2e-scheduled.yml steps to retry a flaky command instead of hand-rolling
+# the same for-loop in each one — a prior omission of exactly this pattern on one gh
+# CLI call (while three siblings had it) is what prompted extracting it here.
+#
+# Usage: retry <max_attempts> <sleep_seconds> <command...>
+# Runs <command...>, retrying up to <max_attempts> times with <sleep_seconds> between
+# attempts (never after the final one). Exits 0 on the first successful attempt —
+# stdout/stderr and the exit status are the wrapped command's own, so
+# `out=$(retry 3 5 some-command args...)` behaves like a normal command substitution.
+# Exits 1 once all attempts are exhausted.
+retry() {
+  local max_attempts="$1"
+  local sleep_seconds="$2"
+  shift 2
+  local attempt
+  for attempt in $(seq 1 "$max_attempts"); do
+    if "$@"; then
+      return 0
+    fi
+    echo "Command failed (attempt $attempt/$max_attempts): $*" >&2
+    [ "$attempt" -lt "$max_attempts" ] && sleep "$sleep_seconds"
+  done
+  return 1
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -177,18 +177,23 @@ every nightly VSIX has one commit that pins both its source and its version.
 - The force-push uses `GITHUB_TOKEN`, whose pushes do not trigger workflows, so the
   nightly build cannot re-enter itself.
 - After every validation job passes, the workflow force-moves the `nightly` Git tag to
-  that exact stamped commit. The tag is not a GitHub Release and has no release assets;
-  the VSIX remains available from the workflow run.
+  that exact stamped commit, then overwrites the `nightly` prerelease to target it, with
+  that night's timestamped VSIX as its only asset. The release is deleted and recreated
+  rather than edited: the tag has just moved, and an existing release keeps pointing at
+  the commit it was created from; the asset filename also carries the timestamped version,
+  so editing in place would accumulate one VSIX per night instead of replacing it.
+- The release exists so the VSIX is reachable by tag rather than only through the
+  authenticated Actions artifact API — `e2e-scheduled.yml` downloads it from there (see
+  "Scheduled E2E testing" below). Its once-a-day delete/recreate window is why that
+  workflow retries every `gh release` call.
 - The machine branch is named `builds/nightly`, while the stable public marker remains
   the `nightly` tag. Keeping separate names avoids ambiguous Git ref resolution.
-- On the first run after this migration, the tag job removes the legacy `nightly`
-  GitHub Release before moving the tag. That release currently contains an old
-  `5.12.0-SNAPSHOT` VSIX; retaining it would attach a stale asset to every new tag target.
 
-Every release or pre-release GitHub release carries two assets — the VSIX and the bundled LS jar — so the server
-can be downloaded on its own to debug a regression, or pointed at an existing install via
-`ballerina.langServerPath`. It is the exact jar inside the VSIX, packed at the same version,
-so the two can never disagree about what was built.
+Every release or pre-release GitHub release cut by `release-pre-release.yml` carries two assets —
+the VSIX and the bundled LS jar (the nightly prerelease is the exception; it carries only the
+VSIX) — so the server can be downloaded on its own to debug a regression, or pointed at an
+existing install via `ballerina.langServerPath`. It is the exact jar inside the VSIX, packed at
+the same version, so the two can never disagree about what was built.
 
 | Dispatch | GitHub release + tag | LS GitHub Package | Version commit + `release/X.Y.Z` |
 |---|---|---|---|
@@ -197,7 +202,7 @@ so the two can never disagree about what was built.
 | Pre-release + `githubRelease: true` | yes, on the dispatched commit | yes | no |
 | Pre-release + `githubRelease: false` | no; VSIX artifact only | no | no |
 | Custom development build | no | no | no |
-| Scheduled nightly build | no; updates the `nightly` Git tag | no | nightly version commit only |
+| Scheduled nightly build | yes; overwrites the `nightly` tag + prerelease (VSIX only) | no | nightly version commit only |
 
 Marketplace publishing remains manual: `publish-vsix.yml` takes the `VSIX` workflow artifact
 by run ID (30-day retention), independently of the GitHub release.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,6 +15,7 @@ workflow because the extension manifest owns the shared extension/LS version.
 | `reusable-build.yml` | `workflow_call` only | Reusable build pipeline (ballerina-only) |
 | `devBuild.yml` | manual + `workflow_call` | Builds a custom branch as a timestamped pre-release VSIX. It creates workflow artifacts only: no GitHub release and no marketplace publication. `schedule.yml` reuses this workflow after stamping the nightly branch. |
 | `schedule.yml` | nightly cron + manual | Syncs the `builds/nightly` branch, runs the LS multi-branch pack/test/Windows-build matrix, calls `devBuild.yml`, and moves the `nightly` tag after every job passes. Manual runs can select a source branch and otherwise behave exactly like scheduled nightlies, including notifications. The VSIX remains a workflow artifact; no GitHub Release is created. See [Versioning](#versioning) and [The nightly branch](#the-nightly-branch). |
+| `e2e-scheduled.yml` | every 6h cron + manual | Runs the Playwright E2E suite against the nightly VSIX without rebuilding, and tracks flakiness over time. See [Scheduled E2E testing](#scheduled-e2e-testing). |
 | `pull-request.yml` | PRs + manual | Detects changes with `dorny/paths-filter`; if anything build-relevant changed, runs `reusable-build.yml` which builds the entire chain (LS via Gradle, then all TS packages and the extension VSIX via rush) in a single job. Windows LS coverage runs in `schedule.yml` only. |
 | `release-pre-release.yml` | manual dispatch | Builds either a timestamped pre-release or the release version authored in the extension manifest. Its `githubRelease` input creates a GitHub Release with the VSIX and LS jar and publishes the matching `io.ballerina:ballerina-language-server` package. Real releases also perform the release branch/PR handling. |
 | `publish-vsix.yml` | manual dispatch | Publishes a built VSIX (passed by `workflowRunId`) to VSCode Marketplace + OpenVSX |
@@ -157,11 +158,13 @@ where one repo held several extensions and each needed its own stable trunk
 
 ## The nightly branch
 
-`schedule.yml` builds from a `builds/nightly` branch that it maintains itself. Scheduled
-runs reset it to `origin/main`; manual runs reset it to the selected `sourceBranch`, which
-defaults to `main`. The workflow then commits the timestamped version and force-pushes the
-branch. Therefore `git diff origin/<sourceBranch> builds/nightly` is exactly the version
-bump, and every nightly VSIX has one commit that pins both its source and its version.
+`schedule.yml` builds from a `builds/nightly` branch that it maintains itself. Scheduled runs,
+and manual runs with `sourceBranch` left blank, reset it to the latest `staging/*` branch if one
+exists, otherwise `main` — resolved by the `resolve-source-branch` composite action. A manual
+run can still pass an explicit `sourceBranch` to override that. The workflow then commits the
+timestamped version and force-pushes the branch.
+Therefore `git diff origin/<resolved-branch> builds/nightly` is exactly the version bump, and
+every nightly VSIX has one commit that pins both its source and its version.
 
 - **Never open a PR against `builds/nightly` and never merge it anywhere** — it is discarded
   and recreated on every run.
@@ -205,6 +208,96 @@ everything, with `publish-vsix.yml` demoting a real release to a proper release 
 marketplace served it. That staged promotion had a failure mode with no signal: cut a release
 and skip publishing, and it stayed labelled a pre-release forever. `publish-vsix.yml` still
 patches the label, which is now a harmless no-op for releases cut after this change.
+
+## Scheduled E2E testing
+
+`e2e-scheduled.yml` runs the Playwright E2E suite (`packages/ballerina-extension/e2e-test/`)
+every 6 hours, purely to track flakiness over time — not for fresh-code feedback, which PR
+builds already cover. It exists because E2E was too flaky to keep gating the nightly build and
+was disabled there (see the `TODO` in `schedule.yml`'s `Build` job).
+
+**Tests the nightly VSIX instead of rebuilding.** The `E2E` job downloads the `ballerina-*.vsix`
+asset from the `nightly` GitHub Release rather than running a full `rush build`/`vsce package`,
+saving that cost 4x/day. Testing the same build across all 4 daily runs is deliberate: it holds
+product code constant so variance is attributable to test flakiness, not code churn. The
+`nightly` tag only moves once `schedule.yml`'s build and LS tests all pass, so it always points
+at the last known-good build — no separate fallback is needed for "what if last night's build
+failed". The job's own checkout stays on the default ref rather than the `nightly` tag's commit,
+because every local `uses: ./.github/actions/...` step resolves against whatever is checked
+out — pinning to an older tag commit would break (permanently, not just once) whenever an
+action under `.github/actions/` changes, until a future nightly build advanced the tag past it.
+The accepted trade-off is that test source and the installed VSIX are no longer commit-matched.
+For the same reason, `setup-ballerina`'s `gradlePropertiesRef: nightly` input pins the installed
+Ballerina distribution version to what the nightly LS actually shipped with, not to
+`gradle.properties` on the current checkout — otherwise a version bump on the default branch
+between nightly builds would fail the whole suite in a way indistinguishable from flakiness.
+
+**Handles GitHub's "Re-run failed jobs" across the whole pipeline.** A matrix group can be
+re-run independently, advancing only its own `github.run_attempt`; `run-e2e-group` restores the
+previous attempt's `.last-run.json` to resume `--last-failed` targeting, and deliberately keeps
+(does not discard) the restored `e2e-reports/` report — a re-run is a continuation of the same
+logical test run, so a test's full attempt history across it (failures before the re-run, plus
+the re-run's own attempts) is what should be recorded, not just the re-run's small subset. Each
+re-run's own report is written to a `run_attempt`-suffixed filename so a *second* re-run can't
+overwrite the first re-run's data the same way. The `Report` job mirrors this at the group level:
+it picks whichever artifact attempt actually exists per group (a passing group's artifact stays
+at a lower attempt number than a re-run group's), rather than assuming every group is at the
+run's current attempt.
+
+**The `nightly` release is briefly unavailable once a day.** `schedule.yml`'s `Tag` job deletes
+then recreates it, so every `gh release view`/`gh release download`/artifact-listing call in
+this workflow retries (`.github/scripts/retry.sh`, sourced rather than duplicated — a prior
+omission of the retry on one of these calls, while its siblings had it, is what prompted
+extracting it) instead of failing outright on that narrow window. One related race is accepted
+rather than closed: `sourceSha` is resolved once in `Prepare` before the E2E matrix starts, but
+each matrix leg separately re-downloads the VSIX later, so a retag landing in between could in
+principle leave a leg testing a different commit than the one recorded in its history row. Fully
+closing that would mean downloading the VSIX once and distributing it to all 4 legs as a shared
+artifact — a real redesign for a multi-second daily window with no effect on the tests
+themselves, so it's left as a known, narrow gap rather than solved here.
+
+**Reports go outside Playwright's `outputDir`.** Both the first-attempt and re-run JSON reports
+are written to `e2e-reports/`, not `test-results/` — Playwright wipes its `outputDir`
+(`test-results/`) at the start of every invocation, so a report placed there would be deleted by
+the very next invocation before ever being read (confirmed by reproducing it locally, not just
+by inspection).
+
+**`aggregate-e2e-results.js`** merges a group's report(s) into one Markdown summary (posted to
+the run's Step Summary) and one NDJSON line per test, keyed by `spec.id` + project name (not
+`file::title`, which collides across `describe` blocks reusing a title). It separately tracks
+and warns on: unparseable report files, groups with no report at all (e.g. killed by the
+60-minute job timeout), and groups that hit `maxFailures` and stopped early. The last needs two
+signals together, since neither alone is precise: a top-level Playwright error containing
+"maximum allowed failures" (emitted only when the cap is hit, but also when the cap happens to
+land on the suite's last test with nothing left to run) AND at least one test with status
+`skipped` and no `skip`/`fixme` annotation (true for a test the cap left un-run, but also true
+for one skipped by a failed `beforeAll`/`beforeEach` hook). Requiring both rules out a suite that
+legitimately finished on its Nth failure and a hook failure that coincidentally also reaches the
+cap. Any of these marks the run failed, not just a test failure. Each NDJSON row also carries a
+`skipCause` (`'involuntary'`/`'intentional'`/`null`) using the same annotation check, so a
+history reader can tell a test that never ran due to the cap apart from one skipped on purpose,
+even though both show `finalStatus: 'skipped'` — this is per-test detail the group-level
+truncation warning above doesn't carry.
+
+**History persists to an orphan `e2e-metrics` branch**, appended once per scheduled run (not
+batched across the day — see below), in a throwaway clone rather than the job's own checkout
+(switching that checkout to `e2e-metrics`, which contains only `history/`, would delete every
+other tracked file the job still needs, including `./.github/actions/failure-notification`).
+The clone is `--depth 1 --single-branch`: `e2e-metrics` is an orphan branch with no relation to
+`main`'s history, so an unrestricted clone would still pull the whole repo's packfiles for a
+branch that only ever holds small `history/YYYY-MM.jsonl` files (rotated monthly to bound
+growth). Each NDJSON row also carries `sourceSha` — the `nightly` release's `targetCommitish`,
+resolved once in the `Prepare` job before the E2E matrix starts (not re-queried later in
+`Report`, which risks reading a commit the tag has since moved past) — so a regression from a
+new nightly build and a genuinely flaky test remain distinguishable in the history, since the
+`nightly` tag itself moves nightly while `E2E_SOURCE_TAG` stays a constant label.
+
+*Why not batch the whole day's stats into one write instead of one per run?* Each of the 4 daily
+runs is an independent GitHub Actions job with no shared filesystem, so batching would mean
+stashing each run's stats in an artifact (its own retention window, its own chance of expiring)
+until some later run decides it's "last" and pushes for the day — new failure modes for a
+problem the shallow clone above already solves directly. Writing immediately after each run
+means each run's data is durably committed the moment it exists, with no held state to lose.
 
 ## The bundled language server
 
@@ -271,9 +364,11 @@ configured.
 | Action | Used by |
 |---|---|
 | `build` | `reusable-build.yml` — runs rush install + `rush build --to ballerina` |
-| `setup-ballerina` | Build and LS workflows — installs the distribution version declared by the LS `gradle.properties` |
+| `setup-ballerina` | Build and LS workflows — installs the distribution version declared by the LS `gradle.properties`; accepts an optional `gradlePropertiesRef` to read that file from a git tag instead of the checkout (used by `e2e-scheduled.yml` to pin to the `nightly` tag) |
 | `updateVersion` | `build`, `schedule.yml` — resolves and writes the version in the extension manifest |
+| `resolve-source-branch` | `schedule.yml` — the latest-`staging/*`-else-`main` resolution described under [The nightly branch](#the-nightly-branch) |
+| `run-e2e-group` | `reusable-build.yml`, `e2e-scheduled.yml` — runs one matrix group of the E2E suite (first attempt + `--last-failed` re-run) and uploads its artifacts; see [Scheduled E2E testing](#scheduled-e2e-testing) |
 | `release` | `release-pre-release.yml` — owns everything that materialises a release: the version commit, `release/<version>`, the tag, the GitHub release and its assets |
 | `pr` | `release-pre-release.yml` — opens the follow-up pull requests (release PR into `X.Y.x`, next-snapshot PR into `main`) + Google Chat notification |
 | `dailyBuildNotification` | `schedule.yml` — success chat notification |
-| `failure-notification` | `schedule.yml`, `release-pre-release.yml` — failure chat notification |
+| `failure-notification` | `schedule.yml`, `release-pre-release.yml`, `e2e-scheduled.yml` — failure chat notification |

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -18,10 +18,23 @@ jobs:
   # Tests the VSIX schedule.yml already built and published, rather than rebuilding —
   # this workflow exists for flakiness signal, not fresh-code feedback (PR builds cover
   # that), so testing the same nightly build across all 4 daily runs is fine, and holds
-  # code constant so variance is attributable to test flakiness rather than code churn.
-  # The 'nightly' tag/release only moves once schedule.yml's build + LS tests succeed
-  # (see schedule.yml's Tag job), so it always points at the last known-good build —
-  # no separate handling is needed here for "what if last night's build failed".
+  # product code constant so variance is attributable to test flakiness rather than
+  # code churn. The 'nightly' tag/release only moves once schedule.yml's build + LS
+  # tests succeed (see schedule.yml's Tag job), so it always points at the last
+  # known-good build — no separate handling is needed here for "what if last night's
+  # build failed".
+  #
+  # Only the VSIX binary is pulled from that release, not the source tree: this job's
+  # own checkout stays on the default ref (whatever normally triggers this workflow),
+  # because every 'uses: ./.github/actions/...' step below resolves against whatever
+  # is actually checked out. Checking out the 'nightly' tag's commit here would make
+  # those local action references resolve against that older tree instead of this
+  # repo's current commits — breaking (permanently, not just once) whenever an action
+  # under .github/actions is added or changed, until a future nightly build happens to
+  # advance the tag past that change. The trade-off: test source and the installed
+  # VSIX are no longer commit-matched, so a test added/changed today could reference
+  # product behavior the last-built VSIX doesn't have yet — accepted as the smaller
+  # risk against a guaranteed-broken workflow.
   E2E:
     name: Run Ballerina e2e Test (${{ matrix.group }})
     timeout-minutes: 60
@@ -31,10 +44,9 @@ jobs:
         group: [group1, group2, group3, group4]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout nightly commit
+      - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: refs/tags/nightly
           persist-credentials: false
 
       - name: Download nightly VSIX
@@ -81,12 +93,38 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download E2E test results
+      # Downloaded per group into an explicit subfolder rather than one pattern-based
+      # call across all 4: download-artifact only nests results under a per-artifact
+      # subfolder when more than one artifact matches — if 3 of 4 groups never
+      # uploaded (e.g. cancelled before their `if: always()` upload step), the lone
+      # survivor would land flattened at the root with no group name to key off of.
+      - name: Download group1 test results
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         continue-on-error: true
         with:
-          pattern: Ballerina-e2e-test-results-linux-*-${{ github.run_attempt }}
-          path: e2e-results
+          name: Ballerina-e2e-test-results-linux-group1-${{ github.run_attempt }}
+          path: e2e-results/group1
+
+      - name: Download group2 test results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        continue-on-error: true
+        with:
+          name: Ballerina-e2e-test-results-linux-group2-${{ github.run_attempt }}
+          path: e2e-results/group2
+
+      - name: Download group3 test results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        continue-on-error: true
+        with:
+          name: Ballerina-e2e-test-results-linux-group3-${{ github.run_attempt }}
+          path: e2e-results/group3
+
+      - name: Download group4 test results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        continue-on-error: true
+        with:
+          name: Ballerina-e2e-test-results-linux-group4-${{ github.run_attempt }}
+          path: e2e-results/group4
 
       - name: Aggregate results
         id: aggregate

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -15,6 +15,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Single source of truth for the matrix group list — consumed by both the E2E job's
+  # own matrix and the Report job's per-group downloads, so the two can't drift out of
+  # sync the way 4 hand-written "Download groupN" steps did.
+  Prepare:
+    name: Resolve matrix groups
+    runs-on: ubuntu-latest
+    outputs:
+      groups: ${{ steps.groups.outputs.groups }}
+    steps:
+      - id: groups
+        run: echo 'groups=["group1","group2","group3","group4"]' >> "$GITHUB_OUTPUT"
+
   # Tests the VSIX schedule.yml already built and published, rather than rebuilding —
   # this workflow exists for flakiness signal, not fresh-code feedback (PR builds cover
   # that), so testing the same nightly build across all 4 daily runs is fine, and holds
@@ -37,11 +49,12 @@ jobs:
   # risk against a guaranteed-broken workflow.
   E2E:
     name: Run Ballerina e2e Test (${{ matrix.group }})
+    needs: Prepare
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        group: [group1, group2, group3, group4]
+        group: ${{ fromJson(needs.Prepare.outputs.groups) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -82,57 +95,57 @@ jobs:
 
   Report:
     name: Aggregate flakiness report
-    needs: E2E
+    needs:
+      - Prepare
+      - E2E
     if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      # Downloaded per group into an explicit subfolder rather than one pattern-based
-      # call across all 4: download-artifact only nests results under a per-artifact
-      # subfolder when more than one artifact matches — if 3 of 4 groups never
-      # uploaded (e.g. cancelled before their `if: always()` upload step), the lone
-      # survivor would land flattened at the root with no group name to key off of.
-      - name: Download group1 test results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        continue-on-error: true
-        with:
-          name: Ballerina-e2e-test-results-linux-group1-${{ github.run_attempt }}
-          path: e2e-results/group1
-
-      - name: Download group2 test results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        continue-on-error: true
-        with:
-          name: Ballerina-e2e-test-results-linux-group2-${{ github.run_attempt }}
-          path: e2e-results/group2
-
-      - name: Download group3 test results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        continue-on-error: true
-        with:
-          name: Ballerina-e2e-test-results-linux-group3-${{ github.run_attempt }}
-          path: e2e-results/group3
-
-      - name: Download group4 test results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        continue-on-error: true
-        with:
-          name: Ballerina-e2e-test-results-linux-group4-${{ github.run_attempt }}
-          path: e2e-results/group4
+      # Per group, download whichever attempt actually has an artifact — not just
+      # github.run_attempt. "Re-run failed jobs" only advances the attempt number of
+      # the groups that failed; a passing group's artifact stays at its original,
+      # lower attempt number. Downloading strictly by the *run's* current attempt
+      # would silently miss every group that never needed a re-run. run-e2e-group
+      # already handles this per-group look-back for resuming --last-failed; this
+      # does the equivalent for the Report job's cross-group aggregation.
+      - name: Download latest available test results per group
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GROUPS_JSON: ${{ needs.Prepare.outputs.groups }}
+        run: |
+          set -euo pipefail
+          for group in $(echo "$GROUPS_JSON" | jq -r '.[]'); do
+            name=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+              --paginate --jq '.artifacts[].name' \
+              | grep -E "^Ballerina-e2e-test-results-linux-${group}-[0-9]+$" \
+              | sort -V | tail -n1) || true
+            if [ -z "${name:-}" ]; then
+              echo "No artifact found for ${group}; skipping."
+              continue
+            fi
+            echo "Downloading ${name} for ${group}"
+            mkdir -p "e2e-results/${group}"
+            gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" \
+              -n "${name}" -D "e2e-results/${group}"
+          done
 
       - name: Aggregate results
         id: aggregate
         shell: bash
         env:
-          # Every run tests the same 'nightly' tag/release now, not a freshly resolved
-          # branch — this labels the history data accordingly.
-          E2E_SOURCE_BRANCH: builds/nightly
+          # Every run tests the VSIX from the 'nightly' GitHub Release/tag now, not a
+          # freshly resolved branch — this labels the history data accordingly. (Not
+          # 'builds/nightly' — that's schedule.yml's own internal build branch, a
+          # different thing from the 'nightly' release tag this workflow reads.)
+          E2E_SOURCE_TAG: nightly
         run: |
           set -o pipefail
           node .github/scripts/aggregate-e2e-results.js e2e-results e2e-run-stats.jsonl \

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: refs/tags/nightly
+          persist-credentials: false
 
       - name: Download nightly VSIX
         env:
@@ -62,87 +63,10 @@ jobs:
       - name: Install Ballerina distribution
         uses: ./.github/actions/setup-ballerina
 
-      - name: Check for previous test results
-        shell: bash
-        if: github.run_attempt > 1
-        run: |
-          PREVIOUS_ATTEMPT=$((${{ github.run_attempt }} - 1))
-          echo "PREVIOUS_ATTEMPT=$PREVIOUS_ATTEMPT" >> $GITHUB_ENV
-
-      - name: Download previous test results
-        id: check-results
-        if: github.run_attempt > 1
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        continue-on-error: true
+      - name: Run e2e test group
+        uses: ./.github/actions/run-e2e-group
         with:
-          name: Ballerina-e2e-test-results-linux-${{ matrix.group }}-${{ env.PREVIOUS_ATTEMPT }}
-          path: packages/ballerina-extension/test-results
-
-      - name: Install packages
-        shell: bash
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y xvfb ffmpeg gnome-keyring libsecret-1.0 dbus-x11
-          cd packages/ballerina-extension && npx playwright install
-
-      - name: Run Ballerina e2e Test (First Attempt)
-        shell: bash
-        id: run-tests-first
-        if: github.run_attempt == 1 || steps.check-results.outcome == 'failure'
-        continue-on-error: true
-        env:
-          # A distinct filename from the re-run's report below: both are full Playwright
-          # JSON reports written by separate CLI invocations, so a shared name would let
-          # the re-run silently overwrite the first attempt's results instead of adding
-          # to them — aggregate-e2e-results.js merges both by matching this prefix.
-          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-first.json
-        run: |
-          export $(dbus-launch)
-          export DISPLAY=:98.0
-          cd packages/ballerina-extension
-          xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ matrix.group }}"
-
-      - name: Run Failed Ballerina e2e Test (Re-run)
-        shell: bash
-        if: steps.run-tests-first.outcome == 'failure' || steps.check-results.outcome == 'success'
-        env:
-          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-rerun.json
-        run: |
-          rm -rf packages/ballerina-extension/e2e-test/data/new-project
-          export $(dbus-launch)
-          export DISPLAY=:98.0
-          cd packages/ballerina-extension
-          xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ matrix.group }} --last-failed"
-
-      - name: Upload Ballerina e2e Test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
-        with:
-          name: Ballerina-e2e-test-results-linux-${{ matrix.group }}-${{ github.run_attempt }}
-          path: packages/ballerina-extension/test-results/**
-          retention-days: 5
-          include-hidden-files: true
-
-      - name: Upload Ballerina e2e Test recordings
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
-        with:
-          name: Ballerina-e2e-test-recording-linux-${{ matrix.group }}-${{ github.run_attempt }}
-          path: |
-            packages/ballerina-extension/e2e-test/test-resources/videos/**
-            packages/ballerina-extension/e2e-test/test-resources/screenshots/**
-            packages/ballerina-extension/e2e-test/test-resources/snapshots/**
-            packages/ballerina-extension/record.mp4
-          retention-days: 5
-
-      - name: Upload Ballerina e2e Test project data
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
-        with:
-          name: Ballerina-e2e-test-project-linux-${{ matrix.group }}-${{ github.run_attempt }}
-          path: |
-            packages/ballerina-extension/e2e-test/data/new-project/**
-          retention-days: 5
+          group: ${{ matrix.group }}
 
   Report:
     name: Aggregate flakiness report
@@ -177,6 +101,7 @@ jobs:
             | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Persist run stats
+        id: persist
         if: ${{ always() && github.repository == 'ballerina-platform/ballerina-vscode' }}
         run: |
           set -euo pipefail
@@ -187,28 +112,41 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          pushed=false
           for attempt in 1 2 3; do
             git fetch origin e2e-metrics || true
             if git show-ref --verify --quiet refs/remotes/origin/e2e-metrics; then
               git checkout -B e2e-metrics origin/e2e-metrics
             else
-              git checkout --orphan e2e-metrics
+              # A prior failed iteration this run may have already left an orphan
+              # branch checked out here — detach and drop it first so re-orphaning
+              # can't collide with itself on retry.
+              git checkout --detach 2>/dev/null || true
+              git branch -D e2e-metrics-tmp 2>/dev/null || true
+              git checkout --orphan e2e-metrics-tmp
               git rm -rf --quiet . || true
             fi
             mkdir -p history
             cat e2e-run-stats.jsonl >> history/e2e-history.jsonl
             git add history/e2e-history.jsonl
             git commit -m "E2E stats: run ${{ github.run_id }} attempt ${{ github.run_attempt }}"
-            if git push origin e2e-metrics; then
+            # Explicit refspec: the local branch name (e2e-metrics or the orphan
+            # scratch e2e-metrics-tmp above) doesn't matter, only HEAD's content does.
+            if git push origin HEAD:e2e-metrics; then
+              pushed=true
               break
             fi
             echo "Push to e2e-metrics rejected (non-fast-forward?), retrying ($attempt/3)..."
-            git reset --hard HEAD^
             sleep $((attempt * 5))
           done
 
+          if [ "$pushed" != true ]; then
+            echo "::error::Failed to persist e2e stats to e2e-metrics after 3 attempts."
+            exit 1
+          fi
+
       - name: Notify on failure
-        if: ${{ always() && (steps.aggregate.outcome == 'failure' || needs.E2E.result != 'success') && github.repository == 'ballerina-platform/ballerina-vscode' }}
+        if: ${{ always() && (steps.aggregate.outcome == 'failure' || steps.persist.outcome == 'failure' || needs.E2E.result != 'success') && github.repository == 'ballerina-platform/ballerina-vscode' }}
         uses: ./.github/actions/failure-notification
         with:
           title: "Scheduled E2E Tests Failed"

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -1,0 +1,119 @@
+name: Scheduled E2E Tests
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      sourceBranch:
+        description: >-
+          Branch to run the E2E suite against. Leave blank to auto-select: the
+          latest staging/* branch if one exists, otherwise main.
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+# Runs every 6 hours; a run should always finish well within that window, but
+# guard against overlap rather than assume it.
+concurrency:
+  group: e2e-scheduled
+  cancel-in-progress: false
+
+jobs:
+  resolve-branch:
+    name: Resolve source branch
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.resolve.outputs.branch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Resolve source branch
+        id: resolve
+        uses: ./.github/actions/resolve-source-branch
+        with:
+          sourceBranch: ${{ inputs.sourceBranch }}
+
+  E2E:
+    name: Run E2E suite
+    needs: resolve-branch
+    uses: ./.github/workflows/reusable-build.yml
+    secrets:
+      COPILOT_ROOT_URL: ${{ secrets.COPILOT_ROOT_URL }}
+      COPILOT_DEV_ROOT_URL: ${{ secrets.COPILOT_DEV_ROOT_URL }}
+      APPINSIGHTS_INSTRUMENTATION_KEY: ${{ secrets.APPINSIGHTS_INSTRUMENTATION_KEY }}
+    with:
+      ref: ${{ needs.resolve-branch.outputs.branch }}
+      runOnAWS: false
+      isPreRelease: true
+      nightly: false
+      ballerina: false
+      isReleaseBuild: false
+      runFastTests: false
+      runBalE2ETests: true
+      runLSTests: false
+
+  Report:
+    name: Aggregate flakiness report
+    needs:
+      - resolve-branch
+      - E2E
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Download E2E test results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        continue-on-error: true
+        with:
+          pattern: Ballerina-e2e-test-results-linux-*-${{ github.run_attempt }}
+          path: e2e-results
+
+      - name: Aggregate results
+        id: aggregate
+        env:
+          E2E_SOURCE_BRANCH: ${{ needs.resolve-branch.outputs.branch }}
+        run: node .github/scripts/aggregate-e2e-results.js e2e-results e2e-run-stats.jsonl | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Persist run stats
+        if: ${{ always() && github.repository == 'ballerina-platform/ballerina-vscode' }}
+        run: |
+          set -euo pipefail
+          if [ ! -f e2e-run-stats.jsonl ]; then
+            echo "No test results to persist; skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin e2e-metrics || true
+          if git show-ref --verify --quiet refs/remotes/origin/e2e-metrics; then
+            git checkout -B e2e-metrics origin/e2e-metrics
+          else
+            git checkout --orphan e2e-metrics
+            git rm -rf --quiet . || true
+          fi
+          mkdir -p history
+          cat e2e-run-stats.jsonl >> history/e2e-history.jsonl
+          git add history/e2e-history.jsonl
+          git commit -m "E2E stats: run ${{ github.run_id }} attempt ${{ github.run_attempt }}"
+          git push origin e2e-metrics
+
+      - name: Notify on failure
+        if: ${{ always() && (steps.aggregate.outcome == 'failure' || contains(needs.*.result, 'failure')) && github.repository == 'ballerina-platform/ballerina-vscode' }}
+        uses: ./.github/actions/failure-notification
+        with:
+          title: "Scheduled E2E Tests Failed"
+          run_id: ${{ github.run_id }}
+          chat_api: ${{ secrets.EDITOR_TEAM_CHAT_API }}
+          repository: ${{ github.repository }}
+          thread_key: e2e-scheduled

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -4,14 +4,6 @@ on:
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:
-    inputs:
-      sourceBranch:
-        description: >-
-          Branch to run the E2E suite against. Leave blank to auto-select: the
-          latest staging/* branch if one exists, otherwise main.
-        required: false
-        type: string
-        default: ''
 
 permissions:
   contents: read
@@ -23,45 +15,138 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  resolve-branch:
-    name: Resolve source branch
-    runs-on: ubuntu-latest
-    outputs:
-      branch: ${{ steps.resolve.outputs.branch }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Resolve source branch
-        id: resolve
-        uses: ./.github/actions/resolve-source-branch
-        with:
-          sourceBranch: ${{ inputs.sourceBranch }}
-
+  # Tests the VSIX schedule.yml already built and published, rather than rebuilding —
+  # this workflow exists for flakiness signal, not fresh-code feedback (PR builds cover
+  # that), so testing the same nightly build across all 4 daily runs is fine, and holds
+  # code constant so variance is attributable to test flakiness rather than code churn.
+  # The 'nightly' tag/release only moves once schedule.yml's build + LS tests succeed
+  # (see schedule.yml's Tag job), so it always points at the last known-good build —
+  # no separate handling is needed here for "what if last night's build failed".
   E2E:
-    name: Run E2E suite
-    needs: resolve-branch
-    uses: ./.github/workflows/reusable-build.yml
-    secrets:
-      COPILOT_ROOT_URL: ${{ secrets.COPILOT_ROOT_URL }}
-      COPILOT_DEV_ROOT_URL: ${{ secrets.COPILOT_DEV_ROOT_URL }}
-      APPINSIGHTS_INSTRUMENTATION_KEY: ${{ secrets.APPINSIGHTS_INSTRUMENTATION_KEY }}
-    with:
-      ref: ${{ needs.resolve-branch.outputs.branch }}
-      runOnAWS: false
-      isPreRelease: true
-      nightly: false
-      ballerina: false
-      isReleaseBuild: false
-      runFastTests: false
-      runBalE2ETests: true
-      runLSTests: false
+    name: Run Ballerina e2e Test (${{ matrix.group }})
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [group1, group2, group3, group4]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout nightly commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: refs/tags/nightly
+
+      - name: Download nightly VSIX
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p packages/ballerina-extension/vsix
+          gh release download nightly --repo "${{ github.repository }}" \
+            --pattern 'ballerina-*.vsix' --dir packages/ballerina-extension/vsix --clobber
+
+      - name: Setup Rush
+        uses: gigara/setup-rush@7ba3446572d15f5eacc85de383ad9679dfb7223c # v1.2.0
+        with:
+          pnpm: 10.10.0
+          node: 22.x
+          rush-install: true
+
+      - name: Build playwright-vscode-tester
+        # The only in-repo build dependency the e2e harness has once the ballerina VSIX
+        # is supplied externally: its compiled lib/ is gitignored, and rush install only
+        # links dependencies, it doesn't build them. Targeted so it doesn't pull in the
+        # full ballerina extension build.
+        run: rush build -t @wso2/playwright-vscode-tester
+
+      - name: Install Ballerina distribution
+        uses: ./.github/actions/setup-ballerina
+
+      - name: Check for previous test results
+        shell: bash
+        if: github.run_attempt > 1
+        run: |
+          PREVIOUS_ATTEMPT=$((${{ github.run_attempt }} - 1))
+          echo "PREVIOUS_ATTEMPT=$PREVIOUS_ATTEMPT" >> $GITHUB_ENV
+
+      - name: Download previous test results
+        id: check-results
+        if: github.run_attempt > 1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        continue-on-error: true
+        with:
+          name: Ballerina-e2e-test-results-linux-${{ matrix.group }}-${{ env.PREVIOUS_ATTEMPT }}
+          path: packages/ballerina-extension/test-results
+
+      - name: Install packages
+        shell: bash
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y xvfb ffmpeg gnome-keyring libsecret-1.0 dbus-x11
+          cd packages/ballerina-extension && npx playwright install
+
+      - name: Run Ballerina e2e Test (First Attempt)
+        shell: bash
+        id: run-tests-first
+        if: github.run_attempt == 1 || steps.check-results.outcome == 'failure'
+        continue-on-error: true
+        env:
+          # A distinct filename from the re-run's report below: both are full Playwright
+          # JSON reports written by separate CLI invocations, so a shared name would let
+          # the re-run silently overwrite the first attempt's results instead of adding
+          # to them — aggregate-e2e-results.js merges both by matching this prefix.
+          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-first.json
+        run: |
+          export $(dbus-launch)
+          export DISPLAY=:98.0
+          cd packages/ballerina-extension
+          xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ matrix.group }}"
+
+      - name: Run Failed Ballerina e2e Test (Re-run)
+        shell: bash
+        if: steps.run-tests-first.outcome == 'failure' || steps.check-results.outcome == 'success'
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-rerun.json
+        run: |
+          rm -rf packages/ballerina-extension/e2e-test/data/new-project
+          export $(dbus-launch)
+          export DISPLAY=:98.0
+          cd packages/ballerina-extension
+          xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ matrix.group }} --last-failed"
+
+      - name: Upload Ballerina e2e Test results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: Ballerina-e2e-test-results-linux-${{ matrix.group }}-${{ github.run_attempt }}
+          path: packages/ballerina-extension/test-results/**
+          retention-days: 5
+          include-hidden-files: true
+
+      - name: Upload Ballerina e2e Test recordings
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: Ballerina-e2e-test-recording-linux-${{ matrix.group }}-${{ github.run_attempt }}
+          path: |
+            packages/ballerina-extension/e2e-test/test-resources/videos/**
+            packages/ballerina-extension/e2e-test/test-resources/screenshots/**
+            packages/ballerina-extension/e2e-test/test-resources/snapshots/**
+            packages/ballerina-extension/record.mp4
+          retention-days: 5
+
+      - name: Upload Ballerina e2e Test project data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: Ballerina-e2e-test-project-linux-${{ matrix.group }}-${{ github.run_attempt }}
+          path: |
+            packages/ballerina-extension/e2e-test/data/new-project/**
+          retention-days: 5
 
   Report:
     name: Aggregate flakiness report
-    needs:
-      - resolve-branch
-      - E2E
+    needs: E2E
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -81,9 +166,15 @@ jobs:
 
       - name: Aggregate results
         id: aggregate
+        shell: bash
         env:
-          E2E_SOURCE_BRANCH: ${{ needs.resolve-branch.outputs.branch }}
-        run: node .github/scripts/aggregate-e2e-results.js e2e-results e2e-run-stats.jsonl | tee -a "$GITHUB_STEP_SUMMARY"
+          # Every run tests the same 'nightly' tag/release now, not a freshly resolved
+          # branch — this labels the history data accordingly.
+          E2E_SOURCE_BRANCH: builds/nightly
+        run: |
+          set -o pipefail
+          node .github/scripts/aggregate-e2e-results.js e2e-results e2e-run-stats.jsonl \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Persist run stats
         if: ${{ always() && github.repository == 'ballerina-platform/ballerina-vscode' }}
@@ -95,21 +186,29 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin e2e-metrics || true
-          if git show-ref --verify --quiet refs/remotes/origin/e2e-metrics; then
-            git checkout -B e2e-metrics origin/e2e-metrics
-          else
-            git checkout --orphan e2e-metrics
-            git rm -rf --quiet . || true
-          fi
-          mkdir -p history
-          cat e2e-run-stats.jsonl >> history/e2e-history.jsonl
-          git add history/e2e-history.jsonl
-          git commit -m "E2E stats: run ${{ github.run_id }} attempt ${{ github.run_attempt }}"
-          git push origin e2e-metrics
+
+          for attempt in 1 2 3; do
+            git fetch origin e2e-metrics || true
+            if git show-ref --verify --quiet refs/remotes/origin/e2e-metrics; then
+              git checkout -B e2e-metrics origin/e2e-metrics
+            else
+              git checkout --orphan e2e-metrics
+              git rm -rf --quiet . || true
+            fi
+            mkdir -p history
+            cat e2e-run-stats.jsonl >> history/e2e-history.jsonl
+            git add history/e2e-history.jsonl
+            git commit -m "E2E stats: run ${{ github.run_id }} attempt ${{ github.run_attempt }}"
+            if git push origin e2e-metrics; then
+              break
+            fi
+            echo "Push to e2e-metrics rejected (non-fast-forward?), retrying ($attempt/3)..."
+            git reset --hard HEAD^
+            sleep $((attempt * 5))
+          done
 
       - name: Notify on failure
-        if: ${{ always() && (steps.aggregate.outcome == 'failure' || contains(needs.*.result, 'failure')) && github.repository == 'ballerina-platform/ballerina-vscode' }}
+        if: ${{ always() && (steps.aggregate.outcome == 'failure' || needs.E2E.result != 'success') && github.repository == 'ballerina-platform/ballerina-vscode' }}
         uses: ./.github/actions/failure-notification
         with:
           title: "Scheduled E2E Tests Failed"

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -165,7 +165,7 @@ jobs:
 
           pushed=false
           for attempt in 1 2 3; do
-            git fetch origin e2e-metrics || true
+            git fetch origin e2e-metrics:refs/remotes/origin/e2e-metrics || true
             if git show-ref --verify --quiet refs/remotes/origin/e2e-metrics; then
               git checkout -B e2e-metrics origin/e2e-metrics
             else

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -1,5 +1,8 @@
 name: Scheduled E2E Tests
 
+# See "Scheduled E2E testing" in .github/workflows/README.md for the full design
+# rationale — this file intentionally keeps comments to short pointers, not prose.
+
 on:
   schedule:
     - cron: '0 */6 * * *'
@@ -8,45 +11,52 @@ on:
 permissions:
   contents: read
 
-# Runs every 6 hours; a run should always finish well within that window, but
-# guard against overlap rather than assume it.
 concurrency:
   group: e2e-scheduled
   cancel-in-progress: false
 
 jobs:
-  # Single source of truth for the matrix group list — consumed by both the E2E job's
-  # own matrix and the Report job's per-group downloads, so the two can't drift out of
-  # sync the way 4 hand-written "Download groupN" steps did.
   Prepare:
     name: Resolve matrix groups
     runs-on: ubuntu-latest
     outputs:
       groups: ${{ steps.groups.outputs.groups }}
+      nightlySha: ${{ steps.nightly-commit.outputs.sha }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
       - id: groups
         run: echo 'groups=["group1","group2","group3","group4"]' >> "$GITHUB_OUTPUT"
 
-  # Tests the VSIX schedule.yml already built and published, rather than rebuilding —
-  # this workflow exists for flakiness signal, not fresh-code feedback (PR builds cover
-  # that), so testing the same nightly build across all 4 daily runs is fine, and holds
-  # product code constant so variance is attributable to test flakiness rather than
-  # code churn. The 'nightly' tag/release only moves once schedule.yml's build + LS
-  # tests succeed (see schedule.yml's Tag job), so it always points at the last
-  # known-good build — no separate handling is needed here for "what if last night's
-  # build failed".
-  #
-  # Only the VSIX binary is pulled from that release, not the source tree: this job's
-  # own checkout stays on the default ref (whatever normally triggers this workflow),
-  # because every 'uses: ./.github/actions/...' step below resolves against whatever
-  # is actually checked out. Checking out the 'nightly' tag's commit here would make
-  # those local action references resolve against that older tree instead of this
-  # repo's current commits — breaking (permanently, not just once) whenever an action
-  # under .github/actions is added or changed, until a future nightly build happens to
-  # advance the tag past that change. The trade-off: test source and the installed
-  # VSIX are no longer commit-matched, so a test added/changed today could reference
-  # product behavior the last-built VSIX doesn't have yet — accepted as the smaller
-  # risk against a guaranteed-broken workflow.
+      - name: Resolve nightly build commit
+        id: nightly-commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          source .github/scripts/retry.sh
+          # jq prints the literal string "null" for a JSON null targetCommitish, which
+          # isn't empty and would otherwise pass as if it were a real commit hash —
+          # folded into the retried command itself so a "null" result also retries.
+          resolve_nightly_sha() {
+            local out
+            # No stderr suppression: a real (non-race) failure's actual gh error should
+            # reach the log, not just retry.sh's generic "attempt N/3" line.
+            out=$(gh release view nightly --repo "${{ github.repository }}" --json targetCommitish --jq .targetCommitish) || return 1
+            [ "$out" != "null" ] || return 1
+            echo "$out"
+          }
+          # Retries: schedule.yml's Tag job briefly deletes then recreates this release.
+          if ! sha=$(retry 3 5 resolve_nightly_sha); then
+            sha=""
+            echo "::warning::Could not resolve the nightly release commit after 3 attempts; this run's history rows will have an empty sourceSha."
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
   E2E:
     name: Run Ballerina e2e Test (${{ matrix.group }})
     needs: Prepare
@@ -61,9 +71,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-          # @wso2/playwright-vscode-tester (built below) and other common-libs the e2e
-          # harness imports live in the wso2-vscode-extensions submodule — without this,
-          # its project folders don't exist and Setup Rush/the build step fail outright.
           submodules: recursive
 
       - name: Download nightly VSIX
@@ -71,9 +78,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          source .github/scripts/retry.sh
           mkdir -p packages/ballerina-extension/vsix
-          gh release download nightly --repo "${{ github.repository }}" \
-            --pattern 'ballerina-*.vsix' --dir packages/ballerina-extension/vsix --clobber
+          # Same brief delete+recreate race on the 'nightly' release as Prepare's commit
+          # lookup, but unlike that lookup (which degrades to an empty sourceSha),
+          # exhausting retries here fails this whole 60-minute job — more attempts and
+          # longer backoff than the metadata-only lookup is worth paying for.
+          if ! retry 6 10 gh release download nightly --repo "${{ github.repository }}" \
+            --pattern 'ballerina-*.vsix' --dir packages/ballerina-extension/vsix --clobber; then
+            echo "::error::Failed to download the nightly VSIX after 6 attempts."
+            exit 1
+          fi
 
       - name: Setup Rush
         uses: gigara/setup-rush@7ba3446572d15f5eacc85de383ad9679dfb7223c # v1.2.0
@@ -83,21 +98,11 @@ jobs:
           rush-install: true
 
       - name: Build playwright-vscode-tester
-        # The only in-repo build dependency the e2e harness has once the ballerina VSIX
-        # is supplied externally: its compiled lib/ is gitignored, and rush install only
-        # links dependencies, it doesn't build them. Targeted so it doesn't pull in the
-        # full ballerina extension build.
         run: rush build -t @wso2/playwright-vscode-tester
 
       - name: Install Ballerina distribution
         uses: ./.github/actions/setup-ballerina
         with:
-          # Pin to what the nightly-built LS actually shipped with, not to whatever
-          # ballerinaLangVersion is on the current checkout — the extension under test
-          # is the nightly tag's VSIX, and if that value gets bumped on the default
-          # branch between nightly builds, reading it from the checkout would install a
-          # distribution the tested LS was never packaged against, failing the whole
-          # suite in a way that would otherwise get logged as flakiness.
           gradlePropertiesRef: nightly
 
       - name: Run e2e test group
@@ -119,49 +124,47 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # This job only needs .github/scripts/ and .github/actions/failure-notification
-          # from the current tree — no history. The e2e-metrics push below does its git
-          # work in an isolated throwaway clone (see "Persist run stats"), so this
-          # checkout never pushes and doesn't need full history or persisted credentials.
           persist-credentials: false
 
-      # Per group, download whichever attempt actually has an artifact — not just
-      # github.run_attempt. "Re-run failed jobs" only advances the attempt number of
-      # the groups that failed; a passing group's artifact stays at its original,
-      # lower attempt number. Downloading strictly by the *run's* current attempt
-      # would silently miss every group that never needed a re-run. run-e2e-group
-      # already handles this per-group look-back for resuming --last-failed; this
-      # does the equivalent for the Report job's cross-group aggregation.
       - name: Download latest available test results per group
         env:
           GH_TOKEN: ${{ github.token }}
           GROUPS_JSON: ${{ needs.Prepare.outputs.groups }}
         run: |
           set -euo pipefail
+          source .github/scripts/retry.sh
+          list_artifacts() {
+            gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+              --paginate --jq '.artifacts[].name'
+          }
+          # Retried: one shared call for all 4 groups is more efficient than one per
+          # group, but a transient failure here would otherwise abort every group at
+          # once instead of degrading independently the way 4 separate calls would.
+          if ! artifacts=$(retry 3 5 list_artifacts); then
+            echo "::error::Failed to list this run's artifacts after 3 attempts."
+            exit 1
+          fi
           for group in $(echo "$GROUPS_JSON" | jq -r '.[]'); do
-            name=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
-              --paginate --jq '.artifacts[].name' \
-              | grep -E "^Ballerina-e2e-test-results-linux-${group}-[0-9]+$" \
-              | sort -V | tail -n1) || true
+            name=$(echo "$artifacts" | grep -E "^Ballerina-e2e-test-results-linux-${group}-[0-9]+$" | sort -V | tail -n1 || true)
             if [ -z "${name:-}" ]; then
               echo "No artifact found for ${group}; skipping."
               continue
             fi
             echo "Downloading ${name} for ${group}"
             mkdir -p "e2e-results/${group}"
-            gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" \
-              -n "${name}" -D "e2e-results/${group}"
+            if ! retry 3 5 gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" \
+              -n "${name}" -D "e2e-results/${group}"; then
+              echo "::error::Failed to download artifact ${name} for ${group} after 3 attempts."
+              exit 1
+            fi
           done
 
       - name: Aggregate results
         id: aggregate
         shell: bash
         env:
-          # Every run tests the VSIX from the 'nightly' GitHub Release/tag now, not a
-          # freshly resolved branch — this labels the history data accordingly. (Not
-          # 'builds/nightly' — that's schedule.yml's own internal build branch, a
-          # different thing from the 'nightly' release tag this workflow reads.)
           E2E_SOURCE_TAG: nightly
+          E2E_SOURCE_SHA: ${{ needs.Prepare.outputs.nightlySha }}
           EXPECTED_GROUPS_JSON: ${{ needs.Prepare.outputs.groups }}
         run: |
           set -o pipefail
@@ -183,18 +186,6 @@ jobs:
           STATS_FILE="$(pwd)/e2e-run-stats.jsonl"
           CLONE_DIR="$(mktemp -d)"
           REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          # Do the e2e-metrics branch work in a throwaway clone, not this job's own
-          # checkout: switching the working tree to e2e-metrics (which contains only
-          # history/) would delete every other tracked file from this workspace,
-          # including ./.github/actions/failure-notification — which the "Notify on
-          # failure" step right after this one needs to still be there.
-          #
-          # e2e-metrics is an orphan branch (disjoint history from main), so a plain
-          # 'git clone' here would still pull every packfile reachable from the repo's
-          # other refs — hundreds of MB, for a branch that only ever holds one small
-          # jsonl file. --depth 1 --single-branch fetches only e2e-metrics' own tiny
-          # tree. On the very first run ever, the branch doesn't exist yet, so this
-          # clone fails outright — fall back to an empty repo instead of a full clone.
           if ! git clone --quiet --depth 1 --single-branch --branch e2e-metrics "$REPO_URL" "$CLONE_DIR" 2>/dev/null; then
             mkdir -p "$CLONE_DIR"
             git -C "$CLONE_DIR" init --quiet
@@ -210,20 +201,25 @@ jobs:
             if git show-ref --verify --quiet refs/remotes/origin/e2e-metrics; then
               git checkout -B e2e-metrics origin/e2e-metrics
             else
-              # A prior failed iteration this run may have already left an orphan
-              # branch checked out here — detach and drop it first so re-orphaning
-              # can't collide with itself on retry.
               git checkout --detach 2>/dev/null || true
               git branch -D e2e-metrics-tmp 2>/dev/null || true
               git checkout --orphan e2e-metrics-tmp
               git rm -rf --quiet . || true
             fi
+            MONTH_FILE="history/$(date -u +%Y-%m).jsonl"
             mkdir -p history
-            cat "$STATS_FILE" >> history/e2e-history.jsonl
-            git add history/e2e-history.jsonl
+            # If this run/attempt's rows are already in the fetched history, a prior
+            # Persist run already succeeded and only a later step (e.g. Notify) failed —
+            # "Re-run failed jobs" re-executes this whole job regardless, and would
+            # otherwise duplicate every row on each such re-run.
+            if [ -f "$MONTH_FILE" ] && grep -q "\"runId\":\"${{ github.run_id }}\",\"runAttempt\":\"${{ github.run_attempt }}\"" "$MONTH_FILE"; then
+              echo "Stats for run ${{ github.run_id }} attempt ${{ github.run_attempt }} already persisted; skipping."
+              pushed=true
+              break
+            fi
+            cat "$STATS_FILE" >> "$MONTH_FILE"
+            git add "$MONTH_FILE"
             git commit -m "E2E stats: run ${{ github.run_id }} attempt ${{ github.run_attempt }}"
-            # Explicit refspec: the local branch name (e2e-metrics or the orphan
-            # scratch e2e-metrics-tmp above) doesn't matter, only HEAD's content does.
             if git push origin HEAD:e2e-metrics; then
               pushed=true
               break
@@ -238,10 +234,6 @@ jobs:
           fi
 
       - name: Notify on failure
-        # job.status catches steps that fail outright with no outcome to check (e.g. the
-        # artifact-download step above, which has no continue-on-error) — without it, a
-        # step failing there skips Aggregate/Persist entirely, so neither of their
-        # outcomes is ever 'failure' and this job goes red with no notification sent.
         if: ${{ always() && (steps.aggregate.outcome == 'failure' || steps.persist.outcome == 'failure' || needs.E2E.result != 'success' || job.status == 'failure') && github.repository == 'ballerina-platform/ballerina-vscode' }}
         uses: ./.github/actions/failure-notification
         with:

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -61,6 +61,10 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+          # @wso2/playwright-vscode-tester (built below) and other common-libs the e2e
+          # harness imports live in the wso2-vscode-extensions submodule — without this,
+          # its project folders don't exist and Setup Rush/the build step fail outright.
+          submodules: recursive
 
       - name: Download nightly VSIX
         env:
@@ -87,6 +91,14 @@ jobs:
 
       - name: Install Ballerina distribution
         uses: ./.github/actions/setup-ballerina
+        with:
+          # Pin to what the nightly-built LS actually shipped with, not to whatever
+          # ballerinaLangVersion is on the current checkout — the extension under test
+          # is the nightly tag's VSIX, and if that value gets bumped on the default
+          # branch between nightly builds, reading it from the checkout would install a
+          # distribution the tested LS was never packaged against, failing the whole
+          # suite in a way that would otherwise get logged as flakiness.
+          gradlePropertiesRef: nightly
 
       - name: Run e2e test group
         uses: ./.github/actions/run-e2e-group
@@ -107,7 +119,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          fetch-depth: 0
+          # This job only needs .github/scripts/ and .github/actions/failure-notification
+          # from the current tree — no history. The e2e-metrics push below does its git
+          # work in an isolated throwaway clone (see "Persist run stats"), so this
+          # checkout never pushes and doesn't need full history or persisted credentials.
+          persist-credentials: false
+          persist-credentials: false
 
       # Per group, download whichever attempt actually has an artifact — not just
       # github.run_attempt. "Re-run failed jobs" only advances the attempt number of
@@ -146,6 +163,7 @@ jobs:
           # 'builds/nightly' — that's schedule.yml's own internal build branch, a
           # different thing from the 'nightly' release tag this workflow reads.)
           E2E_SOURCE_TAG: nightly
+          EXPECTED_GROUPS_JSON: ${{ needs.Prepare.outputs.groups }}
         run: |
           set -o pipefail
           node .github/scripts/aggregate-e2e-results.js e2e-results e2e-run-stats.jsonl \
@@ -154,12 +172,36 @@ jobs:
       - name: Persist run stats
         id: persist
         if: ${{ always() && github.repository == 'ballerina-platform/ballerina-vscode' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if [ ! -f e2e-run-stats.jsonl ]; then
             echo "No test results to persist; skipping."
             exit 0
           fi
+
+          STATS_FILE="$(pwd)/e2e-run-stats.jsonl"
+          CLONE_DIR="$(mktemp -d)"
+          REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          # Do the e2e-metrics branch work in a throwaway clone, not this job's own
+          # checkout: switching the working tree to e2e-metrics (which contains only
+          # history/) would delete every other tracked file from this workspace,
+          # including ./.github/actions/failure-notification — which the "Notify on
+          # failure" step right after this one needs to still be there.
+          #
+          # e2e-metrics is an orphan branch (disjoint history from main), so a plain
+          # 'git clone' here would still pull every packfile reachable from the repo's
+          # other refs — hundreds of MB, for a branch that only ever holds one small
+          # jsonl file. --depth 1 --single-branch fetches only e2e-metrics' own tiny
+          # tree. On the very first run ever, the branch doesn't exist yet, so this
+          # clone fails outright — fall back to an empty repo instead of a full clone.
+          if ! git clone --quiet --depth 1 --single-branch --branch e2e-metrics "$REPO_URL" "$CLONE_DIR" 2>/dev/null; then
+            mkdir -p "$CLONE_DIR"
+            git -C "$CLONE_DIR" init --quiet
+            git -C "$CLONE_DIR" remote add origin "$REPO_URL"
+          fi
+          cd "$CLONE_DIR"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -178,7 +220,7 @@ jobs:
               git rm -rf --quiet . || true
             fi
             mkdir -p history
-            cat e2e-run-stats.jsonl >> history/e2e-history.jsonl
+            cat "$STATS_FILE" >> history/e2e-history.jsonl
             git add history/e2e-history.jsonl
             git commit -m "E2E stats: run ${{ github.run_id }} attempt ${{ github.run_attempt }}"
             # Explicit refspec: the local branch name (e2e-metrics or the orphan
@@ -197,7 +239,11 @@ jobs:
           fi
 
       - name: Notify on failure
-        if: ${{ always() && (steps.aggregate.outcome == 'failure' || steps.persist.outcome == 'failure' || needs.E2E.result != 'success') && github.repository == 'ballerina-platform/ballerina-vscode' }}
+        # job.status catches steps that fail outright with no outcome to check (e.g. the
+        # artifact-download step above, which has no continue-on-error) — without it, a
+        # step failing there skips Aggregate/Persist entirely, so neither of their
+        # outcomes is ever 'failure' and this job goes red with no notification sent.
+        if: ${{ always() && (steps.aggregate.outcome == 'failure' || steps.persist.outcome == 'failure' || needs.E2E.result != 'success' || job.status == 'failure') && github.repository == 'ballerina-platform/ballerina-vscode' }}
         uses: ./.github/actions/failure-notification
         with:
           title: "Scheduled E2E Tests Failed"

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -124,7 +124,6 @@ jobs:
           # work in an isolated throwaway clone (see "Persist run stats"), so this
           # checkout never pushes and doesn't need full history or persisted credentials.
           persist-credentials: false
-          persist-credentials: false
 
       # Per group, download whichever attempt actually has an artifact — not just
       # github.run_attempt. "Re-run failed jobs" only advances the attempt number of

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -320,6 +320,8 @@ jobs:
         id: run-tests-first
         if: github.run_attempt == 1 || steps.check-results.outcome == 'failure'
         continue-on-error: true
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-first.json
         run: |
           export $(dbus-launch)
           export DISPLAY=:98.0
@@ -329,6 +331,8 @@ jobs:
       - name: Run Failed Ballerina e2e Test (Re-run)
         shell: bash
         if: steps.run-tests-first.outcome == 'failure' || steps.check-results.outcome == 'success'
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-rerun.json
         run: |
           rm -rf packages/ballerina-extension/e2e-test/data/new-project
           export $(dbus-launch)

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -292,83 +292,10 @@ jobs:
       - name: Install Ballerina distribution
         uses: ./.github/actions/setup-ballerina
 
-      - name: Check for previous test results
-        shell: bash
-        if: github.run_attempt > 1
-        run: |
-          PREVIOUS_ATTEMPT=$((${{ github.run_attempt }} - 1))
-          echo "PREVIOUS_ATTEMPT=$PREVIOUS_ATTEMPT" >> $GITHUB_ENV
-
-      - name: Download previous test results
-        id: check-results
-        if: github.run_attempt > 1
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        continue-on-error: true
+      - name: Run e2e test group
+        uses: ./.github/actions/run-e2e-group
         with:
-          name: Ballerina-e2e-test-results-linux-${{ matrix.group }}-${{ env.PREVIOUS_ATTEMPT }}
-          path: packages/ballerina-extension/test-results
-
-      - name: Install packages
-        shell: bash
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y xvfb ffmpeg gnome-keyring libsecret-1.0 dbus-x11
-          cd packages/ballerina-extension && npx playwright install
-
-      - name: Run Ballerina e2e Test (First Attempt)
-        shell: bash
-        id: run-tests-first
-        if: github.run_attempt == 1 || steps.check-results.outcome == 'failure'
-        continue-on-error: true
-        env:
-          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-first.json
-        run: |
-          export $(dbus-launch)
-          export DISPLAY=:98.0
-          cd packages/ballerina-extension
-          xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ matrix.group }}"
-
-      - name: Run Failed Ballerina e2e Test (Re-run)
-        shell: bash
-        if: steps.run-tests-first.outcome == 'failure' || steps.check-results.outcome == 'success'
-        env:
-          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/e2e-results-rerun.json
-        run: |
-          rm -rf packages/ballerina-extension/e2e-test/data/new-project
-          export $(dbus-launch)
-          export DISPLAY=:98.0
-          cd packages/ballerina-extension
-          xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ matrix.group }} --last-failed"
-
-      - name: Upload Ballerina e2e Test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
-        with:
-          name: Ballerina-e2e-test-results-linux-${{ matrix.group }}-${{ github.run_attempt }}
-          path: packages/ballerina-extension/test-results/**
-          retention-days: 5
-          include-hidden-files: true
-
-      - name: Upload Ballerina e2e Test recordings
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
-        with:
-          name: Ballerina-e2e-test-recording-linux-${{ matrix.group }}-${{ github.run_attempt }}
-          path: |
-            packages/ballerina-extension/e2e-test/test-resources/videos/**
-            packages/ballerina-extension/e2e-test/test-resources/screenshots/**
-            packages/ballerina-extension/e2e-test/test-resources/snapshots/**
-            packages/ballerina-extension/record.mp4
-          retention-days: 5
-
-      - name: Upload Ballerina e2e Test project data
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
-        with:
-          name: Ballerina-e2e-test-project-linux-${{ matrix.group }}-${{ github.run_attempt }}
-          path: |
-            packages/ballerina-extension/e2e-test/data/new-project/**
-          retention-days: 5
+          group: ${{ matrix.group }}
 
   LSTest_Ballerina:
     name: Run Ballerina LS tests (${{ matrix.os }})

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -61,30 +61,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Reset builds/nightly to the source branch
-        env:
-          INPUT_SOURCE_BRANCH: ${{ inputs.sourceBranch }}
+      - name: Configure git identity
         run: |
-          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if [ -n "${INPUT_SOURCE_BRANCH}" ]; then
-            SOURCE_BRANCH="${INPUT_SOURCE_BRANCH}"
-          else
-            # No explicit source given (scheduled run, or manual run left blank): prefer the
-            # latest staging/* branch (e.g. staging/5.14.0) if one exists, so the nightly
-            # pipeline follows the active release staging branch without a workflow edit
-            # each time one is cut. Falls back to main once no staging/* branch remains.
-            latest_staging=$(git ls-remote --heads origin \
-              | awk -F'refs/heads/' '/refs\/heads\/staging\// { print $2 }' \
-              | sort -t/ -k2 -V | tail -n 1)
-            SOURCE_BRANCH="${latest_staging:-main}"
-          fi
+      - name: Resolve source branch
+        id: resolve-source
+        uses: ./.github/actions/resolve-source-branch
+        with:
+          sourceBranch: ${{ inputs.sourceBranch }}
 
+      - name: Reset builds/nightly to the source branch
+        env:
+          SOURCE_BRANCH: ${{ steps.resolve-source.outputs.branch }}
+        run: |
+          set -euo pipefail
           # Checkout fetches only the triggering ref, so fetch the requested source
           # explicitly even though the initial checkout uses fetch-depth 0.
-          SOURCE_BRANCH="$(git check-ref-format --branch "${SOURCE_BRANCH}")"
           git fetch origin \
             "refs/heads/${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}"
           git checkout -B builds/nightly "origin/${SOURCE_BRANCH}"

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Configure git identity
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ coverage/
 .vscode-test/
 test-resources/
 packages/ballerina-extension/test-results/
+packages/ballerina-extension/e2e-reports/
 extractedDistribution/
-packages/ballerina-extension/test-results/
 .npmrc
 .env
 .hintrc

--- a/packages/ballerina-extension/e2e-test/playwright.config.js
+++ b/packages/ballerina-extension/e2e-test/playwright.config.js
@@ -9,7 +9,7 @@ exports.default = (0, test_1.defineConfig)({
     retries: process.env.BI_E2E_RETRIES ? Number(process.env.BI_E2E_RETRIES) : 2,
     maxFailures: 10,
     workers: 1,
-    reporter: 'html',
+    reporter: [['html'], ['json', { outputFile: 'test-results/e2e-results.json' }]],
     use: {
         trace: 'on-first-retry',
     },

--- a/packages/ballerina-extension/e2e-test/playwright.config.js
+++ b/packages/ballerina-extension/e2e-test/playwright.config.js
@@ -9,7 +9,7 @@ exports.default = (0, test_1.defineConfig)({
     retries: process.env.BI_E2E_RETRIES ? Number(process.env.BI_E2E_RETRIES) : 2,
     maxFailures: 10,
     workers: 1,
-    reporter: [['html'], ['json', { outputFile: 'test-results/e2e-results.json' }]],
+    reporter: [['html'], ['json', { outputFile: '../test-results/e2e-results.json' }]],
     use: {
         trace: 'on-first-retry',
     },

--- a/packages/ballerina-extension/e2e-test/playwright.config.js
+++ b/packages/ballerina-extension/e2e-test/playwright.config.js
@@ -9,7 +9,7 @@ exports.default = (0, test_1.defineConfig)({
     retries: process.env.BI_E2E_RETRIES ? Number(process.env.BI_E2E_RETRIES) : 2,
     maxFailures: 10,
     workers: 1,
-    reporter: [['html'], ['json', { outputFile: '../test-results/e2e-results.json' }]],
+    reporter: [['html'], ['json', { outputFile: '../e2e-reports/e2e-results.json' }]],
     use: {
         trace: 'on-first-retry',
     },


### PR DESCRIPTION
## Purpose
E2E tests were disabled from the nightly build on 2026-08-02 due to flakiness. Add a standalone workflow that runs the Playwright suite every 6 hours against the same staging/main branch the nightly build targets, independent of the release pipeline.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Add a standalone Playwright E2E workflow that runs every six hours against the nightly VSIX.
- Run four E2E groups in parallel with retries and failed-test reruns.
- Aggregate JSON results and publish flakiness and skip-cause metrics.
- Persist E2E history to the canonical repository with duplicate detection.
- Add reusable actions for source-branch resolution and E2E execution.
- Update nightly workflows to use shared branch resolution and reusable E2E execution.
- Generate JSON Playwright reports for automated processing.
- Update workflow documentation and ignore generated E2E reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->