### PR TITLE
Add tooltips to all artifact cards in the Add Artifact view

### DIFF
--- a/packages/ballerina-visualizer/src/views/BI/ComponentListView/AIAgentPanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ComponentListView/AIAgentPanel.tsx
@@ -98,7 +98,7 @@ export function AIAgentPanel(props: AIAgentPanelProps) {
                         title={AI_CHAT_AGENT_CARD.displayName}
                         onClick={handleClick}
                         disabled={isDisabled}
-                        tooltip={isDisabled ? OutOfScopeComponentTooltip : ""}
+                        tooltip={isDisabled ? OutOfScopeComponentTooltip : AI_CHAT_AGENT_CARD.tooltip}
                     />
                 )}
                 {props.triggers.local.length === 0 && <RelativeLoader />}
@@ -110,7 +110,7 @@ export function AIAgentPanel(props: AIAgentPanelProps) {
                         icon={getEntryNodeIcon(item)}
                         onClick={() => handleMcpClick(DIRECTORY_MAP.SERVICE, item)}
                         disabled={isDisabled}
-                        tooltip={isDisabled ? OutOfScopeComponentTooltip : ""}
+                        tooltip={isDisabled ? OutOfScopeComponentTooltip : item.documentation}
                         isBeta={isBetaModule(item.moduleName)}
                     />
                 ))}

--- a/packages/ballerina-visualizer/src/views/BI/ComponentListView/AutomationPanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ComponentListView/AutomationPanel.tsx
@@ -54,7 +54,7 @@ export function AutomationPanel(props: AutomationPanelProps) {
         ? OutOfScopeComponentTooltip
         : automationExists
             ? AutomationAlreadyExistsTooltip
-            : "";
+            : AUTOMATION_CARD.tooltip;
 
     const handleClick = async () => {
         await rpcClient.getVisualizerRpcClient().openView({

--- a/packages/ballerina-visualizer/src/views/BI/ComponentListView/CentralSearchPanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ComponentListView/CentralSearchPanel.tsx
@@ -154,6 +154,7 @@ export function CentralSearchPanel(props: CentralSearchPanelProps) {
                                 title={item.name}
                                 icon={getEntryNodeIcon(item)}
                                 onClick={() => handleSelect(item, false)}
+                                tooltip={item.documentation}
                                 isBeta={isBetaModule(item.moduleName)}
                             />
                         ))}
@@ -176,6 +177,7 @@ export function CentralSearchPanel(props: CentralSearchPanelProps) {
                                 title={item.name}
                                 icon={getEntryNodeIcon(item)}
                                 onClick={() => handleSelect(item, true)}
+                                tooltip={item.documentation}
                                 isBeta={isBetaModule(item.moduleName)}
                             />
                         ))}

--- a/packages/ballerina-visualizer/src/views/BI/ComponentListView/EventIntegrationPanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ComponentListView/EventIntegrationPanel.tsx
@@ -88,7 +88,7 @@ export function EventIntegrationPanel(props: EventIntegrationPanelProps) {
                                         handleClick(DIRECTORY_MAP.SERVICE, item);
                                     }}
                                     disabled={isDisabled}
-                                    tooltip={isDisabled ? OutOfScopeComponentTooltip : ""}
+                                    tooltip={isDisabled ? OutOfScopeComponentTooltip : item.documentation}
                                     isBeta={isBetaModule(item.moduleName)}
                                 />
                             );

--- a/packages/ballerina-visualizer/src/views/BI/ComponentListView/FileIntegrationPanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ComponentListView/FileIntegrationPanel.tsx
@@ -88,7 +88,7 @@ export function FileIntegrationPanel(props: FileIntegrationPanelProps) {
                                     handleOnSelect(item);
                                 }}
                                 disabled={isDisabled}
-                                tooltip={isDisabled ? OutOfScopeComponentTooltip : ""}
+                                tooltip={isDisabled ? OutOfScopeComponentTooltip : item.documentation}
                             />
                         );
                     })}

--- a/packages/ballerina-visualizer/src/views/BI/ComponentListView/IntegrationApiPanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ComponentListView/IntegrationApiPanel.tsx
@@ -66,7 +66,7 @@ export function IntegrationAPIPanel(props: IntegrationAPIPanelProps) {
                         title={card.displayName}
                         onClick={() => handleClick(card)}
                         disabled={isDisabled}
-                        tooltip={isDisabled ? OutOfScopeComponentTooltip : ""}
+                        tooltip={isDisabled ? OutOfScopeComponentTooltip : card.tooltip}
                         isBeta={card.isBeta}
                     />
                 ))}

--- a/packages/ballerina-visualizer/src/views/BI/ComponentListView/OtherArtifactsPanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ComponentListView/OtherArtifactsPanel.tsx
@@ -142,6 +142,7 @@ export function OtherArtifactsPanel(props: OtherArtifactsPanelProps) {
                         icon={card.icon}
                         title={card.displayName}
                         onClick={() => handleClick(card.directoryKey)}
+                        tooltip={card.tooltip}
                         isBeta={card.isBeta}
                     />
                 ))}

--- a/packages/ballerina-visualizer/src/views/BI/components/artifactCards.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/components/artifactCards.tsx
@@ -120,6 +120,7 @@ export const AUTOMATION_CARD: ArtifactCard = {
     kind: "automation",
     displayName: "Automation",
     icon: <Icon name="bi-task" />,
+    tooltip: "Integration logic that runs on a schedule or is triggered manually."
 };
 
 export const WORKFLOW_CARD: ArtifactCard = {
@@ -144,6 +145,7 @@ export const AI_CHAT_AGENT_CARD: ArtifactCard = {
     kind: "ai-agent",
     displayName: "Chat Agent Service",
     icon: <Icon name="bi-ai-agent" />,
+    tooltip: "AI chat agent, backed by tools and memory, exposed as a service."
 };
 
 /** TODO: Add the gRPC service card once gRPC support is working. */
@@ -153,6 +155,7 @@ export const INTEGRATION_API_CARDS: ArtifactCard[] = [
         kind: "service",
         displayName: "HTTP Service",
         icon: <Icon name="bi-globe" />,
+        tooltip: "Expose your integration over HTTP as a REST API.",
         artifactInfo: {
             org: "ballerina",
             packageName: "http",
@@ -164,6 +167,7 @@ export const INTEGRATION_API_CARDS: ArtifactCard[] = [
         kind: "service",
         displayName: "GraphQL Service",
         icon: <Icon name="bi-graphql" sx={{ color: "#e535ab" }} />,
+        tooltip: "Expose your integration as a GraphQL API with a typed schema.",
         isBeta: true,
         artifactInfo: {
             org: "ballerina",
@@ -176,6 +180,7 @@ export const INTEGRATION_API_CARDS: ArtifactCard[] = [
         kind: "service",
         displayName: "TCP Service",
         icon: <Icon name="bi-tcp" />,
+        tooltip: "Handle raw TCP socket connections and byte streams.",
         isBeta: true,
         artifactInfo: {
             org: "ballerina",
@@ -198,6 +203,7 @@ export interface OtherArtifactCard {
     requiresNaturalFunctions?: boolean;
     /** Shown only inside a library package. */
     requiresLibrary?: boolean;
+    tooltip?: string;
 }
 
 export const OTHER_ARTIFACT_CARDS: OtherArtifactCard[] = [
@@ -206,6 +212,7 @@ export const OTHER_ARTIFACT_CARDS: OtherArtifactCard[] = [
         displayName: "Function",
         icon: <Icon name="bi-function" />,
         directoryKey: DIRECTORY_MAP.FUNCTION,
+        tooltip: "Reusable logic that can be called from anywhere in your integration.",
     },
     {
         id: "bi-ai-function",
@@ -214,30 +221,35 @@ export const OTHER_ARTIFACT_CARDS: OtherArtifactCard[] = [
         directoryKey: DIRECTORY_MAP.NP_FUNCTION,
         isBeta: true,
         requiresNaturalFunctions: true,
+        tooltip: "Function whose behaviour is described in natural language and run by an LLM.",
     },
     {
         id: "data-mapper",
         displayName: "Data Mapper",
         icon: <Icon name="dataMapper" />,
         directoryKey: DIRECTORY_MAP.DATA_MAPPER,
+        tooltip: "Visually map and transform data from one type to another.",
     },
     {
         id: "type",
         displayName: "Type",
         icon: <Icon name="bi-type" />,
         directoryKey: DIRECTORY_MAP.TYPE,
+        tooltip: "Record, enum, or union type that shapes the data in your integration.",
     },
     {
         id: "connection",
         displayName: "Connection",
         icon: <Icon name="bi-connection" />,
         directoryKey: DIRECTORY_MAP.CONNECTION,
+        tooltip: "Reusable client connection to an external system or service.",
     },
     {
         id: "agent",
         displayName: "Agent",
         icon: <Icon name="bi-ai-agent" />,
         directoryKey: DIRECTORY_MAP.AGENT,
+        tooltip: "AI agent, backed by tools and memory, that your integration can call.",
     },
     {
         id: "agent-definition",
@@ -245,11 +257,13 @@ export const OTHER_ARTIFACT_CARDS: OtherArtifactCard[] = [
         icon: <Icon name="symbol-class" isCodicon={true} />,
         directoryKey: DIRECTORY_MAP.AGENT_DEFINITION,
         requiresLibrary: true,
+        tooltip: "Reusable agent definition that can be shared across integrations.",
     },
     {
         id: "configurable",
         displayName: "Configuration",
         icon: <Icon name="bi-config" />,
         directoryKey: DIRECTORY_MAP.CONFIGURABLE,
+        tooltip: "Configurable value that is supplied at deployment time.",
     },
 ];


### PR DESCRIPTION
## Purpose
Tooltips are shown only for the two Durable Workflow cards in the Add Artifact view. Every other artifact card renders with no tooltip, so new users get no explanation of what an artifact does before creating it.

Resolves wso2/product-integrator#2147

## Goals
Give every card in the Add Artifact view a tooltip, using the same mechanism the workflow cards already use.

## Approach
The tooltip plumbing already exists. `ButtonCard` wraps every card in a `Tooltip`, and `ArtifactCard` has an optional tooltip field. Only the two workflow cards set it, while the other panels passed an empty string whenever the card was enabled. The fix is therefore data and wiring, with no component changes.

**Static cards**

- Added tooltip copy to `AUTOMATION_CARD`, `AI_CHAT_AGENT_CARD`, and the three `INTEGRATION_API_CARDS`.
- `OtherArtifactCard` had no tooltip field at all, so the field was added along with copy for all eight entries.

**Dynamic cards** (event, file and MCP triggers, plus Central search results)

- These are built from `ServiceModel`, which already carries a `documentation` field, so they use that instead of invented copy.
- When the language server sends no documentation the tooltip is absent, which matches today's behaviour, so there is no regression.

**Panels**

- The enabled branch now resolves to the card's own tooltip instead of an empty string.
- The disabled-state messages are untouched and still take precedence.

### Files changed
- `views/BI/components/artifactCards.tsx`
- `views/BI/ComponentListView/AutomationPanel.tsx`
- `views/BI/ComponentListView/AIAgentPanel.tsx`
- `views/BI/ComponentListView/IntegrationApiPanel.tsx`
- `views/BI/ComponentListView/EventIntegrationPanel.tsx`
- `views/BI/ComponentListView/FileIntegrationPanel.tsx`
- `views/BI/ComponentListView/OtherArtifactsPanel.tsx`
- `views/BI/ComponentListView/CentralSearchPanel.tsx`

## UI Component Development
- [x] Added reusable UI components to the ui-toolkit: N/A, no new components. Reuses the existing `ButtonCard` and `Tooltip`.
- [x] Use ui-toolkit components wherever possible: unchanged, the existing tooltip in `ButtonCard` does the work.
- [x] Matches with the native VSCode look and feel: unchanged, no styling touched.

## User stories
As a new user browsing the Add Artifact view, I can hover any artifact card and read what it does before deciding to create it.

## Release note
Artifact cards in the Add Artifact view now show a descriptive tooltip on hover. Previously only the Durable Workflow cards did.

## Documentation
N/A. No documented behaviour changes, this only adds hover text to existing cards.

## Training
N/A

## Certification
N/A. No change to product concepts or workflows that certification exams cover.

## Automation tests
- Unit tests
  > None added. The change is static copy plus prop wiring, and there are no existing tests for the artifact panels to extend.
- Integration tests
  > None added.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A, TypeScript and React only, no Java changed.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Not verified in a running IDE. I was unable to build the monorepo locally, since the language server build needs JDK 21, a Ballerina distribution and a GitHub PAT with `read:packages`. The change is source-only and follows the existing workflow panel pattern, but please confirm the rendered tooltips in a dev build before merging.

## Learning
Traced the existing tooltip path from the workflow panel through `ButtonCard` to the shared tooltip in the ui-toolkit, then compared it against the other panels to find where the value was being dropped.

### Note for reviewers on the tooltip wording
The copy for the static cards is proposed, not authoritative. I wrote it to match the tone of the two existing workflow tooltips. The PR template asks for UI text to be reviewed by documentation@wso2.com, so please treat these strings as a starting point and reword as needed.

| Card | Proposed tooltip |
|---|---|
| Automation | Integration logic that runs on a schedule or is triggered manually. |
| Chat Agent Service | AI chat agent, backed by tools and memory, exposed as a service. |
| HTTP Service | Expose your integration over HTTP as a REST API. |
| GraphQL Service | Expose your integration as a GraphQL API with a typed schema. |
| TCP Service | Handle raw TCP socket connections and byte streams. |
| Function | Reusable logic that can be called from anywhere in your integration. |
| Natural Function | Function whose behaviour is described in natural language and run by an LLM. |
| Data Mapper | Visually map and transform data from one type to another. |
| Type | Record, enum, or union type that shapes the data in your integration. |
| Connection | Reusable client connection to an external system or service. |
| Agent | AI agent, backed by tools and memory, that your integration can call. |
| Agent Definition | Reusable agent definition that can be shared across integrations. |
| Configuration | Configurable value that is supplied at deployment time. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added tooltips to artifact cards in the Add Artifact view.
- Added descriptive text for static artifact cards.
- Used service documentation for dynamic artifact cards.
- Preserved existing out-of-scope messages for disabled cards.
- Extended `OtherArtifactCard` with optional tooltip support.
- Updated panels to pass tooltip text when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->