### PR TITLE
Skip unwanted analyze diff step in the release workflow

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -87,18 +87,17 @@ jobs:
           fetch-depth: 2
           submodules: recursive
 
+      # Skipped for release builds: they ship the whole branch, so there is no
+      # meaningful baseline to diff against, and fetching one pulled in the
+      # submodule commits main references — which fails once any is unreachable.
       - name: Analyze diff
+        if: ${{ !inputs.isReleaseBuild }}
         shell: bash
         id: diff
         run: |
           echo "hasBalDiff=false" >> $GITHUB_OUTPUT
 
-          if [[ ${{ inputs.isReleaseBuild }} = 'true' ]]; then
-            git fetch origin main
-            CHANGED_DIRS=$(git diff --name-only HEAD..refs/remotes/origin/main | grep -E "^/*" || true)
-          else
-            CHANGED_DIRS=$(git diff --name-only HEAD^..HEAD | grep -E "^/*" || true)
-          fi
+          CHANGED_DIRS=$(git diff --name-only HEAD^..HEAD | grep -E "^/*" || true)
 
           echo "$CHANGED_DIRS"
 
@@ -110,6 +109,7 @@ jobs:
           fi
 
       - name: Set test matrix
+        if: ${{ !inputs.isReleaseBuild }}
         shell: bash
         id: testMatrix
         run: |
@@ -155,7 +155,7 @@ jobs:
     needs: Build_Stage
     if: false
     # Re-enable once unit tests are stable in CI:
-    # if: ${{ inputs.runTests || (inputs.isReleaseBuild && inputs.ballerina) || needs.Build_Stage.outputs.runBalExtTests == 'true' || endsWith(github.base_ref, '.x') }}
+    # if: ${{ inputs.runTests || endsWith(github.base_ref, '.x') }}
     timeout-minutes: 45
     runs-on: ${{ inputs.runOnAWS && inputs.awsRunnerId || 'ubuntu-latest' }}
     steps:


### PR DESCRIPTION
## Purpose

The `Release / Pre-release Build` workflow fails in the **Analyze diff** step, before any build,
test, or publish job runs:

```
Fetching submodule submodules/wso2-vscode-extensions
fatal: remote error: upload-pack: not our ref 01e3917cc827d48f4f68066a3df9b731edbe9dad
Errors during submodule fetch: submodules/wso2-vscode-extensions
##[error]Process completed with exit code 1.
```

Failing run: https://github.com/ballerina-platform/ballerina-vscode/actions/runs/32098410814/job/95594095464

On the release path only, `Analyze diff` ran `git fetch origin main` to compute a changed-file list
against `main`. Three things combine to break it:

1. `fetch.recurseSubmodules` defaults to `on-demand`, so the fetch also pulls submodule commits
   newly referenced by the fetched history — not just the tip.
2. Somewhere in `main`'s history a commit records `wso2-vscode-extensions` at `01e3917c`, which is
   no longer reachable from any ref in `wso2/vscode-extensions`. (`main`'s current pointer is fine;
   the bad gitlink is historical.)
3. GitHub's `upload-pack` refuses to serve unreachable objects, so the fetch exits non-zero — and
   the step runs under `bash -e -o pipefail`, taking the whole release build down.

Nothing in this repository changed to cause this; a force-push in the submodule's repository
orphaned that commit. Any release build was going to hit it from that moment on.

## Goals

Stop release builds from depending on the reachability of every submodule commit `main` has ever
pointed at, for a diff they have no use for.

## Approach

A release build ships the entire branch — there is no baseline to diff against and no decision for
the step to make. So `Analyze diff` is skipped outright on that path rather than branching
internally:

- `Analyze diff` and `Set test matrix` both gain `if: ${{ !inputs.isReleaseBuild }}`.
- The `if [[ isReleaseBuild ]] … else … fi` block inside `Analyze diff` collapses to the single
  local `git diff --name-only HEAD^..HEAD`. No `git fetch`, no network, no submodules.
- The commented-out `if:` on the disabled `ExtTest_Ballerina` job drops its
  `(inputs.isReleaseBuild && inputs.ballerina)` and `runBalExtTests` terms, so re-enabling it later
  doesn't reference a value that is no longer produced on every path.

Behaviour per caller:

| Caller | `isReleaseBuild` | Effect |
|---|---|---|
| `pull-request.yml` | `false` (default) | unchanged — same local diff, same `hasBalDiff` |
| `devBuild.yml`, nightly via `schedule.yml` | `false` | unchanged |
| `release-pre-release.yml` | `true` | both steps skipped; nothing left to fail |

Worth noting `pull-request.yml` already gates on the same path globs with `dorny/paths-filter`
before it ever calls this workflow, and `hasBalDiff`'s only consumer — `ExtTest_Ballerina` — is
currently disabled with `if: false`. The step earns its keep on the PR path only.

## UI Component Development

N/A — CI workflow change only, no UI surface.

## User stories

N/A

## Release note

Fixed the release build failing during diff analysis when a submodule commit referenced in `main`'s
history is unreachable.

## Documentation

N/A — internal CI change with no user-facing behaviour.

## Training

N/A

## Certification

N/A — no impact on certification exams.

## Marketing

N/A

## Automation tests

- Unit tests
  > N/A — GitHub Actions workflow change, not covered by the test suites.
- Integration tests
  > `PR Build` on this branch exercises the non-release path (`Analyze diff` still runs, unchanged).
  > The release path is verified by a `workflow_dispatch` run of `Release / Pre-release Build`, where
  > both steps report as skipped and the job proceeds straight to `Build`.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no product source changes.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

GitHub-hosted `ubuntu-latest` runners, git 2.54.0.

## Learning

`git fetch` recurses into submodules by default (`fetch.recurseSubmodules=on-demand`) and inspects
all newly fetched commits, not just the ref tip — so a fetch performed purely for diffing can fail
on submodule history that has since been orphaned upstream. Either scope such a fetch with
`--no-recurse-submodules`, or don't perform it where its result isn't used.
