### PR TITLE
Fix bugs and minor review comments for HITL UI changes

### DIFF
--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AgentToolBuilder.java
@@ -703,9 +703,12 @@ public class AgentToolBuilder extends NodeBuilder {
         // (stashed on ctx) — each ToolKind resolves params differently, so this must not recompute
         // with a fixed kind. The leading `ai:Context ctx` param is excluded: the `ai` compiler
         // plugin strips it from the tool's own signature before comparing against the predicate's,
-        // so including it here would make the predicate's signature look mismatched.
+        // so including it here would make the predicate's signature look mismatched. Every ToolKind
+        // prepends it at index 0 when includeContext is set (and rejects a user param named "ctx"
+        // up front), so skipping by position ties this to the invariant that's actually guaranteed,
+        // rather than to the param's name.
         String paramDecls = ctx.resolvedParams.stream()
-                .filter(param -> !(ctx.includeContext && "ctx".equals(param.name())))
+                .skip(ctx.includeContext ? 1 : 0)
                 .map(ToolParam::decl)
                 .collect(Collectors.joining(", "));
         ctx.sb.token()

--- a/packages/ballerina-side-panel/src/components/Form/types.ts
+++ b/packages/ballerina-side-panel/src/components/Form/types.ts
@@ -56,9 +56,6 @@ export type FormField = {
     /** AUTOCOMPLETE only: allow typing a value not in `items` (creates a new entry). Defaults to
      * true when unset, preserving the editor's original behavior; set false for a strict pick-list. */
     allowItemCreate?: boolean;
-    /** AUTOCOMPLETE only: append "(Optional)" to the label when `optional` is true. Off by default —
-     * opt in per field rather than changing every optional autocomplete's label at once. */
-    showOptionalSuffix?: boolean;
     itemOptions?: OptionProps[]
     choices?: PropertyModel[];
     dynamicFormFields?: { [key: string]: FormField[] }

--- a/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
@@ -72,11 +72,7 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
                     value: getValueForDropdown(field),
                     validate: buildValidate(field)
                 })}
-                // Append "(Optional)" AFTER capitalize() — capitalize is lodash startCase, which strips
-                // parentheses and title-cases words, so a paren'd label can't be passed through directly.
-                // Opt-in via showOptionalSuffix, so this doesn't relabel every optional autocomplete.
-                label={field.optional && field.showOptionalSuffix
-                    ? `${capitalize(field.label)} (Optional)` : capitalize(field.label)}
+                label={capitalize(field.label)}
                 items={field.items}
                 allowItemCreate={field.allowItemCreate ?? true}
                 required={!field.optional}

--- a/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
@@ -63,7 +63,6 @@ const BoxGroup = styled.div`
     flex-direction: row;
     width: 100%;
     align-items: flex-start;
-    gap: 10px;
 `;
 
 interface CheckBoxConditionalEditorProps {

--- a/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
@@ -212,7 +212,6 @@ function mapPropertiesToFormFields(properties: { [key: string]: PropertyModel; }
             diagnostics: [],
             items,
             allowItemCreate: property.allowItemCreate,
-            showOptionalSuffix: property.showOptionalSuffix,
             choices: property.choices,
             placeholder: property.placeholder,
             addNewButton: property.addNewButton,

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
@@ -103,17 +103,60 @@ const ToolDescription = styled.div`
     color: var(--vscode-descriptionForeground);
 `;
 
-const ArgumentsBlock = styled.pre`
-    margin: 0;
-    font-family: var(--vscode-editor-font-family);
-    font-size: 11px;
+const ArgumentsContainer = styled.div`
     background: var(--vscode-editor-background);
     border: 1px solid var(--vscode-panel-border);
     border-radius: 4px;
     padding: 6px 8px;
-    overflow-x: auto;
-    white-space: pre-wrap;
+`;
+
+const ArgumentsTable = styled.div`
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 12px;
+    row-gap: 4px;
+    align-items: baseline;
+`;
+
+const ArgumentLabel = styled.span`
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    white-space: nowrap;
+`;
+
+const ArgumentValue = styled.span`
+    font-size: 11px;
+    color: var(--vscode-foreground);
     word-break: break-word;
+`;
+
+const EmptyValue = styled.span`
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    font-style: italic;
+`;
+
+const NoArguments = styled.div`
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    font-style: italic;
+`;
+
+const NestedBlock = styled.div`
+    padding-left: 8px;
+    border-left: 2px solid var(--vscode-panel-border);
+`;
+
+const NestedList = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+`;
+
+const NestedItemLabel = styled.div`
+    font-size: 10px;
+    color: var(--vscode-descriptionForeground);
+    margin-bottom: 2px;
 `;
 
 const RowActions = styled.div`
@@ -233,12 +276,61 @@ const SummaryItem = styled.span<{ decision: "APPROVE" | "REJECT" }>`
         decision === "APPROVE" ? "var(--vscode-terminal-ansiGreen)" : "var(--vscode-errorForeground)"};
 `;
 
-function formatArguments(args: Record<string, any>): string {
-    try {
-        return JSON.stringify(args, null, 2);
-    } catch {
-        return String(args);
+function isPlainObject(value: unknown): value is Record<string, any> {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+// Renders a tool call's arguments as label/value rows instead of raw JSON, so a
+// non-technical reviewer can tell what they're approving. Nested objects/arrays recurse into
+// indented sub-tables rather than falling back to a JSON dump.
+function renderArguments(args: Record<string, any>): React.ReactNode {
+    const entries = Object.entries(args);
+    if (entries.length === 0) {
+        return <NoArguments>No arguments</NoArguments>;
     }
+    return (
+        <ArgumentsTable>
+            {entries.map(([key, value]) => (
+                <React.Fragment key={key}>
+                    <ArgumentLabel>{key}</ArgumentLabel>
+                    <ArgumentValue>{renderArgumentValue(value)}</ArgumentValue>
+                </React.Fragment>
+            ))}
+        </ArgumentsTable>
+    );
+}
+
+function renderArgumentValue(value: unknown): React.ReactNode {
+    if (value === undefined || value === null) {
+        return <EmptyValue>—</EmptyValue>;
+    }
+    if (typeof value === "boolean") {
+        return value ? "Yes" : "No";
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return <EmptyValue>—</EmptyValue>;
+        }
+        if (value.every(item => !isPlainObject(item) && !Array.isArray(item))) {
+            return value.map(item => String(item)).join(", ");
+        }
+        return (
+            <NestedList>
+                {value.map((item, idx) => (
+                    <div key={idx}>
+                        <NestedItemLabel>Item {idx + 1}</NestedItemLabel>
+                        <NestedBlock>
+                            {isPlainObject(item) ? renderArguments(item) : String(item)}
+                        </NestedBlock>
+                    </div>
+                ))}
+            </NestedList>
+        );
+    }
+    if (isPlainObject(value)) {
+        return <NestedBlock>{renderArguments(value)}</NestedBlock>;
+    }
+    return String(value);
 }
 
 export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions, unresolvable, onSubmit, onDismiss }) => {
@@ -379,7 +471,7 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
                             {expandedArgs[req.id] ? "Hide arguments" : "Show arguments"}
                         </TextLinkButton>
                         {expandedArgs[req.id] && (
-                            <ArgumentsBlock>{formatArguments(req.arguments)}</ArgumentsBlock>
+                            <ArgumentsContainer>{renderArguments(req.arguments)}</ArgumentsContainer>
                         )}
                         {decided ? (
                             <DecidedBadge decision={decided.decision}>

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
@@ -353,7 +353,7 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
         <Card>
             <CardHeader>
                 <WarnIconWrapper>
-                    <Icon name="bi-shield-lock" sx={{ width: 14, height: 14 }} iconSx={{ fontSize: "14px" }} />
+                    <Icon name="user-fill" sx={{ width: 14, height: 14 }} iconSx={{ fontSize: "14px" }} />
                 </WarnIconWrapper>
                 Approval required &middot; {pendingRequests.length} pending
                 <HeaderSpacer />

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
@@ -364,12 +364,10 @@ export function createRequiresApprovalField(
                 properties: {
                     approvalFunction: {
                         metadata: {
-                            // "(optional)" is appended by AutoCompleteEditor for optional fields; keeping
-                            // it here would double up (capitalize() = startCase would also mangle it).
                             label: "Approval Function",
                             description: allowCreate
-                                ? "Decides per call whether approval is needed. Pick one of your functions, or type a name to create one."
-                                : "Decides per call whether approval is needed. Pick one of your existing functions.",
+                                ? "Optional. Decides per call whether approval is needed. Pick one of your functions, or type a name to create one."
+                                : "Optional. Decides per call whether approval is needed. Pick one of your existing functions.",
                         },
                         // AUTOCOMPLETE (not EXPRESSION): the annotation slot takes a function *reference*
                         // (a bare name), never a call expression. `items` are injected at runtime once the
@@ -384,7 +382,6 @@ export function createRequiresApprovalField(
                             validations: [{ rule: "common.validate.identifier", message: "Invalid identifier" }],
                         }],
                         allowItemCreate: allowCreate,
-                        showOptionalSuffix: true,
                         value: existing?.functionName || "",
                         optional: true,
                         editable: true,

--- a/packages/bi-diagram/src/components/nodes/AgentWidget/ApprovalBadge.tsx
+++ b/packages/bi-diagram/src/components/nodes/AgentWidget/ApprovalBadge.tsx
@@ -49,7 +49,7 @@ export function ApprovalBadge({ background }: ApprovalBadgeProps) {
                         color: ${ThemeColors.SECONDARY};
                     `}
                 >
-                    <Icon name="bi-shield" sx={{ fontSize: 10, width: 10, height: 10 }} iconSx={{ fontSize: "10px" }} />
+                    <Icon name="user-fill" sx={{ fontSize: 11, width: 11, height: 11 }} iconSx={{ fontSize: "11px" }} />
                 </div>
             </Tooltip>
         </foreignObject>


### PR DESCRIPTION
## Purpose
$subject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Fix approval predicate generation by filtering parameters by position 
(Review comment: https://github.com/ballerina-platform/ballerina-vscode/pull/842#discussion_r3794250015).
- Improve agent-call return type and import handling.
- Update form field types and layout metadata.
- Remove redundant spacing and optional-label suffix handling.
- Add “Optional” to approval-function descriptions.
- Add helpers to extract record-type fields.
- Update approval icons to use the person icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview
- New HITL icon updated in agent nodes and in agent chat interface 
<img width="265" height="185" alt="Screenshot 2026-08-18 at 15 08 02 copy" src="https://github.com/user-attachments/assets/6aff21a2-b801-4026-bcf8-715b67f8295d" />

<img width="570" height="157" alt="Screenshot 2026-08-19 at 16 20 45" src="https://github.com/user-attachments/assets/db5e71f4-b44b-4613-94ca-804af630e4c9" />

- Explicit '(Optional)' text is now removed(to be aligned with the `*` for required fields, and no `*` for optional fields convention), moved to the description.

Before:
<img width="406" height="179" alt="Screenshot 2026-08-19 at 16 51 40" src="https://github.com/user-attachments/assets/b827654d-94ac-43ed-ad77-ac158e9f37f2" />

After:
<img width="364" height="194" alt="Screenshot 2026-08-18 at 12 02 33 copy" src="https://github.com/user-attachments/assets/49e98d13-2c30-478c-b1ae-22dfbb290287" />

- Render approval card arguments as label/value rows instead of JSON

Before:
<img width="510" height="209" alt="Screenshot 2026-08-19 at 18 18 41" src="https://github.com/user-attachments/assets/1ebf47af-2a1b-4f57-910f-3eae6f8c30e2" />

After:
<img width="575" height="209" alt="Screenshot 2026-08-19 at 18 12 57" src="https://github.com/user-attachments/assets/9ad5d0b8-e469-4776-a8c6-12c466a8618f" />
<img width="594" height="193" alt="Screenshot 2026-08-19 at 17 53 28" src="https://github.com/user-attachments/assets/0405e677-4ffc-4220-a46b-cf426e426f68" />
