### PR TITLE
Add WSO2 Cloud Knowledge Bases to the Add Knowledge Base panel

### DIFF
--- a/packages/ballerina-side-panel/src/components/CardList/index.tsx
+++ b/packages/ballerina-side-panel/src/components/CardList/index.tsx
@@ -396,11 +396,13 @@ export interface CardListProps {
     // Supply both to keep a group expanded across view switches (e.g. returning from a form).
     expandedGroupId?: string | null;
     onExpandedGroupChange?: (groupId: string | null) => void;
+    // Optional extra content rendered below the categories (e.g. a WSO2 Cloud section).
+    extraSection?: React.ReactNode;
 }
 
 function CardList(props: CardListProps) {
     const { categories, title, searchPlaceholder, onSelect, onSearch, onBack, onClose,
-        expandedGroupId: controlledExpandedGroupId, onExpandedGroupChange } = props;
+        expandedGroupId: controlledExpandedGroupId, onExpandedGroupChange, extraSection } = props;
 
     const [searchText, setSearchText] = useState<string>("");
     const [isSearching, setIsSearching] = useState(false);
@@ -660,27 +662,30 @@ function CardList(props: CardListProps) {
 
             {!isSearching && (
                 <S.PanelBody>
-                    {!hasContent ? (
+                    {!hasContent && !extraSection ? (
                         <S.EmptyState>
                             <S.EmptyStateText>No results found</S.EmptyStateText>
                             <S.EmptyStateSubText>Try adjusting your search terms</S.EmptyStateSubText>
                         </S.EmptyState>
                     ) : (
-                        filteredCategories.map((category, index) => {
-                            if (!category?.items || category.items.length === 0) {
-                                return null;
-                            }
+                        <>
+                            {filteredCategories.map((category, index) => {
+                                if (!category?.items || category.items.length === 0) {
+                                    return null;
+                                }
 
-                            return (
-                                <S.CategorySection key={category.title + index}>
-                                    <S.CategoryTitle>{category.title}</S.CategoryTitle>
-                                    {category.description && (
-                                        <S.CategoryDescription>{category.description}</S.CategoryDescription>
-                                    )}
-                                    {renderCards(category.items)}
-                                </S.CategorySection>
-                            );
-                        })
+                                return (
+                                    <S.CategorySection key={category.title + index}>
+                                        <S.CategoryTitle>{category.title}</S.CategoryTitle>
+                                        {category.description && (
+                                            <S.CategoryDescription>{category.description}</S.CategoryDescription>
+                                        )}
+                                        {renderCards(category.items)}
+                                    </S.CategorySection>
+                                );
+                            })}
+                            {extraSection}
+                        </>
                     )}
                 </S.PanelBody>
             )}

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/CloudKnowledgeBasePage.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/CloudKnowledgeBasePage.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { Codicon, ProgressRing } from "@wso2/ui-toolkit";
+import { useQuery } from "@tanstack/react-query";
+import { GetMarketplaceItemsParams, MarketplaceItem } from "@wso2/wso2-platform-core";
+import ButtonCard from "../../../../components/ButtonCard";
+import { BodyTinyInfo } from "../../../styles";
+import { usePlatformExtContext } from "../../../../providers/platform-ext-ctx-provider";
+import { ConnectorsGrid, Section, SectionHeader, SectionTitle } from "../AddConnectionPopup/styles";
+import { ProgressWrap } from "./utils";
+
+// Devant tags knowledge base services with this tag.
+const KB_TAG = "knowledge-base-as-service";
+const isKnowledgeBase = (item: MarketplaceItem) => item.tags?.includes(KB_TAG) ?? false;
+
+interface CloudKnowledgeBasePageProps {
+    // Opens a blank CloudKnowledgeBase create form (manual entry, no Devant service pre-selected).
+    onCreateNew: () => void;
+    // Selecting an existing cloud KB service runs the auto-provisioned create flow.
+    onSelectExisting: (item: MarketplaceItem) => void;
+}
+
+/**
+ * Intermediate page shown when the "WSO2 Cloud Knowledge Base" box is selected. Offers creating a
+ * new knowledge base manually, and lists the existing WSO2 Cloud knowledge bases to connect to.
+ */
+export function CloudKnowledgeBasePage(props: CloudKnowledgeBasePageProps) {
+    const { onCreateNew, onSelectExisting } = props;
+    const { platformExtState, platformRpcClient } = usePlatformExtContext();
+
+    const isSignedIn = !!platformExtState?.isLoggedIn && !!platformExtState?.selectedContext?.project;
+
+    const getMarketPlaceParams: GetMarketplaceItemsParams = {
+        limit: 24,
+        offset: 0,
+        networkVisibilityFilter: "all",
+        networkVisibilityprojectId: platformExtState?.selectedContext?.project?.id,
+        sortBy: "createdTime",
+        searchContent: false,
+    };
+
+    const { data: knowledgeBases, isLoading } = useQuery({
+        queryKey: [
+            "kb-marketplace-services",
+            platformExtState?.selectedContext?.org?.uuid,
+            platformExtState?.selectedContext?.project?.id,
+        ],
+        queryFn: () =>
+            platformRpcClient?.getMarketplaceItems({
+                orgId: platformExtState?.selectedContext?.org?.id?.toString(),
+                request: getMarketPlaceParams,
+            }),
+        enabled: isSignedIn,
+        select: (data) => ({ ...data, data: (data?.data || []).filter(isKnowledgeBase) }),
+    });
+
+    const items: MarketplaceItem[] = knowledgeBases?.data || [];
+
+    return (
+        <>
+            <Section>
+                <ConnectorsGrid>
+                    <ButtonCard
+                        id="create-new-cloud-kb"
+                        title="Manually Config WSO2 Cloud Knowledge Base"
+                        description="Create and configure a new knowledge base"
+                        icon={<Codicon name="add" />}
+                        onClick={onCreateNew}
+                    />
+                </ConnectorsGrid>
+            </Section>
+
+            <div style={{ height: 16 }} />
+
+            {isSignedIn && (
+                <Section>
+                    <SectionHeader>
+                        <SectionTitle variant="h4">Existing WSO2 Cloud Knowledge Bases</SectionTitle>
+                    </SectionHeader>
+                    {isLoading ? (
+                        <ProgressWrap>
+                            <ProgressRing />
+                        </ProgressWrap>
+                    ) : items.length === 0 ? (
+                        <BodyTinyInfo style={{ paddingBottom: "10px" }}>
+                            No knowledge bases found in your WSO2 Cloud organization
+                        </BodyTinyInfo>
+                    ) : (
+                        <ConnectorsGrid>
+                            {items.map((item) => (
+                                <ButtonCard
+                                    key={item.resourceId}
+                                    id={`kb-connector-${item.resourceId}`}
+                                    title={item.name}
+                                    description={item.description}
+                                    icon={<Codicon name="database" />}
+                                    onClick={() => onSelectExisting(item)}
+                                />
+                            ))}
+                        </ConnectorsGrid>
+                    )}
+                </Section>
+            )}
+        </>
+    );
+}

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/CloudKnowledgeBasePage.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/CloudKnowledgeBasePage.tsx
@@ -80,7 +80,7 @@ export function CloudKnowledgeBasePage(props: CloudKnowledgeBasePageProps) {
                     <ButtonCard
                         id="create-new-cloud-kb"
                         title="Manually Config WSO2 Cloud Knowledge Base"
-                        description="Create and configure a new knowledge base"
+                        description="Add configurations for the Knowledge Base connection."
                         icon={<Codicon name="add" />}
                         onClick={onCreateNew}
                     />

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantBIConnectorInitForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantBIConnectorInitForm.tsx
@@ -28,8 +28,13 @@ import { useMutation } from "@tanstack/react-query";
 import { DevantTempConfig } from "@wso2/ballerina-core/lib/rpc-types/platform-ext/interfaces";
 import { ConnectionConfigurationForm, ConnectionConfigurationFormProps } from "../ConnectionConfigurationPopup";
 import { DIRECTORY_MAP } from "@wso2/ballerina-core";
-import { DevantConnectionFlow, generateInitialConnectionName, isValidDevantConnName } from "./utils";
-import { getInitialVisibility, getPossibleVisibilities } from "./DevantConnectorCreateForm";
+import {
+    DevantConnectionFlow,
+    generateInitialConnectionName,
+    getInitialVisibility,
+    getPossibleVisibilities,
+    isValidDevantConnName,
+} from "./utils";
 
 interface Props extends Omit<ConnectionConfigurationFormProps, "devantConfigs"> {
     importedConnection?: ConnectionListItem;

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantConnectorCreateForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantConnectorCreateForm.tsx
@@ -19,8 +19,6 @@
 import {
     type MarketplaceItem,
     type MarketplaceItemSchema,
-    type Project,
-    ServiceInfoVisibilityEnum,
     capitalizeFirstLetter,
     getTypeForDisplayType,
 } from "@wso2/wso2-platform-core";
@@ -33,7 +31,14 @@ import { usePlatformExtContext } from "../../../../providers/platform-ext-ctx-pr
 import { useMutation } from "@tanstack/react-query";
 import { ActionButton, ConnectorContentContainer, ConnectorInfoContainer, FooterContainer } from "../styles";
 import { DevantTempConfig } from "@wso2/ballerina-core/lib/rpc-types/platform-ext/interfaces";
-import { DevantConnectionFlow, generateInitialConnectionName, isValidDevantConnName } from "./utils";
+import {
+    DevantConnectionFlow,
+    generateInitialConnectionName,
+    getInitialVisibility,
+    getPossibleSchemas,
+    getPossibleVisibilities,
+    isValidDevantConnName,
+} from "./utils";
 
 const Row = styled.div<{}>`
     display: flex;
@@ -61,80 +66,6 @@ const RowTitle = styled.div`
     gap: 2px;
     align-items: center;
 `;
-
-export const getPossibleVisibilities = (marketplaceItem: MarketplaceItem, project: Project) => {
-    const { connectionSchemas = [], visibility: visibilities = [] } = marketplaceItem ?? {};
-    const filteredVisibilities = visibilities.filter((item) => {
-        if (item === ServiceInfoVisibilityEnum.Project) {
-            return marketplaceItem.projectId === project.id;
-        }
-        return item;
-    });
-    /**
-     *
-     * There can be services with multiple visibilities but only with one schema.
-     * [PROJECT, ORGANIZATION] => Default OAuth Connection - Organization
-     *
-     * In this case, the visibilities should be filtered to only include the one that mathces the schema.
-     *
-     * If the schema is Unsecured, the visibilities should be filtered to include only Organization and Public
-     * else, the visibilities should be filtered to include only the visibilities that match the schema name.
-     */
-    if (connectionSchemas.length === 1 && filteredVisibilities.length > 1) {
-        return filteredVisibilities.filter((v) => {
-            const connectionSchemaName = connectionSchemas[0].name.toLowerCase();
-            if (connectionSchemaName.includes("Unsecured".toLowerCase())) {
-                return v === ServiceInfoVisibilityEnum.Organization || v === ServiceInfoVisibilityEnum.Public;
-            }
-            return connectionSchemaName.includes(v.toLowerCase());
-        });
-    }
-    return filteredVisibilities;
-};
-
-export const getInitialVisibility = (item: MarketplaceItem, visibilities: string[] = []) => {
-    if (item?.isThirdParty) {
-        return ServiceInfoVisibilityEnum.Public;
-    }
-    if (visibilities.includes(ServiceInfoVisibilityEnum.Project)) {
-        return ServiceInfoVisibilityEnum.Project;
-    }
-    if (visibilities.includes(ServiceInfoVisibilityEnum.Organization)) {
-        return ServiceInfoVisibilityEnum.Organization;
-    }
-    return ServiceInfoVisibilityEnum.Public;
-};
-
-const getPossibleSchemas = (
-    item: MarketplaceItem,
-    selectedVisibility: string,
-    connectionSchemas: MarketplaceItemSchema[] = [],
-) => {
-    if (!item) {
-        return [];
-    }
-    // If third party, return schemas without filtering
-    if (item.isThirdParty) {
-        return item.connectionSchemas;
-    }
-    // Set the filtered schemas based on the selected visibility
-    // organization and public visibilities can have
-    // Oauth2, api key or unauthenaticated
-    // project visibility can have only project
-    const schemasFiltered = connectionSchemas.filter((schema) => {
-        if (
-            selectedVisibility.toLowerCase().includes("organization") ||
-            selectedVisibility.toLowerCase().includes("public")
-        ) {
-            return (
-                schema.name.toLowerCase().includes(selectedVisibility.toLowerCase()) ||
-                schema.name.toLowerCase().includes("unsecured")
-            );
-        }
-        return schema.name.toLowerCase().includes("project");
-    });
-    return schemasFiltered;
-};
 
 interface CreateConnectionForm {
     name?: string;

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/devant-kb-utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/devant-kb-utils.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AvailableNode, FlowNode, LinePosition } from "@wso2/ballerina-core";
+import { DevantTempConfig, PlatformExtState } from "@wso2/ballerina-core/lib/rpc-types/platform-ext/interfaces";
+import { BallerinaRpcClient } from "@wso2/ballerina-rpc-client";
+import { PlatformExtRpcClient } from "@wso2/ballerina-rpc-client/lib/rpc-clients/platform-ext/platform-ext-client";
+import { MarketplaceItem, getTypeForDisplayType } from "@wso2/wso2-platform-core";
+import { generateInitialConnectionName, getInitialVisibility, getPossibleSchemas, getPossibleVisibilities } from "./utils";
+
+// OAuth2 auth entries wired from Devant environment variables (OAuth2 only for now).
+const OAUTH2_ENTRY_NAMES = ["ServiceURL", "TokenURL", "ConsumerKey", "ConsumerSecret"];
+
+export interface PrepareDevantKnowledgeBaseDeps {
+    rpcClient: BallerinaRpcClient;
+    platformRpcClient: PlatformExtRpcClient;
+    platformExtState: PlatformExtState;
+    item: MarketplaceItem;
+    node: AvailableNode;
+    projectPath: string;
+    target: LinePosition;
+    fileName: string;
+}
+
+/**
+ * Registers a Devant connection for the given knowledge base service, writes its credentials as
+ * `os:getEnv(...)` configurables, and returns a CloudKnowledgeBase form node pre-filled.
+ */
+export async function prepareDevantKnowledgeBase(deps: PrepareDevantKnowledgeBaseDeps): Promise<FlowNode | null> {
+    const { rpcClient, platformRpcClient, platformExtState, item, node, projectPath, target, fileName } = deps;
+
+    const schema = item.connectionSchemas?.[0];
+    const neededEntries = (schema?.entries || []).filter((e) => OAUTH2_ENTRY_NAMES.includes(e.name));
+
+    // Devant rejects a duplicate connection name in a project (409), so generate a unique one.
+    let existingDevantConnNames: string[] = [];
+    try {
+        const projConns = await platformRpcClient.getConnections({
+            projectId: platformExtState?.selectedContext?.project?.id,
+            orgId: platformExtState?.selectedContext?.org?.id?.toString(),
+            componentId: "",
+        });
+        existingDevantConnNames = (projConns || []).map((c) => c.name);
+    } catch (e) {
+        console.warn(">>> Could not fetch existing Devant connections for name dedup", e);
+    }
+    const connName = generateInitialConnectionName([], existingDevantConnNames, item.name);
+
+    // Create placeholder configurables in config.bal.
+    const devantConfigs: DevantTempConfig[] = [];
+    for (const [i, entry] of neededEntries.entries()) {
+        const varName = `${connName}_${entry.name}`;
+        const resp = await platformRpcClient.addDevantTempConfig({ name: varName, newLine: i === 0 });
+        devantConfigs.push({
+            id: entry.name,
+            name: varName,
+            value: "",
+            isSecret: entry.isSensitive,
+            type: (entry.type as "string" | "int") || "string",
+            node: resp.configNode,
+        });
+    }
+
+    // Register the connection in Devant. The schema must match the chosen visibility, else
+    // Devant rejects it (mirrors the normal connection form).
+    const isProjectLevel = !platformExtState.selectedComponent?.metadata?.id;
+    const visibilities = getPossibleVisibilities(item, platformExtState?.selectedContext?.project);
+    const visibility = getInitialVisibility(item, visibilities);
+    const chosenSchema = getPossibleSchemas(item, visibility, item.connectionSchemas)[0] || schema;
+    const createdConnection = await platformRpcClient.createInternalConnection({
+        componentId: isProjectLevel ? "" : platformExtState.selectedComponent?.metadata?.id,
+        name: connName,
+        orgId: platformExtState.selectedContext?.org?.id?.toString(),
+        orgUuid: platformExtState.selectedContext?.org?.uuid,
+        projectId: platformExtState.selectedContext?.project?.id,
+        serviceSchemaId: chosenSchema?.id || "",
+        serviceId: item.serviceId,
+        serviceVisibility: visibility,
+        componentType: isProjectLevel
+            ? "non-component"
+            : getTypeForDisplayType(platformExtState.selectedComponent?.spec?.type),
+        componentPath: projectPath,
+        generateCreds: true,
+    });
+
+    // createInternalConnection resolves to undefined on failure; roll back the placeholder configs.
+    if (!createdConnection) {
+        await platformRpcClient.deleteDevantTempConfigs({ nodes: devantConfigs.map((c) => c.node!) });
+        return null;
+    }
+
+    // Rewrite each placeholder to `= os:getEnv("CHOREO_...")` using Devant's env-var names.
+    await platformRpcClient.replaceDevantTempConfigValues({ configs: devantConfigs, createdConnection });
+
+    // Register the local connection config so the run step resolves this connection's secrets and
+    // injects the CHOREO_* env vars; without it os:getEnv(...) is empty at runtime.
+    await platformRpcClient.createConnectionConfig({
+        marketplaceItem: item,
+        name: connName,
+        visibility,
+        componentDir: projectPath,
+    });
+
+    // Fetch the CloudKnowledgeBase form node from the LS.
+    const templateResp = await rpcClient.getBIDiagramRpcClient().getNodeTemplate({
+        position: target,
+        filePath: fileName,
+        id: node.codedata,
+    });
+    const flowNode = templateResp.flowNode;
+
+    // Pre-fill serviceUrl/auth to reference the configurables as expressions (not string literals).
+    const varOf = (entryName: string) => devantConfigs.find((c) => c.id === entryName)?.name;
+    const selectExpression = (prop: any) => {
+        if (prop?.types) {
+            prop.types = prop.types.map((t: any) => ({ ...t, selected: t.fieldType === "EXPRESSION" }));
+        }
+    };
+    const props: any = flowNode.properties;
+    if (props?.variable) {
+        props.variable.value = connName;
+    }
+    if (props?.serviceUrl) {
+        props.serviceUrl.value = varOf("ServiceURL");
+        selectExpression(props.serviceUrl);
+    }
+    if (props?.knowledgeBaseAuthConfig) {
+        props.knowledgeBaseAuthConfig.value = `{auth: {tokenUrl: ${varOf("TokenURL")}, clientId: ${varOf(
+            "ConsumerKey",
+        )}, clientSecret: ${varOf("ConsumerSecret")}}}`;
+        selectExpression(props.knowledgeBaseAuthConfig);
+    }
+
+    // The auth record literal never uses the `http:` prefix, so drop the http import the template
+    // carries or it lands unused in connections.bal (BCE2002 unused module prefix 'http').
+    Object.values(props || {}).forEach((p: any) => {
+        if (p?.imports?.http) {
+            delete p.imports.http;
+        }
+    });
+
+    return flowNode;
+}

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/devant-kb-utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/devant-kb-utils.ts
@@ -44,8 +44,19 @@ export interface PrepareDevantKnowledgeBaseDeps {
 export async function prepareDevantKnowledgeBase(deps: PrepareDevantKnowledgeBaseDeps): Promise<FlowNode | null> {
     const { rpcClient, platformRpcClient, platformExtState, item, node, projectPath, target, fileName } = deps;
 
-    const schema = item.connectionSchemas?.[0];
-    const neededEntries = (schema?.entries || []).filter((e) => OAUTH2_ENTRY_NAMES.includes(e.name));
+    // Resolve the schema that matches the chosen visibility first, then derive the OAuth2 entries
+    // from that schema (the one we actually register with) so the configurables can't reference a
+    // different schema's entries.
+    const isProjectLevel = !platformExtState.selectedComponent?.metadata?.id;
+    const visibilities = getPossibleVisibilities(item, platformExtState?.selectedContext?.project);
+    const visibility = getInitialVisibility(item, visibilities);
+    const chosenSchema =
+        getPossibleSchemas(item, visibility, item.connectionSchemas)[0] || item.connectionSchemas?.[0];
+    const neededEntries = (chosenSchema?.entries || []).filter((e) => OAUTH2_ENTRY_NAMES.includes(e.name));
+    if (neededEntries.length !== OAUTH2_ENTRY_NAMES.length) {
+        console.error(">>> Devant KB service does not expose the expected OAuth2 entries", chosenSchema?.name);
+        return null;
+    }
 
     // Devant rejects a duplicate connection name in a project (409), so generate a unique one.
     let existingDevantConnNames: string[] = [];
@@ -76,12 +87,7 @@ export async function prepareDevantKnowledgeBase(deps: PrepareDevantKnowledgeBas
         });
     }
 
-    // Register the connection in Devant. The schema must match the chosen visibility, else
-    // Devant rejects it (mirrors the normal connection form).
-    const isProjectLevel = !platformExtState.selectedComponent?.metadata?.id;
-    const visibilities = getPossibleVisibilities(item, platformExtState?.selectedContext?.project);
-    const visibility = getInitialVisibility(item, visibilities);
-    const chosenSchema = getPossibleSchemas(item, visibility, item.connectionSchemas)[0] || schema;
+    // Register the connection in Devant (schema/visibility resolved above).
     const createdConnection = await platformRpcClient.createInternalConnection({
         componentId: isProjectLevel ? "" : platformExtState.selectedComponent?.metadata?.id,
         name: connName,

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
@@ -17,6 +17,7 @@
  */
 
 import { AvailableNode, Category, IntrospectCredentialsResponse, PropertyModel } from "@wso2/ballerina-core";
+import { MarketplaceItem, MarketplaceItemSchema, Project, ServiceInfoVisibilityEnum } from "@wso2/wso2-platform-core";
 import styled from "@emotion/styled";
 
 export const ProgressWrap = styled.div`
@@ -349,3 +350,74 @@ export const dbCredentialsToFieldValues = (
     });
     return result;
 }
+
+// Devant "service -> connection params" helpers, shared by the connection form and the KB flow.
+export const getPossibleVisibilities = (marketplaceItem: MarketplaceItem, project: Project) => {
+    const { connectionSchemas = [], visibility: visibilities = [] } = marketplaceItem ?? {};
+    const filteredVisibilities = visibilities.filter((item) => {
+        if (item === ServiceInfoVisibilityEnum.Project) {
+            return marketplaceItem.projectId === project.id;
+        }
+        return item;
+    });
+    /**
+     * There can be services with multiple visibilities but only with one schema.
+     * [PROJECT, ORGANIZATION] => Default OAuth Connection - Organization
+     *
+     * In this case, the visibilities should be filtered to only include the one that matches the schema.
+     * If the schema is Unsecured, include only Organization and Public;
+     * else include only the visibilities that match the schema name.
+     */
+    if (connectionSchemas.length === 1 && filteredVisibilities.length > 1) {
+        return filteredVisibilities.filter((v) => {
+            const connectionSchemaName = connectionSchemas[0].name.toLowerCase();
+            if (connectionSchemaName.includes("Unsecured".toLowerCase())) {
+                return v === ServiceInfoVisibilityEnum.Organization || v === ServiceInfoVisibilityEnum.Public;
+            }
+            return connectionSchemaName.includes(v.toLowerCase());
+        });
+    }
+    return filteredVisibilities;
+};
+
+export const getInitialVisibility = (item: MarketplaceItem, visibilities: string[] = []) => {
+    if (item?.isThirdParty) {
+        return ServiceInfoVisibilityEnum.Public;
+    }
+    if (visibilities.includes(ServiceInfoVisibilityEnum.Project)) {
+        return ServiceInfoVisibilityEnum.Project;
+    }
+    if (visibilities.includes(ServiceInfoVisibilityEnum.Organization)) {
+        return ServiceInfoVisibilityEnum.Organization;
+    }
+    return ServiceInfoVisibilityEnum.Public;
+};
+
+export const getPossibleSchemas = (
+    item: MarketplaceItem,
+    selectedVisibility: string,
+    connectionSchemas: MarketplaceItemSchema[] = [],
+) => {
+    if (!item) {
+        return [];
+    }
+    // If third party, return schemas without filtering
+    if (item.isThirdParty) {
+        return item.connectionSchemas;
+    }
+    // Filter schemas based on the selected visibility:
+    // organization/public can have OAuth2, api key or unauthenticated; project can have only project.
+    const schemasFiltered = connectionSchemas.filter((schema) => {
+        if (
+            selectedVisibility.toLowerCase().includes("organization") ||
+            selectedVisibility.toLowerCase().includes("public")
+        ) {
+            return (
+                schema.name.toLowerCase().includes(selectedVisibility.toLowerCase()) ||
+                schema.name.toLowerCase().includes("unsecured")
+            );
+        }
+        return schema.name.toLowerCase().includes("project");
+    });
+    return schemasFiltered;
+};

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
@@ -352,11 +352,11 @@ export const dbCredentialsToFieldValues = (
 }
 
 // Devant "service -> connection params" helpers, shared by the connection form and the KB flow.
-export const getPossibleVisibilities = (marketplaceItem: MarketplaceItem, project: Project) => {
+export const getPossibleVisibilities = (marketplaceItem: MarketplaceItem, project?: Project) => {
     const { connectionSchemas = [], visibility: visibilities = [] } = marketplaceItem ?? {};
     const filteredVisibilities = visibilities.filter((item) => {
         if (item === ServiceInfoVisibilityEnum.Project) {
-            return marketplaceItem.projectId === project.id;
+            return !!project?.id && marketplaceItem.projectId === project.id;
         }
         return item;
     });

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, ReactNode } from "react";
 import { Button, ThemeColors, Typography } from "@wso2/ui-toolkit";
 import { PanelContainer, NodeList, CardList, ExpressionFormField } from "@wso2/ballerina-side-panel";
 import {
@@ -69,6 +69,9 @@ export enum SidePanelView {
     CHUNKER_LIST = "CHUNKER_LIST",
     KNOWLEDGE_BASES = "KNOWLEDGE_BASES",
     KNOWLEDGE_BASE_LIST = "KNOWLEDGE_BASE_LIST",
+    // Intermediate page reached by clicking the "WSO2 Cloud Knowledge Base" box: lists existing
+    // cloud knowledge bases and offers a "create new" action.
+    WSO2_CLOUD_KB_LIST = "WSO2_CLOUD_KB_LIST",
     NEW_AGENT = "NEW_AGENT",
     ADD_TOOL = "ADD_TOOL",
     NEW_TOOL_CUSTOM = "NEW_TOOL_CUSTOM",
@@ -167,6 +170,8 @@ interface PanelManagerProps {
     onImportDevantConn?: (devantConn: ConnectionListItem) => void
     onLinkDevantProject?: () => void;
     onRefreshDevantConnections?: () => void;
+    // Intermediate page rendered for the WSO2_CLOUD_KB_LIST view (existing cloud KBs + create new).
+    wso2CloudKbListSection?: ReactNode;
 }
 
 export function PanelManager(props: PanelManagerProps) {
@@ -239,6 +244,7 @@ export function PanelManager(props: PanelManagerProps) {
         onImportDevantConn,
         onLinkDevantProject,
         onRefreshDevantConnections,
+        wso2CloudKbListSection,
     } = props;
 
     const findSubPanelComponent = (subPanel: SubPanel) => {
@@ -496,6 +502,19 @@ export function PanelManager(props: PanelManagerProps) {
                         onBack={canGoBack ? onBack : undefined}
                         expandedGroupId={expandedGroupId}
                         onExpandedGroupChange={onExpandedGroupChange}
+                    />
+                );
+
+            case SidePanelView.WSO2_CLOUD_KB_LIST:
+                return (
+                    <CardList
+                        categories={[]}
+                        onSelect={onSelectNode}
+                        onClose={onClose}
+                        title={"WSO2 Cloud Knowledge Bases"}
+                        searchPlaceholder={"Search knowledge bases"}
+                        onBack={canGoBack ? onBack : undefined}
+                        extraSection={wso2CloudKbListSection}
                     />
                 );
 

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -83,10 +83,12 @@ import { ConnectionKind } from "../../../components/ConnectionSelector";
 import AddAgentPopup from "../AIChatAgent/AddAgentPopup";
 import { DiagramSkeleton } from "../../../components/Skeletons";
 import { AI_COMPONENT_PROGRESS_MESSAGE, AI_COMPONENT_PROGRESS_MESSAGE_TIMEOUT, FORM_LOADING_MESSAGE, LOADING_MESSAGE } from "../../../constants";
-import { ConnectionListItem } from "@wso2/wso2-platform-core";
+import { ConnectionListItem, MarketplaceItem } from "@wso2/wso2-platform-core";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
 import { requestMiniChatOpen } from "../../../components/AgentStatusOrb/shared";
 import { AgentEditorView, useAgentEditorController } from "../AIChatAgent/useAgentEditorController";
+import { CloudKnowledgeBasePage } from "../Connection/DevantConnections/CloudKnowledgeBasePage";
+import { prepareDevantKnowledgeBase } from "../Connection/DevantConnections/devant-kb-utils";
 
 const Container = styled.div`
     width: 100%;
@@ -186,6 +188,8 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     const isMountedRef = useRef(true);
     const selectedNodeRef = useRef<FlowNode>();
     const nodeTemplateRef = useRef<FlowNode>();
+    // The "WSO2 Cloud Knowledge Base" box node captured on click; its codedata drives the create flows.
+    const cloudKbNodeRef = useRef<AvailableNode>();
     const hasRenameOperation = useRef<boolean>(false);
     const topNodeRef = useRef<FlowNode | Branch>();
     const targetRef = useRef<LineRange>();
@@ -642,6 +646,71 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         } else {
             console.log(">>> KNOWLEDGE_BASE_LIST not found in navigation stack, closing panel");
             closeSidePanelAndFetchUpdatedFlowModel();
+        }
+    };
+
+    // Registers a Devant-backed WSO2 Cloud knowledge base and opens its pre-filled create form.
+    const handleCreateDevantKnowledgeBase = async (node: AvailableNode, item: MarketplaceItem) => {
+        setShowProgressIndicator(true);
+        pushToNavigationStack(sidePanelView, categories, selectedNodeRef.current, selectedClientName.current);
+        try {
+            const flowNode = await prepareDevantKnowledgeBase({
+                rpcClient,
+                platformRpcClient,
+                platformExtState,
+                item,
+                node,
+                projectPath,
+                target: targetRef.current.startLine,
+                fileName: model?.fileName,
+            });
+            if (!flowNode) {
+                showConnectorError();
+                return;
+            }
+            selectedNodeRef.current = flowNode;
+            nodeTemplateRef.current = flowNode;
+            showEditForm.current = false;
+            isCreatingNewVectorKnowledgeBase.current = true; // reuse KB post-create navigation
+            setSidePanelView(SidePanelView.FORM);
+            setShowSidePanel(true);
+        } catch (error) {
+            console.error(">>> Error setting up WSO2 Cloud knowledge base", error);
+        } finally {
+            setShowProgressIndicator(false);
+        }
+    };
+
+    // "Create new" on the WSO2 Cloud KB intermediate page: open a blank CloudKnowledgeBase form
+    // (manual entry, no Devant service pre-selected). Mirrors the generic node-template -> form path.
+    const handleCreateNewCloudKnowledgeBase = async () => {
+        const kbCodedata = cloudKbNodeRef.current?.codedata;
+        if (!kbCodedata) {
+            return;
+        }
+        setShowProgressIndicator(true);
+        pushToNavigationStack(sidePanelView, categories, selectedNodeRef.current, selectedClientName.current);
+        try {
+            const response = await rpcClient.getBIDiagramRpcClient().getNodeTemplate({
+                position: targetRef.current.startLine,
+                filePath: model?.fileName,
+                id: kbCodedata,
+            });
+            if ((response as any)?.errorMsg) {
+                showConnectorError((response as any).errorMsg);
+                return;
+            }
+            selectedNodeRef.current = response.flowNode;
+            nodeTemplateRef.current = response.flowNode;
+            showEditForm.current = false;
+            isCreatingNewVectorKnowledgeBase.current = true; // reuse KB post-create navigation
+            setSidePanelView(SidePanelView.FORM);
+            setShowSidePanel(true);
+        } catch (error) {
+            console.error(">>> Error opening WSO2 Cloud knowledge base form", error);
+            showConnectorError();
+        } finally {
+            setShowProgressIndicator(false);
         }
     };
 
@@ -1681,6 +1750,18 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         pushToNavigationStack(sidePanelView, categories, selectedNodeRef.current, selectedClientName.current);
 
         const showFormLoader = AI_COMPONENT_PICKER_VIEWS.includes(sidePanelView);
+
+        // The "WSO2 Cloud Knowledge Base" box routes to an intermediate page (list existing cloud KBs
+        // + create new) instead of the generic form.
+        if (
+            sidePanelView === SidePanelView.KNOWLEDGE_BASES &&
+            node.codedata.packageName === "ai.wso2.integration"
+        ) {
+            cloudKbNodeRef.current = node; // reuse this codedata for the list/create flows
+            setSidePanelView(SidePanelView.WSO2_CLOUD_KB_LIST);
+            setShowSidePanel(true);
+            return;
+        }
 
         switch (node.codedata.node) {
             case "FUNCTION":
@@ -4110,6 +4191,15 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     platformExtState?.selectedContext?.project && !platformExtState?.devantConns?.loading
                         ? () => platformRpcClient?.refreshConnectionList()
                         : undefined
+                }
+                wso2CloudKbListSection={
+                    <CloudKnowledgeBasePage
+                        onCreateNew={handleCreateNewCloudKnowledgeBase}
+                        onSelectExisting={(item) =>
+                            cloudKbNodeRef.current &&
+                            handleCreateDevantKnowledgeBase(cloudKbNodeRef.current, item)
+                        }
+                    />
                 }
             />
 


### PR DESCRIPTION
## Purpose
> Add a "WSO2 Cloud Knowledge Base" entry to the Add Knowledge Base chooser that opens an intermediate page: it lists the existing WSO2 Cloud (Devant) knowledge bases and offers a "Manually Config" action. Selecting an existing service auto-provisions a Devant connection (credentials written as os:getEnv-backed configurables in config.bal) and opens the pre-filled CloudKnowledgeBase form; "Manually Config" opens a blank form.

Fix : https://github.com/wso2/product-integrator/issues/2163

## Goals
> To solve the Knowledge base integration to the WI and Sync WSO2 Integrator with WSO2 Integrator Platform Given in issues,
https://github.com/wso2-enterprise/integration-engineering/issues/1929
https://github.com/wso2-enterprise/integration-engineering/issues/1971

## Demo

https://github.com/user-attachments/assets/8cd6f979-1c72-4f64-9d43-9f450a83fbde

## Summary
> Frontend only. The entry box itself is surfaced by the language server discovering the sumudunissanka/ai.wso2.integration package (published/registered separately); this change does not modify the language server.

- CardList: optional extraSection slot rendered below the categories
- PanelManager: new WSO2_CLOUD_KB_LIST view for the intermediate page
- CloudKnowledgeBasePage: the intermediate page (manual-create card + existing list)
- FlowDiagram: route the WSO2 Cloud KB box selection to the intermediate page
- devant-kb-utils.prepareDevantKnowledgeBase: register Devant connection, write configurables, return the pre-filled CloudKnowledgeBase form node
- utils: shared getPossibleVisibilities/getInitialVisibility/getPossibleSchemas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds WSO2 Cloud Knowledge Bases to the Add Knowledge Base panel.

- Lists existing Devant knowledge bases and supports manual configuration.
- Provisions Devant connections with visibility- and schema-matched OAuth2 configurables.
- Stores credentials through `os:getEnv` configurables.
- Opens pre-filled or blank `CloudKnowledgeBase` forms.
- Adds routing, loading, error, and empty states for the new flow.
- Handles unlinked projects and avoids undefined required configuration values.
- Extends `CardList` and centralizes Devant visibility and schema utilities.
- Does not modify the language server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->