### PR TITLE
Rename WSO2 Integrator Copilot to WSO2 Integration Intelligence

### DIFF
--- a/packages/ballerina-extension/package.json
+++ b/packages/ballerina-extension/package.json
@@ -281,7 +281,7 @@
                     "type": "boolean",
                     "default": false,
                     "scope": "window",
-                    "description": "Enable Model Context Protocol (MCP) tool support in the WSO2 Integrator Copilot."
+                    "description": "Enable Model Context Protocol (MCP) tool support in the WSO2 Integration Intelligence."
                 },
                 "ballerina.copilot.skills": {
                     "type": "object",
@@ -642,7 +642,7 @@
             },
             {
                 "command": "ballerina.open.ai.panel",
-                "title": "Open WSO2 Integrator Copilot",
+                "title": "Open WSO2 Integration Intelligence",
                 "category": "Ballerina",
                 "icon": {
                     "dark": "./resources/icons/light-ai-chat.svg",
@@ -1141,7 +1141,7 @@
                     "command": "ballerina.open.ai.panel",
                     "group": "navigation@1",
                     "when": "resourceLangId == ballerina || isBallerinaDiagram || (isBalVisualizerActive && isBIProject)",
-                    "title": "Open WSO2 Integrator Copilot"
+                    "title": "Open WSO2 Integration Intelligence"
                 },
                 {
                     "command": "BI.project.run",

--- a/packages/ballerina-extension/src/features/ai/agent/agents-md/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/agents-md/index.ts
@@ -41,7 +41,7 @@ import { FILE_READ_TOOL_NAME } from '../tools/text-editor';
 const AGENTS_MD_FILENAME = 'AGENTS.md';
 const MAX_LINES_IN_BLOCK = 200;
 
-const STARTER_TEMPLATE = `# Project instructions for the WSO2 Integrator Copilot
+const STARTER_TEMPLATE = `# Project instructions for the WSO2 Integration Intelligence
 `;
 
 /** Stored on a generation after a REMOVAL_NOTE. Non-hex so it can't collide with a SHA-1. */

--- a/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/followups/prompt.ts
@@ -79,7 +79,7 @@ function buildSystemPrompt(situation: FollowupSituation): string {
     const framing = situation === "aborted" ? ABORTED_FRAMING
         : situation === "error" ? ERROR_FRAMING
         : COMPLETED_FRAMING;
-    return `You help users of the WSO2 Integrator Copilot decide what to do next.
+    return `You help users of WSO2 Integration Intelligence decide what to do next.
 
 ${framing}
 

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -66,7 +66,7 @@ import { WEB_SEARCH_TOOL_NAME, WEB_FETCH_TOOL_NAME } from "./tools/web-tools";
  * Generates the system prompt for the design agent
  */
 export function getSystemPrompt(projects: ProjectSource[], op: OperationType, userSkills: ProjectSkillMeta[], disabledSkills?: Set<string>, disabledSkillMetas?: Array<{ name: string; trigger: string }>): string {
-    return `You are WSO2 Integrator Copilot, an expert assistant specialized in Ballerina help with relavant integration usecases. You will be helping with designing a solution for user query in a step-by-step manner.
+    return `You are WSO2 Integration Intelligence (WII) — you can also go by "Wii" — an expert assistant specialized in Ballerina help with relavant integration usecases. You will be helping with designing a solution for user query in a step-by-step manner.
 
 Answer queries related to Ballerina and integrations. If a query is unrelated, politely decline.
 

--- a/packages/ballerina-extension/src/features/ai/constants.ts
+++ b/packages/ballerina-extension/src/features/ai/constants.ts
@@ -22,13 +22,13 @@ export const CONFIG_FILE_NAME = "Config.toml";
 export const CONFIGURE_DEFAULT_MODEL_COMMAND = "ballerina.configureWso2DefaultModelProvider";
 
 export const CLOSE_AI_PANEL_COMMAND = "ballerina.close.ai.panel";
-export const SIGN_IN_BI_COPILOT = "Sign in to WSO2 Integrator Copilot";
+export const SIGN_IN_BI_COPILOT = "Sign in to WSO2 Integration Intelligence";
 export const PROGRESS_BAR_MESSAGE_FROM_WSO2_DEFAULT_MODEL = "Fetching and saving access token for WSO2 default model provider.";
 export const PROGRESS_BAR_MESSAGE_FROM_WSO2_DEFAULT_EMBEDDING = "Fetching and saving access token for WSO2 default embedding provider.";
 export const ERROR_NO_BALLERINA_SOURCES = "No Ballerina sources";
-export const LOGIN_REQUIRED_WARNING = "Please sign in to WSO2 Integrator Copilot to use this feature.";
-export const LOGIN_REQUIRED_WARNING_FOR_DEFAULT_MODEL = "Please sign in to WSO2 Integrator Copilot to configure the WSO2 default model provider.";
-export const LOGIN_REQUIRED_WARNING_FOR_DEFAULT_EMBEDDING = "Please sign in to WSO2 Integrator Copilot to configure the WSO2 default embedding provider.";
+export const LOGIN_REQUIRED_WARNING = "Please sign in to WSO2 Integration Intelligence to use this feature.";
+export const LOGIN_REQUIRED_WARNING_FOR_DEFAULT_MODEL = "Please sign in to WSO2 Integration Intelligence to configure the WSO2 default model provider.";
+export const LOGIN_REQUIRED_WARNING_FOR_DEFAULT_EMBEDDING = "Please sign in to WSO2 Integration Intelligence to configure the WSO2 default embedding provider.";
 export const DEFAULT_PROVIDER_ADDED = "WSO2 default model provider configuration values were added to the Config.toml file.";
 export const DEFAULT_EMBEDDING_PROVIDER_ADDED = "WSO2 default embedding provider configuration values were added to the Config.toml file.";
 export const LLM_API_BASE_PATH = "/llm-api/v1.0";

--- a/packages/ballerina-extension/src/features/ai/migration/orchestrator.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/orchestrator.ts
@@ -359,7 +359,7 @@ export async function checkAndRunPendingEnhancement(): Promise<void> {
         _activeSession = { isActive: false, aiFeatureUsed: true, fullyEnhanced: false };
 
         const action = await window.showInformationMessage(
-            "Migration AI enhancement was paused. You can resume it from 'WSO2 Integrator Copilot'.",
+            "Migration AI enhancement was paused. You can resume it from 'WSO2 Integration Intelligence'.",
             "Open Copilot"
         );
 
@@ -372,7 +372,7 @@ export async function checkAndRunPendingEnhancement(): Promise<void> {
         _activeSession = { isActive: false, aiFeatureUsed: false, fullyEnhanced: false };
         console.log("[MigrationEnhancement] AI not enabled at wizard – notification shown.");
         const action = await window.showInformationMessage(
-            "Your migrated project is ready. Open 'WSO2 Integrator Copilot' to run AI enhancement — it can resolve TODOs, fix build errors, and refine tests.",
+            "Your migrated project is ready. Open 'WSO2 Integration Intelligence' to run AI enhancement — it can resolve TODOs, fix build errors, and refine tests.",
             "Open Copilot"
         );
         if (action === "Open Copilot") {
@@ -726,7 +726,7 @@ async function runStagesForPackage(opts: StageRunnerOpts): Promise<void> {
 let _migrationAbortController: AbortController | undefined;
 
 /** Module-level selected model ID (set by the UI's model selector). */
-let _selectedModelId: string = "wso2"; // default to WSO2 Integrator Copilot
+let _selectedModelId: string = "wso2"; // default to WSO2 Integration Intelligence
 
 /**
  * Update the selected model ID from the webview.
@@ -977,7 +977,7 @@ async function ensureAuthenticated(): Promise<boolean> {
     }
 
     // Tell the wizard UI we're signing in
-    const signingInMsg = { type: "content_block" as const, content: "Signing in to WSO2 Integrator Copilot...\n\n" };
+    const signingInMsg = { type: "content_block" as const, content: "Signing in to WSO2 Integration Intelligence...\n\n" };
     sendVisualizerMigrationNotification(signingInMsg);
     _wizardChatEmitter.fire(signingInMsg);
 
@@ -1047,7 +1047,7 @@ export function isAIAuthenticated(): boolean {
 }
 
 /**
- * Triggers the WSO2 Integrator Copilot browser sign-in flow and waits until the user is
+ * Triggers the WSO2 Integration Intelligence browser sign-in flow and waits until the user is
  * authenticated, cancels, or the 2-minute timeout elapses.
  *
  * Unlike `ensureAuthenticated`, this function does NOT emit any messages to a
@@ -1309,7 +1309,7 @@ export async function runWizardMigrationEnhancement(): Promise<void> {
     if (!isAuthenticated) {
         eventHandler({
             type: "error",
-            content: "Please sign in to WSO2 Integrator Copilot to use AI enhancement. Please retry the AI Enhancement step.",
+            content: "Please sign in to WSO2 Integration Intelligence to use AI enhancement. Please retry the AI Enhancement step.",
         });
         return;
     }

--- a/packages/ballerina-extension/src/features/ai/migration/orchestrator.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/orchestrator.ts
@@ -360,10 +360,10 @@ export async function checkAndRunPendingEnhancement(): Promise<void> {
 
         const action = await window.showInformationMessage(
             "Migration AI enhancement was paused. You can resume it from 'WSO2 Integration Intelligence'.",
-            "Open Copilot"
+            "Open WSO2 Integration Intelligence"
         );
 
-        if (action === "Open Copilot") {
+        if (action === "Open WSO2 Integration Intelligence") {
             openAIPanelWithPrompt();
         }
     } else {
@@ -373,9 +373,9 @@ export async function checkAndRunPendingEnhancement(): Promise<void> {
         console.log("[MigrationEnhancement] AI not enabled at wizard – notification shown.");
         const action = await window.showInformationMessage(
             "Your migrated project is ready. Open 'WSO2 Integration Intelligence' to run AI enhancement — it can resolve TODOs, fix build errors, and refine tests.",
-            "Open Copilot"
+            "Open WSO2 Integration Intelligence"
         );
-        if (action === "Open Copilot") {
+        if (action === "Open WSO2 Integration Intelligence") {
             openAIPanelWithPrompt();
         }
     }

--- a/packages/ballerina-extension/src/features/ai/state/AgentStatusManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/AgentStatusManager.ts
@@ -54,7 +54,7 @@ class AgentStatusManager {
             return;
         }
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 98);
-        this.statusBarItem.name = 'WSO2 Integrator Copilot';
+        this.statusBarItem.name = 'WSO2 Integration Intelligence';
         this.statusBarItem.command = SHARED_COMMANDS.OPEN_AI_PANEL;
         context.subscriptions.push(this.statusBarItem, new vscode.Disposable(() => this.clearResetTimer()));
         this.render();
@@ -196,7 +196,7 @@ class AgentStatusManager {
         const label = truncate(this.status.label, STATUS_BAR_LABEL_MAX);
         switch (this.status.state) {
             case 'running':
-                this.statusBarItem.text = `$(loading~spin) ${label ?? 'WSO2 Integrator Copilot'}`;
+                this.statusBarItem.text = `$(loading~spin) ${label ?? 'WSO2 Integration Intelligence'}`;
                 this.statusBarItem.backgroundColor = undefined;
                 break;
             case 'awaiting-input':
@@ -213,7 +213,7 @@ class AgentStatusManager {
                 break;
         }
         const tooltip = new vscode.MarkdownString();
-        tooltip.appendMarkdown(`**WSO2 Integrator Copilot**${this.status.label ? ` — ${this.status.label}` : ''}\n\n`);
+        tooltip.appendMarkdown(`**WSO2 Integration Intelligence**${this.status.label ? ` — ${this.status.label}` : ''}\n\n`);
         tooltip.appendMarkdown('Click to open the Copilot chat.');
         this.statusBarItem.tooltip = tooltip;
         this.statusBarItem.show();

--- a/packages/ballerina-extension/src/features/ai/state/AgentStatusManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/AgentStatusManager.ts
@@ -200,21 +200,21 @@ class AgentStatusManager {
                 this.statusBarItem.backgroundColor = undefined;
                 break;
             case 'awaiting-input':
-                this.statusBarItem.text = `$(bi-ai-chat) Copilot needs your input`;
+                this.statusBarItem.text = `$(bi-ai-chat) WSO2 Integration Intelligence needs your input`;
                 this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
                 break;
             case 'completed':
-                this.statusBarItem.text = `$(check) Copilot finished`;
+                this.statusBarItem.text = `$(check) WSO2 Integration Intelligence finished`;
                 this.statusBarItem.backgroundColor = undefined;
                 break;
             case 'error':
-                this.statusBarItem.text = `$(error) Copilot error`;
+                this.statusBarItem.text = `$(error) WSO2 Integration Intelligence error`;
                 this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
                 break;
         }
         const tooltip = new vscode.MarkdownString();
         tooltip.appendMarkdown(`**WSO2 Integration Intelligence**${this.status.label ? ` — ${this.status.label}` : ''}\n\n`);
-        tooltip.appendMarkdown('Click to open the Copilot chat.');
+        tooltip.appendMarkdown('Click to open the WSO2 Integration Intelligence chat.');
         this.statusBarItem.tooltip = tooltip;
         this.statusBarItem.show();
     }

--- a/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
@@ -450,7 +450,7 @@ export function getErrorMessage(error: unknown): string {
             return "The AI service returned an invalid response. Please try again.";
         }
         if (msg.includes("Unsupported login method")) {
-            return "Please sign in to WSO2 Integrator Copilot to use AI features.";
+            return "Please sign in to WSO2 Integration Intelligence to use AI features.";
         }
 
         return msg;

--- a/packages/ballerina-extension/src/features/natural-programming/constants.ts
+++ b/packages/ballerina-extension/src/features/natural-programming/constants.ts
@@ -47,4 +47,4 @@ export const MONITERED_EXTENSIONS = [
 export const CONFIG_FILE_NAME = "Config.toml";
 export const DEFAULT_MODULE = "DEFAULT_MODULE";
 export const ERROR_NO_BALLERINA_SOURCES = "No Ballerina sources";
-export const LOGIN_REQUIRED_WARNING = "Please sign in to WSO2 Integrator Copilot to use this feature.";
+export const LOGIN_REQUIRED_WARNING = "Please sign in to WSO2 Integration Intelligence to use this feature.";

--- a/packages/ballerina-extension/src/utils/ai/auth.ts
+++ b/packages/ballerina-extension/src/utils/ai/auth.ts
@@ -202,7 +202,7 @@ export const exchangeStsToCopilotToken = async (stsToken: string): Promise<BIInt
         throw new Error(response.data?.message || response.data?.reason || `Status ${response.status}`);
     } catch (error) {
         const reason = error instanceof Error ? error.message : 'Unknown error';
-        vscode.window.showErrorMessage(`WSO2 Integrator Copilot authentication failed: ${reason}`);
+        vscode.window.showErrorMessage(`WSO2 Integration Intelligence authentication failed: ${reason}`);
         throw error;
     }
 };
@@ -245,7 +245,7 @@ export const clearAuthCredentials = async (): Promise<void> => {
 };
 
 // ==================================
-// WSO2 Integrator Copilot Auth Utils
+// WSO2 Integration Intelligence Auth Utils
 // ==================================
 export const getLoginMethod = async (): Promise<LoginMethod | undefined> => {
     // Priority 1: Check Anthropic API key from environment

--- a/packages/ballerina-extension/src/views/ai-panel/activate.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/activate.ts
@@ -80,7 +80,7 @@ export function activateAiPanel(ballerinaExtInstance: BallerinaExtension) {
     //
     // // Status bar for auto-dream visibility
     // const dreamStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99);
-    // dreamStatusBar.tooltip = 'WSO2 Integrator Copilot memory consolidation';
+    // dreamStatusBar.tooltip = 'WSO2 Integration Intelligence memory consolidation';
     // ballerinaExtInstance.context.subscriptions.push(dreamStatusBar);
     //
     // let dreamHideTimeout: ReturnType<typeof setTimeout> | undefined;

--- a/packages/ballerina-extension/src/views/ai-panel/errorCodes.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/errorCodes.ts
@@ -20,7 +20,7 @@ import { ErrorCode } from "@wso2/ballerina-core";
 
 export const NOT_LOGGED_IN: ErrorCode = {
     code: 1,
-    message: "You need to be logged in to use WSO2 Integrator Copilot Features. Please login and try again."
+    message: "You need to be logged in to use WSO2 Integration Intelligence Features. Please login and try again."
 };
 
 export const TIMEOUT: ErrorCode = {

--- a/packages/ballerina-extension/src/views/ai-panel/errorCodes.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/errorCodes.ts
@@ -35,7 +35,7 @@ export const PARSING_ERROR: ErrorCode = {
 
 export const UNKNOWN_ERROR: ErrorCode = {
     code: 4,
-    message: "An unknown error occurred while generating code. Try login again to copilot"
+    message: "An unknown error occurred while generating code. Try login again to WSO2 Integration Intelligence"
 };
 
 export const MODIFIYING_ERROR: ErrorCode = {

--- a/packages/ballerina-extension/src/views/ai-panel/utils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/utils.ts
@@ -120,7 +120,7 @@ export const logout = async (_isUserLogout: boolean = true) => {
  */
 export async function initiateDevantAuth(): Promise<boolean> {
     if (!isPlatformExtensionAvailable()) {
-        throw new Error('WSO2 Platform extension is not installed. Please install it to use WSO2 Integrator Copilot.');
+        throw new Error('WSO2 Platform extension is not installed. Please install it to use WSO2 Integration Intelligence.');
     }
 
     // Trigger platform extension login command

--- a/packages/ballerina-extension/src/views/ai-panel/webview.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/webview.ts
@@ -50,7 +50,7 @@ export class AiPanelWebview {
     private static createWebview(): vscode.WebviewPanel {
         const panel = vscode.window.createWebviewPanel(
             AiPanelWebview.viewType,
-            "WSO2 Integrator Copilot",
+            "WSO2 Integration Intelligence",
             ViewColumn.Beside,
             {
                 enableScripts: true,

--- a/packages/ballerina-extension/src/views/migration-panel/webview.ts
+++ b/packages/ballerina-extension/src/views/migration-panel/webview.ts
@@ -25,9 +25,9 @@ import { RPCLayer } from "../../RPCLayer";
 /**
  * Standalone Migration Enhancement Panel.
  *
- * Decoupled from the AI Chat (WSO2 Integrator Copilot) panel so that users can choose any
+ * Decoupled from the AI Chat (WSO2 Integration Intelligence) panel so that users can choose any
  * LLM model through the VS Code Language Model API or direct provider keys,
- * without requiring WSO2 Integrator Copilot authentication.
+ * without requiring WSO2 Integration Intelligence authentication.
  */
 export class MigrationPanelWebview {
     public static currentPanel: MigrationPanelWebview | undefined;

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
@@ -178,7 +178,7 @@ export function CopilotHeroBox({ placeholder }: { placeholder: string }) {
                         openCopilot();
                     }
                 }}
-                aria-label={label ? `WSO2 Integration Intelligence: ${label}. Open the Copilot chat.` : undefined}
+                aria-label={label ? `WSO2 Integration Intelligence: ${label}. Open the WSO2 Integration Intelligence chat.` : undefined}
             >
                 <OrbHolder>
                     {webglFailed ? (
@@ -204,7 +204,7 @@ export function CopilotHeroBox({ placeholder }: { placeholder: string }) {
                     <>
                         <StatusText>{label}</StatusText>
                         <OpenHint>
-                            Open Copilot <Codicon name="arrow-right" />
+                            Open WSO2 Integration Intelligence <Codicon name="arrow-right" />
                         </OpenHint>
                     </>
                 ) : (

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
@@ -178,7 +178,7 @@ export function CopilotHeroBox({ placeholder }: { placeholder: string }) {
                         openCopilot();
                     }
                 }}
-                aria-label={label ? `WSO2 Integrator Copilot: ${label}. Open the Copilot chat.` : undefined}
+                aria-label={label ? `WSO2 Integration Intelligence: ${label}. Open the Copilot chat.` : undefined}
             >
                 <OrbHolder>
                     {webglFailed ? (
@@ -219,11 +219,11 @@ export function CopilotHeroBox({ placeholder }: { placeholder: string }) {
                                 }
                             }}
                             placeholder={placeholder}
-                            aria-label="Message WSO2 Integrator Copilot"
+                            aria-label="Message WSO2 Integration Intelligence"
                         />
                         <SendButton
-                            title="Send to WSO2 Integrator Copilot"
-                            aria-label="Send to WSO2 Integrator Copilot"
+                            title="Send to WSO2 Integration Intelligence"
+                            aria-label="Send to WSO2 Integration Intelligence"
                             onClick={(event) => {
                                 event.stopPropagation();
                                 submit();

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/MiniChat.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/MiniChat.tsx
@@ -976,10 +976,10 @@ export function MiniChat({ anchor, onClose, takeInitialPrompt }: MiniChatProps) 
     const transcript = renderTranscript(msgs, streaming);
 
     return (
-        <Panel style={panelPosition(anchor)} role="dialog" aria-label="WSO2 Integrator Copilot mini chat">
+        <Panel style={panelPosition(anchor)} role="dialog" aria-label="WSO2 Integration Intelligence mini chat">
             <Header>
                 <Icon name="bi-ai-chat" sx={{ width: 16, height: 16, flex: "none" }} iconSx={{ fontSize: "16px" }} />
-                <HeaderTitle>WSO2 Integrator Copilot</HeaderTitle>
+                <HeaderTitle>WSO2 Integration Intelligence</HeaderTitle>
                 <HeaderButton title="Open full chat" aria-label="Open the full Copilot chat" onClick={openFullChat}>
                     <Codicon name="screen-full" />
                 </HeaderButton>
@@ -1048,7 +1048,7 @@ export function MiniChat({ anchor, onClose, takeInitialPrompt }: MiniChatProps) 
                                 ? "What should I add here?"
                                 : "What should we work on?"
                     }
-                    aria-label="Message WSO2 Integrator Copilot"
+                    aria-label="Message WSO2 Integration Intelligence"
                     disabled={runActive}
                 />
                 <SendButton title="Send" aria-label="Send message" onClick={send} disabled={runActive || !input.trim()}>

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
@@ -513,7 +513,7 @@ export function AgentStatusOrb() {
                         placeholder="How can I help?"
                         aria-label="Message WSO2 Integration Intelligence"
                     />
-                    <InviteDismiss title="Hide" aria-label="Hide the copilot prompt" onClick={() => setInviteDismissed(true)}>
+                    <InviteDismiss title="Hide" aria-label="Hide the WSO2 Integration Intelligence prompt" onClick={() => setInviteDismissed(true)}>
                         ✕
                     </InviteDismiss>
                 </InviteBox>
@@ -526,7 +526,7 @@ export function AgentStatusOrb() {
                 onPointerMove={handlePointerMove}
                 onPointerUp={handlePointerUp}
                 title={label ? `WSO2 Integration Intelligence — ${label}` : "WSO2 Integration Intelligence"}
-                aria-label={label ? `WSO2 Integration Intelligence: ${label}. Open the Copilot mini chat.` : "Open the WSO2 Integration Intelligence mini chat"}
+                aria-label={label ? `WSO2 Integration Intelligence: ${label}. Open the WSO2 Integration Intelligence mini chat.` : "Open the WSO2 Integration Intelligence mini chat"}
             >
                 {(state === "running" || state === "awaiting-input") && <Halo colors={colors} />}
                 <Aura colors={colors} state={state} />

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
@@ -373,7 +373,7 @@ export function AgentStatusOrb() {
 
     const state = status.state;
     const colors = ORB_COLORS[state];
-    const label = state === "idle" ? "Chat with WSO2 Integrator Copilot" : activeStateLabel(status);
+    const label = state === "idle" ? "Chat with WSO2 Integration Intelligence" : activeStateLabel(status);
     const dragging = dragPos !== null && !snapping;
     // Active states keep the pill visible the whole time. Idle shows the
     // invitation input; dismissing only collapses it into the orb — hovering
@@ -511,7 +511,7 @@ export function AgentStatusOrb() {
                             }
                         }}
                         placeholder="How can I help?"
-                        aria-label="Message WSO2 Integrator Copilot"
+                        aria-label="Message WSO2 Integration Intelligence"
                     />
                     <InviteDismiss title="Hide" aria-label="Hide the copilot prompt" onClick={() => setInviteDismissed(true)}>
                         ✕
@@ -525,8 +525,8 @@ export function AgentStatusOrb() {
                 onPointerDown={handlePointerDown}
                 onPointerMove={handlePointerMove}
                 onPointerUp={handlePointerUp}
-                title={label ? `WSO2 Integrator Copilot — ${label}` : "WSO2 Integrator Copilot"}
-                aria-label={label ? `WSO2 Integrator Copilot: ${label}. Open the Copilot mini chat.` : "Open the WSO2 Integrator Copilot mini chat"}
+                title={label ? `WSO2 Integration Intelligence — ${label}` : "WSO2 Integration Intelligence"}
+                aria-label={label ? `WSO2 Integration Intelligence: ${label}. Open the Copilot mini chat.` : "Open the WSO2 Integration Intelligence mini chat"}
             >
                 {(state === "running" || state === "awaiting-input") && <Halo colors={colors} />}
                 <Aura colors={colors} state={state} />

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -133,18 +133,18 @@ export const AmbientFrame = styled.div<AmbientFrameProps>`
 `;
 
 /** User-facing label for a non-idle run state, shared by the orb and the hero box. */
-export const AWAITING_INPUT_LABEL = "Copilot needs your input";
+export const AWAITING_INPUT_LABEL = "WSO2 Integration Intelligence needs your input";
 
 export function activeStateLabel(status: AgentRunStatus): string {
     switch (status.state) {
         case "completed":
-            return "Done — click to open Copilot";
+            return "Done — click to open WSO2 Integration Intelligence";
         case "running":
             return status.label ?? "Working on it…";
         case "awaiting-input":
             return status.label ?? AWAITING_INPUT_LABEL;
         case "error":
-            return status.label ?? "Copilot hit an error";
+            return status.label ?? "WSO2 Integration Intelligence hit an error";
         default:
             return "Chat with WSO2 Integration Intelligence";
     }

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -146,7 +146,7 @@ export function activeStateLabel(status: AgentRunStatus): string {
         case "error":
             return status.label ?? "Copilot hit an error";
         default:
-            return "Chat with WSO2 Integrator Copilot";
+            return "Chat with WSO2 Integration Intelligence";
     }
 }
 

--- a/packages/ballerina-visualizer/src/views/AIPanel/DisabledSection/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/DisabledSection/index.tsx
@@ -43,7 +43,7 @@ export const DisabledWindow = () => {
                 buttonTitle="Retry"
                 onClick={Retry}
                 subTitle={
-                    "An error occurred while trying to establish a connection with the WSO2 Integrator Copilot server. Please click retry to try again."
+                    "An error occurred while trying to establish a connection with the WSO2 Integration Intelligence server. Please click retry to try again."
                 }
                 title={"Error in establishing Connection"}
             />

--- a/packages/ballerina-visualizer/src/views/AIPanel/LoginPanel/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/LoginPanel/index.tsx
@@ -285,7 +285,7 @@ const LoginPanel: React.FC = () => {
                     sx={{ width: 54, height: 54 }}
                     iconSx={{ fontSize: "54px", color: "var(--vscode-foreground)", cursor: "default" }}
                 />
-                <Title>Welcome to WSO2 Integrator Copilot</Title>
+                <Title>Welcome to WSO2 Integration Intelligence</Title>
                 <Typography
                     variant="body1"
                     sx={{
@@ -313,7 +313,7 @@ const LoginPanel: React.FC = () => {
                 ) : (
                     <InstallingContainer>
                         <Typography variant="body2" sx={{ textAlign: "center", color: "var(--vscode-descriptionForeground)" }}>
-                            Install the WSO2 Integrator extension to sign in and use WSO2 Integrator Copilot.
+                            Install the WSO2 Integrator extension to sign in and use WSO2 Integration Intelligence.
                         </Typography>
                         <InstallButton
                             disabled={isInstallingExtension}

--- a/packages/ballerina-visualizer/src/views/AIPanel/WaitingForLoginSection/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/WaitingForLoginSection/index.tsx
@@ -363,7 +363,7 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
                 <AlertContainer variant="primary">
                     <Title>Connect with Anthropic API Key</Title>
                     <SubTitle>
-                        Enter your Anthropic API key to connect to WSO2 Integrator Copilot. Your API key will be securely stored
+                        Enter your Anthropic API key to connect to WSO2 Integration Intelligence. Your API key will be securely stored
                         and used for authentication.
                     </SubTitle>
 
@@ -698,7 +698,7 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
                 <AlertContainer variant="primary">
                     <Title>Connect with AWS Bedrock</Title>
                     <SubTitle>
-                        Enter your AWS credentials to connect to WSO2 Integrator Copilot via AWS Bedrock. Your credentials will be securely stored
+                        Enter your AWS credentials to connect to WSO2 Integration Intelligence via AWS Bedrock. Your credentials will be securely stored
                         and used for authentication.
                     </SubTitle>
 
@@ -813,7 +813,7 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
                 <AlertContainer variant="primary">
                     <Title>Connect with Google Vertex AI</Title>
                     <SubTitle>
-                        Select the GCP service account JSON key file to authenticate WSO2 Integrator Copilot with Google Vertex AI.
+                        Select the GCP service account JSON key file to authenticate WSO2 Integration Intelligence with Google Vertex AI.
                         The path is stored locally and read on each request, so the file must remain accessible at this location.
                     </SubTitle>
 
@@ -1062,7 +1062,7 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
                 buttonTitle="Cancel"
                 onClick={cancelLogin}
                 subTitle={
-                    "Waiting for the login credentials. Please sign in to your WSO2 Integrator Copilot account in the browser window to continue."
+                    "Waiting for the login credentials. Please sign in to your WSO2 Integration Intelligence account in the browser window to continue."
                 }
                 title={"Waiting for Login"}
             />

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Welcome/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Welcome/index.tsx
@@ -90,10 +90,6 @@ const WelcomeOrb = styled.div`
     flex: none;
 `;
 
-const SerifI = styled.span`
-    font-family: Georgia, "Times New Roman", serif;
-`;
-
 const GuideChip = styled.div`
     margin: 42px auto 0;
     padding: 8px 16px;
@@ -177,7 +173,7 @@ const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ isOnboarding = false })
                         marginTop: "16px",
                     }}
                 >
-                    <SerifI>II</SerifI> (Double <SerifI>I</SerifI>) here to help you build, update, and understand your integration. Tell me what you’d like to do.
+                    Hi, this is WSO2 Integration Intelligence (WII). You can call me Wii. I’m built to be an expert in integration. Let’s do integration together.
                 </Typography>
                 <Typography
                     variant="body1"

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Welcome/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Welcome/index.tsx
@@ -90,6 +90,10 @@ const WelcomeOrb = styled.div`
     flex: none;
 `;
 
+const SerifI = styled.span`
+    font-family: Georgia, "Times New Roman", serif;
+`;
+
 const GuideChip = styled.div`
     margin: 42px auto 0;
     padding: 8px 16px;
@@ -173,7 +177,7 @@ const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ isOnboarding = false })
                         marginTop: "16px",
                     }}
                 >
-                    Hi, this is WSO2 Integration Intelligence (WII). You can call me Wii. I’m built to be an expert in integration. Let’s do integration together.
+                    Hi, this is WSO2 Integration Intelligence (<SerifI>WII</SerifI>). You can call me Wii. I’m built to be an expert in integration. Let’s do integration together.
                 </Typography>
                 <Typography
                     variant="body1"

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Welcome/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Welcome/index.tsx
@@ -90,6 +90,10 @@ const WelcomeOrb = styled.div`
     flex: none;
 `;
 
+const SerifI = styled.span`
+    font-family: Georgia, "Times New Roman", serif;
+`;
+
 const GuideChip = styled.div`
     margin: 42px auto 0;
     padding: 8px 16px;
@@ -133,7 +137,7 @@ const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ isOnboarding = false })
             <TopSpacer />
             <Content>
                 <WelcomeOrbHalo>
-                    <WelcomeOrb role="img" aria-label="WSO2 Integrator Copilot">
+                    <WelcomeOrb role="img" aria-label="WSO2 Integration Intelligence">
                         {webglFailed ? (
                             <Sphere colors={ORB_COLORS.idle} energy={ORB_ENERGY.idle} />
                         ) : (
@@ -162,7 +166,7 @@ const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ isOnboarding = false })
                         margin: "12px 0",
                     }}
                 >
-                    WSO2 Integrator Copilot
+                    WSO2 Integration Intelligence
                 </Typography>
                 <Typography
                     variant="body1"
@@ -173,7 +177,7 @@ const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ isOnboarding = false })
                         marginTop: "16px",
                     }}
                 >
-                    I can help you build, update, and understand your integration. Tell me what you’d like to do.
+                    <SerifI>II</SerifI> (Double <SerifI>I</SerifI>) here to help you build, update, and understand your integration. Tell me what you’d like to do.
                 </Typography>
                 <Typography
                     variant="body1"

--- a/packages/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -822,7 +822,7 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
     );
 
     const formDiagnosticsFixTooltip = !isAiUserAuthenticated
-        ? "You need to be logged into WSO2 Integrator Copilot to fix diagnostics"
+        ? "You need to be logged into WSO2 Integration Intelligence to fix diagnostics"
         : !diagnosticsTargetRange
             ? "No source location available for diagnostics"
             : formDiagnostics.length === 0

--- a/packages/ballerina-visualizer/src/views/BI/ImportIntegration/MigrationProgressView.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ImportIntegration/MigrationProgressView.tsx
@@ -169,7 +169,7 @@ export function MigrationProgressView({
                                 <RadioInput type="radio" name="ai-enhancement-mode-report" checked={!aiEnhancementEnabled} onChange={() => setAiEnhancementEnabled(false)} />
                                 <RadioContent>
                                     <RadioTitle>Skip for Now, Enhance Later</RadioTitle>
-                                    <RadioDescription>Keep the project as-is. You can trigger AI enhancement later from the WSO2 Integration Intelligence.</RadioDescription>
+                                    <RadioDescription>Keep the project as-is. You can trigger AI enhancement later from WSO2 Integration Intelligence.</RadioDescription>
                                 </RadioContent>
                             </RadioOption>
                         </RadioGroup>

--- a/packages/ballerina-visualizer/src/views/BI/ImportIntegration/MigrationProgressView.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ImportIntegration/MigrationProgressView.tsx
@@ -169,7 +169,7 @@ export function MigrationProgressView({
                                 <RadioInput type="radio" name="ai-enhancement-mode-report" checked={!aiEnhancementEnabled} onChange={() => setAiEnhancementEnabled(false)} />
                                 <RadioContent>
                                     <RadioTitle>Skip for Now, Enhance Later</RadioTitle>
-                                    <RadioDescription>Keep the project as-is. You can trigger AI enhancement later from the WSO2 Integrator Copilot.</RadioDescription>
+                                    <RadioDescription>Keep the project as-is. You can trigger AI enhancement later from the WSO2 Integration Intelligence.</RadioDescription>
                                 </RadioContent>
                             </RadioOption>
                         </RadioGroup>

--- a/packages/ballerina-visualizer/src/views/MigrationPanel/MigrationPanel.tsx
+++ b/packages/ballerina-visualizer/src/views/MigrationPanel/MigrationPanel.tsx
@@ -497,7 +497,7 @@ export function MigrationPanel() {
                         title="Select LLM model"
                     >
                         <option value="copilot">VS Code Copilot</option>
-                        <option value="wso2">WSO2 Integrator Copilot</option>
+                        <option value="wso2">WSO2 Integration Intelligence</option>
                         <option value="anthropic">Anthropic (API Key)</option>
                     </ModelSelector>
                 </HeaderActions>
@@ -603,7 +603,7 @@ export function MigrationPanel() {
                 ) : (
                     <>
                         <span style={{ opacity: 0.6 }}>
-                            Model: {selectedModel === "copilot" ? "VS Code Copilot" : selectedModel === "wso2" ? "WSO2 Integrator Copilot" : "Anthropic"}
+                            Model: {selectedModel === "copilot" ? "VS Code Copilot" : selectedModel === "wso2" ? "WSO2 Integration Intelligence" : "Anthropic"}
                         </span>
                         {messages.length > 0 && (
                             <ActionButton

--- a/packages/bi-diagram/src/components/DiagnosticsPopUp/index.tsx
+++ b/packages/bi-diagram/src/components/DiagnosticsPopUp/index.tsx
@@ -257,7 +257,7 @@ export function DiagnosticsPopUp(props: DiagnosticsPopUpProps) {
     };
 
     const disabledFixTooltip = !isUserAuthenticated
-        ? "You need to be logged into WSO2 Integrator Copilot to fix diagnostics"
+        ? "You need to be logged into WSO2 Integration Intelligence to fix diagnostics"
         : !targetRange
             ? "No source location available for diagnostics"
             : diagnosticMessages.length === 0

--- a/packages/bi-diagram/src/components/NodeLink/NodeLinkWidget.tsx
+++ b/packages/bi-diagram/src/components/NodeLink/NodeLinkWidget.tsx
@@ -271,7 +271,7 @@ export const NodeLinkWidget: React.FC<NodeLinkWidgetProps> = ({ link, engine }) 
                                 visibility: ${shouldHighlight ? "visible" : "hidden"};
                             `}
                         >
-                            {!isUserAuthenticated && <title>You need to be logged into WSO2 Integrator Copilot to access AI features</title>}
+                            {!isUserAuthenticated && <title>You need to be logged into WSO2 Integration Intelligence to access AI features</title>}
                             <path
                                 fill={ADD_BUTTON_BG_COLOR}
                                 d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"

--- a/packages/bi-diagram/src/components/nodes/EmptyNode/EmptyNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/EmptyNode/EmptyNodeWidget.tsx
@@ -225,7 +225,7 @@ export function EmptyNodeWidget(props: EmptyNodeWidgetProps) {
                                 cursor: ${isUserAuthenticated ? "pointer" : "not-allowed"};
                             `}
                         >
-                            {!isUserAuthenticated && <title>You need to be logged into WSO2 Integrator Copilot to access AI features</title>}
+                            {!isUserAuthenticated && <title>You need to be logged into WSO2 Integration Intelligence to access AI features</title>}
                             <path
                                 fill={ADD_BUTTON_BG_COLOR}
                                 d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"

--- a/packages/bi-diagram/src/test/__snapshots__/Diagram.flowModel.render.test.tsx.snap
+++ b/packages/bi-diagram/src/test/__snapshots__/Diagram.flowModel.render.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`bi-diagram — render + snapshot from a real captured flow model matche
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -228,7 +228,7 @@ exports[`bi-diagram — render + snapshot from a real captured flow model matche
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -327,7 +327,7 @@ exports[`bi-diagram — render + snapshot from a real captured flow model matche
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -446,7 +446,7 @@ exports[`bi-diagram — render + snapshot from a real captured flow model matche
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -545,7 +545,7 @@ exports[`bi-diagram — render + snapshot from a real captured flow model matche
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -716,7 +716,7 @@ exports[`bi-diagram — render + snapshot from a real captured flow model matche
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"

--- a/packages/bi-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
+++ b/packages/bi-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
@@ -214,7 +214,7 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -334,7 +334,7 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -454,7 +454,7 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -591,7 +591,7 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -691,7 +691,7 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -791,7 +791,7 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -891,7 +891,7 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -1872,7 +1872,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -1972,7 +1972,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -2072,7 +2072,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -2172,7 +2172,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -2272,7 +2272,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -2372,7 +2372,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -2472,7 +2472,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -2592,7 +2592,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -2712,7 +2712,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -2812,7 +2812,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -2912,7 +2912,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -3126,7 +3126,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -3246,7 +3246,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -3346,7 +3346,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -3446,7 +3446,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -3640,7 +3640,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -3740,7 +3740,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -3840,7 +3840,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -3940,7 +3940,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -4114,7 +4114,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -4214,7 +4214,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -4314,7 +4314,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -4414,7 +4414,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -4514,7 +4514,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -4614,7 +4614,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -4734,7 +4734,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -4854,7 +4854,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -4991,7 +4991,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -5091,7 +5091,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -5211,7 +5211,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -5311,7 +5311,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -5485,7 +5485,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -5585,7 +5585,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -5685,7 +5685,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -5785,7 +5785,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -5885,7 +5885,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -8667,7 +8667,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -8764,7 +8764,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -8909,7 +8909,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -9325,7 +9325,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -9425,7 +9425,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -9545,7 +9545,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -9645,7 +9645,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -9819,7 +9819,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -10275,7 +10275,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -10375,7 +10375,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -10475,7 +10475,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -10575,7 +10575,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -10675,7 +10675,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -10775,7 +10775,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -10875,7 +10875,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -10975,7 +10975,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -12191,7 +12191,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -12267,7 +12267,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -12343,7 +12343,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -12610,7 +12610,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with diagnostics correctly: fl
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -12710,7 +12710,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with diagnostics correctly: fl
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -12810,7 +12810,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with diagnostics correctly: fl
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -13380,7 +13380,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with error handler correctly: 
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -13596,7 +13596,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with error handler correctly: 
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -13821,7 +13821,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with suggestions correctly: fl
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -13921,7 +13921,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with suggestions correctly: fl
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -14021,7 +14021,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with suggestions correctly: fl
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"
@@ -14501,7 +14501,7 @@ exports[`BI Diagram - Snapshot Tests renders start flow correctly: start-flow 1`
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    You need to be logged into WSO2 Integrator Copilot to access AI features
+                    You need to be logged into WSO2 Integration Intelligence to access AI features
                   </title>
                   <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2127

- Renames the assistant across the extension from **WSO2 Integrator Copilot** to **WSO2 Integration Intelligence** (short form "WII", said "Wii")
- Welcome screen introduces the new name and nickname: "Hi, this is WSO2 Integration Intelligence (WII). You can call me Wii. I'm built to be an expert in integration. Let's do integration together."
- Renamed every other visible "WSO2 Integrator Copilot" string: login/waiting/disabled AI panel sections, the floating orb and mini chat, the migration panel, bi-diagram tooltips, status bar text, error messages, the `AGENTS.md` starter template, and `package.json` command titles/description (command ids untouched)
- Updated the agent system prompt and follow-up prompt so the model identifies as "WSO2 Integration Intelligence (WII)" / "Wii" in conversation, not just in the UI
- Regenerated the two `bi-diagram` Jest snapshots affected by the tooltip text change

<img width="1912" height="1192" alt="image" src="https://github.com/user-attachments/assets/9436e2d9-9183-4ab5-9b17-bec2eb609b86" />


## Test plan
- [x] Rebuild and launch the Extension Dev Host (F5) to confirm the Welcome screen renders correctly
- [x] Sanity-check the renamed strings across the login/waiting/disabled AI panel states, the floating orb, and the migration panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Renamed user-facing “WSO2 Integrator Copilot” references to “WSO2 Integration Intelligence” across the extension, visualizer, and BI diagram.
- Updated WII/Wii branding in welcome content and agent prompts.
- Updated authentication messages, status labels, tooltips, templates, metadata, and migration-panel text.
- Preserved command IDs and application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->