### PR TITLE
Revamp `Use Connection` agent tool creation UX

### DIFF
--- a/packages/ballerina-core/src/interfaces/bi.ts
+++ b/packages/ballerina-core/src/interfaces/bi.ts
@@ -79,6 +79,7 @@ export type AgentToolData = Record<string, CodeDataValue> & (
         agentVarName: string;
         includeContext: boolean;
         description: string;
+        returnType?: string;
         node?: never;
         connection?: never;
     }

--- a/packages/ballerina-core/src/interfaces/extended-lang-client.ts
+++ b/packages/ballerina-core/src/interfaces/extended-lang-client.ts
@@ -979,6 +979,7 @@ export type SearchQueryParams = {
     /** ACTIVITY_CALL search: node kind stamped on result items (e.g. DURABLE_AGENT_ADD_ACTIVITY). */
     nodeKind?: string;
     source?: string;
+    connectorSet?: "GROUPED";
 }
 
 export type SearchKind =

--- a/packages/ballerina-extension/src/features/library-browser/activator.ts
+++ b/packages/ballerina-extension/src/features/library-browser/activator.ts
@@ -99,7 +99,7 @@ export function getLibrariesList(kind?: LibraryKind): Promise<LibrariesListRespo
 
         req.on('error', error => {
             debug(error.message);
-            reject();
+            reject(error);
         });
 
         req.end();
@@ -132,7 +132,7 @@ export function getAllResources(): Promise<LibrarySearchResponse | undefined> {
 
         req.on('error', error => {
             debug(error.message);
-            reject();
+            reject(error);
         });
 
         req.end();
@@ -157,18 +157,22 @@ export function getLibraryData(orgName: string, moduleName: string, version: str
             res.on('end',function(){
                 if (res.statusCode !== 200) {
                     debug(`Failed to fetch the library data for ${orgName}:${moduleName}`);
-                    return null;
-                } else {
+                    return reject(new Error(`Failed to fetch library data for ${orgName}/${moduleName}:${version} (status ${res.statusCode})`));
+                }
+                try {
                     const libraryData = JSON.parse(body);
                     cachedLibraryData.set(`${orgName}_${moduleName}_${version}`, libraryData);
                     return resolve(libraryData);
+                } catch (error) {
+                    debug(`Failed to parse the library data for ${orgName}:${moduleName}`);
+                    return reject(error);
                 }
             });
         });
 
         req.on('error', error => {
             debug(error.message);
-            reject();
+            reject(error);
         });
 
         req.end();

--- a/packages/ballerina-side-panel/src/components/Form/index.tsx
+++ b/packages/ballerina-side-panel/src/components/Form/index.tsx
@@ -33,7 +33,7 @@ import {
 } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
 
-import { ExpressionFormField, FieldDerivation, FormExpressionEditorProps, FormField, FormImports, FormValues } from "./types";
+import { ExpressionFormField, FieldDerivation, FieldGroup, FormExpressionEditorProps, FormField, FormImports, FormValues } from "./types";
 import { FieldFactory } from "../editors/FieldFactory";
 import { InputMode } from "../editors/MultiModeExpressionEditor/ChipExpressionEditor/types";
 import { getValueForDropdown, isDropdownField } from "../editors/utils";
@@ -66,6 +66,7 @@ import {
     formatJSONLikeString,
     updateFormFieldWithImports,
     hasIncompleteRequiredFormFields,
+    groupHasBlockingIssue,
     shouldRunExternalFormValidation,
     isPrioritizedField,
     hasRequiredParameters,
@@ -143,6 +144,85 @@ namespace S {
         border-top: ${({ topBorder }) => (topBorder ? `1px solid ${ThemeColors.OUTLINE_VARIANT}` : "none")};
     `;
 
+    export const GroupCard = styled.div`
+        width: 100%;
+        border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+        border-radius: 4px;
+        background-color: ${ThemeColors.SURFACE_DIM};
+        transition: background-color 120ms ease, border-color 120ms ease;
+
+        &:hover {
+            border-color: ${ThemeColors.PRIMARY};
+        }
+    `;
+
+    export const GroupHeader = styled.button`
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        width: 100%;
+        padding: 10px 12px;
+        background: none;
+        border: none;
+        cursor: pointer;
+        text-align: left;
+        color: var(--vscode-editor-foreground);
+        font-family: var(--vscode-font-family);
+
+        &:focus-visible {
+            outline: 1px solid ${ThemeColors.PRIMARY};
+            outline-offset: -1px;
+            border-radius: 4px;
+        }
+    `;
+
+    export const GroupTitle = styled.span`
+        font-family: var(--vscode-font-family);
+        font-size: 13px;
+        color: var(--vscode-editor-foreground);
+    `;
+
+    export const GroupIssueIcon = styled.span`
+        display: flex;
+        align-items: center;
+        flex-shrink: 0;
+        margin-left: auto;
+        color: ${ThemeColors.ERROR};
+    `;
+
+    export const GroupChevron = styled.span<{ expanded?: boolean }>`
+        display: flex;
+        align-items: center;
+        flex-shrink: 0;
+        color: var(--vscode-descriptionForeground);
+        transform: rotate(${({ expanded }) => (expanded ? "180deg" : "0deg")});
+        transition: transform 150ms ease;
+    `;
+
+    export const GroupSection = styled.div`
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        width: 100%;
+    `;
+
+    export const GroupDivider = styled.hr`
+        width: 100%;
+        margin: 0 0 8px;
+        border: 0;
+        border-top: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    `;
+
+    export const GroupBody = styled.div`
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        padding: 16px 14px;
+        border-top: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+        margin-top: -1px;
+    `;
+
     export const CheckboxRow = styled.div<{}>`
         display: flex;
         flex-direction: row;
@@ -171,7 +251,6 @@ namespace S {
         z-index: 10;
         width: 100%;
         padding: 16px 0 0;
-        background: var(--vscode-editor-background);
         border-top: 1px solid var(--vscode-panel-border);
     `;
 
@@ -364,6 +443,8 @@ export interface FormProps {
     // its `propertyPath` resolves to; anything unresolvable falls back to the form-level banner.
     serverValidationErrors?: ValidationResult[];
     preserveOrder?: boolean;
+    groups?: FieldGroup[];
+    opensPrefilled?: boolean;
     handleSelectedTypeChange?: (type: string | CompletionItem) => void;
     scopeFieldAddon?: React.ReactNode;
     onChange?: (fieldKey: string, value: any, allValues: FormValues) => void;
@@ -426,6 +507,8 @@ export const Form = forwardRef((props: FormProps, _ref) => {
         concertMessage,
         formImports,
         preserveOrder = false,
+        groups,
+        opensPrefilled = false,
         bottomFields = [],
         handleSelectedTypeChange,
         scopeFieldAddon,
@@ -503,6 +586,13 @@ export const Form = forwardRef((props: FormProps, _ref) => {
     }, [serverValidationErrors, setError]);
 
     const [showAdvancedOptions, setShowAdvancedOptions] = useState(props.defaultExpandAdvanced ?? false);
+    const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+    const toggleGroup = (groupId: string) =>
+        setExpandedGroups((prev) => {
+            const group = (props.groups ?? []).find((candidate) => candidate.id === groupId);
+            const current = prev[groupId] ?? !(group?.defaultCollapsed ?? true);
+            return { ...prev, [groupId]: !current };
+        });
     const [activeFormField, setActiveFormField] = useState<string | undefined>(undefined);
     const [diagnosticsInfo, setDiagnosticsInfo] = useState<FormDiagnostics[] | undefined>(undefined);
     const [isMarkdownExpanded, setIsMarkdownExpanded] = useState(false);
@@ -537,7 +627,35 @@ export const Form = forwardRef((props: FormProps, _ref) => {
             return next;
         });
     }, []);
-    const isFormLoading = loadingFields.size > 0;
+    const [initialLoadSettled, setInitialLoadSettled] = useState(false);
+    const expectsInitialLoadRef = useRef<boolean | null>(null);
+    if (expectsInitialLoadRef.current === null) {
+        expectsInitialLoadRef.current = (props.formFields ?? []).some(
+            (field) => !field.hidden && typeof field.value === "string" && field.value !== ""
+        );
+    }
+    const sawInitialLoadingRef = useRef(false);
+    useEffect(() => {
+        if (!opensPrefilled) {
+            return;
+        }
+        if (loadingFields.size > 0) {
+            sawInitialLoadingRef.current = true;
+        }
+        if (initialLoadSettled || loadingFields.size > 0) {
+            return;
+        }
+        if (sawInitialLoadingRef.current) {
+            setInitialLoadSettled(true);
+            return;
+        }
+        const timer = setTimeout(() => setInitialLoadSettled(true), 0);
+        return () => clearTimeout(timer);
+    }, [loadingFields.size, initialLoadSettled, opensPrefilled]);
+
+    const isFormLoading = opensPrefilled
+        ? !initialLoadSettled && (loadingFields.size > 0 || expectsInitialLoadRef.current)
+        : loadingFields.size > 0;
 
     // Bubble loading state up to the parent form when this is a nested form
     useEffect(() => {
@@ -850,17 +968,20 @@ export const Form = forwardRef((props: FormProps, _ref) => {
     }, [formFields, unregister, trigger]);
 
     // has advance fields
-    const hasAdvanceFields = formFields.some((field) => field.advanced && field.enabled && !field.hidden)
+    const groupIds = useMemo(() => new Set((groups ?? []).map((group) => group.id)), [groups]);
+    const isGroupedField = (field: FormField) => Boolean(field.group && groupIds.has(field.group));
+    const hasAdvanceFields =
+        formFields.some((field) => field.advanced && field.enabled && !field.hidden && !isGroupedField(field))
         || advancedChoiceFields.length > 0
         || injectedComponents?.some((component) => component.advanced) === true;
-    const variableField = formFields.find((field) => field.key === "variable");
+    const variableField = formFields.find((field) => field.key === "variable" && !isGroupedField(field));
     // Exclude PARAM_FOR_TYPE_INFER fields (e.g. the activity/human-task "Databinding Type"): those are
     // rendered via targetTypeField below, so matching them here too would render the same field twice.
-    const typeField = formFields.find((field) => !field.advanced && !field.hidden && field.codedata?.kind !== "PARAM_FOR_TYPE_INFER" && getPrimaryInputType(field.types)?.fieldType === "TYPE");
+    const typeField = formFields.find((field) => !field.advanced && !field.hidden && !isGroupedField(field) && field.codedata?.kind !== "PARAM_FOR_TYPE_INFER" && getPrimaryInputType(field.types)?.fieldType === "TYPE");
     const expressionField = formFields.find((field) => getSecondaryInputType(field.types)?.fieldType === "EXPRESSION" || getPrimaryInputType(field.types)?.fieldType === "ACTION_OR_EXPRESSION");
-    const targetTypeField = formFields.find((field) => field.codedata?.kind === "PARAM_FOR_TYPE_INFER");
+    const targetTypeField = formFields.find((field) => field.codedata?.kind === "PARAM_FOR_TYPE_INFER" && !isGroupedField(field));
     const bottomFieldList = bottomFields.length > 0
-        ? formFields.filter((field) => bottomFields.includes(field.key) && !field.hidden)
+        ? formFields.filter((field) => bottomFields.includes(field.key) && !field.hidden && !isGroupedField(field))
         : [];
     const hasParameters = hasRequiredParameters(formFields, selectedNode) || hasOptionalParameters(formFields);
 
@@ -901,6 +1022,11 @@ export const Form = forwardRef((props: FormProps, _ref) => {
     const firstEditableFieldIndex = formFields.findIndex(
         (field) => field.editable !== false && getPrimaryInputType(field.types)?.fieldType === "IDENTIFIER"
     );
+
+    const firstEditableFieldValue = formFields[firstEditableFieldIndex]?.value;
+    const autoFocusFirstField =
+        firstEditableFieldIndex >= 0 &&
+        (!opensPrefilled || firstEditableFieldValue === undefined || firstEditableFieldValue === "");
 
     const isValid = useMemo(() => {
         let hasDiagnostics: boolean = false;
@@ -964,6 +1090,12 @@ export const Form = forwardRef((props: FormProps, _ref) => {
     // rather than calling the store twice — see the disableSaveButton comment for what these cover.
     const hasBlockingLiveErrors = diagnosticsStore.hasBlockingErrors();
     const isLiveValidating = diagnosticsStore.isAnyValidating();
+
+    const hasFieldLiveError = (fieldKey: string): boolean => {
+        const fieldDiagnostics = diagnosticsStore.getField(fieldKey);
+        return [...fieldDiagnostics.client, ...fieldDiagnostics.ls, ...fieldDiagnostics.compiler]
+            .some((diagnostic) => diagnostic.severity === "ERROR");
+    };
 
     // Call onValidityChange when form validity changes
     useEffect(() => {
@@ -1186,7 +1318,8 @@ export const Form = forwardRef((props: FormProps, _ref) => {
                 {(() => {
                     const fieldsToRender = [...formFields]
                         .sort((a, b) => (b.groupNo ?? 0) - (a.groupNo ?? 0))
-                        .filter((field) => field.type !== "VIEW");
+                        .filter((field) => field.type !== "VIEW")
+                        .filter((field) => !isGroupedField(field));
 
                     const renderedComponents: React.ReactNode[] = [];
                     let renderedFieldCount = 0;
@@ -1235,7 +1368,7 @@ export const Form = forwardRef((props: FormProps, _ref) => {
                                     subPanelView={subPanelView}
                                     handleFormValidation={handleFormValidation}
                                     handleOnFieldFocus={handleOnFieldFocus}
-                                    autoFocus={firstEditableFieldIndex === formFields.indexOf(updatedField) && !hideSaveButton}
+                                    autoFocus={autoFocusFirstField && firstEditableFieldIndex === formFields.indexOf(updatedField) && !hideSaveButton}
                                     recordTypeFields={recordTypeFields}
                                     onIdentifierEditingStateChange={handleIdentifierEditingStateChange}
                                     setSubComponentEnabled={setIsSubComponentEnabled}
@@ -1311,7 +1444,7 @@ export const Form = forwardRef((props: FormProps, _ref) => {
                         const advancedInjections = injectedComponents?.filter((ic) => ic.advanced);
 
                         formFields.forEach((field) => {
-                            if (field.advanced && !field.hidden) {
+                            if (field.advanced && !field.hidden && !isGroupedField(field)) {
                                 if (advancedInjections) {
                                     advancedInjections.forEach((injected) => {
                                         if (injected.index === advancedFieldCount && !advancedInjectedIndices.has(injected.index)) {
@@ -1362,6 +1495,81 @@ export const Form = forwardRef((props: FormProps, _ref) => {
 
                         return advancedComponents;
                     })()}
+                {(() => {
+                    const sections = (groups ?? [])
+                        .map((group) => ({
+                            group,
+                            groupFields: formFields.filter(
+                                (field) => field.group === group.id && !field.hidden && field.enabled !== false
+                            ),
+                        }))
+                        .filter((section) => section.groupFields.length > 0);
+                    if (sections.length === 0) {
+                        return null;
+                    }
+                    return (
+                        <S.GroupSection>
+                        <S.GroupDivider />
+                        {sections.map(({ group, groupFields }) => {
+                    const renderGroupField = (field: FormField) => {
+                        const updatedField = updateFormFieldWithImports(field, formImports);
+                        return (
+                            <S.Row key={updatedField.key}>
+                                <FieldFactory
+                                    field={updatedField}
+                                    selectedNode={selectedNode}
+                                    openRecordEditor={
+                                        openRecordEditor &&
+                                        ((open: boolean, newType?: string | NodeProperties) =>
+                                            handleOpenRecordEditor(open, updatedField, newType))
+                                    }
+                                    openSubPanel={handleOpenSubPanel}
+                                    subPanelView={subPanelView}
+                                    handleOnFieldFocus={handleOnFieldFocus}
+                                    recordTypeFields={recordTypeFields}
+                                    onIdentifierEditingStateChange={handleIdentifierEditingStateChange}
+                                    onBlur={handleOnBlur}
+                                    handleFormValidation={handleFormValidation}
+                                />
+                            </S.Row>
+                        );
+                    };
+                    const expanded = expandedGroups[group.id] ?? !(group.defaultCollapsed ?? true);
+                    const showIssueIcon = !expanded && groupHasBlockingIssue({
+                        groupFields,
+                        errors,
+                        values: watchedValues,
+                        hasFieldError: hasFieldLiveError,
+                    });
+                    return (
+                        <S.GroupCard key={group.id}>
+                            <S.GroupHeader
+                                type="button"
+                                aria-expanded={expanded}
+                                onClick={() => toggleGroup(group.id)}
+                            >
+                                <S.GroupTitle>{group.label}</S.GroupTitle>
+                                {showIssueIcon && (
+                                    <S.GroupIssueIcon
+                                        title="This section has a required or invalid field"
+                                        aria-label="This section has a required or invalid field"
+                                    >
+                                        <Codicon name="warning" iconSx={{ fontSize: 14 }} sx={{ height: 14 }} />
+                                    </S.GroupIssueIcon>
+                                )}
+                                <S.GroupChevron expanded={expanded}>
+                                    <Codicon name="chevron-down" iconSx={{ fontSize: 14 }} sx={{ height: 14 }} />
+                                </S.GroupChevron>
+                            </S.GroupHeader>
+                            <S.GroupBody style={{ display: expanded ? "flex" : "none" }}>
+                                {groupFields.map(renderGroupField)}
+                            </S.GroupBody>
+                        </S.GroupCard>
+                            );
+                        })}
+                        </S.GroupSection>
+                    );
+                })()}
                 {hasAdvanceFields &&
                     showAdvancedOptions &&
                     advancedChoiceFields.map((field) => {

--- a/packages/ballerina-side-panel/src/components/Form/types.ts
+++ b/packages/ballerina-side-panel/src/components/Form/types.ts
@@ -58,6 +58,9 @@ export type FormField = {
     dynamicFormFields?: { [key: string]: FormField[] }
     paramManagerProps?: ParamConfig;
     types: InputType[];
+    hideModeSwitcher?: boolean;
+    growRange?: { start: number; offset: number };
+    group?: string;
     groupNo?: number;
     groupName?: string;
     addNewButton?: boolean;
@@ -81,6 +84,12 @@ export type FormField = {
         showMarkers?: boolean;
         valueFormatter?: (value: number) => string;
     };
+};
+
+export type FieldGroup = {
+    id: string;
+    label: string;
+    defaultCollapsed?: boolean;
 };
 
 export type ParameterValue = {

--- a/packages/ballerina-side-panel/src/components/Form/utils.ts
+++ b/packages/ballerina-side-panel/src/components/Form/utils.ts
@@ -105,6 +105,22 @@ export function shouldRunExternalFormValidation({
     return formStateIsValid && Object.keys(errors ?? {}).length === 0 && !hasIncompleteRequiredFields;
 }
 
+export function groupHasBlockingIssue({
+    groupFields,
+    errors,
+    values,
+    hasFieldError,
+}: {
+    groupFields: FormField[];
+    errors?: Record<string, unknown>;
+    values?: Record<string, unknown>;
+    hasFieldError?: (fieldKey: string) => boolean;
+}): boolean {
+    return groupFields.some((field) => !!errors?.[field.key])
+        || hasIncompleteRequiredFormFields(groupFields, values)
+        || groupFields.some((field) => hasFieldError?.(field.key) === true);
+}
+
 export function isPrioritizedField(field: FormField): boolean {
     return field.key === "variable" || getPrimaryInputType(field.types)?.fieldType === "TYPE" || field.codedata?.kind === "PARAM_FOR_TYPE_INFER";
 }

--- a/packages/ballerina-side-panel/src/components/NodeList/index.tsx
+++ b/packages/ballerina-side-panel/src/components/NodeList/index.tsx
@@ -25,6 +25,7 @@ import {
     SidePanelBody,
     Switch,
     TextArea,
+    Typography,
     ThemeColors,
     Tooltip,
 } from "@wso2/ui-toolkit";
@@ -118,6 +119,14 @@ namespace S {
     export const SubTitle = styled.div<{}>`
         font-size: 12px;
         opacity: 0.9;
+    `;
+
+    export const Description = styled(Typography)`
+        width: 100%;
+        font-weight: normal;
+        font-size: 13px !important;
+        margin: 0 0 12px !important;
+        color: var(--vscode-descriptionForeground);
     `;
 
     export const BodyText = styled.div<{}>`
@@ -355,6 +364,7 @@ interface NodeListProps {
     categories: Category[];
     showAiPanel?: boolean;
     title?: string;
+    description?: string;
     onSelect: (id: string, metadata?: any) => void;
     onSelectConnector?: (id: string, metadata?: any) => void; // For connector routing
     onSearchTextChange?: (text: string) => void;
@@ -372,6 +382,7 @@ interface NodeListProps {
     searchText?: string;
     panelBodySx?: React.CSSProperties;
     alwaysCollapsedCategories?: string[];
+    alwaysExpandedCategories?: string[];
     loading?: boolean;
 }
 
@@ -380,6 +391,7 @@ export function NodeList(props: NodeListProps) {
         categories,
         showAiPanel,
         title,
+        description,
         onSelect,
         onSelectConnector,
         onSearchTextChange,
@@ -396,6 +408,7 @@ export function NodeList(props: NodeListProps) {
         onRefreshDevantConnections,
         panelBodySx,
         alwaysCollapsedCategories,
+        alwaysExpandedCategories,
         loading
     } = props;
 
@@ -439,6 +452,12 @@ export function NodeList(props: NodeListProps) {
             if (alwaysCollapsedCategories) {
                 alwaysCollapsedCategories.forEach((cat) => {
                     mergedState[cat] = false;
+                });
+            }
+
+            if (alwaysExpandedCategories) {
+                alwaysExpandedCategories.forEach((cat) => {
+                    mergedState[cat] = true;
                 });
             }
 
@@ -952,39 +971,44 @@ export function NodeList(props: NodeListProps) {
     return (
         <S.Container>
             <S.HeaderContainer>
-                <S.Row>
-                    {showAiPanel && (
-                        <Switch
-                            leftLabel="Search"
-                            rightLabel="Generate"
-                            checked={showGeneratePanel}
-                            checkedColor={ThemeColors.PRIMARY}
-                            enableTransition={true}
-                            onChange={() => {
-                                setShowGeneratePanel(!showGeneratePanel);
-                            }}
-                            sx={{
-                                margin: "auto",
-                                zIndex: "2",
-                                border: "unset",
-                            }}
-                            disabled={false}
-                        />
-                    )}
-                    {onBack && title && (
-                        <S.LeftAlignRow>
-                            <S.BackButton appearance="icon" onClick={handleBackClick}>
-                                <BackIcon />
-                            </S.BackButton>
-                            {title}
-                        </S.LeftAlignRow>
-                    )}
-                    {onClose && (
-                        <S.CloseButton appearance="icon" onClick={onClose}>
-                            <CloseIcon />
-                        </S.CloseButton>
-                    )}
-                </S.Row>
+                {(showAiPanel || (onBack && title) || onClose) && (
+                    <S.Row>
+                        {showAiPanel && (
+                            <Switch
+                                leftLabel="Search"
+                                rightLabel="Generate"
+                                checked={showGeneratePanel}
+                                checkedColor={ThemeColors.PRIMARY}
+                                enableTransition={true}
+                                onChange={() => {
+                                    setShowGeneratePanel(!showGeneratePanel);
+                                }}
+                                sx={{
+                                    margin: "auto",
+                                    zIndex: "2",
+                                    border: "unset",
+                                }}
+                                disabled={false}
+                            />
+                        )}
+                        {onBack && title && (
+                            <S.LeftAlignRow>
+                                <S.BackButton appearance="icon" onClick={handleBackClick}>
+                                    <BackIcon />
+                                </S.BackButton>
+                                {title}
+                            </S.LeftAlignRow>
+                        )}
+                        {onClose && (
+                            <S.CloseButton appearance="icon" onClick={onClose}>
+                                <CloseIcon />
+                            </S.CloseButton>
+                        )}
+                    </S.Row>
+                )}
+                {!showGeneratePanel && description && (
+                    <S.Description variant="body2">{description}</S.Description>
+                )}
                 {!showGeneratePanel && (
                     <S.Row>
                         <S.StyledSearchInput

--- a/packages/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -635,7 +635,7 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
             : `${field.documentation}.`
         : '';
 
-    const modeSwitcherNode = modeSwitcherContext?.isModeSwitcherEnabled ? (
+    const modeSwitcherNode = modeSwitcherContext?.isModeSwitcherEnabled && !field.hideModeSwitcher ? (
         <S.FieldInfoSection>
             {isLoading ? (
                 <SkeletonBase height="24px" width="112px" style={{ borderRadius: '2px', marginTop: '2px' }} />

--- a/packages/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -136,12 +136,16 @@ export namespace S {
         display: 'block'
     });
 
-    export const HeaderContainer = styled.div({
-        display: 'flex',
-        alignItems: 'flex-end',
-        justifyContent: 'space-between',
-        minHeight: '26px'
-    });
+    // The min-height reserves the mode switcher's row. Fields that hide the switcher have nothing
+    // to reserve it for, so the slack reads as uneven spacing above the label.
+    export const HeaderContainer = styled.div<{ reserveSwitcherRow?: boolean }>(
+        ({ reserveSwitcherRow = true }: { reserveSwitcherRow?: boolean }) => ({
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'space-between',
+            ...(reserveSwitcherRow ? { minHeight: '26px' } : {}),
+        })
+    );
 
     export const Header = styled.div({
         display: 'flex',
@@ -663,7 +667,7 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
                 {showHeader && (
                     <S.Header>
                         {field.label && (
-                            <S.HeaderContainer>
+                            <S.HeaderContainer reserveSwitcherRow={!field.hideModeSwitcher}>
                                 {isLoading ? (
                                     <SkeletonBase height="14px" width="40%" />
                                 ) : (

--- a/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/NodeReferenceSelectEditor/NodeReferenceSelectEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/NodeReferenceSelectEditor/NodeReferenceSelectEditor.tsx
@@ -28,10 +28,27 @@ import {
     SearchNodesQuery,
     SearchNodesTypeConstraint,
 } from "@wso2/ballerina-core";
-import { Codicon, LinkButton, ProgressRing } from "@wso2/ui-toolkit";
+import { Button, Codicon, LinkButton, ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
 import { FormField } from "../../../Form/types";
 import { NodeReferenceSelect, NodeReferenceSelectItem } from "../../NodeReferenceSelect";
 import { useFormContext } from "../../../../context";
+
+const EmptyPrompt = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 16px 12px;
+    border: 1px dashed ${ThemeColors.OUTLINE_VARIANT};
+    border-radius: 4px;
+    background-color: ${ThemeColors.SURFACE_DIM};
+`;
+
+const EmptyPromptText = styled.div`
+    text-align: center;
+    font-size: 13px;
+    color: var(--vscode-descriptionForeground);
+`;
 
 function humanizeKind(kind: string): string {
     return kind
@@ -107,6 +124,7 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
     const filterKey = hasFilters
         ? nodeReferenceFilters!.map((f) => `${f.module ?? ""}:${f.object ?? ""}`).join("|")
         : "";
+    const startLineKey = `${targetLineRange?.startLine?.line}:${targetLineRange?.startLine?.offset}`;
     const applyNodeReferenceFilter = (items: NodeReferenceSelectItem[]): NodeReferenceSelectItem[] => {
         if (!hasFilters) return items;
         return items.filter(item =>
@@ -123,10 +141,10 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
     const [loading, setLoading] = useState<boolean>(!!searchNodesKind && !itemsPreloaded);
     const requestIdRef = useRef(0);
 
-    const fetchItems = () => {
+    const fetchItems = (silent = false) => {
         const requestId = ++requestIdRef.current;
         if (!searchNodesKind || itemsPreloaded) return;
-        setLoading(true);
+        if (!silent) setLoading(true);
         rpcClient.getBIDiagramRpcClient().searchNodes({
             filePath: fileName,
             position: targetLineRange.startLine,
@@ -146,9 +164,13 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
                         iconUrl,
                     };
                 });
-            setSelectItems(ensureValueInItems(
+            const resolved = ensureValueInItems(
                 applyNodeReferenceFilter([...staticItems, ...items]), value, searchNodesKind
-            ));
+            );
+            setSelectItems(resolved);
+            if (!value && resolved.length > 0) {
+                onChange(resolved[0].value, resolved[0].value.length);
+            }
         }).finally(() => {
             if (requestId === requestIdRef.current) setLoading(false);
         });
@@ -162,7 +184,7 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
             return;
         }
         fetchItems();
-    }, [queryKey, fileName, targetLineRange.startLine, filterKey, itemsPreloaded]);
+    }, [queryKey, fileName, startLineKey, filterKey, itemsPreloaded]);
 
     useEffect(() => {
         if (!value && staticItems.length > 0) {
@@ -173,7 +195,7 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
     useEffect(() => {
         if (!value || selectItems.some(item => item.value === value)) return;
         setSelectItems(prev => ensureValueInItems(prev, value, searchNodesKind));
-        fetchItems();
+        fetchItems(true);
     }, [value]);
 
     // A field carries at most one way to create the referenced node: explicit connector
@@ -233,10 +255,40 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
     const createNewLabel = !showCreateNew
         ? ""
         : agentCodeData?.object
-        ? agentCodeData.object
-        : creationCodeData?.module && creationCodeData?.object
-        ? `${humanizeKind(creationCodeData.module.split(".").pop() ?? "")} ${creationCodeData.object}`
-        : humanizeKind(searchNodesKind);
+            ? agentCodeData.object
+            : creationCodeData?.module && creationCodeData?.object
+                ? `${humanizeKind(creationCodeData.module.split(".").pop() ?? "")} ${creationCodeData.object}`
+                : humanizeKind(searchNodesKind);
+
+    const creationName = agentCodeData?.object
+        ?? (creationCodeData?.module ? humanizeKind(creationCodeData.module.split(".").pop() ?? "") : "");
+    const isAgentReference = !!agentCodeData;
+    const qualifier = creationName ? `${creationName} ` : "";
+    const emptyTitle = isAgentReference
+        ? `No ${creationName || "agent"} in this project`
+        : `No ${qualifier}connection in this project`;
+    const emptyAction = isAgentReference
+        ? `Create ${creationName || "Agent"}`
+        : `Create ${qualifier}Connection`;
+    const showEmptyPrompt = showCreateNew && !loading && !field.optional && selectItems.length === 0;
+
+    const handleCreateNode = () => onCreateNode(
+        searchNodesKind,
+        (varName) => onChange(varName, varName?.length),
+        creationCodeData
+    );
+
+    if (showEmptyPrompt) {
+        return (
+            <EmptyPrompt>
+                <EmptyPromptText>{emptyTitle}</EmptyPromptText>
+                <Button appearance="primary" onClick={handleCreateNode}>
+                    <Codicon name="add" sx={{ marginRight: 6 }} />
+                    {emptyAction}
+                </Button>
+            </EmptyPrompt>
+        );
+    }
 
     return (
         <>
@@ -269,11 +321,7 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
             )}
             {showCreateNew && (
                 <LinkButton
-                    onClick={() => onCreateNode(
-                        searchNodesKind,
-                        (varName) => onChange(varName, varName?.length),
-                        creationCodeData
-                    )}
+                    onClick={handleCreateNode}
                     sx={{ padding: "4px 6px", margin: 0, marginTop: "6px", fontSize: "13px" }}
                 >
                     <Codicon name="add" />

--- a/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/NodeReferenceSelectEditor/NodeReferenceSelectEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/NodeReferenceSelectEditor/NodeReferenceSelectEditor.tsx
@@ -168,7 +168,8 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
                 applyNodeReferenceFilter([...staticItems, ...items]), value, searchNodesKind
             );
             setSelectItems(resolved);
-            if (!value && resolved.length > 0) {
+            // Required fields only, and never over the static default the mount effect picks.
+            if (!value && !field.optional && staticItems.length === 0 && resolved.length > 0) {
                 onChange(resolved[0].value, resolved[0].value.length);
             }
         }).finally(() => {

--- a/packages/ballerina-side-panel/src/components/editors/NodeReferenceSelect.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/NodeReferenceSelect.tsx
@@ -32,6 +32,7 @@ const NODE_ICON_MAP: Record<string, string> = {
     SHORT_TERM_MEMORY_STORE: "bi-memory",
     AGENT: "bi-ai-agent",
     TYPED_AGENT: "bi-ai-agent",
+    NEW_CONNECTION: "bi-connection",
 };
 
 // Modules that always use node-type icons, skipping the icon URL fallback
@@ -216,6 +217,8 @@ export const NodeReferenceSelect: React.FC<NodeReferenceSelectProps> = ({
 
     const isEmpty = items.length === 0;
     const selectedItem = items.find((item) => item.value === value);
+    const showLoading = loading && !selectedItem;
+    const inert = disabled || isEmpty || showLoading;
 
     const handleSelect = (itemValue: string) => {
         onChange(itemValue);
@@ -228,7 +231,7 @@ export const NodeReferenceSelect: React.FC<NodeReferenceSelectProps> = ({
     };
 
     const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (disabled || isEmpty || loading) return;
+        if (inert) return;
         if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             setOpen(!open);
@@ -272,13 +275,13 @@ export const NodeReferenceSelect: React.FC<NodeReferenceSelectProps> = ({
                     role="combobox"
                     aria-expanded={open}
                     aria-haspopup="listbox"
-                    tabIndex={disabled || isEmpty || loading ? -1 : 0}
-                    disabled={disabled || isEmpty || loading}
-                    onClick={() => !disabled && !isEmpty && !loading && setOpen(!open)}
+                    tabIndex={inert ? -1 : 0}
+                    disabled={inert}
+                    onClick={() => !inert && setOpen(!open)}
                     onKeyDown={handleKeyDown}
                 >
                     <SelectedDisplay>
-                        {loading ? (
+                        {showLoading ? (
                             <>
                                 <ProgressRing sx={{ height: 16, width: 16 }} color="var(--vscode-input-placeholderForeground)" />
                                 <Placeholder>Loading...</Placeholder>
@@ -292,9 +295,9 @@ export const NodeReferenceSelect: React.FC<NodeReferenceSelectProps> = ({
                             <Placeholder>{isEmpty ? emptyMessage : placeholder}</Placeholder>
                         )}
                     </SelectedDisplay>
-                    {!loading && !isEmpty && <Codicon name="chevron-down" sx={{ fontSize: 14, flexShrink: 0 }} />}
+                    {!showLoading && !isEmpty && <Codicon name="chevron-down" sx={{ fontSize: 14, flexShrink: 0 }} />}
                 </SelectTrigger>
-                {open && !disabled && !loading && items.length > 0 && (
+                {open && !disabled && !showLoading && items.length > 0 && (
                     <DropdownPanel role="listbox">
                         {items.map((item, index) => (
                             <OptionItem

--- a/packages/ballerina-side-panel/src/components/editors/TextAreaEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/TextAreaEditor.tsx
@@ -109,7 +109,7 @@ export function TextAreaEditor(props: TextAreaEditorProps) {
                                 onFocus={() => handleOnFieldFocus?.(field.key)}
                                 autoFocus={autoFocus}
                                 onChange={onChange}
-                                growRange={{ start: 4, offset: 12 }}
+                                growRange={field.growRange ?? { start: 4, offset: 12 }}
                             />
                             <div id="textarea-editor-expand" style={{ position: 'absolute', bottom: '9px', right: '6px' }}>
                                 <FloatingToggleButton onClick={handleOpenExpandedMode} title="Expand Editor">

--- a/packages/ballerina-side-panel/src/index.ts
+++ b/packages/ballerina-side-panel/src/index.ts
@@ -34,3 +34,4 @@ export * from "./components/Skeletons";
 export * from "./context";
 
 export * from "./utils/path-validations";
+export * from "./utils/formatMethodName";

--- a/packages/ballerina-side-panel/src/test/formValidationUtils.test.ts
+++ b/packages/ballerina-side-panel/src/test/formValidationUtils.test.ts
@@ -25,7 +25,11 @@
 //     required child revealed by a dynamic selection) with no value blocks submit.
 
 import type { FormField } from "../components/Form/types";
-import { hasIncompleteRequiredFormFields, shouldRunExternalFormValidation } from "../components/Form/utils";
+import {
+    groupHasBlockingIssue,
+    hasIncompleteRequiredFormFields,
+    shouldRunExternalFormValidation,
+} from "../components/Form/utils";
 
 // The functions read a handful of FormField props; build partials without dragging
 // the full type into every fixture.
@@ -223,5 +227,56 @@ describe("hasIncompleteRequiredFormFields", () => {
                 hasIncompleteRequiredFormFields([optionalParent], { optionalSelector: "", requiredChild: "" })
             ).toBe(false);
         });
+    });
+});
+
+describe("groupHasBlockingIssue", () => {
+    const required = (key: string) => field({ key, optional: false, hidden: false, enabled: true });
+
+    it("is clean when every required field has a value and nothing is failing", () => {
+        expect(
+            groupHasBlockingIssue({ groupFields: [required("query")], values: { query: "SELECT 1" } })
+        ).toBe(false);
+    });
+
+    it("flags a react-hook-form error on a field in the group", () => {
+        expect(
+            groupHasBlockingIssue({
+                groupFields: [required("query")],
+                errors: { query: { type: "required" } },
+                values: { query: "SELECT 1" },
+            })
+        ).toBe(true);
+    });
+
+    it("flags a required field left empty, with no error entry", () => {
+        expect(
+            groupHasBlockingIssue({ groupFields: [required("query")], errors: {}, values: { query: "" } })
+        ).toBe(true);
+    });
+
+    it("flags an ERROR-severity live diagnostic on a field in the group", () => {
+        expect(
+            groupHasBlockingIssue({
+                groupFields: [required("query")],
+                values: { query: "SELECT 1" },
+                hasFieldError: (key) => key === "query",
+            })
+        ).toBe(true);
+    });
+
+    it("ignores errors and diagnostics belonging to fields outside the group", () => {
+        expect(
+            groupHasBlockingIssue({
+                groupFields: [required("query")],
+                errors: { name: { type: "required" } },
+                values: { query: "SELECT 1", name: "" },
+                hasFieldError: (key) => key === "name",
+            })
+        ).toBe(false);
+    });
+
+    it("is clean for an empty group", () => {
+        expect(groupHasBlockingIssue({ groupFields: [], values: {} })).toBe(false);
     });
 });

--- a/packages/ballerina-side-panel/src/test/formatMethodName.test.ts
+++ b/packages/ballerina-side-panel/src/test/formatMethodName.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { formatMethodName } from "../utils/formatMethodName";
+
+describe("formatMethodName", () => {
+    it("splits camelCase and snake_case into words", () => {
+        expect(formatMethodName("basicAck")).toBe("Basic Ack");
+        expect(formatMethodName("onMessage")).toBe("On Message");
+        expect(formatMethodName("get_user_url")).toBe("Get User URL");
+    });
+
+    it("strips every leading special character", () => {
+        expect(formatMethodName("'commit")).toBe("Commit");
+        expect(formatMethodName("__weird_name")).toBe("Weird Name");
+    });
+
+    it("keeps an existing all-caps word as-is", () => {
+        expect(formatMethodName("HTTPRequest")).toBe("HTTP Request");
+        expect(formatMethodName("parseJSON")).toBe("Parse JSON");
+        expect(formatMethodName("toXML")).toBe("To XML");
+    });
+
+    it("upper-cases a known acronym that arrives lower-cased", () => {
+        expect(formatMethodName("getUserId")).toBe("Get User ID");
+        expect(formatMethodName("deleteAcl")).toBe("Delete ACL");
+        expect(formatMethodName("sendSms")).toBe("Send SMS");
+        expect(formatMethodName("listSqlDatabases")).toBe("List SQL Databases");
+    });
+
+    it("breaks a word at a digit-to-uppercase boundary", () => {
+        expect(formatMethodName("method2Call")).toBe("Method2 Call");
+    });
+
+    it("lower-cases trailing words in sentence casing, acronyms excepted", () => {
+        expect(formatMethodName("createPresignedUrl", { casing: "sentence" })).toBe("Create presigned URL");
+        expect(formatMethodName("getUserId", { casing: "sentence" })).toBe("Get user ID");
+        expect(formatMethodName("HTTPRequest", { casing: "sentence" })).toBe("HTTP request");
+    });
+
+    it("returns an empty string for a missing name", () => {
+        expect(formatMethodName("")).toBe("");
+        expect(formatMethodName(undefined as unknown as string)).toBe("");
+        expect(formatMethodName(42 as unknown as string)).toBe("");
+    });
+
+    it("falls back to the original when nothing survives cleaning", () => {
+        expect(formatMethodName("'''")).toBe("'''");
+    });
+
+    it("trims surrounding whitespace", () => {
+        expect(formatMethodName("  spaced  ")).toBe("Spaced");
+    });
+});

--- a/packages/ballerina-side-panel/src/utils/formatMethodName.ts
+++ b/packages/ballerina-side-panel/src/utils/formatMethodName.ts
@@ -16,6 +16,15 @@
  * under the License.
  */
 
+const ACRONYMS = new Set([
+    "ACL", "API", "CSV", "DNS", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "JWT", "MFA",
+    "OTP", "PDF", "SMS", "SQL", "SSH", "SSO", "TLS", "TTL", "UI", "URI", "URL", "UUID", "XML",
+]);
+
+export interface FormatMethodNameOptions {
+    casing?: "title" | "sentence";
+}
+
 /**
 * Converts a camelCase or snake_case method name into a user-friendly display format.
 *
@@ -27,16 +36,17 @@
 * formatMethodName("'commit") // Returns "Commit"
 * formatMethodName("onMessage") // Returns "On Message"
 * formatMethodName("HTTPRequest") // Returns "HTTP Request"
-* formatMethodName("method2Call") // Returns "Method 2 Call"
+* formatMethodName("method2Call") // Returns "Method2 Call"
+* formatMethodName("createPresignedUrl", { casing: "sentence" }) // Returns "Create presigned URL"
 */
-export function formatMethodName(methodName: string): string {
+export function formatMethodName(methodName: string, options?: FormatMethodNameOptions): string {
     // Handle null, undefined, or empty strings
     if (!methodName || typeof methodName !== "string") {
         return "";
     }
 
     // Remove leading special characters like apostrophes, underscores, etc.
-    let cleaned = methodName.trim().replace(/^[^\w]/g, "");
+    let cleaned = methodName.trim().replace(/^[^\w]+/, "");
 
     // Handle edge case where all characters were special
     if (!cleaned) {
@@ -49,21 +59,26 @@ export function formatMethodName(methodName: string): string {
     // 2. Inserts space before uppercase letters that are followed by lowercase (e.g., "HTTPRequest" -> "HTTP Request")
     // 3. Handles underscores by replacing them with spaces
     let formatted = cleaned
-        .replace(/([a-z])([A-Z])/g, "$1 $2") // Insert space before uppercase after lowercase
+        .replace(/([a-z0-9])([A-Z])/g, "$1 $2") // Insert space before uppercase after lowercase or digit
         .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2") // Insert space before last uppercase in sequence
         .replace(/_/g, " ") // Replace underscores with spaces
         .replace(/\s+/g, " ") // Normalize multiple spaces to single space
         .trim();
 
-    // Capitalize first letter of each word
+    const sentence = options?.casing === "sentence";
+
     const words = formatted.split(" ");
     const capitalized = words
-        .map((word) => {
-            if (!word) return "";
-            // Keep existing capitalization for acronyms (all caps) but capitalize first letter otherwise
-            return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-        })
         .filter((word) => word.length > 0) // Remove empty strings from split
+        .map((word, index) => {
+            const upper = word.toUpperCase();
+            if (word === upper || ACRONYMS.has(upper)) {
+                return upper;
+            }
+            return sentence && index > 0
+                ? word.toLowerCase()
+                : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+        })
         .join(" ");
 
     return capitalized;

--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/useCreateNode.tsx
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/useCreateNode.tsx
@@ -41,10 +41,12 @@ const readCreatedVariable = (node: FlowNode): string | undefined => {
 export function useCreateNode(
     fileName?: string,
     targetLineRange?: LineRange,
-    onNodeCreated?: () => void
+    onNodeCreated?: () => void,
+    options?: { preferModal?: boolean }
 ) {
     const { rpcClient } = useRpcContext();
-    const panelOverlay = useContext(PanelOverlayContext);
+    const panelOverlayContext = useContext(PanelOverlayContext);
+    const panelOverlay = options?.preferModal ? undefined : panelOverlayContext;
     const { addModal, closeModal } = useModalStack();
 
     const handleCreated = (variableName: string, onCreated: (variableName: string) => void) => {
@@ -103,7 +105,12 @@ export function useCreateNode(
         try {
             const flowNode = await fetchTemplate();
             addModal(renderCreator(flowNode, () => closeModal(modalId)), modalId, title, 600, 520);
-        } catch {}
+        } catch (error) {
+            console.error("Error fetching connector template", error);
+            await rpcClient.getCommonRpcClient().showErrorMessage({
+                message: "Could not load the connector. Please try again.",
+            });
+        }
     };
 
     return (kind: string, onCreated: (variableName: string) => void, nodeCodeData?: CodeData) => {

--- a/packages/ballerina-visualizer/src/constants.ts
+++ b/packages/ballerina-visualizer/src/constants.ts
@@ -51,6 +51,7 @@ export const RESOURCE_ACTION_CALL = "RESOURCE_ACTION_CALL";
 export const REMOTE_ACTION_CALL = "REMOTE_ACTION_CALL";
 export const FUNCTION_CALL = "FUNCTION_CALL";
 export const METHOD_CALL = "METHOD_CALL";
+export const NEW_CONNECTION = "NEW_CONNECTION";
 
 export const LOADING_MESSAGE = "Loading...";
 export const FORM_LOADING_MESSAGE = "Loading form...";

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
@@ -981,8 +981,8 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             const approvalCandidates = await fetchCompatibleApprovalFunctions();
             compatibleApprovalFunctionsRef.current = approvalCandidates ?? [];
 
-            setFields((prevFields) => [
-                ...prevFields.map((field) => {
+            setFields((prevFields) => {
+                const baseFields = prevFields.map((field) => {
                     if (field.key === "description") {
                         return { ...field, value: templateDescription };
                     }
@@ -993,11 +993,17 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                         return buildRequiresApprovalField(field, approvalCandidates);
                     }
                     return field;
-                }),
-                ...(connectionField ? [connectionField] : []),
-                ...groupedInputFields,
-                ...oauthFields,
-            ]);
+                });
+                // The connection outranks the approval gate here, so it goes first.
+                const approvalField = baseFields.find((field) => field.key === "requiresApproval");
+                return [
+                    ...baseFields.filter((field) => field.key !== "requiresApproval"),
+                    ...(connectionField ? [connectionField] : []),
+                    ...(approvalField ? [approvalField] : []),
+                    ...groupedInputFields,
+                    ...oauthFields,
+                ];
+            });
         } catch (error) {
             console.error(">>> Error fetching node template", error);
         }

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { NodeList, Category as PanelCategory, FormField, FormImports, FormValues, MarkdownDescription } from "@wso2/ballerina-side-panel";
@@ -51,7 +51,6 @@ import {
     convertBICategoriesToSidePanelCategories,
     convertConfig,
     convertFunctionCategoriesToSidePanelCategories,
-    convertNodePropertyToFormField,
     filterToolInputSymbolDiagnostics,
     getImportsForProperty
 } from "../../../utils/bi";
@@ -60,14 +59,32 @@ import { RelativeLoader } from "../../../components/RelativeLoader";
 import styled from "@emotion/styled";
 import { URI, Utils } from "vscode-uri";
 import { cloneDeep } from "lodash";
-import { buildAgentToolFields, createDefaultParameterValue, createToolInputFields, createToolParameters, prepareToolInputFields, stripCodeFences, stripCodeFencesInline } from "./formUtils";
+import { buildAgentToolFields, buildOAuthFields, createDefaultParameterValue, createToolInputFields, createToolParameters, extractRecordTypeFields, extractRecordTypeFieldsFromEntries, prepareToolInputFields, stripCodeFences, stripCodeFencesInline } from "./formUtils";
 import { ImplementationBadge } from "../../../components/ImplementationBadge";
 import { FUNCTION_CALL, METHOD_CALL, REMOTE_ACTION_CALL, RESOURCE_ACTION_CALL } from "../../../constants";
 import { NewToolSelectionMode } from "./NewTool";
-import { fetchOAuthConfigProperties } from "./utils";
+import { fetchOAuthConfigProperties, ZERO_LINE_RANGE } from "./utils";
 import { updateResourcePathProperty } from "./agentTools";
 import { AddConnectionPopupContent } from "../Connection/AddConnectionPopup/AddConnectionPopupContent";
 import { ConnectionConfigurationForm } from "../Connection/ConnectionConfigurationPopup";
+import {
+    ActionSelection,
+    ConnectorBrowser,
+    WizardStep,
+    buildConnectionSelectField,
+    displayResourcePath,
+} from "../Connection/ConnectorBrowser";
+import {
+    INCLUDE_CONTEXT_KEY,
+    RESULT_TYPE_GROUP,
+    TOOL_INPUT_GROUP,
+    buildIncludeContextField,
+    buildToolFormGroups,
+    getExistingToolNames,
+    resourceToolNameSeed,
+    suggestToolName,
+} from "./toolForm";
+import { useCreateNode } from "../../../components/ConnectionSelector/useCreateNode";
 import { ConnectorIcon } from "@wso2/bi-diagram";
 import {
     BackButton,
@@ -99,53 +116,6 @@ const PopupLoaderContainer = styled.div`
     p {
         font-size: 13px;
     }
-`;
-
-const ImplementationInfoContainer = styled.div`
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    padding-top: 20px;
-    margin-top: -4px;
-    border-top: 1px solid var(--vscode-editorWidget-border);
-`;
-
-const ImplementationInfo = styled.div`
-    display: flex;
-    align-items: center;
-    background-color: var(--vscode-input-background);
-    border: 1px solid var(--vscode-editorWidget-border);
-    padding: 10px 10px;
-    border-radius: 4px;
-    margin-top: 4px;
-    overflow: hidden;
-    p {
-        margin: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-`;
-
-const ImplementationDescription = styled.span`
-    color: var(--vscode-list-deemphasizedForeground)
-`;
-
-const ContextOption = styled.label`
-    display: flex;
-    align-items: flex-start;
-    gap: 8px;
-    cursor: pointer;
-    font-size: var(--vscode-font-size);
-    color: var(--vscode-foreground);
-`;
-
-const ContextHint = styled.div`
-    font-size: 11px;
-    color: var(--vscode-descriptionForeground);
-    margin-top: 2px;
-    line-height: 1.4;
 `;
 
 const DependencyFormContainer = styled.div`
@@ -378,6 +348,7 @@ export enum SidePanelView {
     CONNECTOR_SELECT = "CONNECTOR_SELECT",
     DEPENDENCY_FORM = "DEPENDENCY_FORM",
     CONNECTION_CONFIG = "CONNECTION_CONFIG",
+    CONNECTOR_WIZARD = "CONNECTOR_WIZARD",
 }
 
 export interface ConnectionDependencyConfig {
@@ -410,11 +381,13 @@ export interface ExtendedAgentToolRequest {
     functionNode?: FunctionNode;
     flowNode?: FlowNode;
     parameterImports?: { [prefix: string]: string };
+    connectionName?: string;
 }
 
 // Ensure "io", "log", and "time" module functions always appear under "Standard Library",
 // even if they've been imported (which moves them to "Imported Functions" from the LS)
 const STANDARD_LIB_MODULES = ["io", "log", "time"];
+
 function ensureStandardLibModules(categories: PanelCategory[]): PanelCategory[] {
     const stdLib = categories.find((cat) => cat.title === "Standard Library");
     const imported = categories.find((cat) => cat.title?.includes("Imported"));
@@ -452,8 +425,14 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
     const { rpcClient } = useRpcContext();
     const dependencyMode = Boolean(connectionDependency);
 
-    const [sidePanelView, setSidePanelView] = useState<SidePanelView>(SidePanelView.NODE_LIST);
+    const connectorFirst = mode === NewToolSelectionMode.CONNECTION && !dependencyMode;
+
+    const [sidePanelView, setSidePanelView] = useState<SidePanelView>(
+        connectorFirst ? SidePanelView.CONNECTOR_WIZARD : SidePanelView.NODE_LIST
+    );
     const [categories, setCategories] = useState<PanelCategory[]>([]);
+    const wizardBackRef = useRef<(() => void) | undefined>(undefined);
+    const connectorRef = useRef<AvailableNode | undefined>(undefined);
     const [selectedNodeCodeData, setSelectedNodeCodeData] = useState<CodeData>(undefined);
     const [toolNodeId, setToolNodeId] = useState<string>(undefined);
 
@@ -465,7 +444,6 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
     const [fields, setFields] = useState<FormField[]>(INITIAL_FIELDS);
     const [recordTypeFields, setRecordTypeFields] = useState<RecordTypeField[]>([]);
     const [showOAuthConfig, setShowOAuthConfig] = useState<boolean>(false);
-    const [includeContext, setIncludeContext] = useState<boolean>(false);
 
     const targetRef = useRef<LineRange>(
         dependencyMode && agentNode?.codedata?.lineRange
@@ -494,6 +472,13 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
     const oauthConfigPropertiesRef = useRef<{ key: string; property: Property }[]>([]);
     const isSelectingNodeRef = useRef<boolean>(false);
 
+    const handleCreateNode = useCreateNode(
+        agentFilePath.current,
+        targetRef.current,
+        () => { void fetchNodes(true); },
+        { preferModal: true }
+    );
+
     // Create custom diagnostic filter for Tool Input parameters
     const customDiagnosticFilter = useCallback((diagnostics: Diagnostic[]) => {
         if (!parameterFieldsRef.current || parameterFieldsRef.current.length === 0) {
@@ -518,28 +503,47 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
     useEffect(() => {
         if (sidePanelView === SidePanelView.TOOL_FORM) {
             onViewChange?.(SidePanelView.TOOL_FORM, () => {
-                setSidePanelView(SidePanelView.NODE_LIST);
-                setFields(INITIAL_FIELDS);
-                onViewChange?.(SidePanelView.NODE_LIST);
+                const target = connectorFirst ? SidePanelView.CONNECTOR_WIZARD : SidePanelView.NODE_LIST;
+                resetToolForm();
+                setSidePanelView(target);
+                onViewChange?.(target, connectorFirst ? wizardBackRef.current : undefined);
             });
+        } else if (sidePanelView === SidePanelView.CONNECTOR_WIZARD) {
+            onViewChange?.(SidePanelView.CONNECTOR_WIZARD, wizardBackRef.current);
         } else {
             onViewChange?.(SidePanelView.NODE_LIST);
         }
     }, [sidePanelView]);
 
+    const resetToolForm = () => {
+        setFields(INITIAL_FIELDS);
+        setRecordTypeFields([]);
+        setShowOAuthConfig(false);
+        connectorRef.current = undefined;
+        flowNode.current = null;
+        functionNode.current = null;
+        oauthConfigPropertiesRef.current = [];
+        parameterFieldsRef.current = [];
+    };
+
     const getImplementationString = (codeData: CodeData | undefined): string => {
         if (!codeData) {
             return "";
         }
+        const receiver = codeData.parentSymbol
+            || connectorRef.current?.metadata?.label
+            || codeData.object
+            || codeData.module
+            || "";
         switch (codeData.node) {
             case RESOURCE_ACTION_CALL:
-                return `${codeData.parentSymbol} -> ${codeData.symbol} ${codeData.resourcePath}`;
+                return `${receiver} -> ${codeData.symbol} ${displayResourcePath(codeData.resourcePath)}`;
             case REMOTE_ACTION_CALL:
-                return `${codeData.parentSymbol} -> ${codeData.symbol}`;
+                return `${receiver} -> ${codeData.symbol}`;
             case FUNCTION_CALL:
                 return `${codeData.symbol}`;
             case METHOD_CALL:
-                return `${codeData.parentSymbol} -> ${codeData.symbol}`;
+                return `${receiver} -> ${codeData.symbol}`;
             default:
                 return "";
         }
@@ -562,11 +566,12 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
         });
     }, [rpcClient]);
 
-    const fetchNodes = async () => {
-        setLoading(true);
+    const fetchNodes = async (silent = false) => {
+        const settleLoading = () => { if (!silent) setLoading(false); };
+        if (!silent) setLoading(true);
 
         if (mode === NewToolSelectionMode.CUSTOM_TOOL) {
-            setLoading(false);
+            settleLoading();
             return;
         }
 
@@ -578,7 +583,7 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                 setCategories(categories);
                 initialCategoriesRef.current = categories;
             } catch { } finally {
-                setLoading(false);
+                settleLoading();
             }
             return;
         }
@@ -627,6 +632,7 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                     });
                 }
                 connectionsCategory.at(0).items = filteredConnectionsCategory;
+
             }
             const convertedCategories = convertBICategoriesToSidePanelCategories(connectionsCategory);
             if (dependencyMode) {
@@ -664,7 +670,7 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             setCategories(filteredCategories);
             initialCategoriesRef.current = filteredCategories;
         } finally {
-            setLoading(false);
+            settleLoading();
         }
     };
 
@@ -743,26 +749,28 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
         return ensureStandardLibModules(convertFunctionCategoriesToSidePanelCategories(filteredResponse, functionType));
     };
 
-    const extractRecordTypeFieldsFromEntries = (entries: { key: string; property: Property }[]): RecordTypeField[] => {
-        return entries
-            .filter(({ property }) => {
-                const primaryInputType = getPrimaryInputType(property?.types);
-                return primaryInputType?.typeMembers &&
-                    primaryInputType?.typeMembers.some(member => member.kind === "RECORD_TYPE");
-            })
-            .map(({ key, property }) => ({
-                key,
-                property,
-                recordTypeMembers: getPrimaryInputType(property?.types)?.typeMembers.filter(member => member.kind === "RECORD_TYPE")
-            }));
-    };
+    const isResultTypeField = (field: FormField) =>
+        field.key === "type"
+        || field.key === "targetType"
+        || field.key === "rowType"
+        || field.codedata?.kind === "PARAM_FOR_TYPE_INFER"
+        || getPrimaryInputType(field.types)?.fieldType === "TYPE";
 
-    const extractRecordTypeFields = (properties: NodeProperties): RecordTypeField[] => {
-        const entries = Object.entries(properties).map(([key, property]) => ({ key, property }));
-        return extractRecordTypeFieldsFromEntries(entries);
-    };
+    const buildGroupedInputFields = (toolInputFields: FormField[], parameterFields: FormField[]): FormField[] =>
+        [
+            buildIncludeContextField(TOOL_INPUT_GROUP) as FormField,
+            ...toolInputFields,
+            ...parameterFields.map((field) => ({
+                ...field,
+                value: typeof field.value === 'string' ? field.value.replace(/^\$/, '') : field.value,
+            })),
+        ].map((field) => ({
+            ...field,
+            group: isResultTypeField(field) ? RESULT_TYPE_GROUP : TOOL_INPUT_GROUP,
+            advanced: false,
+        }));
 
-    const loadFunctionCallFields = async (node: AvailableNode): Promise<void> => {
+    const loadFunctionCallFields = async (node: AvailableNode, options?: { suggestedToolName?: string }): Promise<void> => {
         try {
             const functionNodeResponse = await rpcClient.getBIDiagramRpcClient().getFunctionNode({
                 functionName: node.codedata.symbol,
@@ -818,13 +826,10 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
 
             const templateDescription = stripCodeFences(functionNodeTemplate.flowNode?.metadata?.description || "");
 
-            let oauthFields: FormField[] = [];
             const position = funcDef?.codedata.lineRange.startLine || { line: 0, offset: 0 };
             const oauthProperties = await fetchOAuthConfigProperties(rpcClient, functionFilePath.current, position);
             oauthConfigPropertiesRef.current = oauthProperties;
-            oauthFields = oauthProperties.map(({ key, property }) =>
-                convertNodePropertyToFormField(key, property)
-            );
+            const oauthFields = buildOAuthFields(oauthProperties);
             setShowOAuthConfig(oauthFields.length > 0);
 
             const nodeRecordTypeFields = functionNodeTemplate.flowNode?.properties
@@ -834,14 +839,16 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             setRecordTypeFields([...nodeRecordTypeFields, ...oauthRecordTypeFields]);
 
             setFields((prevFields) => [
-                ...prevFields.map((field) =>
-                    field.key === "description" ? { ...field, value: templateDescription } : field
-                ),
-                ...toolInputFields,
-                ...functionParameterFields.map(field => ({
-                    ...field,
-                    value: typeof field.value === 'string' ? field.value.replace(/^\$/, '') : field.value
-                })),
+                ...prevFields.map((field) => {
+                    if (field.key === "description") {
+                        return { ...field, value: templateDescription };
+                    }
+                    if (field.key === "name" && options?.suggestedToolName) {
+                        return { ...field, value: options.suggestedToolName };
+                    }
+                    return field;
+                }),
+                ...buildGroupedInputFields(toolInputFields, functionParameterFields),
                 ...oauthFields,
             ]);
         } catch (error) {
@@ -849,13 +856,21 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
         }
     };
 
-    const loadConnectionCallFields = async (node: AvailableNode): Promise<void> => {
+    const loadConnectionCallFields = async (
+        node: AvailableNode,
+        options?: { connectionName?: string; suggestedToolName?: string; connector?: AvailableNode }
+    ): Promise<void> => {
         try {
             const nodeTemplate = await rpcClient.getBIDiagramRpcClient().getNodeTemplate({
                 position: { line: 0, offset: 0 },
                 filePath: agentFilePath.current,
                 id: node.codedata,
             });
+
+            const connectionProperty = nodeTemplate.flowNode?.properties?.connection as Property | undefined;
+            if (options?.connectionName && connectionProperty) {
+                connectionProperty.value = options.connectionName;
+            }
 
             if (nodeTemplate.flowNode) {
                 // Remove imports from optional+advanced properties to avoid unnecessary imports in genTool
@@ -869,7 +884,7 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                 }
                 flowNode.current = nodeTemplate.flowNode;
             } else {
-                console.error("Node template flowNode not found");
+                console.error("Node template flowNode not found", { response: nodeTemplate });
             }
 
             const nodeParameterFields = nodeTemplate.flowNode?.properties
@@ -877,13 +892,27 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                 : [];
 
             const toolInputFields = createToolInputFields(prepareToolInputFields(nodeParameterFields));
-            const templateDescription = stripCodeFences(nodeTemplate.flowNode?.metadata?.description || "");
-            let oauthFields: FormField[] = [];
+            let connectionField: FormField | undefined;
+            if (options?.connector) {
+                const connectionIndex = nodeParameterFields.findIndex((field) => field.key === "connection");
+                const ballerinaType = getPrimaryInputType(
+                    nodeParameterFields[connectionIndex]?.types
+                )?.ballerinaType;
+                connectionField = buildConnectionSelectField(
+                    options.connector.codedata,
+                    ballerinaType,
+                    options.connectionName ?? String(connectionProperty?.value ?? "")
+                ) as unknown as FormField;
+                if (connectionIndex >= 0) {
+                    nodeParameterFields.splice(connectionIndex, 1);
+                }
+            }
+            const templateDescription = stripCodeFences(
+                nodeTemplate.flowNode?.metadata?.description || node.metadata?.description || ""
+            );
             const oauthProperties = await fetchOAuthConfigProperties(rpcClient, agentFilePath.current);
             oauthConfigPropertiesRef.current = oauthProperties;
-            oauthFields = oauthProperties.map(({ key, property }) =>
-                convertNodePropertyToFormField(key, property)
-            );
+            const oauthFields = buildOAuthFields(oauthProperties);
             setShowOAuthConfig(oauthFields.length > 0);
 
             const nodeRecordTypeFields = nodeTemplate.flowNode?.properties
@@ -892,20 +921,36 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             const oauthRecordTypeFields = extractRecordTypeFieldsFromEntries(oauthProperties);
             setRecordTypeFields([...nodeRecordTypeFields, ...oauthRecordTypeFields]);
 
+            const groupedInputFields = buildGroupedInputFields(toolInputFields, nodeParameterFields);
+
             setFields((prevFields) => [
-                ...prevFields.map((field) =>
-                    field.key === "description" ? { ...field, value: templateDescription } : field
-                ),
-                ...toolInputFields,
-                ...nodeParameterFields.map(field => ({
-                    ...field,
-                    value: typeof field.value === 'string' ? field.value.replace(/^\$/, '') : field.value
-                })),
+                ...prevFields.map((field) => {
+                    if (field.key === "description") {
+                        return { ...field, value: templateDescription };
+                    }
+                    if (field.key === "name" && options?.suggestedToolName) {
+                        return { ...field, value: options.suggestedToolName };
+                    }
+                    return field;
+                }),
+                ...(connectionField ? [connectionField] : []),
+                ...groupedInputFields,
                 ...oauthFields,
             ]);
         } catch (error) {
             console.error(">>> Error fetching node template", error);
         }
+    };
+
+    const suggestToolNameForAction = (codedata: CodeData | undefined): string | undefined => {
+        const symbol = codedata?.symbol;
+        if (!symbol) {
+            return undefined;
+        }
+        const seed = codedata?.node === RESOURCE_ACTION_CALL && codedata?.resourcePath
+            ? resourceToolNameSeed(symbol, codedata.resourcePath)
+            : symbol;
+        return suggestToolName(seed, getExistingToolNames(agentNode));
     };
 
     const handleOnSelectNode = async (nodeId: string, metadata?: any) => {
@@ -920,10 +965,40 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             setSelectedNodeCodeData(node.codedata);
 
             if (nodeId === FUNCTION_CALL) {
-                await loadFunctionCallFields(node);
+                await loadFunctionCallFields(node, {
+                    suggestedToolName: suggestToolNameForAction(node.codedata),
+                });
             } else if (nodeId === REMOTE_ACTION_CALL || nodeId === RESOURCE_ACTION_CALL || nodeId === METHOD_CALL) {
-                await loadConnectionCallFields(node);
+                await loadConnectionCallFields(node, {
+                    suggestedToolName: suggestToolNameForAction(node.codedata),
+                });
             }
+
+            setSidePanelView(SidePanelView.TOOL_FORM);
+        } finally {
+            setLoading(false);
+            isSelectingNodeRef.current = false;
+        }
+    };
+
+    const handleWizardSelect = async (selection: ActionSelection) => {
+        if (isSelectingNodeRef.current) return;
+        isSelectingNodeRef.current = true;
+        setLoading(true);
+
+        try {
+            const { action, connector, connectionName } = selection;
+            connectorRef.current = connector;
+
+            setToolNodeId(action.codedata.node);
+            selectedNodeRef.current = action;
+            setSelectedNodeCodeData(action.codedata);
+
+            await loadConnectionCallFields(action, {
+                connectionName,
+                connector,
+                suggestedToolName: suggestToolNameForAction(action.codedata),
+            });
 
             setSidePanelView(SidePanelView.TOOL_FORM);
         } finally {
@@ -1202,9 +1277,11 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                     }
                 });
             }
-        } else if ((toolNodeId === REMOTE_ACTION_CALL || toolNodeId === RESOURCE_ACTION_CALL || toolNodeId === METHOD_CALL) && Array.isArray(data["parameters"])) {
+        } else if (toolNodeId === REMOTE_ACTION_CALL || toolNodeId === RESOURCE_ACTION_CALL || toolNodeId === METHOD_CALL) {
             clonedFlowNode = flowNode.current ? cloneDeep(flowNode.current) : null;
-            toolParameters = updateToolParameters(data["parameters"]);
+            if (Array.isArray(data["parameters"])) {
+                toolParameters = updateToolParameters(data["parameters"]);
+            }
 
             // Update flowNode parameter values from data["parameters"]
             if (clonedFlowNode?.properties && typeof clonedFlowNode?.properties === "object" && !Array.isArray(clonedFlowNode?.properties)) {
@@ -1237,6 +1314,10 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             clonedFlowNode.properties.variable.value = flowNode.current?.properties?.variable?.value || cleanName + "Result";
         }
 
+        const chosenConnection = String(
+            data["connection"] ?? clonedFlowNode?.properties?.connection?.value ?? ""
+        ).trim();
+
         // Inject OAuth client config into codedata.data.auth
         const targetNode = clonedFunctionNode || clonedFlowNode;
         if (targetNode && showOAuthConfig) {
@@ -1265,14 +1346,14 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
         const toolModel: ExtendedAgentToolRequest = {
             toolName: cleanName,
             description: data["description"],
-            includeContext,
+            includeContext: data[INCLUDE_CONTEXT_KEY] === true,
             selectedCodeData: selectedNodeCodeData,
             toolParameters: toolParameters,
             functionNode: clonedFunctionNode,
             flowNode: clonedFlowNode,
             parameterImports: paramImports,
+            connectionName: chosenConnection || undefined,
         };
-        console.log("New Agent Tool:", toolModel);
         setSubmittingTool(true);
         try {
             await onSubmit(toolModel);
@@ -1281,11 +1362,17 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
         }
     };
 
+    const toolFormGroups = useMemo(() => buildToolFormGroups(fields), [fields]);
+
     let searchPlaceholder = "Search";
+    let listDescription: string | undefined;
     if (mode === NewToolSelectionMode.CONNECTION) {
         searchPlaceholder = "Search connections";
     } else if (mode === NewToolSelectionMode.FUNCTION) {
         searchPlaceholder = "Search functions";
+        listDescription =
+            "Pick a function from your integration or from a library. " +
+            "The function you choose becomes the tool.";
     }
 
     const isConnectionPopupOpen =
@@ -1308,7 +1395,34 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                     <RelativeLoader />
                 </LoaderContainer>
             )}
-            {!loading && sidePanelView !== SidePanelView.TOOL_FORM && displayedCategories.length > 0 && (
+            {connectorFirst && (
+                <div
+                    style={{
+                        display: sidePanelView === SidePanelView.CONNECTOR_WIZARD && !loading ? "contents" : "none",
+                    }}
+                >
+                    <ConnectorBrowser
+                        filePath={agentFilePath.current}
+                        target={targetRef.current.startLine}
+                        existingConnectionCategories={categories}
+                        connectorSet="GROUPED"
+                        description="Pick an existing connection or a connector to browse its actions."
+                        noActionsHint="You can still add it as a connection and create the tool from an action later."
+                        onSelect={handleWizardSelect}
+                        onStepChange={(step, goBack) => {
+                            wizardBackRef.current = goBack;
+                            onViewChange?.(
+                                step === WizardStep.CONNECTOR_LIST
+                                    ? SidePanelView.NODE_LIST
+                                    : SidePanelView.CONNECTOR_WIZARD,
+                                goBack
+                            );
+                        }}
+                    />
+                </div>
+            )}
+            {!loading && !connectorFirst && sidePanelView !== SidePanelView.TOOL_FORM
+                && displayedCategories.length > 0 && (
                 <NodeList
                     categories={displayedCategories}
                     onSelect={handleOnSelectNode}
@@ -1317,6 +1431,7 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                     onAddFunction={() => handleOnAddFunction(MACHINE_VIEW.BIFunctionForm, DIRECTORY_MAP.FUNCTION)}
                     onSearchTextChange={mode !== NewToolSelectionMode.CONNECTION ? (searchText) => handleSearchFunction(searchText, FUNCTION_TYPE.REGULAR, true) : undefined}
                     title={"Functions"}
+                    description={listDescription}
                     searchPlaceholder={searchPlaceholder}
                     panelBodySx={{ height: "calc(100vh - 140px)" }}
                     alwaysCollapsedCategories={["Imported Functions"]}
@@ -1540,10 +1655,13 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                 <ArtifactForm
                     preserveFieldOrder={false}
                     fileName={agentFilePath.current}
-                    targetLineRange={{ startLine: { line: 0, offset: 0 }, endLine: { line: 0, offset: 0 } }}
+                    targetLineRange={ZERO_LINE_RANGE}
                     fields={fields}
                     recordTypeFields={recordTypeFields}
                     onSubmit={handleToolSubmit}
+                    onCreateNode={handleCreateNode}
+                    groups={toolFormGroups}
+                    opensPrefilled
                     submitText={"Save Tool"}
                     isSaving={submittingTool}
                     helperPaneSide="left"
@@ -1569,48 +1687,6 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                                 </ImplementationBadge>
                             ),
                             index: 0,
-                        },
-                        {
-                            component: (
-                                <ImplementationInfoContainer>
-                                    <p style={{ margin: "0px", fontWeight: "bold" }}>Implementation</p>
-                                    <ImplementationDescription>Configure how tool inputs map to the {mode === NewToolSelectionMode.CONNECTION ? "connection" : "function"}.</ImplementationDescription>
-                                    <ImplementationInfo title={getImplementationString(selectedNodeRef.current.codedata)}>
-                                        <p>{getImplementationString(selectedNodeRef.current.codedata)}</p>
-                                    </ImplementationInfo>
-                                </ImplementationInfoContainer>
-                            ),
-                            index: 3,
-                        },
-                        ...(showOAuthConfig ? [{
-                            component: (
-                                <ImplementationInfoContainer>
-                                    <p style={{ margin: "0px", fontWeight: "bold" }}>OAuth Client Configuration</p>
-                                    <ImplementationDescription>Represents the OAuth 2.0 client configuration required to interact with an external Authorization Server and validate issued access tokens.</ImplementationDescription>
-                                </ImplementationInfoContainer>
-                            ),
-                            index: fields.filter((f) => f.advanced && !f.hidden).length - oauthConfigPropertiesRef.current.length,
-                            advanced: true,
-                        }] : []),
-                        {
-                            component: (
-                                <ContextOption>
-                                    <input
-                                        type="checkbox"
-                                        checked={includeContext}
-                                        onChange={(event) => setIncludeContext(event.target.checked)}
-                                    />
-                                    <div>
-                                        Pass agent context
-                                        <ContextHint>
-                                            Adds ai:Context ctx as the first parameter so this tool can access the
-                                            invoking agent's context.
-                                        </ContextHint>
-                                    </div>
-                                </ContextOption>
-                            ),
-                            index: 0,
-                            advanced: true,
                         },
                     ]}
                 />

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
@@ -9,7 +9,6 @@
 
 import { FlowNode, LineRange, NodePosition } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
-import styled from "@emotion/styled";
 import { cloneDeep, debounce } from "lodash";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { RelativeLoader } from "../../../components/RelativeLoader";
@@ -46,22 +45,6 @@ const AUTH_FIELD_KEY = "auth";
 const RESULT_FIELD_KEY = "variable";
 const TOOLKIT_NAME_FIELD_KEY = "toolKitName";
 const INCLUDE_CONTEXT_PROPERTY = "includeContext";
-
-const ContextOption = styled.label`
-    display: flex;
-    align-items: flex-start;
-    gap: 8px;
-    cursor: pointer;
-    font-size: var(--vscode-font-size);
-    color: var(--vscode-foreground);
-`;
-
-const ContextHint = styled.div`
-    font-size: 11px;
-    color: var(--vscode-descriptionForeground);
-    margin-top: 2px;
-    line-height: 1.4;
-`;
 
 // Delegates to the shared removeQuotes so `"url"` and string `url` compare equal.
 const normalizeExpressionValue = (value: unknown): string =>
@@ -578,20 +561,13 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
             },
             {
                 component: (
-                    <ContextOption>
-                        <input
-                            type="checkbox"
-                            checked={includeContext}
-                            onChange={(event) => setIncludeContext(event.target.checked)}
-                        />
-                        <div>
-                            Pass agent context
-                            <ContextHint>
-                                Adds ai:Context ctx as the first parameter so this tool can access the invoking
-                                agent's context.
-                            </ContextHint>
-                        </div>
-                    </ContextOption>
+                    <RequiresAuthCheckbox
+                        checked={includeContext}
+                        onChange={setIncludeContext}
+                        label="Pass agent context"
+                        description={"Adds ai:Context ctx as the first parameter so the generated tools can "
+                            + "access the invoking agent's context."}
+                    />
                 ),
                 index: 0,
                 advanced: true,

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AddTool.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AddTool.tsx
@@ -83,6 +83,19 @@ const OptionDescription = styled.div`
     line-height: 1.4;
 `;
 
+export const TOOL_OPTION_LABELS = {
+    CONNECTION: "Use Connection",
+    FUNCTION: "Use Function",
+    AGENT: "Use Agent",
+    MCP: "Use MCP Server",
+    CUSTOM: "Create Custom Tool",
+} as const;
+
+export const ADD_TOOL_TITLE = "Add Tool";
+
+export const addToolTitle = (option: keyof typeof TOOL_OPTION_LABELS): string =>
+    `${ADD_TOOL_TITLE} - ${TOOL_OPTION_LABELS[option]}`;
+
 interface AddToolProps {
     agentNode: FlowNode;
     onCreateCustomTool?: () => void;
@@ -129,11 +142,11 @@ export function AddTool(props: AddToolProps): JSX.Element {
                         <OptionIcon>
                             <Icon name="bi-connection" />
                         </OptionIcon>
-                        <OptionTitle>Use Connection</OptionTitle>
+                        <OptionTitle>{TOOL_OPTION_LABELS.CONNECTION}</OptionTitle>
                     </OptionHeader>
                     <OptionDescription>
-                        Turn an existing connection (HTTP client, database, message broker) into an agent tool.
-                        Your agent will be able to make requests and interact with these services.
+                        Call an action on an HTTP client, database, or message broker. Pick the action
+                        first, then the connection it runs on.
                     </OptionDescription>
                 </OptionCard>
 
@@ -142,11 +155,11 @@ export function AddTool(props: AddToolProps): JSX.Element {
                         <OptionIcon>
                             <Icon name="bi-function" />
                         </OptionIcon>
-                        <OptionTitle>Use Function</OptionTitle>
+                        <OptionTitle>{TOOL_OPTION_LABELS.FUNCTION}</OptionTitle>
                     </OptionHeader>
                     <OptionDescription>
-                        Create a tool from an existing function in your integration or from a library function.
-                        This gives your agent the ability to execute specific business logic.
+                        Turn a function from your integration, or one from a library, into a tool the
+                        agent can call for specific business logic.
                     </OptionDescription>
                 </OptionCard>
 
@@ -155,11 +168,11 @@ export function AddTool(props: AddToolProps): JSX.Element {
                         <OptionIcon>
                             <Icon name="bi-ai-agent" />
                         </OptionIcon>
-                        <OptionTitle>Use Agent</OptionTitle>
+                        <OptionTitle>{TOOL_OPTION_LABELS.AGENT}</OptionTitle>
                     </OptionHeader>
                     <OptionDescription>
-                        Delegate to another agent in your integration. The selected agent is wrapped as a tool,
-                        so this agent can hand off relevant requests to it and use its response.
+                        Delegate to another agent in your integration. It is wrapped as a tool, so this
+                        agent can hand off requests and use the response.
                     </OptionDescription>
                 </OptionCard>
 
@@ -168,11 +181,11 @@ export function AddTool(props: AddToolProps): JSX.Element {
                         <OptionIcon>
                             <Icon name="bi-mcp" />
                         </OptionIcon>
-                        <OptionTitle>Use MCP Server</OptionTitle>
+                        <OptionTitle>{TOOL_OPTION_LABELS.MCP}</OptionTitle>
                     </OptionHeader>
                     <OptionDescription>
-                        Connect to a Model Context Protocol (MCP) server to access pre-built tools and resources.
-                        MCP servers provide standardized access to external systems and data sources.
+                        Connect to a Model Context Protocol (MCP) server for pre-built tools and
+                        standardized access to external systems.
                     </OptionDescription>
                 </OptionCard>
 
@@ -181,11 +194,11 @@ export function AddTool(props: AddToolProps): JSX.Element {
                         <OptionIcon>
                             <Icon name="bi-flowchart" />
                         </OptionIcon>
-                        <OptionTitle>Create Custom Tool</OptionTitle>
+                        <OptionTitle>{TOOL_OPTION_LABELS.CUSTOM}</OptionTitle>
                     </OptionHeader>
                     <OptionDescription>
-                        Build a new tool from scratch using the visual flow editor.
-                        Define the tool's logic, inputs, and outputs to give your agent customized capabilities tailored to your exact needs.
+                        Build a tool from scratch in the visual flow editor, defining its logic, inputs,
+                        and outputs to match your exact needs.
                     </OptionDescription>
                 </OptionCard>
             </Column>

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AddTool.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AddTool.tsx
@@ -145,8 +145,8 @@ export function AddTool(props: AddToolProps): JSX.Element {
                         <OptionTitle>{TOOL_OPTION_LABELS.CONNECTION}</OptionTitle>
                     </OptionHeader>
                     <OptionDescription>
-                        Call an action on an HTTP client, database, or message broker. Pick the action
-                        first, then the connection it runs on.
+                        Call an action on an HTTP client, database, or message broker. Pick a connector,
+                        choose the action you want, then point it at a connection.
                     </OptionDescription>
                 </OptionCard>
 

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentEditorPanelContent.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AgentEditorPanelContent.tsx
@@ -18,7 +18,7 @@
 
 import { FlowNode } from "@wso2/ballerina-core";
 import { AddMcpServer } from "./AddMcpServer";
-import { AddTool } from "./AddTool";
+import { ADD_TOOL_TITLE, AddTool, addToolTitle } from "./AddTool";
 import { MemoryManagerConfig } from "./MemoryManagerConfig";
 import { NewTool, NewToolSelectionMode } from "./NewTool";
 import { UseAgentTool } from "./UseAgentTool";
@@ -28,10 +28,14 @@ import { AgentEditorController } from "./useAgentEditorController";
 export function getAgentEditorPanelTitle(controller: AgentEditorController): string {
     switch (controller.view) {
         case "MEMORY": return "Configure Memory";
-        case "NEW_TOOL_AGENT_FORM": return "Use Agent";
-        case "ADD_MCP": return "Add MCP Server";
+        case "NEW_TOOL_CONNECTION": return addToolTitle("CONNECTION");
+        case "NEW_TOOL_FUNCTION": return addToolTitle("FUNCTION");
+        case "NEW_TOOL_CUSTOM": return addToolTitle("CUSTOM");
+        case "NEW_TOOL_AGENT":
+        case "NEW_TOOL_AGENT_FORM": return addToolTitle("AGENT");
+        case "ADD_MCP": return addToolTitle("MCP");
         case "EDIT_MCP": return "Edit MCP Server";
-        default: return "Add Tool";
+        default: return ADD_TOOL_TITLE;
     }
 }
 
@@ -56,7 +60,8 @@ export function AgentEditorPanelContent({ controller }: { controller: AgentEdito
                 mode={controller.view === "NEW_TOOL_CUSTOM" ? NewToolSelectionMode.CUSTOM_TOOL
                     : controller.view === "NEW_TOOL_CONNECTION" ? NewToolSelectionMode.CONNECTION
                         : NewToolSelectionMode.FUNCTION}
-                onSave={controller.close} onBack={controller.back} />;
+                onSave={controller.close} onBack={controller.back}
+                onSetBackOverride={controller.setBackHandler} />;
         case "NEW_TOOL_AGENT":
             return <UseAgentTool agentNode={agent} onSelectAgent={controller.selectAgent}
                 onAgentCreated={controller.onAgentCreated} />;

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/NewTool.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/NewTool.tsx
@@ -19,8 +19,10 @@
 import { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import { EVENT_TYPE, FlowNode, Property } from "@wso2/ballerina-core";
+import { Button } from "@wso2/ui-toolkit";
 import { NodePosition } from "@wso2/syntax-tree";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
+import { Banner } from "../../../components/Banner";
 import { AIAgentSidePanel, ExtendedAgentToolRequest } from "./AIAgentSidePanel";
 import { RelativeLoader } from "../../../components/RelativeLoader";
 import { addToolToAgentNode, buildAgentToolNode, refreshAgentNodeLineRange, resolveAgentNodePosition, updateFlowNodePropertyValuesWithKeys } from "./utils";
@@ -56,6 +58,7 @@ export function NewTool(props: NewToolProps): JSX.Element {
     const agentNode = agentNodeProp ?? null;
     const [savingForm, setSavingForm] = useState<boolean>(false);
     const [ready, setReady] = useState<boolean>(false);
+    const [error, setError] = useState<string>("");
 
     const agentFilePath = useRef<string>("");
     const projectPath = useRef<string>("");
@@ -149,9 +152,10 @@ export function NewTool(props: NewToolProps): JSX.Element {
                 return;
             }
             flowNode = data.flowNode;
-            connection = data.selectedCodeData.parentSymbol || "";
+            connection = data.connectionName || data.selectedCodeData.parentSymbol || "";
         }
 
+        setError("");
         setSavingForm(true);
 
         try {
@@ -184,14 +188,16 @@ export function NewTool(props: NewToolProps): JSX.Element {
                     undefined, data.includeContext),
             });
 
-            if (!toolResponse) {
-                console.error("Tool generation failed");
+            if (!toolResponse || toolResponse.error) {
+                console.error("Tool generation failed", { error: toolResponse?.error });
+                setError("The tool could not be generated. Please try again.");
                 return;
             }
 
             const updatedAgentNode = await addToolToAgentNode(agentNode, data.toolName);
             if (!updatedAgentNode) {
                 console.error("Failed to add tool to agent node");
+                setError("The tool was created but could not be attached to the agent.");
                 return;
             }
             await refreshAgentNodeLineRange(updatedAgentNode, rpcClient, toolResponse.artifacts);
@@ -209,6 +215,7 @@ export function NewTool(props: NewToolProps): JSX.Element {
             onSave?.(await resolveAgentNodePosition(updatedAgentNode, rpcClient));
         } catch (error) {
             console.error("Error saving tool", { error });
+            setError(`The tool could not be saved. ${error instanceof Error ? error.message : ""}`.trim());
         } finally {
             setSavingForm(false);
         }
@@ -216,6 +223,17 @@ export function NewTool(props: NewToolProps): JSX.Element {
 
     return (
         <>
+            {error && (
+                <div style={{ margin: "12px 16px" }}>
+                    <Banner
+                        variant="error"
+                        message={error}
+                        actions={
+                            <Button appearance="secondary" onClick={() => setError("")}>Dismiss</Button>
+                        }
+                    />
+                </div>
+            )}
             {ready && !savingForm && (
                 mode === NewToolSelectionMode.CUSTOM_TOOL ? (
                     <AgentToolForm

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentTool.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentTool.tsx
@@ -129,6 +129,7 @@ export function UseAgentTool(props: UseAgentToolProps): JSX.Element {
                 onSelect={(id: string) => onSelectAgent(id)}
                 onAdd={() => setShowAddAgentPopup(true)}
                 addButtonLabel={"Add Agent"}
+                description={"Pick an agent from your integration to hand off requests to."}
                 searchPlaceholder={"Search agents"}
             />
             {showAddAgentPopup && createPortal(

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentToolForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentToolForm.tsx
@@ -20,12 +20,13 @@ import { useEffect, useMemo, useState } from "react";
 import styled from "@emotion/styled";
 import { ArtifactData, AvailableNode, BISearchRequest, Category, FlowNode, LinePosition, NodePosition, Property,
     RecordTypeField } from "@wso2/ballerina-core";
-import { FieldGroup, FormField, FormValues } from "@wso2/ballerina-side-panel";
+import { FieldGroup, FormField, FormImports, FormValues } from "@wso2/ballerina-side-panel";
 import { Icon } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import ArtifactForm from "../Forms/ArtifactForm";
 import { RelativeLoader } from "../../../components/RelativeLoader";
 import { ImplementationBadge } from "../../../components/ImplementationBadge";
+import { getImportsForProperty } from "../../../utils/bi";
 import { INCLUDE_CONTEXT_KEY, RESULT_TYPE_GROUP, buildIncludeContextField, buildToolFormGroups } from "./toolForm";
 import { addToolToAgentNode, AgentToolHostClass, buildAgentCallToolNode, buildOAuthFields, fetchAgentRunReturnType, fetchOAuthConfigProperties, refreshAgentNodeLineRange, resolveAgentNodePosition, ZERO_LINE_RANGE } from "./utils";
 import { buildAgentToolFields, buildApprovalToolData, buildRequiresApprovalField,
@@ -150,7 +151,7 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
     const overriddenReturnType = (submitted: string): string =>
         submitted.trim() === defaultReturnType.trim() ? "" : submitted;
 
-    const handleSubmit = async (data: FormValues) => {
+    const handleSubmit = async (data: FormValues, formImports?: FormImports) => {
         if (saving) {
             return;
         }
@@ -161,9 +162,18 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
             const description = stripCodeFencesInline(String(data["description"] ?? ""));
             const toolFilePath = hostClass ? hostClass.filePath : agentFilePath;
             const approvalData = buildApprovalToolData(data, approvalCandidates ?? []);
+            const returnType = overriddenReturnType(String(data["returnType"] ?? ""));
             const toolNode = buildAgentCallToolNode(toolName, agentVarName, data[INCLUDE_CONTEXT_KEY] === true,
-                description, hostClass, agentReceiver, overriddenReturnType(String(data["returnType"] ?? "")),
-                approvalData);
+                description, hostClass, agentReceiver, returnType, approvalData);
+
+            // The LS only registers the import itself when it resolves the type itself.
+            const returnTypeImports = returnType ? getImportsForProperty("returnType", formImports) : undefined;
+            if (returnTypeImports && Object.keys(returnTypeImports).length > 0) {
+                toolNode.codedata.data = {
+                    ...toolNode.codedata.data,
+                    returnTypeImports: JSON.stringify(returnTypeImports),
+                };
+            }
 
             const authConfig: Record<string, string> = {};
             for (const { key } of oauthProperties) {

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentToolForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentToolForm.tsx
@@ -16,40 +16,25 @@
  * under the License.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import styled from "@emotion/styled";
-import { ArtifactData, FlowNode, NodePosition } from "@wso2/ballerina-core";
-import { FormField, FormValues } from "@wso2/ballerina-side-panel";
+import { ArtifactData, FlowNode, NodePosition, Property, RecordTypeField } from "@wso2/ballerina-core";
+import { FieldGroup, FormField, FormValues } from "@wso2/ballerina-side-panel";
 import { Icon } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import ArtifactForm from "../Forms/ArtifactForm";
 import { RelativeLoader } from "../../../components/RelativeLoader";
 import { ImplementationBadge } from "../../../components/ImplementationBadge";
-import { addToolToAgentNode, AgentToolHostClass, buildAgentCallToolNode, refreshAgentNodeLineRange, resolveAgentNodePosition } from "./utils";
-import { buildAgentToolFields, stripCodeFencesInline } from "./formUtils";
+import { INCLUDE_CONTEXT_KEY, RESULT_TYPE_GROUP, buildIncludeContextField, buildToolFormGroups } from "./toolForm";
+import { addToolToAgentNode, AgentToolHostClass, buildAgentCallToolNode, fetchAgentRunReturnType, fetchOAuthConfigProperties, refreshAgentNodeLineRange, resolveAgentNodePosition, ZERO_LINE_RANGE } from "./utils";
+import { buildAgentToolFields, buildOAuthFields, extractRecordTypeFieldsFromEntries, stripCodeFencesInline }
+    from "./formUtils";
 
 const LoaderContainer = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
     height: 100%;
-`;
-
-const ContextOption = styled.label`
-    display: flex;
-    align-items: flex-start;
-    gap: 8px;
-    cursor: pointer;
-    font-size: var(--vscode-font-size);
-    color: var(--vscode-foreground);
-    margin-top: 4px;
-`;
-
-const ContextHint = styled.div`
-    font-size: 11px;
-    color: var(--vscode-descriptionForeground);
-    margin-top: 2px;
-    line-height: 1.4;
 `;
 
 interface UseAgentToolFormProps {
@@ -73,26 +58,58 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
     const [agentFilePath, setAgentFilePath] = useState<string>("");
     const [ready, setReady] = useState<boolean>(false);
     const [saving, setSaving] = useState<boolean>(false);
-    const [includeContext, setIncludeContext] = useState<boolean>(false);
+    const [oauthProperties, setOauthProperties] = useState<{ key: string; property: Property }[]>([]);
+    const [defaultReturnType, setDefaultReturnType] = useState<string>("");
 
     useEffect(() => {
-        if (hostClass) {
-            setAgentFilePath(hostClass.filePath);
-            setReady(true);
-            return;
-        }
         (async () => {
-            const fileName = agentNode?.codedata?.lineRange?.fileName ?? "agents.bal";
-            const { filePath } = await rpcClient.getVisualizerRpcClient().joinProjectPath({ segments: [fileName] });
+            const filePath = hostClass
+                ? hostClass.filePath
+                : (await rpcClient.getVisualizerRpcClient().joinProjectPath({
+                    segments: [agentNode?.codedata?.lineRange?.fileName ?? "agents.bal"],
+                })).filePath;
             setAgentFilePath(filePath);
+            setOauthProperties(await fetchOAuthConfigProperties(rpcClient, filePath));
+            setDefaultReturnType(await fetchAgentRunReturnType(rpcClient, filePath, agentVarName,
+                hostClass?.className));
             setReady(true);
         })();
     }, [agentNode]);
 
-    const fields: FormField[] = buildAgentToolFields(
-        `${agentVarName}Tool`,
-        `Delegates a query to ${agentLabel === "Agent" ? "the generic agent" : agentLabel}.`
+    const oauthFields = useMemo<FormField[]>(() => buildOAuthFields(oauthProperties), [oauthProperties]);
+
+    const recordTypeFields = useMemo<RecordTypeField[]>(
+        () => extractRecordTypeFieldsFromEntries(oauthProperties),
+        [oauthProperties]
     );
+
+    const fields = useMemo<FormField[]>(() => [
+        ...buildAgentToolFields(
+            `${agentVarName}Tool`,
+            `Delegates a query to ${agentLabel === "Agent" ? "the generic agent" : agentLabel}.`
+        ),
+        buildIncludeContextField() as FormField,
+        ...oauthFields,
+        {
+            key: "returnType",
+            label: "Result Type",
+            type: "TYPE",
+            optional: true,
+            editable: true,
+            documentation: "The data type this tool will return to the agent.",
+            value: defaultReturnType,
+            placeholder: "string",
+            types: [{ fieldType: "TYPE", selected: true }],
+            group: RESULT_TYPE_GROUP,
+            advanced: false,
+            enabled: true,
+        },
+    ], [agentVarName, agentLabel, oauthFields, defaultReturnType]);
+
+    const groups = useMemo<FieldGroup[]>(() => buildToolFormGroups(fields), [fields]);
+
+    const overriddenReturnType = (submitted: string): string =>
+        submitted.trim() === defaultReturnType.trim() ? "" : submitted;
 
     const handleSubmit = async (data: FormValues) => {
         if (saving) {
@@ -104,10 +121,23 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
             const toolName = String(data["name"] ?? "").trim() || `${agentVarName}Tool`;
             const description = stripCodeFencesInline(String(data["description"] ?? ""));
             const toolFilePath = hostClass ? hostClass.filePath : agentFilePath;
+            const toolNode = buildAgentCallToolNode(toolName, agentVarName, data[INCLUDE_CONTEXT_KEY] === true,
+                description, hostClass, agentReceiver, overriddenReturnType(String(data["returnType"] ?? "")));
+
+            const authConfig: Record<string, string> = {};
+            for (const { key } of oauthProperties) {
+                const value = data[key];
+                if (value !== undefined && value !== "") {
+                    authConfig[key] = String(value);
+                }
+            }
+            if (Object.keys(authConfig).length > 0) {
+                toolNode.codedata.data = { ...toolNode.codedata.data, auth: JSON.stringify(authConfig) };
+            }
+
             const toolResponse = await rpcClient.getBIDiagramRpcClient().getSourceCode({
                 filePath: toolFilePath,
-                flowNode: buildAgentCallToolNode(toolName, agentVarName, includeContext, description,
-                    hostClass, agentReceiver),
+                flowNode: toolNode,
                 artifactData,
             });
             let agentPosition: NodePosition | undefined;
@@ -145,9 +175,11 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
         <ArtifactForm
             preserveFieldOrder={false}
             fileName={agentFilePath}
-            targetLineRange={{ startLine: { line: 0, offset: 0 }, endLine: { line: 0, offset: 0 } }}
+            targetLineRange={ZERO_LINE_RANGE}
             fields={fields}
-            recordTypeFields={[]}
+            groups={groups}
+            opensPrefilled
+            recordTypeFields={recordTypeFields}
             onSubmit={handleSubmit}
             submitText={submitText}
             isSaving={saving}
@@ -161,26 +193,6 @@ export function UseAgentToolForm(props: UseAgentToolFormProps): JSX.Element {
                         </ImplementationBadge>
                     ),
                     index: 0,
-                },
-                {
-                    component: (
-                        <ContextOption>
-                            <input
-                                type="checkbox"
-                                checked={includeContext}
-                                onChange={(e) => setIncludeContext(e.target.checked)}
-                            />
-                            <div>
-                                Pass agent context
-                                <ContextHint>
-                                    Adds ai:Context ctx as the first parameter so this tool can access the invoking
-                                    agent's context.
-                                </ContextHint>
-                            </div>
-                        </ContextOption>
-                    ),
-                    index: 2,
-                    advanced: true,
                 },
             ]}
         />

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
@@ -16,8 +16,11 @@
  * under the License.
  */
 
-import { ValueTypeConstraint, ToolParameters, getPrimaryInputType } from "@wso2/ballerina-core";
+import { NodeProperties, Property, RecordTypeField, ToolParameters, ValueTypeConstraint, getPrimaryInputType }
+    from "@wso2/ballerina-core";
 import { FormField, Parameter } from "@wso2/ballerina-side-panel";
+import { convertNodePropertyToFormField } from "../../../utils/bi";
+import { OAUTH_GROUP } from "./toolForm";
 
 const SQL_PARAMETERIZED_TYPES = ["sql:ParameterizedQuery", "sql:ParameterizedCallQuery"];
 const isSqlParameterizedField = (field: FormField): boolean =>
@@ -311,6 +314,7 @@ export function buildAgentToolFields(nameValue: string, descriptionValue: string
             key: "description",
             label: "Description",
             type: "TEXTAREA",
+            growRange: { start: 3, offset: 12 },
             optional: true,
             editable: true,
             documentation: "Describe what this tool does. The agent uses this to decide when to invoke the tool.",
@@ -319,4 +323,32 @@ export function buildAgentToolFields(nameValue: string, descriptionValue: string
             enabled: true,
         },
     ];
+}
+
+export type PropertyEntry = { key: string; property: Property };
+
+export function buildOAuthFields(entries: PropertyEntry[]): FormField[] {
+    return entries.map(({ key, property }) => ({
+        ...convertNodePropertyToFormField(key, property),
+        group: OAUTH_GROUP,
+        advanced: false,
+    }));
+}
+
+export function extractRecordTypeFieldsFromEntries(entries: PropertyEntry[]): RecordTypeField[] {
+    return entries
+        .filter(({ property }) => getPrimaryInputType(property?.types)?.typeMembers
+            ?.some(member => member.kind === "RECORD_TYPE"))
+        .map(({ key, property }) => ({
+            key,
+            property,
+            recordTypeMembers: getPrimaryInputType(property?.types)?.typeMembers
+                .filter(member => member.kind === "RECORD_TYPE"),
+        }));
+}
+
+export function extractRecordTypeFields(properties: NodeProperties): RecordTypeField[] {
+    return extractRecordTypeFieldsFromEntries(
+        Object.entries(properties).map(([key, property]) => ({ key, property }))
+    );
 }

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/toolForm.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/toolForm.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import {
+    INCLUDE_CONTEXT_KEY,
+    OAUTH_GROUP,
+    TOOL_INPUT_GROUP,
+    buildIncludeContextField,
+    buildToolFormGroups,
+    getExistingToolNames,
+    resourceToolNameSeed,
+    suggestToolName,
+} from "./toolForm";
+
+describe("resourceToolNameSeed", () => {
+    it("names after the last path segment, not just the accessor", () => {
+        expect(resourceToolNameSeed("post", "/users/[userId]/labels")).toBe("postLabels");
+        expect(resourceToolNameSeed("get", "/users/[userId]/drafts")).toBe("getDrafts");
+    });
+
+    it("walks back past trailing path parameters", () => {
+        expect(resourceToolNameSeed("get", "/users/[userId]/labels/[id]")).toBe("getLabels");
+        expect(resourceToolNameSeed("get", "/users/[userId]/messages/[messageId]/attachments/[id]"))
+            .toBe("getAttachments");
+    });
+
+    it("keeps GET and POST on one path distinct", () => {
+        const get = resourceToolNameSeed("get", "/users/[userId]/labels");
+        const post = resourceToolNameSeed("post", "/users/[userId]/labels");
+        expect(get).not.toBe(post);
+    });
+
+    it.each([
+        ["a rest-path placeholder", "post", "/path/to/subdirectory", "post"],
+        ["a dot resource path", "get", "/", "get"],
+        ["an empty path", "get", "", "get"],
+        ["only path parameters", "delete", "/[userId]/[id]", "delete"],
+        ["segments with no alphanumerics", "put", "/[userId]/---", "put"],
+    ])("falls back to the accessor for %s", (_case, accessor, path, expected) => {
+        expect(resourceToolNameSeed(accessor, path)).toBe(expected);
+    });
+
+    it("survives segments that are not bare identifiers", () => {
+        expect(suggestToolName(resourceToolNameSeed("get", "/v1.0/user-profile"), [])).toBe("getUserProfileTool");
+        expect(suggestToolName(resourceToolNameSeed("get", "/users/'limit"), [])).toBe("getLimitTool");
+    });
+
+    it("produces a usable name when the segment starts with a digit", () => {
+        expect(suggestToolName(resourceToolNameSeed("post", "/auth/2fa"), [])).toBe("post2faTool");
+    });
+
+    it("still yields a name with no accessor at all", () => {
+        expect(suggestToolName(resourceToolNameSeed("", "/users/[userId]/labels"), [])).toBe("labelsTool");
+    });
+});
+
+describe("buildToolFormGroups", () => {
+    const input = (over: Record<string, unknown> = {}) =>
+        ({ group: TOOL_INPUT_GROUP, optional: false, value: "key", ...over }) as any;
+    const oauth = (over: Record<string, unknown> = {}) =>
+        ({ group: OAUTH_GROUP, optional: true, value: "", ...over }) as any;
+
+    it("collapses inputs when every required mapping is prefilled", () => {
+        const [inputs] = buildToolFormGroups([input(), input({ value: "value" })]);
+        expect(inputs.id).toBe(TOOL_INPUT_GROUP);
+        expect(inputs.defaultCollapsed).toBe(true);
+    });
+
+    it("opens inputs expanded when a required mapping is empty", () => {
+        const [inputs] = buildToolFormGroups([input(), input({ value: "" })]);
+        expect(inputs.defaultCollapsed).toBe(false);
+    });
+
+    it("treats an undefined value as unfilled", () => {
+        const [inputs] = buildToolFormGroups([input({ value: undefined })]);
+        expect(inputs.defaultCollapsed).toBe(false);
+    });
+
+    it("ignores optional empty fields", () => {
+        const [inputs] = buildToolFormGroups([input(), input({ optional: true, value: "" })]);
+        expect(inputs.defaultCollapsed).toBe(true);
+    });
+
+    it("ignores hidden fields when deciding to expand", () => {
+        const [inputs] = buildToolFormGroups([input(), input({ value: "", hidden: true })]);
+        expect(inputs.defaultCollapsed).toBe(true);
+    });
+
+    it("always collapses OAuth, whose fields are all optional", () => {
+        const groups = buildToolFormGroups([input(), oauth()]);
+        expect(groups.map((group) => group.id)).toEqual([TOOL_INPUT_GROUP, OAUTH_GROUP]);
+        expect(groups[1].defaultCollapsed).toBe(true);
+    });
+
+    it("omits a group with no visible fields", () => {
+        expect(buildToolFormGroups([oauth()]).map((g) => g.id)).toEqual([OAUTH_GROUP]);
+        expect(buildToolFormGroups([oauth({ hidden: true })])).toEqual([]);
+        expect(buildToolFormGroups([])).toEqual([]);
+    });
+
+    it("ignores ungrouped fields", () => {
+        expect(buildToolFormGroups([{ optional: false, value: "" } as any])).toEqual([]);
+    });
+
+    it("keeps inputs collapsed for the optional context flag alone", () => {
+        const [inputs] = buildToolFormGroups([buildIncludeContextField(TOOL_INPUT_GROUP) as any]);
+        expect(inputs.id).toBe(TOOL_INPUT_GROUP);
+        expect(inputs.defaultCollapsed).toBe(true);
+    });
+});
+
+describe("buildIncludeContextField", () => {
+    it("is an optional, unchecked FLAG in the inputs card", () => {
+        const field = buildIncludeContextField(TOOL_INPUT_GROUP);
+        expect(field.key).toBe(INCLUDE_CONTEXT_KEY);
+        expect(field.type).toBe("FLAG");
+        expect(field.value).toBe(false);
+        expect(field.optional).toBe(true);
+        expect(field.group).toBe(TOOL_INPUT_GROUP);
+    });
+
+    it("declares exactly one type", () => {
+        expect(buildIncludeContextField(TOOL_INPUT_GROUP).types).toEqual([{ fieldType: "FLAG", selected: true }]);
+    });
+
+    it("omits the group when a form has no card to host it", () => {
+        expect(buildIncludeContextField()).not.toHaveProperty("group");
+    });
+});
+
+describe("suggestToolName", () => {
+    it("derives a tool name from the action symbol", () => {
+        expect(suggestToolName("append", [])).toBe("appendTool");
+    });
+
+    it("uniquifies against names already used by the agent", () => {
+        expect(suggestToolName("append", ["appendTool"])).toBe("appendTool2");
+        expect(suggestToolName("append", ["appendTool", "appendTool2"])).toBe("appendTool3");
+    });
+
+    it("does not double up when the symbol already ends in tool", () => {
+        expect(suggestToolName("searchTool", [])).toBe("searchTool");
+    });
+
+    it("lower-cases the leading character", () => {
+        expect(suggestToolName("BatchExecute", [])).toBe("batchExecuteTool");
+    });
+
+    it("strips characters that are illegal in identifiers", () => {
+        expect(suggestToolName("get-range!", [])).toBe("getRangeTool");
+    });
+
+    it("falls back for unusable symbols", () => {
+        expect(suggestToolName("***", [])).toBe("newTool");
+    });
+});
+
+describe("getExistingToolNames", () => {
+    it("parses the agent's tools array literal", () => {
+        const agentNode = { properties: { tools: { value: "[sumTool, appendTool]" } } };
+        expect(getExistingToolNames(agentNode as any)).toEqual(["sumTool", "appendTool"]);
+    });
+
+    it("handles an array value", () => {
+        const agentNode = { properties: { tools: { value: ["sumTool"] } } };
+        expect(getExistingToolNames(agentNode as any)).toEqual(["sumTool"]);
+    });
+
+    it("handles an empty list and a missing agent", () => {
+        expect(getExistingToolNames({ properties: { tools: { value: "[]" } } } as any)).toEqual([]);
+        expect(getExistingToolNames(undefined)).toEqual([]);
+    });
+});

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/toolForm.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/toolForm.ts
@@ -98,8 +98,6 @@ export function resourceToolNameSeed(accessor: string, resourcePath: string): st
     return `${accessor}${last.charAt(0).toUpperCase()}${last.slice(1)}`;
 }
 
-const BALLERINA_RESERVED_TOOL_NAMES = new Set(["function", "type", "class", "service", "resource", "remote", "client"]);
-
 export function suggestToolName(symbol: string, taken: Iterable<string>): string {
     const existing = new Set(taken);
     const words = (symbol || "").split(/[^a-zA-Z0-9]+/).filter(Boolean);
@@ -114,9 +112,6 @@ export function suggestToolName(symbol: string, taken: Iterable<string>): string
         base = `tool${base}`;
     }
     if (!base.toLowerCase().endsWith("tool")) {
-        base = `${base}Tool`;
-    }
-    if (BALLERINA_RESERVED_TOOL_NAMES.has(base)) {
         base = `${base}Tool`;
     }
     if (!existing.has(base)) {

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/toolForm.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/toolForm.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { REST_RESOURCE_PATH } from "../Connection/ConnectorBrowser/connectorActions";
+
+export const TOOL_INPUT_GROUP = "toolInputs";
+export const RESULT_TYPE_GROUP = "resultType";
+export const OAUTH_GROUP = "oauthConfig";
+
+export const INCLUDE_CONTEXT_KEY = "includeContext";
+
+export function buildIncludeContextField(group?: string): Record<string, unknown> {
+    return {
+        key: INCLUDE_CONTEXT_KEY,
+        label: "Pass agent context",
+        type: "FLAG",
+        documentation: "Adds ai:Context ctx as the first parameter so this tool can access the "
+            + "invoking agent's context.",
+        optional: true,
+        editable: true,
+        enabled: true,
+        hidden: false,
+        advanced: false,
+        value: false,
+        types: [{ fieldType: "FLAG", selected: true }],
+        ...(group ? { group } : {}),
+    };
+}
+
+interface GroupableField {
+    group?: string;
+    hidden?: boolean;
+    optional?: boolean;
+    value?: unknown;
+}
+
+export interface ToolFormGroup {
+    id: string;
+    label: string;
+    defaultCollapsed: boolean;
+}
+
+export function buildToolFormGroups(fields: GroupableField[]): ToolFormGroup[] {
+    const visibleIn = (group: string) =>
+        fields.filter((field) => field.group === group && !field.hidden);
+
+    const inputFields = visibleIn(TOOL_INPUT_GROUP);
+    const hasUnfilledRequiredInput = inputFields.some(
+        (field) => field.optional === false && (field.value === undefined || field.value === "")
+    );
+
+    const groups: ToolFormGroup[] = [];
+    if (inputFields.length > 0) {
+        groups.push({
+            id: TOOL_INPUT_GROUP,
+            label: "Inputs and Mapping",
+            defaultCollapsed: !hasUnfilledRequiredInput,
+        });
+    }
+    if (visibleIn(OAUTH_GROUP).length > 0) {
+        groups.push({ id: OAUTH_GROUP, label: "OAuth Client Configuration", defaultCollapsed: true });
+    }
+    if (visibleIn(RESULT_TYPE_GROUP).length > 0) {
+        groups.push({ id: RESULT_TYPE_GROUP, label: "Result Type", defaultCollapsed: true });
+    }
+    return groups;
+}
+
+export function resourceToolNameSeed(accessor: string, resourcePath: string): string {
+    const path = (resourcePath || "").trim();
+    if (!path || path === "/" || path === REST_RESOURCE_PATH) {
+        return accessor || "";
+    }
+
+    const named = path
+        .split("/")
+        .filter((segment) => segment && !segment.startsWith("[") && /[a-zA-Z0-9]/.test(segment));
+
+    const last = named.length > 0 ? named[named.length - 1] : "";
+    if (!last) {
+        return accessor || "";
+    }
+    return `${accessor}${last.charAt(0).toUpperCase()}${last.slice(1)}`;
+}
+
+const BALLERINA_RESERVED_TOOL_NAMES = new Set(["function", "type", "class", "service", "resource", "remote", "client"]);
+
+export function suggestToolName(symbol: string, taken: Iterable<string>): string {
+    const existing = new Set(taken);
+    const words = (symbol || "").split(/[^a-zA-Z0-9]+/).filter(Boolean);
+    const cleaned = words
+        .map((word, index) => (index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)))
+        .join("");
+    if (!cleaned) {
+        return "newTool";
+    }
+    let base = `${cleaned.charAt(0).toLowerCase()}${cleaned.slice(1)}`;
+    if (!/^[a-zA-Z_]/.test(base)) {
+        base = `tool${base}`;
+    }
+    if (!base.toLowerCase().endsWith("tool")) {
+        base = `${base}Tool`;
+    }
+    if (BALLERINA_RESERVED_TOOL_NAMES.has(base)) {
+        base = `${base}Tool`;
+    }
+    if (!existing.has(base)) {
+        return base;
+    }
+    let suffix = 2;
+    while (existing.has(`${base}${suffix}`)) {
+        suffix++;
+    }
+    return `${base}${suffix}`;
+}
+
+export function getExistingToolNames(agentNode: { properties?: Record<string, any> } | undefined): string[] {
+    const raw = agentNode?.properties?.tools?.value;
+    if (Array.isArray(raw)) {
+        return raw.map((entry) => String(entry).trim()).filter(Boolean);
+    }
+    if (typeof raw !== "string") {
+        return [];
+    }
+    return raw
+        .replace(/^\s*\[/, "")
+        .replace(/\]\s*$/, "")
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+}

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/useAgentEditorController.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/useAgentEditorController.ts
@@ -61,6 +61,7 @@ export interface AgentEditorController {
     selectAgent(name: string): void;
     close(position?: NodePosition): void;
     back(): void;
+    setBackHandler(handler: (() => void) | null): void;
 }
 
 const memoryKeyOf = (node?: FlowNode): string =>
@@ -73,6 +74,7 @@ export function useAgentEditorController(host: AgentEditorHost): AgentEditorCont
     const [memoryNode, setMemoryNode] = useState<FlowNode>();
     const [selectedTool, setSelectedTool] = useState<ToolData>();
     const [selectedAgentName, setSelectedAgentName] = useState("");
+    const [backOverride, setBackOverride] = useState<(() => void) | null>(null);
     const activate = useCallback((node: FlowNode) => {
         setAgentNode(node);
         host.onSelectionChange?.(node);
@@ -81,6 +83,7 @@ export function useAgentEditorController(host: AgentEditorHost): AgentEditorCont
     const setLoading = (loading: boolean) => host.onLoadingChange?.(loading);
 
     const close = useCallback((position?: NodePosition) => {
+        setBackOverride(null);
         setView("NONE");
         setMemoryNode(undefined);
         setSelectedTool(undefined);
@@ -139,6 +142,7 @@ export function useAgentEditorController(host: AgentEditorHost): AgentEditorCont
             existing = nodes?.[0];
         }
         setMemoryNode(existing);
+        setBackOverride(null);
         setView("MEMORY");
     }, [activate, host.filePath, rpcClient]);
 
@@ -302,10 +306,14 @@ export function useAgentEditorController(host: AgentEditorHost): AgentEditorCont
 
     const diagramCallbacks = useMemo<AgentNodeActions>(() => ({
         onModelSelect: (node) => { const n = resolve(node); activate(n); host.onModelSelect(n); },
-        onAddTool: (node) => { activate(resolve(node)); setView("ADD_TOOL"); },
-        onAddMcpServer: (node) => { activate(resolve(node)); setSelectedTool(undefined); setView("ADD_MCP"); },
+        onAddTool: (node) => { setBackOverride(null); activate(resolve(node)); setView("ADD_TOOL"); },
+        onAddMcpServer: (node) => {
+            setBackOverride(null); activate(resolve(node)); setSelectedTool(undefined); setView("ADD_MCP");
+        },
         onSelectTool: (tool, node) => void openTool(tool, resolve(node), true),
-        onSelectMcpToolkit: (tool, node) => { activate(resolve(node)); setSelectedTool(tool); setView("EDIT_MCP"); },
+        onSelectMcpToolkit: (tool, node) => {
+            setBackOverride(null); activate(resolve(node)); setSelectedTool(tool); setView("EDIT_MCP");
+        },
         onDeleteTool: (tool, node) => void deleteTool(tool, resolve(node)),
         goToTool: (tool, node) => void openTool(tool, resolve(node), false),
         onSelectMemoryManager: (node) => void selectMemory(resolve(node)),
@@ -313,12 +321,33 @@ export function useAgentEditorController(host: AgentEditorHost): AgentEditorCont
         onChatWithAgent: host.onChat && ((node) => host.onChat(resolve(node))),
     }), [activate, deleteMemory, deleteTool, host, openTool, resolve, selectMemory]);
 
-    const back = () => setView(view === "NEW_TOOL_AGENT_FORM" ? "NEW_TOOL_AGENT" : "ADD_TOOL");
-    const selectAgent = (name: string) => { setSelectedAgentName(name); setView("NEW_TOOL_AGENT_FORM"); };
+    const setBackHandler = useCallback(
+        (handler: (() => void) | null) => setBackOverride(() => handler),
+        []
+    );
+
+    const back = () => {
+        if (backOverride) {
+            backOverride();
+            return;
+        }
+        setView(view === "NEW_TOOL_AGENT_FORM" ? "NEW_TOOL_AGENT" : "ADD_TOOL");
+    };
+
+    const openView = useCallback((next: AgentEditorView) => {
+        setBackOverride(null);
+        setView(next);
+    }, []);
+
+    const selectAgent = (name: string) => {
+        setBackOverride(null);
+        setSelectedAgentName(name);
+        setView("NEW_TOOL_AGENT_FORM");
+    };
 
     return {
         view, agentNode, memoryNode, memoryPropertyKey: memoryKeyOf(agentNode), selectedTool, selectedAgentName,
         diagramCallbacks, onAgentCreated: host.onAgentCreated,
-        openView: setView, selectAgent, close, back,
+        openView, selectAgent, close, back, setBackHandler,
     };
 }

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/utils.ts
@@ -22,6 +22,8 @@ import { cloneDeep } from "lodash";
 import { URI, Utils } from "vscode-uri";
 import { BALLERINA } from "../../../constants";
 
+const KNOWN_AGENT_NAME_SUFFIXES = ["agent", "model"];
+
 export const AI_WSO2_MODEL_PROVIDER = "wso2ModelProvider";
 
 const WSO2_MODEL_PROVIDER_CODEDATA: CodeData = {
@@ -40,6 +42,59 @@ const OPENAI_PROVIDER_CODEDATA: CodeData = {
     object: "OpenAiProvider",
     symbol: "init",
 };
+
+export function toCamelCase(name: string): string {
+    const words = name.trim().split(/[\s_]+/).filter(Boolean);
+    if (words.length === 0) return "";
+    const firstWord = words[0];
+    const leadingUpper = firstWord.match(/^[A-Z]+/);
+    let lowerFirst: string;
+    if (leadingUpper && leadingUpper[0].length === firstWord.length) {
+        lowerFirst = firstWord.toLowerCase();
+    } else if (leadingUpper && leadingUpper[0].length > 1) {
+        lowerFirst = leadingUpper[0].slice(0, -1).toLowerCase() + firstWord.slice(leadingUpper[0].length - 1);
+    } else {
+        lowerFirst = firstWord.charAt(0).toLowerCase() + firstWord.slice(1);
+    }
+    return lowerFirst + words.slice(1).map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join("");
+}
+
+export function toBaseName(name: string): string {
+    const camel = toCamelCase(name);
+    const lower = camel.toLowerCase();
+    for (const suffix of KNOWN_AGENT_NAME_SUFFIXES) {
+        if (lower.endsWith(suffix) && lower.length > suffix.length) {
+            return camel.slice(0, -suffix.length);
+        }
+    }
+    return camel;
+}
+
+export interface CreatedBuiltInAgent {
+    agentVarName: string;
+    modelVarName: string;
+    baseName: string;
+    usedDefaultModelProvider: boolean;
+}
+
+export const fetchAgentNodeTemplate = async (
+    rpcClient: BallerinaRpcClient,
+    projectPath: string
+): Promise<FlowNode> => {
+    const aiModuleOrg = await getAiModuleOrg(rpcClient);
+    const agentSearchResponse = await rpcClient.getBIDiagramRpcClient().search({
+        filePath: projectPath,
+        queryMap: { orgName: aiModuleOrg },
+        searchKind: "AGENT",
+    });
+    const agentNode = agentSearchResponse?.categories?.[0]?.items?.[0] as AvailableNode | undefined;
+    if (!agentNode) {
+        throw new Error("No agent node found in search response");
+    }
+    return getNodeTemplate(rpcClient, agentNode.codedata, projectPath);
+};
+
+export const ZERO_LINE_RANGE: LineRange = { startLine: { line: 0, offset: 0 }, endLine: { line: 0, offset: 0 } };
 
 function refreshNodeLineRangeFromArtifacts(
     node: FlowNode,
@@ -94,26 +149,6 @@ export const resolveAgentNodePosition = async (
         : undefined;
 };
 
-export function toCamelCase(name: string): string {
-    const words = name.trim().split(/[\s_]+/).filter(Boolean);
-    if (words.length === 0) return "";
-    const firstWord = words[0];
-    const leadingUpper = firstWord.match(/^[A-Z]+/);
-    let lowerFirst: string;
-    if (leadingUpper && leadingUpper[0].length === firstWord.length) {
-        lowerFirst = firstWord.toLowerCase();
-    } else if (leadingUpper && leadingUpper[0].length > 1) {
-        lowerFirst = leadingUpper[0].slice(0, -1).toLowerCase() + firstWord.slice(leadingUpper[0].length - 1);
-    } else {
-        lowerFirst = firstWord.charAt(0).toLowerCase() + firstWord.slice(1);
-    }
-    return lowerFirst + words.slice(1).map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join("");
-}
-
-export function toBaseName(name: string): string {
-    return toCamelCase(name).replace(/^(.+?)(?:agent|model)$/i, "$1");
-}
-
 export interface CreatedBuiltInAgent {
     agentVarName: string;
     modelVarName: string;
@@ -152,27 +187,6 @@ export const ensureModelProvider = async (
     }
 
     return { modelVarName, usedDefaultModelProvider: modelProviderCodedata.symbol === GET_DEFAULT_MODEL_PROVIDER };
-};
-
-/**
- * Fetches the AGENT node template for the project's AI module. The template exposes the friendly
- * `role`/`instructions` fields (the raw `systemPrompt` record is hidden and reconstructed by the LS).
- */
-export const fetchAgentNodeTemplate = async (
-    rpcClient: BallerinaRpcClient,
-    projectPath: string
-): Promise<FlowNode> => {
-    const aiModuleOrg = await getAiModuleOrg(rpcClient);
-    const agentSearchResponse = await rpcClient.getBIDiagramRpcClient().search({
-        filePath: projectPath,
-        queryMap: { orgName: aiModuleOrg },
-        searchKind: "AGENT",
-    });
-    const agentNode = agentSearchResponse?.categories?.[0]?.items?.[0] as AvailableNode | undefined;
-    if (!agentNode) {
-        throw new Error("No agent node found in search response");
-    }
-    return getNodeTemplate(rpcClient, agentNode.codedata, projectPath);
 };
 
 export const createBuiltInAgent = async (
@@ -222,6 +236,33 @@ export const fetchOAuthConfigProperties = async (
     } catch (error) {
         console.error("Error fetching OAuth config properties:", error);
         return [];
+    }
+};
+
+export const fetchAgentRunReturnType = async (
+    rpcClient: BallerinaRpcClient,
+    filePath: string,
+    agentVarName: string,
+    hostClassName?: string
+): Promise<string> => {
+    try {
+        const response = await rpcClient.getBIDiagramRpcClient().getNodeTemplate({
+            position: { line: 0, offset: 0 },
+            filePath,
+            id: {
+                node: "AGENT_TOOL",
+                data: {
+                    toolKind: "AGENT_CALL",
+                    agentVarName,
+                    ...(hostClassName ? { hostClassName } : {}),
+                },
+            } as CodeData,
+        });
+        const value = (response?.flowNode?.properties as any)?.type?.value;
+        return typeof value === "string" ? value.trim() : "";
+    } catch (error) {
+        console.error("Error resolving the agent run return type:", error);
+        return "";
     }
 };
 
@@ -616,12 +657,14 @@ export function buildAgentToolNode(wrappedNode: FlowNode, toolName: string, desc
 }
 
 export function buildAgentCallToolNode(toolName: string, agentVarName: string, includeContext: boolean,
-    description: string, hostClass?: AgentToolHostClass, agentReceiver?: string): FlowNode {
+    description: string, hostClass?: AgentToolHostClass, agentReceiver?: string,
+    returnType?: string): FlowNode {
     const data: AgentToolData = {
         toolKind: "AGENT_CALL",
         agentVarName,
         includeContext,
         description,
+        ...(returnType?.trim() ? { returnType: returnType.trim() } : {}),
         ...(agentReceiver ? { agentReceiver } : {}),
         ...(hostClass ? { hostClassName: hostClass.className, filePath: hostClass.filePath } : {}),
     };

--- a/packages/ballerina-visualizer/src/views/BI/AgentDefinitionEditor/AgentDefinitionDesigner.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AgentDefinitionEditor/AgentDefinitionDesigner.tsx
@@ -35,7 +35,7 @@ import { FlowNodeForm } from "../Forms/FlowNodeForm";
 import { ArtifactForm } from "../Forms/ArtifactForm";
 import { AgentToolHostClass, buildAgentToolNode, parseToolsString, removeToolFromAgentNode } from "../AIChatAgent/utils";
 import { AIAgentSidePanel, ExtendedAgentToolRequest } from "../AIChatAgent/AIAgentSidePanel";
-import { AddTool } from "../AIChatAgent/AddTool";
+import { ADD_TOOL_TITLE, AddTool, addToolTitle } from "../AIChatAgent/AddTool";
 import { NewToolSelectionMode } from "../AIChatAgent/NewTool";
 import { AddMcpServer } from "../AIChatAgent/AddMcpServer";
 import { AgentInfoCard } from "../AIChatAgent/AddAgentPopup/AgentInfoCard";
@@ -1173,7 +1173,13 @@ export function AgentDefinitionDesigner(props: AgentDefinitionDesignerProps) {
         (f) => f.kind !== "INIT" && !agentTools.some((t) => t.name === f.name.value)
     );
     const hasAdvanced = Boolean(initFunction) || methods.length > 0;
-    const toolPanelTitle = editingMcpNode ? "Edit MCP Server" : "Add Tool";
+    const toolPanelTitle = editingMcpNode
+        ? "Edit MCP Server"
+        : toolPanel === "CONNECTION" ? addToolTitle("CONNECTION")
+            : toolPanel === "FUNCTION" ? addToolTitle("FUNCTION")
+                : toolPanel === "CUSTOM" ? addToolTitle("CUSTOM")
+                    : toolPanel === "MCP" ? addToolTitle("MCP")
+                        : ADD_TOOL_TITLE;
     const targetLineRange = {
         startLine: { line: position.startLine, offset: position.startColumn },
         endLine: { line: position.endLine, offset: position.endColumn },

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectionConfigurationPopup/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectionConfigurationPopup/index.tsx
@@ -255,6 +255,7 @@ export interface ConnectionConfigurationFormProps extends Omit<ConnectionConfigu
     devantExpressionEditor?: ExpressionEditorDevantProps;
     onSaveConfiguredConnection?: (node: FlowNode) => Promise<void>;
     footerActionButton?: boolean;
+    submitText?: string;
 }
 
 export function ConnectionConfigurationForm(props: ConnectionConfigurationFormProps) {
@@ -270,6 +271,7 @@ export function ConnectionConfigurationForm(props: ConnectionConfigurationFormPr
         overrideFlowNode,
         onSaveConfiguredConnection,
         footerActionButton,
+        submitText,
     } = props;
     const { rpcClient } = useRpcContext();
 
@@ -534,7 +536,7 @@ export function ConnectionConfigurationForm(props: ConnectionConfigurationFormPr
                         <FormContainer>
                             <ConnectionConfigView
                                 fileName={fileName}
-                                submitText={loading || savingFormStatus === SavingFormStatus.SAVING ? "Saving..." : "Save Connection"}
+                                submitText={loading || savingFormStatus === SavingFormStatus.SAVING ? "Saving..." : (submitText ?? "Save Connection")}
                                 isSaving={loading || savingFormStatus === SavingFormStatus.SAVING}
                                 selectedNode={getNodeForForm(selectedNodeRef.current)}
                                 onSubmit={handleOnFormSubmit}

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/ConnectorActionList.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/ConnectorActionList.tsx
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useMemo, useState } from "react";
+import styled from "@emotion/styled";
+import { AvailableNode } from "@wso2/ballerina-core";
+import { Codicon, SearchBox, ThemeColors, Typography } from "@wso2/ui-toolkit";
+import { ConnectorIcon, NodeIcon } from "@wso2/bi-diagram";
+import { MarkdownDescription } from "@wso2/ballerina-side-panel";
+import { actionDisplayLabel, formatResourceSignature } from "./connectorActions";
+import {
+    Container,
+    EmptyState,
+    HeaderArea,
+    Row as BaseRow,
+    RowChevron,
+    RowDescription,
+    RowIcon,
+    RowLabel as BaseRowLabel,
+    RowText,
+    ScrollArea,
+    Tag,
+} from "./styles";
+
+const isResourceAction = (action: AvailableNode): boolean =>
+    action.codedata?.node === "RESOURCE_ACTION_CALL" && Boolean(action.codedata?.resourcePath);
+
+const InfoCard = styled.div`
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px;
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    border-radius: 8px;
+    background-color: ${ThemeColors.SURFACE_DIM};
+`;
+
+const InfoIcon = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 6px;
+    background-color: ${ThemeColors.SURFACE_CONTAINER};
+    flex-shrink: 0;
+
+    & > * {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+        font-size: 22px;
+    }
+
+    & svg,
+    & img {
+        width: 22px;
+        height: 22px;
+        object-fit: contain;
+    }
+`;
+
+const InfoContent = styled.div`
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+`;
+
+const InfoTitleRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+`;
+
+const InfoName = styled.div`
+    font-size: 14px;
+    font-weight: 700;
+    color: ${ThemeColors.ON_SURFACE};
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const InfoDescription = styled(MarkdownDescription)`
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    margin: 0;
+    overflow: hidden;
+
+    p {
+        font-size: 12px;
+        color: var(--vscode-descriptionForeground);
+        margin: 0;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+`;
+
+const RowList = styled.div`
+    display: flex;
+    flex-direction: column;
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    border-radius: 5px;
+    overflow: hidden;
+`;
+
+const Row = styled(BaseRow)`
+    grid-template-columns: 20px minmax(0, 1fr) 12px;
+    gap: 16px;
+    border: none;
+    border-bottom: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+
+    &:last-of-type {
+        border-bottom: none;
+    }
+
+    &:hover .action-badge,
+    &:focus-visible .action-badge {
+        background-color: ${ThemeColors.PRIMARY_CONTAINER};
+    }
+`;
+
+const RowBadge = styled.span`
+    position: absolute;
+    right: -4px;
+    bottom: -4px;
+    width: 13px;
+    height: 13px;
+    border-radius: 50%;
+    background-color: ${ThemeColors.SURFACE};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.15s ease;
+
+    & svg {
+        width: 10px;
+        height: 10px;
+    }
+`;
+
+const RowLabel = styled(BaseRowLabel)`
+    margin-bottom: 4px;
+`;
+
+const RowSignature = styled.div`
+    font-family: var(--vscode-editor-font-family);
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--vscode-descriptionForeground);
+    word-break: break-word;
+`;
+
+interface ConnectorActionListProps {
+    connector: AvailableNode;
+    actions: AvailableNode[];
+    category?: string;
+    onSelect: (action: AvailableNode) => void;
+}
+
+export function ConnectorActionList(props: ConnectorActionListProps) {
+    const { connector, actions, category, onSelect } = props;
+    const [searchText, setSearchText] = useState<string>("");
+
+    const filteredActions = useMemo(() => {
+        const query = searchText.trim().toLowerCase();
+        if (!query) {
+            return actions;
+        }
+        return actions.filter((action) => {
+            const label = `${action.metadata?.label ?? ""} ${actionDisplayLabel(action.metadata?.label)}`
+                .toLowerCase();
+            const description = action.metadata?.description?.toLowerCase() ?? "";
+            const symbol = action.codedata?.symbol?.toLowerCase() ?? "";
+            const resourcePath = action.codedata?.resourcePath?.toLowerCase() ?? "";
+            return (
+                label.includes(query) ||
+                description.includes(query) ||
+                symbol.includes(query) ||
+                resourcePath.includes(query)
+            );
+        });
+    }, [actions, searchText]);
+
+    const searchPlaceholder = actions.length > 0 ? `Search ${actions.length} actions` : "Search actions";
+
+    return (
+        <Container>
+            <HeaderArea>
+                <InfoCard>
+                    <InfoIcon>
+                        {connector.metadata?.icon ? (
+                            <ConnectorIcon url={connector.metadata.icon} />
+                        ) : (
+                            <Codicon name="package" />
+                        )}
+                    </InfoIcon>
+                    <InfoContent>
+                        <InfoTitleRow>
+                            <InfoName>{connector.metadata?.label ?? "Connector"}</InfoName>
+                            {category && <Tag>{category}</Tag>}
+                        </InfoTitleRow>
+                        {connector.metadata?.description && (
+                            <InfoDescription description={connector.metadata.description} />
+                        )}
+                    </InfoContent>
+                </InfoCard>
+
+                <SearchBox
+                    value={searchText}
+                    placeholder={searchPlaceholder}
+                    autoFocus={true}
+                    onChange={setSearchText}
+                    sx={{ height: 30, width: "100%" }}
+                />
+            </HeaderArea>
+
+            <ScrollArea>
+                {filteredActions.length === 0 ? (
+                    <EmptyState>
+                        <Typography variant="body3">No actions match "{searchText.trim()}".</Typography>
+                    </EmptyState>
+                ) : (
+                    <RowList>
+                        {filteredActions.map((action) => (
+                            <Row
+                                key={`${action.codedata?.node}-${action.codedata?.symbol}-${action.codedata?.resourcePath ?? ""}`}
+                                onClick={() => onSelect(action)}
+                                title={action.metadata?.description || undefined}
+                            >
+                                <RowIcon box={20} icon={18} offset={2}>
+                                    {action.metadata?.icon ? (
+                                        <ConnectorIcon url={action.metadata.icon} />
+                                    ) : (
+                                        <Codicon name="package" />
+                                    )}
+                                    <RowBadge className="action-badge">
+                                        <NodeIcon type={action.codedata?.node} size={10} />
+                                    </RowBadge>
+                                </RowIcon>
+                                <RowText>
+                                    <RowLabel>{actionDisplayLabel(action.metadata?.label)}</RowLabel>
+                                    {isResourceAction(action) ? (
+                                        <RowSignature>
+                                            {formatResourceSignature(
+                                                action.codedata?.symbol ?? "",
+                                                action.codedata?.resourcePath ?? ""
+                                            )}
+                                        </RowSignature>
+                                    ) : (
+                                        action.metadata?.description && (
+                                            <RowDescription>{action.metadata.description}</RowDescription>
+                                        )
+                                    )}
+                                </RowText>
+                                <RowChevron>
+                                    <Codicon name="chevron-right" sx={{ fontSize: 12 }} />
+                                </RowChevron>
+                            </Row>
+                        ))}
+                    </RowList>
+                )}
+            </ScrollArea>
+        </Container>
+    );
+}
+
+export default ConnectorActionList;

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/ConnectorActionList.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/ConnectorActionList.tsx
@@ -202,7 +202,9 @@ export function ConnectorActionList(props: ConnectorActionListProps) {
         });
     }, [actions, searchText]);
 
-    const searchPlaceholder = actions.length > 0 ? `Search ${actions.length} actions` : "Search actions";
+    const searchPlaceholder = actions.length > 0
+        ? `Search ${actions.length} action${actions.length === 1 ? "" : "s"}`
+        : "Search actions";
 
     return (
         <Container>
@@ -238,7 +240,11 @@ export function ConnectorActionList(props: ConnectorActionListProps) {
             <ScrollArea>
                 {filteredActions.length === 0 ? (
                     <EmptyState>
-                        <Typography variant="body3">No actions match "{searchText.trim()}".</Typography>
+                        <Typography variant="body3">
+                            {searchText.trim()
+                                ? `No actions match "${searchText.trim()}".`
+                                : "No actions available."}
+                        </Typography>
                     </EmptyState>
                 ) : (
                     <RowList>

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/ConnectorBrowser.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/ConnectorBrowser.tsx
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import styled from "@emotion/styled";
+import { useRpcContext } from "@wso2/ballerina-rpc-client";
+import { Category as PanelCategory, Node as PanelNode } from "@wso2/ballerina-side-panel";
+import { AvailableNode, BISearchRequest, Item, LinePosition } from "@wso2/ballerina-core";
+import { Button } from "@wso2/ui-toolkit";
+
+import { convertBICategoriesToSidePanelCategories } from "../../../../utils/bi";
+import { RelativeLoader } from "../../../../components/RelativeLoader";
+import { Banner } from "../../../../components/Banner";
+import { fetchConnectorActions, normalizeConnectorSearchCategories } from "./connectorActions";
+import { ConnectorActionList } from "./ConnectorActionList";
+import { ConnectorList } from "./ConnectorList";
+import { CONTENT_HEIGHT } from "./styles";
+import { NEW_CONNECTION } from "../../../../constants";
+
+export enum WizardStep {
+    CONNECTOR_LIST = "CONNECTOR_LIST",
+    ACTION_LIST = "ACTION_LIST",
+}
+
+export interface ActionSelection {
+    action: AvailableNode;
+    connector?: AvailableNode;
+    connectionName?: string;
+}
+
+interface ConnectorBrowserProps {
+    filePath: string;
+    target: LinePosition;
+    existingConnectionCategories: PanelCategory[];
+    onSelect: (selection: ActionSelection) => void;
+    onStepChange?: (step: WizardStep, goBack?: () => void) => void;
+    connectorSet?: "GROUPED";
+    description?: string;
+    noActionsHint?: string;
+}
+
+const LoaderWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: ${CONTENT_HEIGHT};
+`;
+
+export function ConnectorBrowser(props: ConnectorBrowserProps) {
+    const {
+        filePath,
+        target,
+        existingConnectionCategories,
+        onSelect,
+        onStepChange,
+        connectorSet,
+        description,
+        noActionsHint,
+    } = props;
+    const { rpcClient } = useRpcContext();
+
+    const [step, setStep] = useState<WizardStep>(WizardStep.CONNECTOR_LIST);
+    const [catalogCategories, setCatalogCategories] = useState<PanelCategory[]>([]);
+    const [centralCategories, setCentralCategories] = useState<PanelCategory[]>([]);
+    const [loadingConnectors, setLoadingConnectors] = useState<boolean>(true);
+    const [loadingExtras, setLoadingExtras] = useState<boolean>(false);
+    const [searchText, setSearchText] = useState<string>("");
+
+    const [selectedConnector, setSelectedConnector] = useState<AvailableNode>();
+    const [selectedConnectionName, setSelectedConnectionName] = useState<string>();
+    const [selectedCategory, setSelectedCategory] = useState<string>("");
+    const [actions, setActions] = useState<AvailableNode[]>([]);
+    const [loadingActions, setLoadingActions] = useState<boolean>(false);
+    const [actionError, setActionError] = useState<string>("");
+    const latestConnectorRequest = useRef(0);
+    const lastConnectorQuery = useRef<string | undefined>(undefined);
+    const searchDebounce = useRef<ReturnType<typeof setTimeout>>();
+
+    useEffect(() => {
+        void loadConnectors("");
+    }, []);
+
+    const goToConnectorList = () => {
+        setStep(WizardStep.CONNECTOR_LIST);
+        setSelectedConnector(undefined);
+        setSelectedConnectionName(undefined);
+        setSelectedCategory("");
+        setActions([]);
+        setActionError("");
+    };
+
+    useEffect(() => {
+        if (step === WizardStep.ACTION_LIST) {
+            onStepChange?.(step, goToConnectorList);
+        } else {
+            onStepChange?.(step);
+        }
+    }, [step]);
+
+    const loadConnectors = async (query: string) => {
+        const requestId = ++latestConnectorRequest.current;
+        lastConnectorQuery.current = query;
+        try {
+            const request: BISearchRequest = {
+                position: { startLine: target, endLine: target },
+                filePath,
+                queryMap: {
+                    ...(query.trim() ? { q: query.trim(), offset: 0 } : {}),
+                    limit: 60,
+                    ...(connectorSet ? { connectorSet } : {}),
+                },
+                searchKind: "CONNECTOR",
+            };
+            const response = await rpcClient.getBIDiagramRpcClient().search(request);
+            if (requestId !== latestConnectorRequest.current) {
+                return;
+            }
+            const categories = normalizeConnectorSearchCategories(response?.categories as Item[]);
+            const panelCategories = convertBICategoriesToSidePanelCategories(categories);
+            if (query.trim()) {
+                setCentralCategories(panelCategories);
+            } else {
+                setCatalogCategories(panelCategories);
+                setCentralCategories([]);
+            }
+        } catch (error) {
+            console.error(">>> Error searching connectors", error);
+            if (requestId === latestConnectorRequest.current) {
+                setCentralCategories([]);
+            }
+        } finally {
+            if (requestId === latestConnectorRequest.current) {
+                setLoadingConnectors(false);
+                setLoadingExtras(false);
+            }
+        }
+    };
+
+    const visibleConnectionCategories = useMemo(
+        () => existingConnectionCategories.filter((category) => category.items?.length > 0),
+        [existingConnectionCategories]
+    );
+
+    const handleSearchTextChange = (text: string) => {
+        setSearchText(text);
+        if (searchDebounce.current) {
+            clearTimeout(searchDebounce.current);
+        }
+        if (!text.trim()) {
+            setCentralCategories([]);
+            setLoadingExtras(false);
+            lastConnectorQuery.current = "";
+            return;
+        }
+        setLoadingExtras(true);
+        searchDebounce.current = setTimeout(() => {
+            if (text !== lastConnectorQuery.current) {
+                void loadConnectors(text);
+            } else {
+                setLoadingExtras(false);
+            }
+        }, 300);
+    };
+
+    useEffect(() => () => {
+        if (searchDebounce.current) {
+            clearTimeout(searchDebounce.current);
+        }
+    }, []);
+
+    const handleSelectConnection = (connectionName: string, connectionActions: PanelNode[]) => {
+        const actionNodes = connectionActions
+            .map((item) => item.metadata as AvailableNode)
+            .filter(Boolean);
+        const first = actionNodes.at(0);
+        setSelectedConnector({
+            metadata: {
+                label: connectionName,
+                description: first?.metadata?.description ?? "",
+                icon: first?.metadata?.icon,
+            },
+            codedata: first?.codedata,
+            enabled: true,
+        } as AvailableNode);
+        setSelectedConnectionName(connectionName);
+        setSelectedCategory("Connections");
+        setActionError("");
+        setActions(actionNodes);
+        setStep(WizardStep.ACTION_LIST);
+    };
+
+    const handleSelectConnector = async (connector: AvailableNode, category?: string) => {
+        setSelectedConnector(connector);
+        setSelectedConnectionName(undefined);
+        setSelectedCategory(category ?? "");
+        setActions([]);
+        setActionError("");
+        setStep(WizardStep.ACTION_LIST);
+        setLoadingActions(true);
+        try {
+            const fetched = await fetchConnectorActions(rpcClient, connector);
+            if (fetched.length === 0) {
+                setActionError(
+                    `No actions were found for ${connector.metadata?.label ?? "this connector"}.` +
+                    (noActionsHint ? ` ${noActionsHint}` : "")
+                );
+            }
+            setActions(fetched);
+        } catch (error) {
+            console.error(">>> Error fetching connector actions", error);
+            setActionError(
+                `Could not load the actions for ${connector.metadata?.label ?? "this connector"}. ` +
+                `Check your internet connection and try again.`
+            );
+        } finally {
+            setLoadingActions(false);
+        }
+    };
+
+    const handleListSelect = (nodeId: string, metadata?: any) => {
+        const node = (metadata as { node: AvailableNode })?.node;
+        if (!node) {
+            return;
+        }
+        if (nodeId === NEW_CONNECTION) {
+            void handleSelectConnector(node, (metadata as { category?: string })?.category);
+            return;
+        }
+        const connectionName = node.codedata?.parentSymbol;
+        if (connectionName) {
+            onSelect({ action: node, connectionName });
+        }
+    };
+
+    return (
+        <>
+            {step === WizardStep.CONNECTOR_LIST && (
+                <>
+                    {loadingConnectors ? (
+                        <LoaderWrapper>
+                            <RelativeLoader />
+                        </LoaderWrapper>
+                    ) : (
+                        <ConnectorList
+                            connectionCategories={visibleConnectionCategories}
+                            connectorCategories={catalogCategories}
+                            extraCategories={centralCategories}
+                            loadingExtras={loadingExtras}
+                            searchText={searchText}
+                            onSearchTextChange={handleSearchTextChange}
+                            onSelect={handleListSelect}
+                            onSelectConnection={handleSelectConnection}
+                            description={description}
+                        />
+                    )}
+                </>
+            )}
+
+            {step === WizardStep.ACTION_LIST && (
+                <>
+                    {loadingActions ? (
+                        <LoaderWrapper>
+                            <RelativeLoader message="Loading actions..." />
+                        </LoaderWrapper>
+                    ) : actionError ? (
+                        <div style={{ padding: "12px 16px" }}>
+                            <Banner
+                                variant="error"
+                                message={actionError}
+                                actions={
+                                    <Button appearance="secondary" onClick={goToConnectorList}>
+                                        Back to connectors
+                                    </Button>
+                                }
+                            />
+                        </div>
+                    ) : (
+                        <ConnectorActionList
+                            connector={selectedConnector}
+                            actions={actions}
+                            category={selectedCategory}
+                            onSelect={(action) => onSelect({
+                                action,
+                                connector: selectedConnector,
+                                connectionName: selectedConnectionName,
+                            })}
+                        />
+                    )}
+                </>
+            )}
+
+        </>
+    );
+}

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/ConnectorList.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/ConnectorList.tsx
@@ -1,0 +1,434 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import styled from "@emotion/styled";
+import { Category as PanelCategory, Node as PanelNode } from "@wso2/ballerina-side-panel";
+import { Codicon, ProgressRing, SearchBox, ThemeColors, Typography } from "@wso2/ui-toolkit";
+import {
+    Container,
+    EmptyState,
+    HeaderArea as BaseHeaderArea,
+    Row as BaseRow,
+    RowChevron,
+    RowDescription as BaseRowDescription,
+    RowIcon,
+    RowLabel as BaseRowLabel,
+    RowText,
+    ScrollArea as BaseScrollArea,
+    Tag,
+} from "./styles";
+
+const POPULAR_CATEGORY = "Popular";
+
+const HeaderArea = styled(BaseHeaderArea)`
+    gap: 8px;
+    padding-bottom: 8px;
+`;
+
+const Description = styled.div`
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--vscode-descriptionForeground);
+`;
+
+const SearchWrap = styled.div`
+    display: contents;
+`;
+
+const FilterRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+`;
+
+const CategorySelect = styled.select`
+    flex: 1;
+    min-width: 0;
+    height: 26px;
+    padding: 0 6px;
+    font-family: inherit;
+    font-size: 12px;
+    color: var(--vscode-foreground);
+    background-color: var(--vscode-dropdown-background, ${ThemeColors.SURFACE_DIM});
+    border: 1px solid var(--vscode-dropdown-border, ${ThemeColors.OUTLINE_VARIANT});
+    border-radius: 4px;
+    cursor: pointer;
+
+    &:focus-visible {
+        outline: 1px solid ${ThemeColors.PRIMARY};
+        outline-offset: -1px;
+    }
+`;
+
+const ScrollArea = styled(BaseScrollArea)`
+    margin-top: 12px;
+`;
+
+const Section = styled.div`
+    background-color: ${ThemeColors.SURFACE_DIM};
+    border-radius: 5px;
+    margin-bottom: 16px;
+`;
+
+const SectionHeader = styled.div`
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px;
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    border-radius: 5px 5px 0 0;
+    background: ${ThemeColors.SURFACE_DIM};
+    box-shadow: 0 -3px 0 3px ${ThemeColors.SURFACE_DIM};
+`;
+
+const SectionTitle = styled.div`
+    font-size: 14px;
+    font-family: GilmerBold;
+    color: ${ThemeColors.ON_SURFACE};
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`;
+
+const SectionCount = styled.div`
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    flex-shrink: 0;
+`;
+
+const Row = styled(BaseRow)`
+    grid-template-columns: 22px minmax(0, 1fr) 12px;
+    gap: 12px;
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    border-bottom: none;
+
+    &:first-of-type {
+        border-top: none;
+    }
+
+    &:last-child {
+        border-bottom: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+        border-radius: 0 0 5px 5px;
+    }
+`;
+
+const RowLabel = styled(BaseRowLabel)`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const RowDescription = styled(BaseRowDescription)`
+    margin-top: 2px;
+    -webkit-line-clamp: 1;
+`;
+
+const PendingRow = styled.div`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 12px;
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    border-top: none;
+    border-radius: 0 0 5px 5px;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+`;
+
+interface ListSection {
+    key: string;
+    title: string;
+    nodes: PanelNode[];
+    category: string;
+    tag?: string;
+    pending?: boolean;
+}
+
+interface ConnectorListProps {
+    connectionCategories: PanelCategory[];
+    connectorCategories: PanelCategory[];
+    extraCategories?: PanelCategory[];
+    loadingExtras?: boolean;
+    searchText: string;
+    onSearchTextChange: (text: string) => void;
+    onSelect: (nodeId: string, metadata?: any) => void;
+    onSelectConnection?: (connectionName: string, actions: PanelNode[]) => void;
+    description?: string;
+}
+
+const nodesOf = (category: PanelCategory): PanelNode[] =>
+    (category.items ?? []).filter((item): item is PanelNode => "id" in item && !("items" in item));
+
+const subCategoriesOf = (category: PanelCategory): PanelCategory[] =>
+    (category.items ?? []).filter((item): item is PanelCategory => "items" in item);
+
+const CONNECTION_ROW_ID = "__connection__";
+
+const connectionRowsOf = (category: PanelCategory): PanelNode[] => {
+    const subs = subCategoriesOf(category);
+    if (!subs.length) {
+        return nodesOf(category);
+    }
+    return subs
+        .filter((sub) => (sub.items ?? []).length > 0)
+        .map((sub) => {
+            const actions = nodesOf(sub);
+            return {
+                id: CONNECTION_ROW_ID,
+                label: sub.title,
+                description: `${actions.length} action${actions.length === 1 ? "" : "s"}`,
+                icon: sub.icon ?? actions[0]?.icon,
+                metadata: { connectionActions: actions },
+            } as PanelNode;
+        });
+};
+
+const connectorKey = (node: PanelNode): string => {
+    const c = node.metadata?.codedata;
+    return c ? `${c.org}/${c.module}:${c.object}` : node.label;
+};
+
+const scoreNode = (node: PanelNode, category: string, query: string): number => {
+    const label = (node.label ?? "").toLowerCase();
+    if (label === query) return 0;
+    if (label.startsWith(query)) return 1;
+    if (label.includes(` ${query}`)) return 2;
+    if (label.includes(query)) return 3;
+    const module = (node.metadata?.codedata?.module ?? "").toLowerCase();
+    if (module.includes(query)) return 4;
+    if (category.toLowerCase().includes(query)) return 5;
+    if ((node.description ?? "").toLowerCase().includes(query)) return 6;
+    return -1;
+};
+
+export function ConnectorList(props: ConnectorListProps) {
+    const {
+        connectionCategories,
+        connectorCategories,
+        extraCategories,
+        loadingExtras,
+        searchText,
+        onSearchTextChange,
+        onSelect,
+        onSelectConnection,
+        description,
+    } = props;
+
+    const [category, setCategory] = useState<string>("");
+    const [activeIndex, setActiveIndex] = useState<number>(-1);
+    const scrollRef = useRef<HTMLDivElement>(null);
+
+    const query = searchText.trim().toLowerCase();
+
+    const allConnectorSections = useMemo<ListSection[]>(
+        () =>
+            connectorCategories
+                .map((c) => ({ key: c.title, title: c.title, category: c.title, nodes: nodesOf(c) }))
+                .filter((s) => s.nodes.length > 0),
+        [connectorCategories]
+    );
+
+    const popularSection = useMemo(() => {
+        const found = allConnectorSections.find((s) => s.category === POPULAR_CATEGORY);
+        return found ? { ...found, category: "" } : undefined;
+    }, [allConnectorSections]);
+
+    const connectorSections = useMemo(
+        () => allConnectorSections.filter((s) => s.category !== POPULAR_CATEGORY),
+        [allConnectorSections]
+    );
+
+    const connectionSections = useMemo<ListSection[]>(
+        () =>
+            connectionCategories
+                .map((c) => ({
+                    key: `conn-${c.title}`,
+                    title: c.title,
+                    category: c.title,
+                    nodes: connectionRowsOf(c),
+                    tag: "In this integration",
+                }))
+                .filter((s) => s.nodes.length > 0),
+        [connectionCategories]
+    );
+
+    const sections = useMemo<ListSection[]>(() => {
+        if (query) {
+            const pool = category
+                ? connectorSections.filter((s) => s.category === category)
+                : connectorSections;
+            const ranked = [...connectionSections, ...pool]
+                .flatMap((s) => s.nodes.map((node) => ({ node, s, score: scoreNode(node, s.category, query) })))
+                .filter((x) => x.score >= 0)
+                .sort((a, b) => a.score - b.score);
+
+            const seen = new Set(ranked.map((x) => connectorKey(x.node)));
+            const extras = (extraCategories ?? [])
+                .flatMap(nodesOf)
+                .filter((node) => !seen.has(connectorKey(node)));
+
+            const nodes = [...ranked.map((x) => x.node), ...extras];
+            if (!nodes.length && !loadingExtras) {
+                return [];
+            }
+            return [{ key: "results", title: "Results", category: "", nodes, pending: !!loadingExtras }];
+        }
+
+        if (category) {
+            return connectorSections.filter((s) => s.category === category);
+        }
+
+        return [
+            ...connectionSections,
+            ...(popularSection ? [popularSection] : []),
+            ...connectorSections,
+        ];
+    }, [query, category, connectionSections, connectorSections, popularSection, extraCategories, loadingExtras]);
+
+    const flatNodes = useMemo(
+        () => sections.flatMap((s) => s.nodes.map((node) => ({ node, category: s.category }))),
+        [sections]
+    );
+
+    useEffect(() => {
+        setActiveIndex(-1);
+    }, [query, category]);
+
+
+    const handleSelect = (node: PanelNode, cat: string) => {
+        if (node.id === CONNECTION_ROW_ID) {
+            onSelectConnection?.(node.label, node.metadata?.connectionActions ?? []);
+            return;
+        }
+        onSelect(node.id, { node: node.metadata, category: cat });
+    };
+
+    const handleSearchKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            const next =
+                event.key === "ArrowDown"
+                    ? Math.min(activeIndex + 1, flatNodes.length - 1)
+                    : Math.max(activeIndex - 1, 0);
+            setActiveIndex(next);
+            scrollRef.current
+                ?.querySelector(`[data-index="${next}"]`)
+                ?.scrollIntoView({ block: "nearest" });
+        } else if (event.key === "Enter" && activeIndex >= 0) {
+            event.preventDefault();
+            const target = flatNodes[activeIndex];
+            if (target) {
+                handleSelect(target.node, target.category);
+            }
+        }
+    };
+
+    let renderIndex = -1;
+
+    return (
+        <Container>
+            <HeaderArea>
+                {description && <Description>{description}</Description>}
+                <SearchWrap onKeyDown={handleSearchKeyDown}>
+                    <SearchBox
+                        value={searchText}
+                        placeholder="Search connectors"
+                        autoFocus={true}
+                        onChange={onSearchTextChange}
+                        sx={{ height: 30, width: "100%" }}
+                    />
+                </SearchWrap>
+                {connectorSections.length > 1 && (
+                    <FilterRow>
+                        <CategorySelect
+                            value={category}
+                            aria-label="Filter by category"
+                            onChange={(event) => setCategory(event.target.value)}
+                        >
+                            <option value="">All Categories</option>
+                            {connectorSections.map((s) => (
+                                <option key={s.key} value={s.category}>
+                                    {s.title} ({s.nodes.length})
+                                </option>
+                            ))}
+                        </CategorySelect>
+                    </FilterRow>
+                )}
+            </HeaderArea>
+
+            <ScrollArea ref={scrollRef}>
+                {sections.length === 0 ? (
+                    <EmptyState>
+                        <Typography variant="body3">
+                            {query ? `No connectors match "${searchText.trim()}".` : "No connectors available."}
+                        </Typography>
+                    </EmptyState>
+                ) : (
+                    sections.map((section) => (
+                        <Section key={section.key}>
+                            <SectionHeader>
+                                <SectionTitle>{section.title}</SectionTitle>
+                                {section.tag && <Tag>{section.tag}</Tag>}
+                                {!section.pending && <SectionCount>{section.nodes.length}</SectionCount>}
+                            </SectionHeader>
+                            {section.nodes.map((node) => {
+                                renderIndex += 1;
+                                const index = renderIndex;
+                                return (
+                                    <Row
+                                        key={`${section.key}-${node.id}-${index}`}
+                                        data-index={index}
+                                        data-active={index === activeIndex}
+                                        title={node.description || node.label}
+                                        onClick={() => handleSelect(node, section.category)}
+                                    >
+                                        <RowIcon box={22} icon={20} offset={1}>
+                                            {node.icon ?? <Codicon name="package" />}
+                                        </RowIcon>
+                                        <RowText>
+                                            <RowLabel>{node.label}</RowLabel>
+                                            {node.description && (
+                                                <RowDescription>{node.description}</RowDescription>
+                                            )}
+                                        </RowText>
+                                        <RowChevron>
+                                            <Codicon name="chevron-right" sx={{ fontSize: 12 }} />
+                                        </RowChevron>
+                                    </Row>
+                                );
+                            })}
+                            {section.pending && (
+                                <PendingRow>
+                                    <ProgressRing sx={{ height: 14, width: 14 }} />
+                                    <Typography variant="body3">Searching for more connectors…</Typography>
+                                </PendingRow>
+                            )}
+                        </Section>
+                    ))
+                )}
+            </ScrollArea>
+
+        </Container>
+    );
+}
+
+export default ConnectorList;

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/connectorActions.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/connectorActions.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import { AvailableNode } from "@wso2/ballerina-core";
+import {
+    fetchConnectorActions,
+    actionDisplayLabel,
+    formatActionLabel,
+    buildConnectionSelectField,
+    normalizeConnectorSearchCategories,
+    toResourcePathTemplate,
+} from "./connectorActions";
+
+
+const REDIS_CONNECTOR = {
+    metadata: { label: "Redis", description: "Redis cache", icon: "redis.png" },
+    codedata: {
+        node: "NEW_CONNECTION",
+        org: "ballerinax",
+        module: "redis",
+        object: "Client",
+        symbol: "init",
+        version: "3.1.0",
+    },
+    enabled: true,
+} as unknown as AvailableNode;
+
+const makeRpcClient = (docsResponse: unknown, spy?: jest.Mock) =>
+    ({
+        getLibraryBrowserRPCClient: () => ({
+            getLibraryData: spy ?? jest.fn().mockResolvedValue(docsResponse),
+        }),
+    } as any);
+
+const docsWith = (client: Record<string, unknown>, moduleId = "redis") => ({
+    docsData: { modules: [{ id: moduleId, clients: [{ name: "Client", ...client }] }] },
+});
+
+describe("toResourcePathTemplate", () => {
+    it.each([
+        ["users/[string userId]/drafts", "/users/[userId]/drafts"],
+        ["users/[string userId]/drafts/[string id]", "/users/[userId]/drafts/[id]"],
+        ["users/[string userId]/messages/[string messageId]/attachments/[string id]",
+            "/users/[userId]/messages/[messageId]/attachments/[id]"],
+        ["users/[string userId]/profile", "/users/[userId]/profile"],
+        ["/users/[userId]/drafts", "/users/[userId]/drafts"],
+    ])("normalises %s", (docsPath, expected) => {
+        expect(toResourcePathTemplate(docsPath)).toBe(expected);
+    });
+
+    it("maps a lone rest parameter to the LS's placeholder", () => {
+        expect(toResourcePathTemplate("[PathParamType ...path]")).toBe("/path/to/subdirectory");
+        expect(toResourcePathTemplate("[string... path]")).toBe("/path/to/subdirectory");
+    });
+
+    it("drops a trailing rest parameter from a segment list", () => {
+        expect(toResourcePathTemplate("users/[string userId]/[string... rest]")).toBe("/users/[userId]");
+    });
+
+    it("maps a dot resource path and empties to /", () => {
+        expect(toResourcePathTemplate(".")).toBe("/");
+        expect(toResourcePathTemplate("")).toBe("/");
+    });
+});
+
+describe("formatActionLabel", () => {
+    it.each([
+        ["append", "Append"],
+        ["bitCount", "Bit count"],
+        ["bitOpAnd", "Bit op and"],
+        ["decrBy", "Decr by"],
+        ["getRange", "Get range"],
+        ["'commit", "Commit"],
+        ["batch_execute", "Batch execute"],
+        ["listBuckets", "List buckets"],
+        ["createMultipartUpload", "Create multipart upload"],
+    ])("formats %s as %s", (symbol, expected) => {
+        expect(formatActionLabel(symbol)).toBe(expected);
+    });
+
+    it("keeps acronyms shouted", () => {
+        expect(formatActionLabel("getHTTPResponse")).toBe("Get HTTP response");
+        expect(formatActionLabel("createPresignedUrl")).toBe("Create presigned URL");
+        expect(formatActionLabel("getObjectId")).toBe("Get object ID");
+    });
+
+    it("survives empty input", () => {
+        expect(formatActionLabel("")).toBe("");
+    });
+});
+
+describe("actionDisplayLabel", () => {
+    it("formats an identifier label from the language server", () => {
+        expect(actionDisplayLabel("listBuckets")).toBe("List buckets");
+    });
+
+    it.each([
+        "Lists the drafts in the user's mailbox.",
+        "get/users/[string userId]/drafts",
+        "List buckets",
+    ])("leaves %s alone", (label) => {
+        expect(actionDisplayLabel(label)).toBe(label);
+    });
+
+    it("survives a missing label", () => {
+        expect(actionDisplayLabel(undefined)).toBe("");
+    });
+});
+
+describe("fetchConnectorActions", () => {
+    it("maps remote methods to REMOTE_ACTION_CALL nodes with library codedata", async () => {
+        const rpcClient = makeRpcClient(
+            docsWith({ remoteMethods: [{ name: "append", description: "Append a value to a key." }] })
+        );
+
+        const actions = await fetchConnectorActions(rpcClient, REDIS_CONNECTOR);
+
+        expect(actions).toHaveLength(1);
+        expect(actions[0].metadata.label).toBe("Append");
+        expect(actions[0].metadata.description).toBe("Append a value to a key.");
+        expect(actions[0].codedata).toMatchObject({
+            node: "REMOTE_ACTION_CALL",
+            org: "ballerinax",
+            module: "redis",
+            object: "Client",
+            symbol: "append",
+            version: "3.1.0",
+        });
+    });
+
+    it("maps resource methods to RESOURCE_ACTION_CALL and keeps the resource path", async () => {
+        const rpcClient = makeRpcClient(
+            docsWith({
+                resourceMethods: [
+                    {
+                        name: "",
+                        accessor: "get",
+                        resourcePath: "users/[string userId]/drafts",
+                        description: "Lists the drafts in the user's mailbox.",
+                    },
+                ],
+            })
+        );
+
+        const actions = await fetchConnectorActions(rpcClient, REDIS_CONNECTOR);
+
+        expect(actions).toHaveLength(1);
+        expect(actions[0].codedata.node).toBe("RESOURCE_ACTION_CALL");
+        expect(actions[0].codedata.resourcePath).toBe("/users/[userId]/drafts");
+        expect(actions[0].codedata.symbol).toBe("get");
+    });
+
+    it("labels a resource action with its description, as the LS does", async () => {
+        const rpcClient = makeRpcClient(
+            docsWith({
+                resourceMethods: [
+                    {
+                        name: "",
+                        accessor: "delete",
+                        resourcePath: "users/[string userId]/drafts/[string id]",
+                        description:
+                            "Immediately and permanently deletes the specified draft. Does not simply trash it.",
+                    },
+                ],
+            })
+        );
+
+        const actions = await fetchConnectorActions(rpcClient, REDIS_CONNECTOR);
+
+        expect(actions[0].metadata.label).toBe("Immediately and permanently deletes the specified draft.");
+        expect(actions[0].metadata.description).toContain("Does not simply trash it.");
+    });
+
+    it("shows a rest path as a placeholder, not the LS's fake endpoint", async () => {
+        const rpcClient = makeRpcClient(
+            docsWith({ resourceMethods: [{ name: "", accessor: "post", resourcePath: "[PathParamType ...path]" }] })
+        );
+
+        const actions = await fetchConnectorActions(rpcClient, REDIS_CONNECTOR);
+
+        expect(actions[0].codedata.resourcePath).toBe("/path/to/subdirectory");
+        expect(actions[0].metadata.label).toBe("POST /[path...]");
+    });
+
+    it("falls back to the signature when a resource action has no description", async () => {
+        const rpcClient = makeRpcClient(
+            docsWith({
+                resourceMethods: [{ name: "", accessor: "post", resourcePath: "users/[string userId]/drafts" }],
+            })
+        );
+
+        const actions = await fetchConnectorActions(rpcClient, REDIS_CONNECTOR);
+
+        expect(actions[0].metadata.label).toBe("POST /users/[userId]/drafts");
+    });
+
+    it("keeps different accessors on the same path apart", async () => {
+        const rpcClient = makeRpcClient(
+            docsWith({
+                resourceMethods: [
+                    { name: "", accessor: "get", resourcePath: "users/[string userId]/drafts", description: "List." },
+                    { name: "", accessor: "post", resourcePath: "users/[string userId]/drafts", description: "Create." },
+                ],
+            })
+        );
+
+        const actions = await fetchConnectorActions(rpcClient, REDIS_CONNECTOR);
+
+        expect(actions).toHaveLength(2);
+        expect(actions.map((action) => action.codedata.symbol).sort()).toEqual(["get", "post"]);
+    });
+
+    it("skips a resource method with no accessor or no path", async () => {
+        const rpcClient = makeRpcClient(
+            docsWith({
+                resourceMethods: [
+                    { name: "", accessor: "", resourcePath: "users/drafts", description: "No accessor." },
+                    { name: "", accessor: "get", resourcePath: "", description: "No path." },
+                ],
+            })
+        );
+
+        const actions = await fetchConnectorActions(rpcClient, REDIS_CONNECTOR);
+
+        expect(actions).toHaveLength(0);
+    });
+
+    it("skips deprecated methods and de-duplicates", async () => {
+        const rpcClient = makeRpcClient(
+            docsWith({
+                remoteMethods: [
+                    { name: "append" },
+                    { name: "append" },
+                    { name: "oldWay", isDeprecated: true },
+                ],
+            })
+        );
+
+        const actions = await fetchConnectorActions(rpcClient, REDIS_CONNECTOR);
+
+        expect(actions.map((action) => action.codedata.symbol)).toEqual(["append"]);
+    });
+
+    it("sorts actions by label so long lists are scannable", async () => {
+        const rpcClient = makeRpcClient(
+            docsWith({ remoteMethods: [{ name: "set" }, { name: "append" }, { name: "get" }] })
+        );
+
+        const actions = await fetchConnectorActions(rpcClient, REDIS_CONNECTOR);
+
+        expect(actions.map((action) => action.metadata.label)).toEqual(["Append", "Get", "Set"]);
+    });
+
+    it("strips markup from descriptions", async () => {
+        const rpcClient = makeRpcClient(
+            docsWith({ remoteMethods: [{ name: "append", description: "<p>Append   a\nvalue.</p>" }] })
+        );
+
+        const actions = await fetchConnectorActions(rpcClient, REDIS_CONNECTOR);
+
+        expect(actions[0].metadata.description).toBe("Append a value.");
+    });
+
+    it("falls back to any module's client for dotted modules", async () => {
+        const rpcClient = makeRpcClient(docsWith({ remoteMethods: [{ name: "listBuckets" }] }, "s3"));
+
+        const actions = await fetchConnectorActions(rpcClient, {
+            ...REDIS_CONNECTOR,
+            codedata: { ...REDIS_CONNECTOR.codedata, module: "aws.s3" },
+        } as AvailableNode);
+
+        expect(actions.map((action) => action.codedata.symbol)).toEqual(["listBuckets"]);
+        expect(actions[0].codedata.module).toBe("aws.s3");
+    });
+
+    it("requests the connector's own coordinates", async () => {
+        const spy = jest.fn().mockResolvedValue(docsWith({ remoteMethods: [{ name: "append" }] }));
+        await fetchConnectorActions(makeRpcClient(undefined, spy), REDIS_CONNECTOR);
+        expect(spy).toHaveBeenCalledWith({ orgName: "ballerinax", moduleName: "redis", version: "3.1.0" });
+    });
+
+    it("throws when the connector has no package coordinates", async () => {
+        await expect(
+            fetchConnectorActions(makeRpcClient(docsWith({})), {
+                ...REDIS_CONNECTOR,
+                codedata: { node: "NEW_CONNECTION" },
+            } as AvailableNode)
+        ).rejects.toThrow(/package coordinates/);
+    });
+
+    it("throws when docs contain no client", async () => {
+        const rpcClient = makeRpcClient({ docsData: { modules: [{ id: "redis", clients: [] }] } });
+        await expect(fetchConnectorActions(rpcClient, REDIS_CONNECTOR)).rejects.toThrow(/No client found/);
+    });
+
+    it("returns empty rather than throwing when the client has no methods", async () => {
+        const rpcClient = makeRpcClient(docsWith({ remoteMethods: [], resourceMethods: [] }));
+        await expect(fetchConnectorActions(rpcClient, REDIS_CONNECTOR)).resolves.toEqual([]);
+    });
+});
+
+describe("normalizeConnectorSearchCategories", () => {
+    const node = (label: string) =>
+        ({ metadata: { label }, codedata: { node: "NEW_CONNECTION", module: label }, enabled: true } as any);
+
+    it("wraps a flat node list in one category", () => {
+        const result = normalizeConnectorSearchCategories([node("calendar"), node("gcalendar")]);
+        expect(result).toHaveLength(1);
+        expect(result[0].metadata.label).toBe("Search Results");
+        expect(result[0].items).toHaveLength(2);
+    });
+
+    it("uses the supplied label for the wrapper", () => {
+        const result = normalizeConnectorSearchCategories([node("calendar")], "Connectors");
+        expect(result[0].metadata.label).toBe("Connectors");
+    });
+
+    it("passes categories through", () => {
+        const categories = [{ metadata: { label: "SaaS" }, items: [node("calendar")] }] as any;
+        expect(normalizeConnectorSearchCategories(categories)).toEqual(categories);
+    });
+
+    it("drops empty categories", () => {
+        const result = normalizeConnectorSearchCategories([
+            { metadata: { label: "Local" }, items: [] },
+            { metadata: { label: "SaaS" }, items: [node("calendar")] },
+        ] as any);
+        expect(result.map((category) => category.metadata.label)).toEqual(["SaaS"]);
+    });
+
+    it("keeps both shapes when they are mixed", () => {
+        const result = normalizeConnectorSearchCategories([
+            { metadata: { label: "SaaS" }, items: [node("calendar")] },
+            node("gcalendar"),
+        ] as any);
+        expect(result.map((category) => category.metadata.label)).toEqual(["SaaS", "Search Results"]);
+    });
+
+    it("ignores entries that are neither", () => {
+        expect(normalizeConnectorSearchCategories([undefined, null, {}] as any)).toEqual([]);
+        expect(normalizeConnectorSearchCategories(undefined)).toEqual([]);
+    });
+});
+
+describe("buildConnectionSelectField", () => {
+    const httpConnector = {
+        node: "NEW_CONNECTION",
+        org: "ballerina",
+        packageName: "http",
+        module: "http",
+        object: "Client",
+        version: "2.14.1",
+    };
+
+    it("is a reference select over existing connections", () => {
+        const field = buildConnectionSelectField(httpConnector as any, "http:Client", "") as any;
+        expect(field.key).toBe("connection");
+        expect(field.hidden).toBe(false);
+        expect(field.editable).toBe(true);
+        expect(field.codedata.searchNodesKind).toBe("NEW_CONNECTION");
+    });
+
+    it("constrains candidates to the connector's exact client type", () => {
+        const field = buildConnectionSelectField(httpConnector as any, "http:Client", "") as any;
+        expect(field.codedata.targetType).toEqual({
+            relation: "exact",
+            org: "ballerina",
+            packageName: "http",
+            module: "http",
+            name: "Client",
+        });
+    });
+
+    it("omits the version from the type constraint", () => {
+        const field = buildConnectionSelectField(httpConnector as any, "http:Client", "") as any;
+        expect(field.codedata.targetType).not.toHaveProperty("version");
+    });
+
+    it("carries the connector codedata so 'Create New' builds the right connection", () => {
+        const field = buildConnectionSelectField(httpConnector as any, "http:Client", "") as any;
+        expect(field.codedata.data.connection).toEqual(httpConnector);
+    });
+
+    it("preselects a connection when one is supplied", () => {
+        const field = buildConnectionSelectField(httpConnector as any, "http:Client", "httpClient") as any;
+        expect(field.value).toBe("httpClient");
+    });
+
+    it("offers a raw expression as an alternative input mode", () => {
+        const field = buildConnectionSelectField(httpConnector as any, "http:Client", "") as any;
+        expect(field.types.map((t: any) => t.fieldType)).toEqual(["ACTION_EXPRESSION", "EXPRESSION"]);
+        expect(field.types[0].selected).toBe(true);
+    });
+
+    it("omits the constraint when the connector lacks a client object", () => {
+        const field = buildConnectionSelectField({ org: "x", module: "y" } as any, undefined, "") as any;
+        expect(field.codedata.targetType).toBeUndefined();
+    });
+});

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/connectorActions.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/connectorActions.ts
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AvailableNode, Category, CodeData, Item, NodeKind } from "@wso2/ballerina-core";
+import { BallerinaRpcClient } from "@wso2/ballerina-rpc-client";
+import { formatMethodName } from "@wso2/ballerina-side-panel";
+
+const REMOTE_ACTION_CALL: NodeKind = "REMOTE_ACTION_CALL";
+const RESOURCE_ACTION_CALL: NodeKind = "RESOURCE_ACTION_CALL";
+
+export function formatActionLabel(symbol: string): string {
+    return formatMethodName(symbol, { casing: "sentence" });
+}
+
+const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+
+export function actionDisplayLabel(label: string | undefined): string {
+    const text = label ?? "";
+    return IDENTIFIER.test(text) ? formatActionLabel(text) : text;
+}
+
+interface DocsMethod {
+    name?: string;
+    description?: string;
+    accessor?: string;
+    resourcePath?: string;
+    isDeprecated?: boolean;
+}
+
+interface DocsClient {
+    name?: string;
+    remoteMethods?: DocsMethod[];
+    resourceMethods?: DocsMethod[];
+}
+
+const stripMarkup = (value: string): string =>
+    value.replace(/<[^>]*>/g, "").replace(/```[\s\S]*?```/g, "").replace(/\s+/g, " ").trim();
+
+export function firstSentence(value: string): string {
+    const text = (value || "").trim();
+    const end = text.search(/\.(\s|$)/);
+    return end === -1 ? text : text.slice(0, end + 1);
+}
+
+export const REST_RESOURCE_PATH = "/path/to/subdirectory";
+
+const REST_PATH_DISPLAY = "/[path...]";
+
+export function displayResourcePath(resourcePath: string | undefined): string {
+    return resourcePath === REST_RESOURCE_PATH ? REST_PATH_DISPLAY : (resourcePath || "");
+}
+
+export function formatResourceSignature(accessor: string, resourcePath: string): string {
+    return `${(accessor || "").toUpperCase()} ${displayResourcePath(resourcePath)}`.trim();
+}
+
+export function toResourcePathTemplate(docsPath: string): string {
+    const path = (docsPath || "").trim();
+    if (!path || path === ".") {
+        return "/";
+    }
+    if (/^\[[^\]]*\.\.\.[^\]]*\]$/.test(path)) {
+        return REST_RESOURCE_PATH;
+    }
+
+    const segments = path.split("/").filter((segment) => segment.length > 0);
+    const rendered: string[] = [];
+    for (const segment of segments) {
+        const param = segment.match(/^\[([^\]]*)\]$/);
+        if (!param) {
+            rendered.push(segment);
+            continue;
+        }
+        if (param[1].includes("...")) {
+            continue;
+        }
+        const name = param[1].trim().split(/\s+/).pop() ?? "";
+        rendered.push(`[${name}]`);
+    }
+    return rendered.length > 0 ? `/${rendered.join("/")}` : "/";
+}
+
+export async function fetchConnectorActions(
+    rpcClient: BallerinaRpcClient,
+    connector: AvailableNode
+): Promise<AvailableNode[]> {
+    const codedata = connector?.codedata;
+    if (!codedata?.org || !codedata?.module || !codedata?.version) {
+        throw new Error("The selected connector is missing package coordinates.");
+    }
+
+    const response = await rpcClient.getLibraryBrowserRPCClient().getLibraryData({
+        orgName: codedata.org,
+        moduleName: codedata.module,
+        version: codedata.version,
+    });
+
+    const modules = response?.docsData?.modules ?? [];
+    const clientName = codedata.object || "Client";
+    const clients: DocsClient[] = modules
+        .filter((module) => !module.id || module.id === codedata.module)
+        .flatMap((module) => (module.clients ?? []) as DocsClient[]);
+    const allClients: DocsClient[] = clients.length
+        ? clients
+        : modules.flatMap((module) => (module.clients ?? []) as DocsClient[]);
+
+    const client = allClients.find((candidate) => candidate.name === clientName) ?? allClients[0];
+    if (!client) {
+        throw new Error(`No client found in the documentation for ${codedata.org}/${codedata.module}.`);
+    }
+
+    const actions: AvailableNode[] = [];
+    const seen = new Set<string>();
+
+    const push = (method: DocsMethod, node: NodeKind) => {
+        if (method?.isDeprecated) {
+            return;
+        }
+        const isResource = node === RESOURCE_ACTION_CALL;
+        const symbol = (isResource ? method.accessor : method.name)?.trim();
+        const docsPath = method.resourcePath?.trim();
+        if (!symbol || (isResource && !docsPath)) {
+            return;
+        }
+        const resourcePath = isResource ? toResourcePathTemplate(docsPath) : docsPath;
+        const key = `${node}:${symbol}:${resourcePath ?? ""}`;
+        if (seen.has(key)) {
+            return;
+        }
+        seen.add(key);
+
+        const description = stripMarkup(method.description ?? "");
+        const label = isResource
+            ? firstSentence(description) || formatResourceSignature(symbol, resourcePath)
+            : formatActionLabel(symbol);
+
+        const actionCodeData: CodeData = {
+            node,
+            org: codedata.org,
+            module: codedata.module,
+            packageName: codedata.packageName ?? codedata.module,
+            object: client.name ?? clientName,
+            symbol,
+            version: codedata.version,
+            ...(resourcePath ? { resourcePath } : {}),
+        };
+
+        actions.push({
+            metadata: {
+                label,
+                description,
+                icon: connector.metadata?.icon,
+            },
+            codedata: actionCodeData,
+            enabled: true,
+        } as AvailableNode);
+    };
+
+    (client.remoteMethods ?? []).forEach((method) => push(method, REMOTE_ACTION_CALL));
+    (client.resourceMethods ?? []).forEach((method) => push(method, RESOURCE_ACTION_CALL));
+
+    actions.sort((a, b) => (a.metadata?.label ?? "").localeCompare(b.metadata?.label ?? ""));
+    return actions;
+}
+
+export function normalizeConnectorSearchCategories(
+    categories: Item[] | undefined,
+    searchResultLabel = "Search Results"
+): Category[] {
+    const grouped: Category[] = [];
+    const flat: AvailableNode[] = [];
+    (categories ?? []).forEach((entry) => {
+        if (entry && Array.isArray((entry as Category).items)) {
+            const category = entry as Category;
+            if (category.items.length > 0) {
+                grouped.push(category);
+            }
+        } else if ((entry as AvailableNode)?.codedata) {
+            flat.push(entry as AvailableNode);
+        }
+    });
+    if (flat.length > 0) {
+        grouped.push({ metadata: { label: searchResultLabel, description: "" }, items: flat });
+    }
+    return grouped;
+}
+
+export function buildConnectionSelectField(
+    connectorCodeData: CodeData,
+    ballerinaType: string | undefined,
+    value: string
+): Record<string, unknown> {
+    const targetType = connectorCodeData.module && connectorCodeData.object
+        ? {
+            relation: "exact",
+            ...(connectorCodeData.org && { org: connectorCodeData.org }),
+            ...(connectorCodeData.packageName && { packageName: connectorCodeData.packageName }),
+            module: connectorCodeData.module,
+            name: connectorCodeData.object,
+        }
+        : undefined;
+
+    return {
+        key: "connection",
+        label: "Connection",
+        documentation: "The connection this tool runs on.",
+        type: "ACTION_EXPRESSION",
+        optional: false,
+        editable: true,
+        enabled: true,
+        hidden: false,
+        advanced: false,
+        value: value ?? "",
+        hideModeSwitcher: true,
+        types: [
+            { fieldType: "ACTION_EXPRESSION", ballerinaType, selected: true },
+            { fieldType: "EXPRESSION", selected: false },
+        ],
+        codedata: {
+            kind: "REQUIRED",
+            originalName: "connection",
+            searchNodesKind: "NEW_CONNECTION",
+            ...(targetType && { targetType }),
+            data: { connection: connectorCodeData },
+        },
+    };
+}

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/index.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/index.ts
@@ -16,18 +16,19 @@
  * under the License.
  */
 
-const base = require('@wso2/test-config/jest-preset');
-
-module.exports = {
-    ...base,
-    rootDir: '.',
-    moduleNameMapper: {
-        ...base.moduleNameMapper,
-        // Local file mock (keeps existing behavior for this package).
-        '\\.(svg|png|jpg|jpeg|gif|ico|woff|woff2|ttf|eot)$': '<rootDir>/src/test/fileMock.js',
-        '^@wso2/ballerina-side-panel$': '<rootDir>/../ballerina-side-panel/src/utils/formatMethodName.ts',
-    },
-    // These unit tests mock @wso2/ballerina-core and use the pre-built CJS libs,
-    // so no node_modules (incl. @wso2 packages) need transformation.
-    transformIgnorePatterns: ['node_modules/'],
-};
+export { ConnectorBrowser, WizardStep } from "./ConnectorBrowser";
+export type { ActionSelection } from "./ConnectorBrowser";
+export { ConnectorActionList } from "./ConnectorActionList";
+export { ConnectorList } from "./ConnectorList";
+export {
+    actionDisplayLabel,
+    buildConnectionSelectField,
+    displayResourcePath,
+    fetchConnectorActions,
+    firstSentence,
+    formatActionLabel,
+    formatResourceSignature,
+    normalizeConnectorSearchCategories,
+    REST_RESOURCE_PATH,
+    toResourcePathTemplate,
+} from "./connectorActions";

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/styles.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/styles.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import styled from "@emotion/styled";
+import { ThemeColors } from "@wso2/ui-toolkit";
+
+export const CONTENT_HEIGHT = "calc(100vh - 56px)";
+
+export const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    height: ${CONTENT_HEIGHT};
+`;
+
+export const HeaderArea = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px 16px 12px;
+    flex-shrink: 0;
+`;
+
+export const ScrollArea = styled.div`
+    flex: 1;
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+    padding: 0 16px 16px;
+    &::-webkit-scrollbar {
+        width: 10px;
+    }
+    &::-webkit-scrollbar-track {
+        background: transparent;
+    }
+    &::-webkit-scrollbar-thumb {
+        background: transparent;
+        border-radius: 5px;
+        border: 3px solid transparent;
+        background-clip: content-box;
+    }
+    &:hover::-webkit-scrollbar-thumb {
+        background: ${ThemeColors.OUTLINE_VARIANT};
+        background-clip: content-box;
+    }
+`;
+
+export const Tag = styled.div`
+    flex-shrink: 0;
+    padding: 1px 8px;
+    border-radius: 4px;
+    font-size: 10px;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    background-color: ${ThemeColors.SURFACE_CONTAINER};
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+`;
+
+export const Row = styled.button`
+    display: grid;
+    align-items: start;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 12px;
+    background: transparent;
+    color: ${ThemeColors.ON_SURFACE};
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+
+    &:hover,
+    &[data-active="true"] {
+        background-color: ${ThemeColors.PRIMARY_CONTAINER};
+    }
+
+    &:focus-visible {
+        outline: 1px solid ${ThemeColors.PRIMARY};
+        outline-offset: -1px;
+    }
+`;
+
+type RowIconProps = { box: number; icon: number; offset?: number };
+
+export const RowIcon = styled.div<RowIconProps>`
+    position: relative;
+    width: ${({ box }: RowIconProps) => box}px;
+    height: ${({ box }: RowIconProps) => box}px;
+    margin-top: ${({ offset = 0 }: RowIconProps) => offset}px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    & > *:not(.action-badge) {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+        font-size: ${({ icon }: RowIconProps) => icon}px !important;
+    }
+
+    & > *:not(.action-badge) svg,
+    & > *:not(.action-badge) img,
+    & > svg,
+    & > img {
+        width: ${({ icon }: RowIconProps) => icon}px !important;
+        height: ${({ icon }: RowIconProps) => icon}px !important;
+        object-fit: contain;
+    }
+`;
+
+export const RowText = styled.div`
+    min-width: 0;
+`;
+
+export const RowLabel = styled.div`
+    font-size: 13px;
+    font-weight: 500;
+    color: ${ThemeColors.ON_SURFACE};
+`;
+
+export const RowDescription = styled.div`
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--vscode-descriptionForeground);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+`;
+
+export const RowChevron = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: 2px;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    opacity: 0.7;
+`;
+
+export const EmptyState = styled.div`
+    padding: 24px 16px;
+    font-size: 13px;
+    text-align: center;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+`;

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/styles.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectorBrowser/styles.ts
@@ -21,6 +21,9 @@ import { ThemeColors } from "@wso2/ui-toolkit";
 
 export const CONTENT_HEIGHT = "calc(100vh - 56px)";
 
+const CONTENT_INSET = 16;
+const SCROLLBAR_WIDTH = 10;
+
 export const Container = styled.div`
     display: flex;
     flex-direction: column;
@@ -31,7 +34,7 @@ export const HeaderArea = styled.div`
     display: flex;
     flex-direction: column;
     gap: 12px;
-    padding: 16px 16px 12px;
+    padding: ${CONTENT_INSET}px ${CONTENT_INSET}px 12px;
     flex-shrink: 0;
 `;
 
@@ -39,9 +42,9 @@ export const ScrollArea = styled.div`
     flex: 1;
     overflow-y: auto;
     scrollbar-gutter: stable;
-    padding: 0 16px 16px;
+    padding: 0 ${CONTENT_INSET - SCROLLBAR_WIDTH}px ${CONTENT_INSET}px ${CONTENT_INSET}px;
     &::-webkit-scrollbar {
-        width: 10px;
+        width: ${SCROLLBAR_WIDTH}px;
     }
     &::-webkit-scrollbar-track {
         background: transparent;

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
@@ -38,6 +38,7 @@ import { LoaderContainer } from "../../../components/RelativeLoader/styles";
 import { ConnectionListItem } from "@wso2/wso2-platform-core";
 import { ConnectorErrorView } from "./components/ErrorContainer";
 import { NewActivityFromConnection } from "./NewActivityFromConnection";
+import { ADD_TOOL_TITLE, addToolTitle } from "../AIChatAgent/AddTool";
 import { AgentEditorPanelContent } from "../AIChatAgent/AgentEditorPanelContent";
 import { AgentEditorController } from "../AIChatAgent/useAgentEditorController";
 
@@ -699,18 +700,21 @@ export function PanelManager(props: PanelManagerProps) {
         switch (sidePanelView) {
             case SidePanelView.AGENT_MEMORY_MANAGER:
                 return "Configure Memory";
+            case SidePanelView.NEW_TOOL_FROM_AGENT:
             case SidePanelView.NEW_TOOL_FROM_AGENT_FORM:
-                return "Use Agent";
+                return addToolTitle("AGENT");
             case SidePanelView.ADD_MCP_SERVER:
-                return "Add MCP Server";
+                return addToolTitle("MCP");
             case SidePanelView.EDIT_MCP_SERVER:
                 return "Edit MCP Server";
-            case SidePanelView.ADD_TOOL:
-            case SidePanelView.NEW_TOOL_CUSTOM:
             case SidePanelView.NEW_TOOL_FROM_CONNECTION:
+                return addToolTitle("CONNECTION");
             case SidePanelView.NEW_TOOL_FROM_FUNCTION:
-            case SidePanelView.NEW_TOOL_FROM_AGENT:
-                return "Add Tool";
+                return addToolTitle("FUNCTION");
+            case SidePanelView.NEW_TOOL_CUSTOM:
+                return addToolTitle("CUSTOM");
+            case SidePanelView.ADD_TOOL:
+                return ADD_TOOL_TITLE;
             default:
                 return undefined;
         }

--- a/packages/ballerina-visualizer/src/views/BI/Forms/ArtifactForm/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Forms/ArtifactForm/index.tsx
@@ -43,6 +43,7 @@ import {
     ValidationResult
 } from "@wso2/ballerina-core";
 import {
+    FieldGroup,
     FormField,
     FormValues,
     Form,
@@ -130,6 +131,9 @@ interface ArtifactFormProps {
     // continues to a following step). Validated through the same path as submit.
     secondarySubmitText?: string;
     onSecondarySubmit?: (data: FormValues, formImports?: FormImports, importsCodedata?: CodeData) => void;
+    groups?: FieldGroup[];
+    opensPrefilled?: boolean;
+    onCreateNode?: (kind: string, onCreated: (variableName: string) => void, nodeCodeData?: CodeData) => void;
     customDiagnosticFilter?: (diagnostics: Diagnostic[]) => Diagnostic[];
     onValidityChange?: (isValid: boolean) => void;
     recordsOnly?: boolean;
@@ -170,6 +174,9 @@ export function ArtifactForm(props: ArtifactFormProps) {
         changeOptionalFieldTitle,
         onChange,
         hideSaveButton,
+        groups,
+        opensPrefilled,
+        onCreateNode,
         customDiagnosticFilter,
         onValidityChange,
         recordsOnly,
@@ -1123,6 +1130,9 @@ export function ArtifactForm(props: ArtifactFormProps) {
                     serverValidationErrors={serverValidationErrors}
                     onChange={handleFieldChange}
                     hideSaveButton={hideSaveButton}
+                    groups={groups}
+                    opensPrefilled={opensPrefilled}
+                    onCreateNode={onCreateNode}
                     footerActionButton={footerActionButton}
                     onValidityChange={onValidityChange}
                     secondarySubmitButton={

--- a/packages/statement-editor/src/components/LibraryBrowser/Library/index.tsx
+++ b/packages/statement-editor/src/components/LibraryBrowser/Library/index.tsx
@@ -40,14 +40,20 @@ export function Library(props: LibraryProps) {
 
     const onClickOnLibrary = async () => {
         libraryDataFetchingHandler(true);
-        const response = await libraryBrowserRpcClient.getLibraryData({
-            orgName,
-            moduleName: id,
-            version
-        });
+        try {
+            const response = await libraryBrowserRpcClient.getLibraryData({
+                orgName,
+                moduleName: id,
+                version
+            });
 
-        if (response) {
-            libraryBrowsingHandler(response);
+            if (response) {
+                libraryBrowsingHandler(response);
+            }
+        } catch (error) {
+            // tslint:disable-next-line: no-console
+            console.error("Failed to fetch library data", { orgName, moduleName: id, version, error });
+        } finally {
             libraryDataFetchingHandler(false);
         }
     }

--- a/packages/statement-editor/src/components/LibraryBrowser/ModuleElement/index.tsx
+++ b/packages/statement-editor/src/components/LibraryBrowser/ModuleElement/index.tsx
@@ -65,16 +65,22 @@ export function ModuleElement(props: ModuleElementProps) {
         let content = keywords.includes(moduleName) ? `${moduleName}0:${id}` : `${moduleName}:${id}`;
         setClickedModuleElement(content);
         if (isFunction) {
-            const response: LibraryDataResponse = await libraryBrowserRpcClient.getLibraryData({
-                orgName: moduleOrgName,
-                moduleName: moduleId,
-                version: moduleVersion
-            });
+            let response: LibraryDataResponse;
+            try {
+                response = await libraryBrowserRpcClient.getLibraryData({
+                    orgName: moduleOrgName,
+                    moduleName: moduleId,
+                    version: moduleVersion
+                });
+            } catch (error) {
+                // tslint:disable-next-line: no-console
+                console.error("Failed to fetch library data", { moduleOrgName, moduleId, moduleVersion, error });
+            }
 
             let functionProperties: LibraryFunction = null;
-            response.docsData.modules[0].functions.map((libFunction: LibraryFunction) => {
+            response?.docsData?.modules?.[0]?.functions?.map((libFunction: LibraryFunction) => {
                 if (libFunction.name === id) {
-                    functionProperties =  libFunction;
+                    functionProperties = libFunction;
                 }
             });
 


### PR DESCRIPTION
## Summary

Client half of #809, split out from the language-server changes. Revamps the `Use Connection` agent tool creation flow so users can discover connector capabilities before creating a connection.

Resolves https://github.com/wso2/product-integrator/issues/2152

**Depends on #876** for connector categories (`connectorSet: "GROUPED"`), corrected connector names, and agent tool return types. This builds and tests on its own, but category grouping and result-type resolution need the LS change to be in place.

https://github.com/user-attachments/assets/dae11089-d29a-4e85-8489-801f0ecf1cf7

- Replace the connection-first flow with a connector → action → tool form.
- Add a browsable connector catalogue with category navigation, sticky headers, curated Popular entries, and instant local filtering.
- Search Ballerina Central for connectors outside the catalogue, without duplicating catalogue results.
- Discover remote and resource actions from Central documentation, including OpenAPI-generated resource actions.
- Prefill and organize tool forms: suggested names/descriptions, type-filtered connection selection, collapsible Inputs, OAuth, and Result Type sections.
- Improve related action labels, connection-select behavior, form loading, navigation, and deletion behavior.
- Note one intentional product-wide relabel, not scoped to the new browser: `formatMethodName` now preserves acronyms (`getUserId` → "Get User ID"), which also affects its existing `GroupList` caller.

## Related

- Language-server half: #876
- Original combined PR (kept open for reference): #809


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Reworked agent connection tool creation into a connector-first workflow.
- Added connector browsing, category filtering, local search, and action selection.
- Added discovery for remote, resource, and OpenAPI-generated actions.
- Improved tool forms with prefilled values, grouped collapsible sections, OAuth fields, result types, and type-filtered connection selection.
- Improved connection creation, navigation, loading states, error handling, deletion behavior, and user feedback.
- Added acronym-aware method-name formatting, including `getUserId` → `Get User ID`.
- Extended agent tool metadata with optional return types and connection names.
- Added shared form utilities and unit tests for connector actions, tool forms, validation, and method-name formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->