### PR TITLE
Attribute the LS nightly coverage upload to the branch it tested

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -267,6 +267,12 @@ jobs:
           gradle-version: ${{ matrix.version }}
           package-user: ${{ github.actor }}
           package-pat: ${{ secrets.GITHUB_TOKEN }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          # This job checks out matrix.branch, not the ref the schedule fired on, so the
+          # upload has to be attributed explicitly — otherwise Codecov records every leg
+          # against the default branch head and no branch ever gets a baseline. It also
+          # keeps the coverage artifact name unique per leg.
+          codecov-branch: ${{ matrix.branch }}
 
   ls-windows-build:
     name: LS Windows build (${{ matrix.branch }})


### PR DESCRIPTION
## Purpose

The LS nightly matrix checks out `matrix.branch`, but the Codecov action derives branch and commit from the **triggering event** — a cron, which always reports the default branch. So every leg's coverage is recorded against `main`'s head no matter which branch was actually built, and no branch ends up with a usable baseline.

This has not happened yet only because `builds/nightly` did not carry the upload step until now. It is reset from the latest `staging/*` branch, which gained it in #862, so the first misattributed upload lands on the next nightly run.

## Approach

Pass two inputs to `.github/actions/ls-test` in `ls-ubuntu-test`:

- `codecov-branch: ${{ matrix.branch }}` — becomes `override_branch` / `override_commit`, so the report is filed against the branch that was tested. Also makes the coverage artifact name unique per leg.
- `codecov-token: ${{ secrets.CODECOV_TOKEN }}` — otherwise the upload is tokenless.

Both are consumed by `ls-test/action.yml`, which resolves from the `matrix.branch` checkout rather than from `main` — so it is staging's copy of the action that runs, and that copy declares both inputs and has the upload step. `main` is never itself a matrix target.

**Why this targets `main`:** scheduled workflows always run the workflow file from the repository's default branch ("Scheduled workflows will only run on the default branch"). The same wiring already exists on `staging/5.14.0`, but is inert there for the nightly cron.

**The added block is byte-identical to the one on `staging/5.14.0`**, verified by diff, so the next `staging` -> `main` sync merges it cleanly rather than conflicting on the comment text.

## Scope change from the first revision

This PR originally also added the latest `staging/*` branch to the nightly matrix. That has been dropped, for two reasons:

1. It duplicated `.github/actions/resolve-source-branch`, which did not exist when this was written and now holds a byte-identical `git ls-remote | awk | sort -t/ -k2 -V` pipeline. Re-inlining it would leave two copies, and the comment justifying it pointed at inline shell in `sync-nightly` that has since been extracted into that action.
2. Giving `staging/5.14.0` a coverage baseline is a design question, not a wiring fix. The nightly-matrix route makes the baseline up to 24h stale and roughly doubles the LS nightly, since `builds/nightly` *is* staging plus a version commit. A post-merge job would be fresher and cheaper but needs a decision on this repo's deliberate lack of `push` triggers.

That decision is tracked in #934, with both options and the `resolve-source-branch` caveat written up. Nothing is blocked in the meantime: everything in `codecov.yml` is `informational: true`.

## Automation tests

 - Unit tests
   > N/A — workflow-only change, no product code.
 - Integration tests
   > YAML validated (`yaml.safe_load`, all 10 jobs parse). The added block diffed byte-for-byte against `staging/5.14.0`. Behaviour verification is the next nightly run: coverage should appear on Codecov under `builds/nightly` rather than `main`.

## Security checks

 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no source code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes. `CODECOV_TOKEN` is referenced via `secrets`, never inlined, and reuses the same secret the PR build already passes.

## Release note

N/A — CI-only change.

## Related PRs

- #862 — added the Codecov integration to `staging/5.14.0`. Note `main` has no Codecov yet: #862 postdates the last sync, whose merged-in side predates it, so it arrives on `main` at the next `staging` -> `main` sync.
- #934 — the remaining baseline decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Update `.github/workflows/schedule.yml` to discover the latest `staging/*` branch by version.
- Include the staging branch with `builds/nightly` and the latest `X.Y.x` release branch in the LS nightly matrix.
- Pass `codecov-branch: ${{ matrix.branch }}` and the Codecov token so coverage uploads use the correct branch.
- Enable nightly builds and Codecov baseline generation for branches such as `staging/5.14.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->