### PR TITLE
Index azure files icon in the icon registry

### DIFF
--- a/packages/ballerina-core/src/icons/brand-icon-registry.ts
+++ b/packages/ballerina-core/src/icons/brand-icon-registry.ts
@@ -51,6 +51,7 @@ export const BRAND_ICON_REGISTRY: Record<string, BrandIcon> = {
     solace: { glyph: "bi-solace", color: "#00C895" },
     ftp: { glyph: "bi-ftp" },
     smb: { glyph: "bi-smb" },
+    "azure.storage.files": { glyph: "bi-azure-files", color: "#0078D4" },
     file: { glyph: "bi-file" },
     mssql: { glyph: "bi-mssql", color: "#b61d1c" },
     postgresql: { glyph: "bi-postgresql", color: "#336791" },

--- a/packages/ballerina-core/src/icons/brand-icon-registry.ts
+++ b/packages/ballerina-core/src/icons/brand-icon-registry.ts
@@ -51,7 +51,7 @@ export const BRAND_ICON_REGISTRY: Record<string, BrandIcon> = {
     solace: { glyph: "bi-solace", color: "#00C895" },
     ftp: { glyph: "bi-ftp" },
     smb: { glyph: "bi-smb" },
-    "azure.storage.files": { glyph: "bi-azure-files", color: "#0078D4" },
+    "azure.storage.files": { glyph: "bi-azure-files", color: "#2ABADF" },
     file: { glyph: "bi-file" },
     mssql: { glyph: "bi-mssql", color: "#b61d1c" },
     postgresql: { glyph: "bi-postgresql", color: "#336791" },


### PR DESCRIPTION
Adds azure.storage.files to BRAND_ICON_REGISTRY using the bi-azure-files glyph (#2ABADF, sampled from the official Azure Files logo). Includes the wso2-vscode-extensions submodule bump to de2cae32 — the merge commit of wso2/vscode-extensions#2465, which ships the glyph. The submodule diff between the previous pin and this one is exactly that one SVG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds `azure.storage.files` to `BRAND_ICON_REGISTRY` with the `bi-azure-files` glyph and Azure blue tint `#0078D4`. This enables consistent Azure Files branding after the dependent icon changes are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Icon preview

![bi-azure-files](https://raw.githubusercontent.com/YasanPunch/vscode-extensions/assets/azure-files-icon-preview/bi-azure-files-light2.png)
