### PR TITLE
Fix onUpdate function handler UX and other minor issues

### DIFF
--- a/packages/ballerina-core/src/interfaces/service.ts
+++ b/packages/ballerina-core/src/interfaces/service.ts
@@ -118,6 +118,7 @@ export interface FunctionModel {
     group?: string;
     variantLabel?: string;
     addLabel?: string;
+    addDescription?: string;
     repeatable?: RepeatBehavior;
     nameEditable?: boolean;
 

--- a/packages/ballerina-core/src/interfaces/service.ts
+++ b/packages/ballerina-core/src/interfaces/service.ts
@@ -320,6 +320,7 @@ export interface ParameterModel extends PropertyModel {
     name?: PropertyModel;
     headerName?: PropertyModel;
     documentation?: PropertyModel;
+    bindingGroup?: string;
 }
 
 

--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/trigger/models/TriggerUISchemaModel.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/trigger/models/TriggerUISchemaModel.java
@@ -326,6 +326,7 @@ public record TriggerUISchemaModel(
      *                       some connectors bind to a fixed, structural identifier referred to by name
      *                       elsewhere, so only the bound type is user-selected. Defaults to editable
      *                       when unset.
+     * @param bindingGroup   the binding-group id this parameter shares with any sibling parameters
      */
     public record Codedata(
             String type,
@@ -352,7 +353,8 @@ public record TriggerUISchemaModel(
             String valueQualifier,
             String group,
             String variantLabel,
-            Boolean nameEditable) {
+            Boolean nameEditable,
+            String bindingGroup) {
 
         public static Builder builder() {
             return new Builder();
@@ -385,6 +387,7 @@ public record TriggerUISchemaModel(
             private String group;
             private String variantLabel;
             private Boolean nameEditable;
+            private String bindingGroup;
 
             private Builder() {
             }
@@ -514,11 +517,16 @@ public record TriggerUISchemaModel(
                 return this;
             }
 
+            public Builder bindingGroup(String bindingGroup) {
+                this.bindingGroup = bindingGroup;
+                return this;
+            }
+
             public Codedata build() {
                 return new Codedata(type, argType, originalName, moduleName, orgName, packageName, position, path,
                         defaultType, boundType, bindable, bindingKind, typeConstraint, template, modifier, supersedes,
                         targetParam, modifiers, field, optional, value, valueQualifier, group, variantLabel,
-                        nameEditable);
+                        nameEditable, bindingGroup);
             }
         }
     }

--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/trigger/models/TriggerUISchemaModel.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/trigger/models/TriggerUISchemaModel.java
@@ -617,6 +617,7 @@ public record TriggerUISchemaModel(
      * @param addLabel    the label used when offering to add this node
      * @param groupName   the logical group this node is listed under
      * @param badge       a short badge tag shown on the node
+     * @param addDescription the description used when offering to add this node
      */
     public record Metadata(
             String label,
@@ -626,6 +627,7 @@ public record TriggerUISchemaModel(
             String subLabel,
             String addLabel,
             String groupName,
-            String badge) {
+            String badge,
+            String addDescription) {
     }
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/SchemaDrivenSourceGenerator.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/SchemaDrivenSourceGenerator.java
@@ -161,9 +161,17 @@ public final class SchemaDrivenSourceGenerator {
                     continue;
                 }
                 String org = moduleRef.substring(0, slash);
-                String module = moduleRef.substring(slash + 1);
+                String rest = moduleRef.substring(slash + 1).trim();
+                String module = rest;
+                String alias = null;
+                int asIndex = rest.lastIndexOf(" as ");
+                if (asIndex > 0) {
+                    module = rest.substring(0, asIndex).trim();
+                    alias = rest.substring(asIndex + 4).trim();
+                }
                 if (!Utils.importExists(rootNode, org, module)) {
-                    imports.append(Utils.getImportStmt(org, module));
+                    imports.append(alias == null ? Utils.getImportStmt(org, module)
+                            : Utils.getImportStmt(org, module, alias));
                 }
             }
         }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerModelSynthesizer.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerModelSynthesizer.java
@@ -238,21 +238,21 @@ public final class TriggerModelSynthesizer {
         createNewProps.put(LISTENER_CONFIG_GROUP_KEY, configGroup);
         TriggerUISchemaModel.Property createNew = new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata("Create New Listener", "Create a new listener", null, null,
-                        null, null, null, null),
+                        null, null, null, null, null),
                 true, true, false, false, null, null, null, null, null, createNewProps, cd(), null);
 
         Map<String, TriggerUISchemaModel.Property> useExistingProps = new LinkedHashMap<>();
         useExistingProps.put(LISTENER_KEY, existingListenerSelector());
         TriggerUISchemaModel.Property useExisting = new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata("Use Existing Listener", "Attach to an already-declared listener",
-                        null, null, null, null, null, null),
+                        null, null, null, null, null, null, null),
                 false, false, false, false, null, null, null, null, null, useExistingProps, cd(), null);
 
         TriggerUISchemaModel.PropertyType choiceType = new TriggerUISchemaModel.PropertyType(
                 "CHOICE", true, null, null, null, null, null, null);
         TriggerUISchemaModel.Property choice = new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata("Listener", "The listener this service attaches to", null, null, null,
-                        null, null, null),
+                        null, null, null, null),
                 true, true, false, false, null, null, List.of(choiceType), null,
                 List.of(createNew, useExisting), null, cdType(CD_TYPE_LISTENER_CONFIG), null);
         initProperties.put(LISTENER_KEY, choice);
@@ -263,7 +263,7 @@ public final class TriggerModelSynthesizer {
         TriggerUISchemaModel.PropertyType type = new TriggerUISchemaModel.PropertyType(
                 "GROUP_SECTION", true, null, null, null, null, null, null);
         return new TriggerUISchemaModel.Property(
-                new TriggerUISchemaModel.Metadata(label, description, null, null, null, null, null, null),
+                new TriggerUISchemaModel.Metadata(label, description, null, null, null, null, null, null, null),
                 true, true, false, false, null, null, List.of(type), null, null, properties, null, null);
     }
 
@@ -272,7 +272,7 @@ public final class TriggerModelSynthesizer {
                 "IDENTIFIER", true, moduleName + ":Listener", null, null, null, null, null);
         return new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata("Listener Name", "Provide a name for the listener being created",
-                        null, null, null, null, null, null),
+                        null, null, null, null, null, null, null),
                 true, true, false, false, null, moduleName + "Listener", List.of(type), null, null, null,
                 cdType(CD_TYPE_LISTENER_VAR_NAME), null);
     }
@@ -332,7 +332,7 @@ public final class TriggerModelSynthesizer {
                 "SINGLE_SELECT_LISTENER", true, null, null, null, null, null, null);
         return new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata("Listener", "The existing listener to attach to", null, null,
-                        null, null, null, null),
+                        null, null, null, null, null),
                 true, true, false, false, null, null, List.of(type), null, null, null,
                 cdType(CD_TYPE_EXISTING_LISTENER), null);
     }
@@ -358,7 +358,7 @@ public final class TriggerModelSynthesizer {
         TriggerUISchemaModel.Property property = new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata(isBasePath ? "Service Path" : "Identifier",
                         isBasePath ? "The base path this service is exposed on"
-                                : "The identifier for this service", null, null, null, null, null, null),
+                                : "The identifier for this service", null, null, null, null, null, null, null),
                 true, true, optional, false, isBasePath ? "/" : null, null, List.of(type), null, null, null,
                 cdType("SERVICE_ID"), null);
         initProperties.put(IDENTIFIER_KEY, property);
@@ -405,7 +405,7 @@ public final class TriggerModelSynthesizer {
                 "SINGLE_SELECT", true, null, options, null, null, null, null);
         return new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata("Service Type", "The kind of service to create", null, null,
-                        null, null, null, null),
+                        null, null, null, null, null),
                 true, true, false, false, null, serviceTypes.get(0).id(), List.of(type), null, null, null,
                 cdType(ARG_TYPE_SERVICE_TYPE_DESCRIPTOR), null);
     }
@@ -438,7 +438,8 @@ public final class TriggerModelSynthesizer {
         }
 
         return new TriggerUISchemaModel.ServiceTypeModel(
-                new TriggerUISchemaModel.Metadata(humanize(serviceType.id()), null, null, null, null, null, null, null),
+                new TriggerUISchemaModel.Metadata(humanize(serviceType.id()), null, null, null, null, null, null,
+                        null, null),
                 typeName, null, isFirst, multiType, properties, functions, schemaFunctions,
                 cdServiceType(typeName, moduleName));
     }
@@ -484,7 +485,7 @@ public final class TriggerModelSynthesizer {
         TriggerUISchemaModel.ReturnType returnType = buildReturnType(fn.returnType(), fn.returnsError());
         String description = fn.doc() == null || fn.doc().isBlank() ? "The `" + fn.name() + "` handler." : fn.doc();
         return new TriggerUISchemaModel.FunctionModel(
-                new TriggerUISchemaModel.Metadata(fn.name(), description, null, null, null, null, null, null),
+                new TriggerUISchemaModel.Metadata(fn.name(), description, null, null, null, null, null, null, null),
                 fn.name(), false, null, fn.kind(), null, fn.qualifiers(), null, null, true, false, false, false,
                 null, null, null, parameters, null, Map.of(), returnType, cdFunction(fn.name(), moduleName), null);
     }
@@ -495,7 +496,7 @@ public final class TriggerModelSynthesizer {
         return new TriggerUISchemaModel.Parameter(
                 new TriggerUISchemaModel.Metadata(humanize(param.name()),
                         param.doc() == null || param.doc().isBlank() ? null : param.doc(), null, null, null, null,
-                        null, null),
+                        null, null, null),
                 KIND_REQUIRED, typeProperty, nameProperty, null, null, null, null, true, false, param.optional(),
                 false, false, cdType("FUNCTION_PARAM"), null);
     }
@@ -504,7 +505,7 @@ public final class TriggerModelSynthesizer {
         TriggerUISchemaModel.PropertyType type = new TriggerUISchemaModel.PropertyType(
                 "IDENTIFIER", true, null, null, null, null, null, null);
         return new TriggerUISchemaModel.Property(
-                new TriggerUISchemaModel.Metadata(name, null, null, null, null, null, null, null),
+                new TriggerUISchemaModel.Metadata(name, null, null, null, null, null, null, null, null),
                 true, editable, false, false, name, name, List.of(type), null, null, null, null, null);
     }
 
@@ -529,7 +530,7 @@ public final class TriggerModelSynthesizer {
         String label = many ? "Handler" : option.name();
         return new TriggerUISchemaModel.FunctionModel(
                 new TriggerUISchemaModel.Metadata(label, "The `" + option.name() + "` handler.", null, null, null,
-                        many ? "Add Handler" : null, null, null),
+                        many ? "Add Handler" : null, null, null, null),
                 name, many, null, option.kind() == null ? null : option.kind().toUpperCase(Locale.ROOT),
                 null, option.kind() == null ? null : List.of(option.kind()), null, null, false, true, !required,
                 false, null, null, null, parameters, null, properties, returnType,
@@ -585,7 +586,7 @@ public final class TriggerModelSynthesizer {
         String kind = bindingRule != null ? DATA_BINDING : (optional ? DB_KIND_OPTIONAL : KIND_REQUIRED);
         return new TriggerUISchemaModel.Parameter(
                 new TriggerUISchemaModel.Metadata(humanize(name.isEmpty() ? "value" : name), null, null, null,
-                        null, null, null, null),
+                        null, null, null, null, null),
                 kind, typeProperty, nameProperty, null, null, null, null, true, true,
                 optional, false, false, cdType("FUNCTION_PARAM"), null);
     }
@@ -598,12 +599,12 @@ public final class TriggerModelSynthesizer {
         TriggerUISchemaModel.Property typeProperty = new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata("Include " + label,
                         "Tick to include the " + label.toLowerCase(Locale.ROOT) + " parameter in the handler "
-                                + "signature.", null, null, null, null, null, null),
+                                + "signature.", null, null, null, null, null, null, null),
                 true, true, true, false, null, false, List.of(flagType), null, null, null, cd(), null);
         TriggerUISchemaModel.Property nameProperty = identifierProperty(name, false);
         return new TriggerUISchemaModel.Parameter(
                 new TriggerUISchemaModel.Metadata(label, "The " + label.toLowerCase(Locale.ROOT) + " object.", null,
-                        null, null, null, null, null),
+                        null, null, null, null, null, null),
                 DB_KIND_OPTIONAL, typeProperty, nameProperty, null, null, null, null, false, true, true, true, false,
                 cdType("FUNCTION_PARAM"), null);
     }
@@ -613,7 +614,7 @@ public final class TriggerModelSynthesizer {
                 "TYPE", true, typeName, null, null, null, null, null);
         return new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata("Parameter Type", "The type of the parameter", null, null, null, null,
-                        null, null),
+                        null, null, null),
                 true, false, false, false, null, typeName, List.of(type), null, null, null, cd(), null);
     }
 
@@ -662,7 +663,7 @@ public final class TriggerModelSynthesizer {
                 null);
         TriggerUISchemaModel.Property payload = new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata("Payload", "The shape of the received payload", null, null,
-                        null, null, null, null),
+                        null, null, null, null, null),
                 true, true, false, false, null, "", List.of(propertyType), null, null, null,
                 cdPayload(cdType, defaultType, template, field, typeConstraint), null);
 
@@ -688,7 +689,7 @@ public final class TriggerModelSynthesizer {
                 .targetParam(targetParam).build();
         return new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata("Stream (Large Files)", "Process the file content in chunks", null,
-                        null, null, null, null, null),
+                        null, null, null, null, null, null),
                 true, true, false, false, null, false, List.of(flagType), null, null, null, modifierCodedata, null);
     }
 
@@ -708,7 +709,7 @@ public final class TriggerModelSynthesizer {
         boolean enabled = type != null && !"()".equals(type);
         return new TriggerUISchemaModel.ReturnType(
                 new TriggerUISchemaModel.Metadata("Return Type", "The return type of the function.", null, null, null,
-                        null, null, null),
+                        null, null, null, null),
                 type, false, null, enabled, false, enabled, hasError, "", cd(), null);
     }
 
@@ -822,7 +823,7 @@ public final class TriggerModelSynthesizer {
         // No per-field skeleton: an empty "{}" record is enough for the user to fill via the record editor.
         return new TriggerUISchemaModel.Property(
                 new TriggerUISchemaModel.Metadata(humanize(annotation.id()), "Configuration for this service", null,
-                        null, null, null, null, null),
+                        null, null, null, null, null, null),
                 true, true, optional, false, "{}", "{}", List.of(propertyType), null, null, null,
                 cdAnnotation(codedataType, annotationName, pkgModule, pkgOrg, pkgName, optional), null);
     }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/adapter/PropertyValueAdapter.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/adapter/PropertyValueAdapter.java
@@ -105,7 +105,7 @@ public final class PropertyValueAdapter {
         }
         TriggerUISchemaModel.Metadata metadata = value.getMetadata() == null ? null
                 : new TriggerUISchemaModel.Metadata(value.getMetadata().label(), value.getMetadata().description(),
-                        null, null, null, null, null, null);
+                        null, null, null, null, null, null, null);
         List<TriggerUISchemaModel.PropertyType> types = null;
         if (value.getTypes() != null) {
             types = new ArrayList<>();

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/adapter/PropertyValueAdapter.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/adapter/PropertyValueAdapter.java
@@ -243,7 +243,7 @@ public final class PropertyValueAdapter {
                 cd.getDefaultType(), cd.getBoundType(), cd.getBindable(), null, null, cd.getTemplate(),
                 cd.getModifier(), null,
                 cd.getTargetParam(), null, cd.getField(), cd.getOptional(), cd.getValue(),
-                cd.getValueQualifier(), null, null, cd.getNameEditable());
+                cd.getValueQualifier(), null, null, cd.getNameEditable(), null);
     }
 
     /** String values collapse to their literal form; non-string values pass through raw. */

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/adapter/TriggerFunctionAdapter.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/adapter/TriggerFunctionAdapter.java
@@ -290,15 +290,19 @@ public final class TriggerFunctionAdapter {
         Value type = typeBuilder.build();
 
         Value name = identifierValue(paramNameText(model), label, description);
-        return new Parameter.Builder()
+        Parameter.Builder builder = new Parameter.Builder()
                 .metadata(new MetaData(label, description))
                 .kind(bindable ? DATA_BINDING : KIND_REQUIRED)
                 .type(type)
                 .name(name)
                 .optional(false)
                 .enabled(true)
-                .editable(model.editable() == null || model.editable())
-                .build();
+                .editable(model.editable() == null || model.editable());
+        String bindingGroup = model.codedata() == null ? null : model.codedata().bindingGroup();
+        if (notBlank(bindingGroup)) {
+            builder.bindingGroup(bindingGroup);
+        }
+        return builder.build();
     }
 
     /** The module prefix a payload's {@code defaultType} is qualified with (e.g. {@code "jms"} from

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/adapter/TriggerFunctionAdapter.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/adapter/TriggerFunctionAdapter.java
@@ -115,6 +115,7 @@ public final class TriggerFunctionAdapter {
         function.setGroup(notBlank(model.group()) ? model.group() : model.name());
         function.setVariantLabel(variantLabel);
         function.setAddLabel(model.metadata() == null ? null : model.metadata().addLabel());
+        function.setAddDescription(model.metadata() == null ? null : model.metadata().addDescription());
         function.setRepeatable(Repeatable.orDefault(model.repeatable()).effective(function.getGroup()));
         function.setNameEditable(model.nameEditable());
         function.setProperties(toWireProperties(model, variant));

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Function.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Function.java
@@ -75,6 +75,7 @@ public class Function {
     private String group;
     private String variantLabel;
     private String addLabel;
+    private String addDescription;
     @JsonAdapter(RepeatableSerializer.class)
     private Repeatable repeatable;
     private Boolean nameEditable;
@@ -417,6 +418,14 @@ public class Function {
 
     public void setAddLabel(String addLabel) {
         this.addLabel = addLabel;
+    }
+
+    public String getAddDescription() {
+        return addDescription;
+    }
+
+    public void setAddDescription(String addDescription) {
+        this.addDescription = addDescription;
     }
 
     public Repeatable getRepeatable() {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Parameter.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Parameter.java
@@ -59,6 +59,7 @@ public class Parameter {
     private boolean isGraphqlId;
     private String httpParamType;
     private Map<String, Value> properties;
+    private String bindingGroup;
 
     public Parameter(MetaData metadata, String kind, Value type, Value name, Value defaultValue, Value documentation,
                      boolean enabled, boolean editable, boolean optional, boolean advanced, String httpParamType,
@@ -95,6 +96,7 @@ public class Parameter {
         this.headerName = parameter.headerName;
         this.properties = parameter.properties;
         this.isGraphqlId = parameter.isGraphqlId;
+        this.bindingGroup = parameter.bindingGroup;
     }
 
     private static Value name(MetaData metadata) {
@@ -287,6 +289,14 @@ public class Parameter {
         this.headerName = headerName;
     }
 
+    public String getBindingGroup() {
+        return bindingGroup;
+    }
+
+    public void setBindingGroup(String bindingGroup) {
+        this.bindingGroup = bindingGroup;
+    }
+
     public Map<String, Value> getProperties() {
         if (Objects.isNull(properties)) {
             properties = new LinkedHashMap<>();
@@ -353,6 +363,7 @@ public class Parameter {
         private boolean isGraphqlId;
         private String httpParamType;
         private Map<String, Value> properties;
+        private String bindingGroup;
 
 
         public Builder metadata(MetaData metadata) {
@@ -438,10 +449,16 @@ public class Parameter {
             return this;
         }
 
+        public Builder bindingGroup(String bindingGroup) {
+            this.bindingGroup = bindingGroup;
+            return this;
+        }
+
         public Parameter build() {
             Parameter parameter = new Parameter(metadata, kind, type, name, defaultValue, documentation, enabled,
                     editable, optional, advanced, httpParamType, hidden, properties, isGraphqlId);
             parameter.setHeaderName(headerName);
+            parameter.setBindingGroup(bindingGroup);
             return parameter;
         }
     }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
@@ -1241,6 +1241,7 @@
             "label": "On Create",
             "description": "Invoked when a .csv file is created in the monitored directory. Define a row schema below to receive the rows as custom types (e.g., User[], Student[]).",
             "addLabel": "Add On Create Handler (CSV)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileCsv",
@@ -1768,6 +1769,7 @@
             "label": "On Create",
             "description": "Invoked when a .json file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (JSON)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileJson",
@@ -2305,6 +2307,7 @@
             "label": "On Create",
             "description": "Invoked when a .xml file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (XML)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileXml",
@@ -2832,6 +2835,7 @@
             "label": "On Create",
             "description": "Invoked when a .txt file is created in the monitored directory. The content arrives as plain text.",
             "addLabel": "Add On Create Handler (Text)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileText",
@@ -3355,6 +3359,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. Handles any extension without a typed handler; the content arrives as raw, unparsed bytes.",
             "addLabel": "Add On Create Handler (Raw Bytes)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFile",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/ftp.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/ftp.json
@@ -882,6 +882,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. Define a row schema below to receive the rows as custom types (e.g., User[], Student[]).",
             "addLabel": "Add On Create Handler (CSV)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileCsv",
@@ -1450,6 +1451,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (JSON)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileJson",
@@ -1990,6 +1992,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (XML)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileXml",
@@ -2530,6 +2533,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. The content arrives as plain text.",
             "addLabel": "Add On Create Handler (Text)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileText",
@@ -3056,6 +3060,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. The content arrives as raw, unparsed bytes.",
             "addLabel": "Add On Create Handler (Raw Bytes)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFile",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/mssql.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/mssql.json
@@ -753,7 +753,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -937,7 +937,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1121,7 +1121,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1185,7 +1185,8 @@
               "advanced": false,
               "hidden": false,
               "codedata": {
-                "type": "FUNCTION_PARAM"
+                "type": "FUNCTION_PARAM",
+                "bindingGroup": "rowState"
               }
             },
             {
@@ -1213,7 +1214,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1277,7 +1278,8 @@
               "advanced": false,
               "hidden": false,
               "codedata": {
-                "type": "FUNCTION_PARAM"
+                "type": "FUNCTION_PARAM",
+                "bindingGroup": "rowState"
               }
             },
             {
@@ -1397,7 +1399,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/mysql.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/mysql.json
@@ -704,7 +704,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -888,7 +888,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1072,7 +1072,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1136,7 +1136,8 @@
               "advanced": false,
               "hidden": false,
               "codedata": {
-                "type": "FUNCTION_PARAM"
+                "type": "FUNCTION_PARAM",
+                "bindingGroup": "rowState"
               }
             },
             {
@@ -1164,7 +1165,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1228,7 +1229,8 @@
               "advanced": false,
               "hidden": false,
               "codedata": {
-                "type": "FUNCTION_PARAM"
+                "type": "FUNCTION_PARAM",
+                "bindingGroup": "rowState"
               }
             },
             {
@@ -1348,7 +1350,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/oracledb.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/oracledb.json
@@ -783,7 +783,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -967,7 +967,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1151,7 +1151,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1215,7 +1215,8 @@
               "advanced": false,
               "hidden": false,
               "codedata": {
-                "type": "FUNCTION_PARAM"
+                "type": "FUNCTION_PARAM",
+                "bindingGroup": "rowState"
               }
             },
             {
@@ -1243,7 +1244,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1307,7 +1308,8 @@
               "advanced": false,
               "hidden": false,
               "codedata": {
-                "type": "FUNCTION_PARAM"
+                "type": "FUNCTION_PARAM",
+                "bindingGroup": "rowState"
               }
             },
             {
@@ -1427,7 +1429,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/postgresql.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/postgresql.json
@@ -753,7 +753,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -937,7 +937,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1121,7 +1121,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1185,7 +1185,8 @@
               "advanced": false,
               "hidden": false,
               "codedata": {
-                "type": "FUNCTION_PARAM"
+                "type": "FUNCTION_PARAM",
+                "bindingGroup": "rowState"
               }
             },
             {
@@ -1213,7 +1214,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",
@@ -1277,7 +1278,8 @@
               "advanced": false,
               "hidden": false,
               "codedata": {
-                "type": "FUNCTION_PARAM"
+                "type": "FUNCTION_PARAM",
+                "bindingGroup": "rowState"
               }
             },
             {
@@ -1397,7 +1399,7 @@
                 "properties": {
                   "payload": {
                     "metadata": {
-                      "label": "Message Configuration",
+                      "label": "Database Entry",
                       "description": "Define the shape of the database row bound to this parameter."
                     },
                     "value": "record {}",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/smb.json
@@ -540,6 +540,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. The content arrives as plain text.",
             "addLabel": "Add On Create Handler (Text)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileText",
@@ -1067,6 +1068,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (JSON)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileJson",
@@ -1608,6 +1610,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. Define a schema below to receive the content as a custom type (e.g., User, Student).",
             "addLabel": "Add On Create Handler (XML)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileXml",
@@ -2149,6 +2152,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. Define a row schema below to receive the rows as custom types (e.g., User[], Student[]).",
             "addLabel": "Add On Create Handler (CSV)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFileCsv",
@@ -2718,6 +2722,7 @@
             "label": "On Create",
             "description": "Invoked when a file is created in the monitored directory. The content arrives as raw, unparsed bytes.",
             "addLabel": "Add On Create Handler (Raw Bytes)",
+            "addDescription": "Invoked when a file is created in the monitored directory.",
             "badge": "onCreate"
           },
           "name": "onFile",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/AnnotationEmitterTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/AnnotationEmitterTest.java
@@ -75,7 +75,7 @@ public class AnnotationEmitterTest {
     private static TriggerUISchemaModel.Property leaf(boolean enabled, String value, String field, boolean optional) {
         TriggerUISchemaModel.Codedata codedata = new TriggerUISchemaModel.Codedata(null, null, null, null, null, null,
                 null, null, null, null, null, null, null, null, null, null, null, null, field, optional,
-                null, null, null, null, null);
+                null, null, null, null, null, null);
         return new TriggerUISchemaModel.Property(null, enabled, true, optional, false, null, value, null, null,
                 null, null, codedata, null);
     }
@@ -84,7 +84,7 @@ public class AnnotationEmitterTest {
                                                          Map<String, TriggerUISchemaModel.Property> fields) {
         TriggerUISchemaModel.Codedata codedata = new TriggerUISchemaModel.Codedata("COMPLEX_FUNCTION_ANNOTATION", null,
                 name, module, null, null, null, null, null, null, null, null, null, null, null, null,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null, null);
         return new TriggerUISchemaModel.Property(null, true, true, false, false, null, null, null, null, null,
                 fields, codedata, null);
     }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/PropertyValueAdapterTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/PropertyValueAdapterTest.java
@@ -127,6 +127,6 @@ public class PropertyValueAdapterTest {
     private static TriggerUISchemaModel.Codedata codedata(String type, boolean nameEditable) {
         return new TriggerUISchemaModel.Codedata(type, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-                nameEditable);
+                nameEditable, null);
     }
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerFunctionAdapterTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerFunctionAdapterTest.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.servicemodelgenerator.extension.connector;
+
+import io.ballerina.modelgenerator.commons.trigger.models.TriggerUISchemaModel;
+import io.ballerina.servicemodelgenerator.extension.connector.adapter.TriggerFunctionAdapter;
+import io.ballerina.servicemodelgenerator.extension.model.Function;
+import io.ballerina.servicemodelgenerator.extension.model.Parameter;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@link TriggerFunctionAdapter}: the {@code bindingGroup} carried by a CDC
+ * {@code onUpdate} handler's {@code before}/{@code after} parameters so they render as one bindable
+ * payload UI section (see {@code trigger-models/{mssql,mysql,postgresql,oracledb}.json}) though
+ * staying independent real Ballerina parameters.
+ *
+ * @since 1.9.0
+ */
+public class TriggerFunctionAdapterTest {
+
+    private TriggerUISchemaModel model(String moduleName) {
+        return TriggerModelReader.getInstance().getBundledTriggerModel(moduleName).orElseThrow();
+    }
+
+    private TriggerUISchemaModel.FunctionModel schemaFunction(TriggerUISchemaModel model, String name) {
+        return model.serviceTypes().getFirst().schemaFunctions().stream()
+                .filter(f -> name.equals(f.name())).findFirst().orElseThrow();
+    }
+
+    private Parameter parameter(Function function, String name) {
+        return function.getParameters().stream()
+                .filter(p -> name.equals(p.getName().getValue())).findFirst().orElseThrow();
+    }
+
+    @DataProvider(name = "cdcModules")
+    public Object[][] cdcModules() {
+        return new Object[][]{{"mssql"}, {"mysql"}, {"postgresql"}, {"oracledb"}};
+    }
+
+    @Test(dataProvider = "cdcModules")
+    public void testOnUpdateBeforeAfterShareBindingGroup(String moduleName) {
+        Function onUpdate = TriggerFunctionAdapter.toFunction(schemaFunction(model(moduleName), "onUpdate"));
+        Parameter before = parameter(onUpdate, "before");
+        Parameter after = parameter(onUpdate, "after");
+
+        String beforeGroup = before.getBindingGroup();
+        String afterGroup = after.getBindingGroup();
+        Assert.assertNotNull(beforeGroup, moduleName + ": before's bindingGroup must not be null");
+        Assert.assertFalse(beforeGroup.isBlank(), moduleName + ": before's bindingGroup must not be blank");
+        Assert.assertEquals(afterGroup, beforeGroup,
+                moduleName + ": before/after must share the same bindingGroup");
+    }
+
+    @Test(dataProvider = "cdcModules")
+    public void testOnReadSinglePayloadParamHasNoBindingGroup(String moduleName) {
+        Function onRead = TriggerFunctionAdapter.toFunction(schemaFunction(model(moduleName), "onRead"));
+        Parameter afterEntry = parameter(onRead, "after");
+        Assert.assertNull(afterEntry.getBindingGroup(),
+                moduleName + ": onRead's single payload param must not be grouped");
+    }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerImportTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerImportTest.java
@@ -195,4 +195,48 @@ public class TriggerImportTest {
         Assert.assertTrue(allText.contains("import ballerina/http;"),
                 "additional import from importStatements should be emitted: " + allText);
     }
+
+    private String generateWithDriverImport(ModulePartNode root) {
+        String initJson = """
+                { "moduleName":"mssql","orgName":"ballerinax","type":"mssql",
+                  "properties":{"listener":{"enabled":true,"editable":true,"optional":false,"advanced":false,
+                    "types":[{"fieldType":"CHOICE","selected":true}],"codedata":{"type":"LISTENER_CONFIG"},
+                    "choices":[{"enabled":true,"editable":true,"optional":false,"advanced":false,
+                      "properties":{"listenerVarName":{"enabled":true,"editable":true,"optional":false,
+                        "advanced":false,"value":"mssqlListener",
+                        "types":[{"fieldType":"IDENTIFIER","selected":true}],
+                        "codedata":{"type":"LISTENER_VAR_NAME"}}}}]}}}""";
+        String triggerJson = """
+                { "schemaVersion":"1.0","displayName":"MSSQL","description":"d","orgName":"ballerinax",
+                  "packageName":"mssql","moduleName":"mssql","version":"1.0.0","type":"mssql","icon":"i",
+                  "importStatements":["ballerinax/cdc","ballerinax/mssql.cdc.driver as _"],
+                  "serviceTypes":[{"name":"Service","enabled":true,"functions":[],"schemaFunctions":[],
+                    "codedata":{"type":"SERVICE_TYPE_DESCRIPTOR","moduleName":"mssql","originalName":"Service"}}]}""";
+        ServiceInitModel init = gson.fromJson(initJson, ServiceInitModel.class);
+        TriggerUISchemaModel trigger = gson.fromJson(triggerJson, TriggerUISchemaModel.class);
+
+        Map<String, List<TextEdit>> edits = SchemaDrivenSourceGenerator.buildAddServiceEditsForTrigger(
+                init, trigger, root, "svc.bal");
+        return edits.get("svc.bal").stream().map(TextEdit::getNewText).reduce("", String::concat);
+    }
+
+    @Test
+    public void testAliasedAdditionalImportIsEmittedWithAlias() {
+        String allText = generateWithDriverImport(emptyRoot());
+
+        Assert.assertTrue(allText.contains("import ballerinax/mssql.cdc.driver as _;"),
+                "an importStatements entry with an explicit alias must keep that alias: " + allText);
+    }
+
+    @Test
+    public void testAliasedAdditionalImportIsNotDuplicatedWhenAlreadyPresent() {
+        String allText = generateWithDriverImport(rootOf(
+                "import ballerinax/cdc;\nimport ballerinax/mssql;\nimport ballerinax/mssql.cdc.driver as _;\n"));
+
+        long driverImportCount = allText.lines()
+                .filter(line -> line.contains("import ballerinax/mssql.cdc.driver"))
+                .count();
+        Assert.assertEquals(driverImportCount, 0,
+                "an already-imported aliased module must not be re-emitted: " + allText);
+    }
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/cdc_service_model.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/cdc_service_model.json
@@ -187,13 +187,13 @@
         "parameters": [
           {
             "metadata": {
-              "label": "Message Configuration",
+              "label": "Database Entry",
               "description": "Define the shape of the database row bound to this parameter."
             },
             "kind": "DATA_BINDING",
             "type": {
               "metadata": {
-                "label": "Message Configuration",
+                "label": "Database Entry",
                 "description": "Define the shape of the database row bound to this parameter."
               },
               "codedata": {
@@ -219,7 +219,7 @@
             },
             "name": {
               "metadata": {
-                "label": "Message Configuration",
+                "label": "Database Entry",
                 "description": "Define the shape of the database row bound to this parameter."
               },
               "placeholder": "after",
@@ -365,13 +365,13 @@
         "parameters": [
           {
             "metadata": {
-              "label": "Message Configuration",
+              "label": "Database Entry",
               "description": "Define the shape of the database row bound to this parameter."
             },
             "kind": "DATA_BINDING",
             "type": {
               "metadata": {
-                "label": "Message Configuration",
+                "label": "Database Entry",
                 "description": "Define the shape of the database row bound to this parameter."
               },
               "codedata": {
@@ -397,7 +397,7 @@
             },
             "name": {
               "metadata": {
-                "label": "Message Configuration",
+                "label": "Database Entry",
                 "description": "Define the shape of the database row bound to this parameter."
               },
               "placeholder": "before",
@@ -418,17 +418,18 @@
             "optional": false,
             "advanced": false,
             "hidden": false,
-            "isGraphqlId": false
+            "isGraphqlId": false,
+            "bindingGroup": "rowState"
           },
           {
             "metadata": {
-              "label": "Message Configuration",
+              "label": "Database Entry",
               "description": "Define the shape of the database row bound to this parameter."
             },
             "kind": "DATA_BINDING",
             "type": {
               "metadata": {
-                "label": "Message Configuration",
+                "label": "Database Entry",
                 "description": "Define the shape of the database row bound to this parameter."
               },
               "codedata": {
@@ -454,7 +455,7 @@
             },
             "name": {
               "metadata": {
-                "label": "Message Configuration",
+                "label": "Database Entry",
                 "description": "Define the shape of the database row bound to this parameter."
               },
               "placeholder": "after",
@@ -475,7 +476,8 @@
             "optional": false,
             "advanced": false,
             "hidden": false,
-            "isGraphqlId": false
+            "isGraphqlId": false,
+            "bindingGroup": "rowState"
           },
           {
             "metadata": {
@@ -602,13 +604,13 @@
         "parameters": [
           {
             "metadata": {
-              "label": "Message Configuration",
+              "label": "Database Entry",
               "description": "Define the shape of the database row bound to this parameter."
             },
             "kind": "DATA_BINDING",
             "type": {
               "metadata": {
-                "label": "Message Configuration",
+                "label": "Database Entry",
                 "description": "Define the shape of the database row bound to this parameter."
               },
               "codedata": {
@@ -634,7 +636,7 @@
             },
             "name": {
               "metadata": {
-                "label": "Message Configuration",
+                "label": "Database Entry",
                 "description": "Define the shape of the database row bound to this parameter."
               },
               "placeholder": "after",
@@ -769,13 +771,13 @@
         "parameters": [
           {
             "metadata": {
-              "label": "Message Configuration",
+              "label": "Database Entry",
               "description": "Define the shape of the database row bound to this parameter."
             },
             "kind": "DATA_BINDING",
             "type": {
               "metadata": {
-                "label": "Message Configuration",
+                "label": "Database Entry",
                 "description": "Define the shape of the database row bound to this parameter."
               },
               "codedata": {
@@ -801,7 +803,7 @@
             },
             "name": {
               "metadata": {
-                "label": "Message Configuration",
+                "label": "Database Entry",
                 "description": "Define the shape of the database row bound to this parameter."
               },
               "placeholder": "before",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/ftp_service_model.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/ftp_service_model.json
@@ -678,6 +678,7 @@
         "group": "onCreate",
         "variantLabel": "JSON",
         "addLabel": "Add On Create Handler (JSON)",
+        "addDescription": "Invoked when a file is created in the monitored directory.",
         "repeatable": "ONE_EACH_PER_GROUP",
         "nameEditable": false
       },
@@ -1201,6 +1202,7 @@
         "group": "onCreate",
         "variantLabel": "XML",
         "addLabel": "Add On Create Handler (XML)",
+        "addDescription": "Invoked when a file is created in the monitored directory.",
         "repeatable": "ONE_EACH_PER_GROUP",
         "nameEditable": false
       }
@@ -1738,6 +1740,7 @@
         "group": "onCreate",
         "variantLabel": "CSV",
         "addLabel": "Add On Create Handler (CSV)",
+        "addDescription": "Invoked when a file is created in the monitored directory.",
         "repeatable": "ONE_EACH_PER_GROUP",
         "nameEditable": false
       },
@@ -2249,6 +2252,7 @@
         "group": "onCreate",
         "variantLabel": "Text",
         "addLabel": "Add On Create Handler (Text)",
+        "addDescription": "Invoked when a file is created in the monitored directory.",
         "repeatable": "ONE_EACH_PER_GROUP",
         "nameEditable": false
       },
@@ -2783,6 +2787,7 @@
         "group": "onCreate",
         "variantLabel": "Raw Bytes",
         "addLabel": "Add On Create Handler (Raw Bytes)",
+        "addDescription": "Invoked when a file is created in the monitored directory.",
         "repeatable": "ONE_EACH_PER_GROUP",
         "nameEditable": false
       },

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/testng.xml
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/testng.xml
@@ -52,6 +52,7 @@ under the License.
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerModelReaderSchemaDrivenTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerServiceAdapterTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.PayloadComposerTest"/>
+            <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerFunctionAdapterTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.AnnotationEmitterTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerImportTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.util.ModuleAliasResolverTest"/>

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/index.tsx
@@ -882,7 +882,8 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
                                     {hasDefaultPayload(param) ? (
                                         <AddButtonWrapper>
                                             <Tooltip
-                                                content={`Define ${label} for easier access in the flow diagram`}
+                                                content={param.metadata?.description
+                                                    || `Define ${label} for easier access in the flow diagram`}
                                                 position="bottom"
                                             >
                                                 <LinkButton onClick={() => setTypeEditorParamName(param.name?.value ?? null)}>

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/index.tsx
@@ -65,10 +65,12 @@ import {
     CODEDATA_PAYLOAD_MODIFIER,
     CODEDATA_PAYLOAD_TYPE_INCLUDED_RECORD,
     addableCatalogOf,
-    bindingGroupSiblingsOf,
+    bindingGroupDiverges,
+    bindingGroupOf,
     boundRepresentativeOf,
     composePayloadType,
     decomposePayloadType,
+    editTargetsOf,
     functionSignatureKey,
     groupedPayloadParametersOf,
     handlerGroupId,
@@ -456,10 +458,7 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
 
     const metadataFlags = functionModel ? propertiesOfRole(functionModel, CODEDATA_METADATA_FLAG) : [];
     const modifierFlags = functionModel ? propertiesOfRole(functionModel, CODEDATA_PAYLOAD_MODIFIER) : [];
-    // All bindable payload params — a handler may expose more than one (e.g. CDC onUpdate's
-    // before/after), each configured independently below.
     const payloadParams = functionModel ? payloadParametersOf(functionModel) : [];
-    // The first payload param still drives shared UI bits (e.g. the variant dropdown's label).
     const payloadParam = payloadParams[0];
     const groupedPayloadParams = functionModel ? groupedPayloadParametersOf(functionModel) : [];
 
@@ -544,11 +543,9 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
         const typeName = typeof type === "string" ? type : type.name;
         const target = payloadParams.find((p) => p.name?.value === targetName);
         // The parameter keeps its schema-shipped name — only the bound shape changes.
-        const groupNames = new Set(
-            (target ? bindingGroupSiblingsOf(functionModel, target) : []).map((p) => p.name?.value)
-        );
+        const editTargets = new Set(target ? editTargetsOf(functionModel, target) : []);
         const parameters = functionModel.parameters.map((p) => {
-            if (!isPayloadParameter(p) || !groupNames.has(p.name?.value)) {
+            if (!isPayloadParameter(p) || !editTargets.has(p)) {
                 return p;
             }
             const updatedType: PropertyModel = {
@@ -567,9 +564,9 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
         if (!functionModel) {
             return;
         }
-        const groupNames = new Set(bindingGroupSiblingsOf(functionModel, target).map((p) => p.name?.value));
+        const editTargets = new Set(editTargetsOf(functionModel, target));
         const parameters = functionModel.parameters.map((p) =>
-            isPayloadParameter(p) && groupNames.has(p.name?.value)
+            isPayloadParameter(p) && editTargets.has(p)
                 ? { ...p, type: { ...p.type, codedata: { ...p.type.codedata, boundType: undefined } } }
                 : p
         );
@@ -872,15 +869,18 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
                         </FlagsColumn>
                     )}
 
-                    {/* Payload schema — one section per bindable DATA_BINDING param (a handler such
-                        as CDC onUpdate exposes both a before- and an after-image). */}
+                    {/* Payload schema — one section per binding group (CDC onUpdate's before/after
+                        share a group and render as a single section; see groupedPayloadParams). */}
                     {groupedPayloadParams
-                        .filter((param) => param.type?.codedata?.bindable === true)
-                        .map((param) => {
-                            const displayParam = boundRepresentativeOf(functionModel, param);
+                        .map((param) => boundRepresentativeOf(functionModel, param))
+                        .filter((displayParam) => displayParam.type?.codedata?.bindable === true)
+                        .map((displayParam) => {
                             const label = displayLabelOf(displayParam);
+                            const key = bindingGroupDiverges(functionModel, displayParam)
+                                ? (displayParam.name?.value ?? label)
+                                : (bindingGroupOf(displayParam) ?? displayParam.name?.value ?? label);
                             return (
-                                <Fragment key={displayParam.name?.value ?? label}>
+                                <Fragment key={key}>
                                     {hasDefaultPayload(displayParam) ? (
                                         <AddButtonWrapper>
                                             <Tooltip
@@ -936,15 +936,14 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
                                                     const editedElement = decomposePayloadType(
                                                         functionModel, displayParam, editedPayload.type?.value ?? "");
                                                     const editedName = editedPayload.name?.value;
-                                                    const groupNames = new Set(
-                                                        bindingGroupSiblingsOf(functionModel, displayParam)
-                                                            .map((p) => p.name?.value)
+                                                    const editTargets = new Set(
+                                                        editTargetsOf(functionModel, displayParam)
                                                     );
                                                     const parameters = functionModel.parameters.map((p) => {
-                                                        if (!isPayloadParameter(p) || !groupNames.has(p.name?.value)) {
+                                                        if (!isPayloadParameter(p) || !editTargets.has(p)) {
                                                             return p;
                                                         }
-                                                        const isTarget = p.name?.value === displayParam.name?.value;
+                                                        const isTarget = p === displayParam;
                                                         return {
                                                             ...p,
                                                             name: isTarget && editedName !== undefined

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/index.tsx
@@ -66,6 +66,7 @@ import {
     CODEDATA_PAYLOAD_TYPE_INCLUDED_RECORD,
     addableCatalogOf,
     bindingGroupSiblingsOf,
+    boundRepresentativeOf,
     composePayloadType,
     decomposePayloadType,
     functionSignatureKey,
@@ -876,17 +877,18 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
                     {groupedPayloadParams
                         .filter((param) => param.type?.codedata?.bindable === true)
                         .map((param) => {
-                            const label = displayLabelOf(param);
+                            const displayParam = boundRepresentativeOf(functionModel, param);
+                            const label = displayLabelOf(displayParam);
                             return (
-                                <Fragment key={param.name?.value ?? label}>
-                                    {hasDefaultPayload(param) ? (
+                                <Fragment key={displayParam.name?.value ?? label}>
+                                    {hasDefaultPayload(displayParam) ? (
                                         <AddButtonWrapper>
                                             <Tooltip
-                                                content={param.metadata?.description
+                                                content={displayParam.metadata?.description
                                                     || `Define ${label} for easier access in the flow diagram`}
                                                 position="bottom"
                                             >
-                                                <LinkButton onClick={() => setTypeEditorParamName(param.name?.value ?? null)}>
+                                                <LinkButton onClick={() => setTypeEditorParamName(displayParam.name?.value ?? null)}>
                                                     <Codicon name="add" />
                                                     Define {label}
                                                 </LinkButton>
@@ -917,32 +919,32 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
                                                 name+type editor. */}
                                             <Parameters
                                                 parameters={[{
-                                                    ...param,
+                                                    ...displayParam,
                                                     editable: true,
                                                     type: {
-                                                        ...param.type,
-                                                        value: composePayloadType(functionModel, param),
+                                                        ...displayParam.type,
+                                                        value: composePayloadType(functionModel, displayParam),
                                                     },
                                                 }]}
-                                                hideName={param.type?.codedata?.nameEditable === false}
+                                                hideName={displayParam.type?.codedata?.nameEditable === false}
                                                 onChange={(edited) => {
                                                     if (edited.length === 0) {
-                                                        handleDeletePayloadSchema(param);
+                                                        handleDeletePayloadSchema(displayParam);
                                                         return;
                                                     }
                                                     const [editedPayload] = edited;
                                                     const editedElement = decomposePayloadType(
-                                                        functionModel, param, editedPayload.type?.value ?? "");
+                                                        functionModel, displayParam, editedPayload.type?.value ?? "");
                                                     const editedName = editedPayload.name?.value;
                                                     const groupNames = new Set(
-                                                        bindingGroupSiblingsOf(functionModel, param)
+                                                        bindingGroupSiblingsOf(functionModel, displayParam)
                                                             .map((p) => p.name?.value)
                                                     );
                                                     const parameters = functionModel.parameters.map((p) => {
                                                         if (!isPayloadParameter(p) || !groupNames.has(p.name?.value)) {
                                                             return p;
                                                         }
-                                                        const isTarget = p.name?.value === param.name?.value;
+                                                        const isTarget = p.name?.value === displayParam.name?.value;
                                                         return {
                                                             ...p,
                                                             name: isTarget && editedName !== undefined

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/index.tsx
@@ -65,9 +65,11 @@ import {
     CODEDATA_PAYLOAD_MODIFIER,
     CODEDATA_PAYLOAD_TYPE_INCLUDED_RECORD,
     addableCatalogOf,
+    bindingGroupSiblingsOf,
     composePayloadType,
     decomposePayloadType,
     functionSignatureKey,
+    groupedPayloadParametersOf,
     handlerGroupId,
     hasDefaultPayload,
     isModifierActive,
@@ -458,6 +460,7 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
     const payloadParams = functionModel ? payloadParametersOf(functionModel) : [];
     // The first payload param still drives shared UI bits (e.g. the variant dropdown's label).
     const payloadParam = payloadParams[0];
+    const groupedPayloadParams = functionModel ? groupedPayloadParametersOf(functionModel) : [];
 
     /** Recomposes every payload param's rendered type after a modifier/schema change. */
     const withRecomposedPayload = (fn: FunctionModel): FunctionModel => {
@@ -520,7 +523,7 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
     // which. A single-payload handler keeps the plain label.
     const displayLabelOf = (param?: ParameterModel) => {
         const base = labelOfPayload(param);
-        return payloadParams.length > 1 && param?.name?.value ? `${base} (${param.name.value})` : base;
+        return groupedPayloadParams.length > 1 && param?.name?.value ? `${base} (${param.name.value})` : base;
     };
     // The payload param the type-creator modal is currently open for (by name).
     const typeEditorParam = payloadParams.find((p) => p.name?.value === typeEditorParamName);
@@ -538,9 +541,13 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
             return;
         }
         const typeName = typeof type === "string" ? type : type.name;
+        const target = payloadParams.find((p) => p.name?.value === targetName);
         // The parameter keeps its schema-shipped name — only the bound shape changes.
+        const groupNames = new Set(
+            (target ? bindingGroupSiblingsOf(functionModel, target) : []).map((p) => p.name?.value)
+        );
         const parameters = functionModel.parameters.map((p) => {
-            if (!isPayloadParameter(p) || p.name?.value !== targetName) {
+            if (!isPayloadParameter(p) || !groupNames.has(p.name?.value)) {
                 return p;
             }
             const updatedType: PropertyModel = {
@@ -559,8 +566,9 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
         if (!functionModel) {
             return;
         }
+        const groupNames = new Set(bindingGroupSiblingsOf(functionModel, target).map((p) => p.name?.value));
         const parameters = functionModel.parameters.map((p) =>
-            isPayloadParameter(p) && p.name?.value === target.name?.value
+            isPayloadParameter(p) && groupNames.has(p.name?.value)
                 ? { ...p, type: { ...p.type, codedata: { ...p.type.codedata, boundType: undefined } } }
                 : p
         );
@@ -865,7 +873,7 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
 
                     {/* Payload schema — one section per bindable DATA_BINDING param (a handler such
                         as CDC onUpdate exposes both a before- and an after-image). */}
-                    {payloadParams
+                    {groupedPayloadParams
                         .filter((param) => param.type?.codedata?.bindable === true)
                         .map((param) => {
                             const label = displayLabelOf(param);
@@ -925,25 +933,31 @@ export function TriggerHandlerForm(props: TriggerHandlerFormProps) {
                                                     const editedElement = decomposePayloadType(
                                                         functionModel, param, editedPayload.type?.value ?? "");
                                                     const editedName = editedPayload.name?.value;
-                                                    const parameters = functionModel.parameters.map((p) =>
-                                                        isPayloadParameter(p) && p.name?.value === param.name?.value
-                                                            ? {
-                                                                ...p,
-                                                                name: editedName !== undefined
-                                                                    ? { ...p.name, value: editedName }
-                                                                    : p.name,
-                                                                type: {
-                                                                    ...p.type,
-                                                                    imports: editedPayload.type?.imports ?? p.type?.imports,
-                                                                    codedata: {
-                                                                        ...p.type?.codedata,
-                                                                        boundType: editedElement,
-                                                                    },
-                                                                },
-                                                                enabled: true,
-                                                            }
-                                                            : p
+                                                    const groupNames = new Set(
+                                                        bindingGroupSiblingsOf(functionModel, param)
+                                                            .map((p) => p.name?.value)
                                                     );
+                                                    const parameters = functionModel.parameters.map((p) => {
+                                                        if (!isPayloadParameter(p) || !groupNames.has(p.name?.value)) {
+                                                            return p;
+                                                        }
+                                                        const isTarget = p.name?.value === param.name?.value;
+                                                        return {
+                                                            ...p,
+                                                            name: isTarget && editedName !== undefined
+                                                                ? { ...p.name, value: editedName }
+                                                                : p.name,
+                                                            type: {
+                                                                ...p.type,
+                                                                imports: editedPayload.type?.imports ?? p.type?.imports,
+                                                                codedata: {
+                                                                    ...p.type?.codedata,
+                                                                    boundType: editedElement,
+                                                                },
+                                                            },
+                                                            enabled: true,
+                                                        };
+                                                    });
                                                     setFunctionModel(
                                                         withRecomposedPayload({ ...functionModel, parameters }));
                                                 }}

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.test.ts
@@ -52,11 +52,14 @@ import {
     addableCatalogOf,
     addedParametersOf,
     applyTypeTemplate,
+    bindingGroupOf,
+    bindingGroupSiblingsOf,
     catalogFunctionsOf,
     composePayloadType,
     computeHandlerGroups,
     decomposePayloadType,
     functionSignatureKey,
+    groupedPayloadParametersOf,
     handlerGroupId,
     hasConfigurableFields,
     hasDefaultPayload,
@@ -162,7 +165,7 @@ function ftpStreamModifierProp(active: boolean): PropertyModel {
 }
 
 /** cdc's onUpdate before/after payloads — see get_sm_from_source/config/cdc_service_model.json. */
-function cdcPayloadParam(name: "before" | "after", boundType?: string): ParameterModel {
+function cdcPayloadParam(name: "before" | "after", boundType?: string, group?: string): ParameterModel {
     return param({
         kind: "DATA_BINDING",
         name: prop({ value: name, editable: false }),
@@ -177,6 +180,7 @@ function cdcPayloadParam(name: "before" | "after", boundType?: string): Paramete
                 nameEditable: false,
             } as any,
         }),
+        bindingGroup: group,
     });
 }
 
@@ -412,6 +416,48 @@ describe("isPayloadParameter / payloadParameterOf / payloadParametersOf", () => 
 
     it("returns an empty array for a handler with no payload parameters", () => {
         expect(payloadParametersOf(fn({ parameters: [param({ kind: "REQUIRED" })] }))).toEqual([]);
+    });
+});
+
+describe("bindingGroupOf / groupedPayloadParametersOf / bindingGroupSiblingsOf", () => {
+    it("bindingGroupOf reads the parameter-level bindingGroup, undefined when absent", () => {
+        expect(bindingGroupOf(cdcPayloadParam("before", undefined, "rowState"))).toBe("rowState");
+        expect(bindingGroupOf(kafkaPayloadParam())).toBeUndefined();
+    });
+
+    it("groupedPayloadParametersOf collapses cdc's before/after into one representative", () => {
+        const before = cdcPayloadParam("before", undefined, "rowState");
+        const after = cdcPayloadParam("after", undefined, "rowState");
+        const handler = fn({ parameters: [before, after] });
+        expect(groupedPayloadParametersOf(handler)).toEqual([before]);
+    });
+
+    it("groupedPayloadParametersOf leaves ungrouped payload params untouched", () => {
+        const kafka = kafkaPayloadParam();
+        const ftp = ftpPayloadParam();
+        const handler = fn({ parameters: [kafka, ftp] });
+        expect(groupedPayloadParametersOf(handler)).toEqual([kafka, ftp]);
+    });
+
+    it("groupedPayloadParametersOf only collapses params that actually share a group", () => {
+        const before = cdcPayloadParam("before", undefined, "rowState");
+        const kafka = kafkaPayloadParam();
+        const handler = fn({ parameters: [before, kafka] });
+        expect(groupedPayloadParametersOf(handler)).toEqual([before, kafka]);
+    });
+
+    it("bindingGroupSiblingsOf returns every param sharing the group, in declared order", () => {
+        const before = cdcPayloadParam("before", undefined, "rowState");
+        const after = cdcPayloadParam("after", undefined, "rowState");
+        const handler = fn({ parameters: [before, after] });
+        expect(bindingGroupSiblingsOf(handler, before)).toEqual([before, after]);
+        expect(bindingGroupSiblingsOf(handler, after)).toEqual([before, after]);
+    });
+
+    it("bindingGroupSiblingsOf returns just the param itself when ungrouped", () => {
+        const kafka = kafkaPayloadParam();
+        const handler = fn({ parameters: [kafka] });
+        expect(bindingGroupSiblingsOf(handler, kafka)).toEqual([kafka]);
     });
 });
 

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.test.ts
@@ -52,12 +52,15 @@ import {
     addableCatalogOf,
     addedParametersOf,
     applyTypeTemplate,
+    bindingGroupDiverges,
     bindingGroupOf,
     bindingGroupSiblingsOf,
+    boundRepresentativeOf,
     catalogFunctionsOf,
     composePayloadType,
     computeHandlerGroups,
     decomposePayloadType,
+    editTargetsOf,
     functionSignatureKey,
     groupedPayloadParametersOf,
     handlerGroupId,
@@ -458,6 +461,72 @@ describe("bindingGroupOf / groupedPayloadParametersOf / bindingGroupSiblingsOf",
         const kafka = kafkaPayloadParam();
         const handler = fn({ parameters: [kafka] });
         expect(bindingGroupSiblingsOf(handler, kafka)).toEqual([kafka]);
+    });
+});
+
+describe("boundRepresentativeOf / bindingGroupDiverges / editTargetsOf", () => {
+    it("boundRepresentativeOf falls back to the first param when no sibling is bound", () => {
+        const before = cdcPayloadParam("before", undefined, "rowState");
+        const after = cdcPayloadParam("after", undefined, "rowState");
+        const handler = fn({ parameters: [before, after] });
+        expect(boundRepresentativeOf(handler, before)).toBe(before);
+    });
+
+    it("boundRepresentativeOf returns a later sibling when it is the one actually bound", () => {
+        const before = cdcPayloadParam("before", undefined, "rowState");
+        const after = cdcPayloadParam("after", "AfterSchema", "rowState");
+        const handler = fn({ parameters: [before, after] });
+        expect(boundRepresentativeOf(handler, before)).toBe(after);
+    });
+
+    it("bindingGroupDiverges is false when siblings agree (both unbound or same bound type)", () => {
+        const before = cdcPayloadParam("before", undefined, "rowState");
+        const after = cdcPayloadParam("after", undefined, "rowState");
+        const handler = fn({ parameters: [before, after] });
+        expect(bindingGroupDiverges(handler, before)).toBe(false);
+
+        const before2 = cdcPayloadParam("before", "Employee", "rowState");
+        const after2 = cdcPayloadParam("after", "Employee", "rowState");
+        const handler2 = fn({ parameters: [before2, after2] });
+        expect(bindingGroupDiverges(handler2, before2)).toBe(false);
+    });
+
+    it("bindingGroupDiverges is true when siblings hold different bound types", () => {
+        const before = cdcPayloadParam("before", "Employee", "rowState");
+        const after = cdcPayloadParam("after", "EmployeeV2", "rowState");
+        const handler = fn({ parameters: [before, after] });
+        expect(bindingGroupDiverges(handler, before)).toBe(true);
+        expect(bindingGroupDiverges(handler, after)).toBe(true);
+    });
+
+    it("boundRepresentativeOf returns the param itself when its group diverges", () => {
+        const before = cdcPayloadParam("before", "Employee", "rowState");
+        const after = cdcPayloadParam("after", "EmployeeV2", "rowState");
+        const handler = fn({ parameters: [before, after] });
+        expect(boundRepresentativeOf(handler, before)).toBe(before);
+        expect(boundRepresentativeOf(handler, after)).toBe(after);
+    });
+
+    it("groupedPayloadParametersOf falls back to one entry per sibling when they diverge", () => {
+        const before = cdcPayloadParam("before", "Employee", "rowState");
+        const after = cdcPayloadParam("after", "EmployeeV2", "rowState");
+        const handler = fn({ parameters: [before, after] });
+        expect(groupedPayloadParametersOf(handler)).toEqual([before, after]);
+    });
+
+    it("editTargetsOf returns the whole group when siblings agree", () => {
+        const before = cdcPayloadParam("before", undefined, "rowState");
+        const after = cdcPayloadParam("after", undefined, "rowState");
+        const handler = fn({ parameters: [before, after] });
+        expect(editTargetsOf(handler, before)).toEqual([before, after]);
+    });
+
+    it("editTargetsOf returns just the target when its group diverges", () => {
+        const before = cdcPayloadParam("before", "Employee", "rowState");
+        const after = cdcPayloadParam("after", "EmployeeV2", "rowState");
+        const handler = fn({ parameters: [before, after] });
+        expect(editTargetsOf(handler, before)).toEqual([before]);
+        expect(editTargetsOf(handler, after)).toEqual([after]);
     });
 });
 

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.ts
@@ -415,6 +415,13 @@ export function hasDefaultPayload(param: ParameterModel): boolean {
     return !param.type?.codedata?.boundType;
 }
 
+/** The group's already-bound sibling, if any, so an asymmetric pre-existing binding isn't hidden
+ * behind the always-first-listed, possibly-still-unbound representative (e.g. CDC's `before`). */
+export function boundRepresentativeOf(fn: FunctionModel, param: ParameterModel): ParameterModel {
+    const siblings = bindingGroupSiblingsOf(fn, param);
+    return siblings.find((p) => !hasDefaultPayload(p)) ?? param;
+}
+
 /**
  * Converts a bound type name to a parameter name — camelCased, pluralized when the base template
  * produces an array (e.g. CSV rows).

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.ts
@@ -205,16 +205,32 @@ export function bindingGroupOf(param: ParameterModel): string | undefined {
     return param.bindingGroup;
 }
 
+/** Whether a binding group's siblings currently hold different bound types. */
+export function bindingGroupDiverges(fn: FunctionModel, param: ParameterModel): boolean {
+    const boundTypes = new Set(
+        bindingGroupSiblingsOf(fn, param)
+            .map((p) => p.type?.codedata?.boundType)
+            .filter((t): t is string => !!t)
+    );
+    return boundTypes.size > 1;
+}
+
 export function groupedPayloadParametersOf(fn: FunctionModel): ParameterModel[] {
     const seen = new Set<string>();
     const result: ParameterModel[] = [];
     for (const p of payloadParametersOf(fn)) {
         const group = bindingGroupOf(p);
-        if (group) {
-            if (seen.has(group)) {
-                continue;
-            }
-            seen.add(group);
+        if (!group) {
+            result.push(p);
+            continue;
+        }
+        if (seen.has(group)) {
+            continue;
+        }
+        seen.add(group);
+        if (bindingGroupDiverges(fn, p)) {
+            result.push(...bindingGroupSiblingsOf(fn, p));
+            continue;
         }
         result.push(p);
     }
@@ -227,6 +243,15 @@ export function bindingGroupSiblingsOf(fn: FunctionModel, param: ParameterModel)
         return [param];
     }
     return payloadParametersOf(fn).filter((p) => bindingGroupOf(p) === group);
+}
+
+/** The parameters an edit to `target` should apply to: its whole binding group, or just itself when
+ * the group's siblings currently diverge. */
+export function editTargetsOf(fn: FunctionModel, target: ParameterModel): ParameterModel[] {
+    if (bindingGroupDiverges(fn, target)) {
+        return [target];
+    }
+    return bindingGroupSiblingsOf(fn, target);
 }
 
 /** Properties of a given codedata role, keyed as shipped. */
@@ -418,6 +443,9 @@ export function hasDefaultPayload(param: ParameterModel): boolean {
 /** The group's already-bound sibling, if any, so an asymmetric pre-existing binding isn't hidden
  * behind the always-first-listed, possibly-still-unbound representative (e.g. CDC's `before`). */
 export function boundRepresentativeOf(fn: FunctionModel, param: ParameterModel): ParameterModel {
+    if (bindingGroupDiverges(fn, param)) {
+        return param;
+    }
     const siblings = bindingGroupSiblingsOf(fn, param);
     return siblings.find((p) => !hasDefaultPayload(p)) ?? param;
 }

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.ts
@@ -201,6 +201,34 @@ export function payloadParametersOf(fn: FunctionModel): ParameterModel[] {
     return fn.parameters?.filter(isPayloadParameter) ?? [];
 }
 
+export function bindingGroupOf(param: ParameterModel): string | undefined {
+    return param.bindingGroup;
+}
+
+export function groupedPayloadParametersOf(fn: FunctionModel): ParameterModel[] {
+    const seen = new Set<string>();
+    const result: ParameterModel[] = [];
+    for (const p of payloadParametersOf(fn)) {
+        const group = bindingGroupOf(p);
+        if (group) {
+            if (seen.has(group)) {
+                continue;
+            }
+            seen.add(group);
+        }
+        result.push(p);
+    }
+    return result;
+}
+
+export function bindingGroupSiblingsOf(fn: FunctionModel, param: ParameterModel): ParameterModel[] {
+    const group = bindingGroupOf(param);
+    if (!group) {
+        return [param];
+    }
+    return payloadParametersOf(fn).filter((p) => bindingGroupOf(p) === group);
+}
+
 /** Properties of a given codedata role, keyed as shipped. */
 export function propertiesOfRole(fn: FunctionModel, role: string): [string, PropertyModel][] {
     return Object.entries(fn.properties ?? {}).filter(

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/TriggerHandlerForm/payloadComposer.ts
@@ -308,6 +308,10 @@ export function computeHandlerGroups(serviceModel: ServiceModel): HandlerGroup[]
         if (!group.needsForm) {
             group.quickAddFunction = members[0];
         }
+        const addDescription = members.find((member) => member.addDescription)?.addDescription;
+        if (addDescription) {
+            group.description = addDescription;
+        }
     }
     return Array.from(groups.values());
 }

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/index.tsx
@@ -25,6 +25,7 @@ import {
     MACHINE_VIEW,
     ProjectStructureArtifactResponse,
     ComponentInfo,
+    RepeatBehavior,
     ServiceModel,
     Protocol,
     SHARED_COMMANDS,
@@ -58,6 +59,7 @@ import {
     hasConfigurableFields,
     isSchemaTriggerService as checkSchemaTriggerService,
     isSoleRepeatableGroup,
+    repeatBehaviorOf,
 } from "./Forms/TriggerHandlerForm/payloadComposer";
 import { getTryItAIDefaultPromptService, getTryItDropdownOptions, TryItOptionValue, TryItQuickPickItem } from "../shared/tryIt";
 
@@ -504,8 +506,11 @@ export function ServiceDesigner(props: ServiceDesignerProps) {
     const getTriggerHandlerTitle = () => {
         const groupId = selectedTriggerGroup ?? (functionModel ? handlerGroupId(functionModel) : undefined);
         const groupMembers = [...(serviceModel ? catalogFunctionsOf(serviceModel) : []), ...(serviceModel?.functions ?? [])];
-        const groupLabel = groupMembers.find(fn => handlerGroupId(fn) === groupId)?.metadata?.label
-            ?? "Handler";
+        const matchedFunction = groupMembers.find(fn => handlerGroupId(fn) === groupId);
+        const groupLabel = matchedFunction?.metadata?.label ?? "Handler";
+        if (matchedFunction && repeatBehaviorOf(matchedFunction) !== RepeatBehavior.TRUE) {
+            return `Configure ${groupLabel} ${isMcpService ? "Tool" : "Handler"}`;
+        }
         return `${isNew ? "New " : ""}${groupLabel} Configuration`;
     };
 


### PR DESCRIPTION
## Purpose
$subject

This PR include fixes for multiple issues.

1. Group data binding params
Fixes https://github.com/wso2/product-integrator/issues/2044
<img width="1501" height="923" alt="Screenshot 2026-08-17 at 10 10 12" src="https://github.com/user-attachments/assets/1b859099-2bb8-4eff-ac5a-2d80bbf571fc" />

2. Adding duplicated imports
Fixes https://github.com/wso2/product-integrator/issues/2046

3. Improve handler form titles
<img width="411" height="57" alt="Screenshot 2026-08-17 at 10 11 49" src="https://github.com/user-attachments/assets/04ddceb0-d16f-433a-bcec-6c802b4d794c" />

4. Add tooltip description configuring support for data binding input
<img width="629" height="174" alt="Screenshot 2026-08-17 at 10 11 26" src="https://github.com/user-attachments/assets/2350e8dc-552c-4f90-baa0-5c0fee9f0e14" />

5. Add tooltip description configuring support for grouped handlers
<img width="408" height="537" alt="Screenshot 2026-08-17 at 10 11 08" src="https://github.com/user-attachments/assets/37415d3c-f57f-4ad7-9826-4fe39d47c4be" />

Fixes part of https://github.com/wso2/product-integrator/issues/2059


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Group related data-binding parameters in handler payload editors.
- Preserve parameter identity while applying schema and type changes across grouped parameters.
- Prevent duplicate imports and preserve aliases in generated trigger code.
- Improve handler configuration titles for repeatable and non-repeatable handlers.
- Add descriptions and tooltips for data-binding inputs and grouped handlers.
- Extend CDC trigger models with `bindingGroup` and `addDescription` metadata.
- Add tests for CDC payload grouping, handler behavior, and import generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->