### PR TITLE
Skip flaky tests in flow nodes, RabbitMQ integration, and project explorer until root causes are resolved

### DIFF
--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/flow-nodes.spec.ts
@@ -207,7 +207,11 @@ export default function createTests() {
     test.describe.serial('Automation Flow Nodes Tests', {}, async () => {
         initTest(true, true, undefined, undefined, AUTOMATION_PROJECT_TEMPLATE);
 
-        test('Flow Nodes builds Statement and Control nodes from diagram', async () => {
+        // Flaky in CI: the flow node form fails to close after saving a Log Debug
+        // node, timing out on side-panel hidden state. Skipping until the root cause
+        // in the expression-save flow is fixed.
+        // https://github.com/wso2/product-integrator/issues/2188
+        test.skip('Flow Nodes builds Statement and Control nodes from diagram', async () => {
             logStep('Open the pre-baked Automation via the Entry Points tree item');
             // Cold start on a fresh fixture: the sidebar tree isn't guaranteed
             // to be the active viewlet yet and the LS needs time to index the

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/event-integration/rabbitmq.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/event-integration/rabbitmq.spec.ts
@@ -118,7 +118,11 @@ export default function createTests() {
                 .waitFor({ state: 'visible', timeout: 30000 });
         });
 
-        test('Editing RabbitMQ Integration', async ({ }, testInfo) => {
+        // Flaky in CI: ProjectExplorer.findItem times out waiting for a tree item,
+        // suggesting the Project Explorer tree isn't populating in time. Skipping
+        // until the root cause is fixed.
+        // https://github.com/wso2/product-integrator/issues/2188
+        test.skip('Editing RabbitMQ Integration', async ({ }, testInfo) => {
             const testAttempt = testInfo.retry + 1;
             console.log('Editing a service in test attempt: ', testAttempt);
 

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/project-explorer/project-explorer.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/project-explorer/project-explorer.spec.ts
@@ -185,7 +185,11 @@ export default function createTests() {
             await expect(mainItem).not.toBeVisible({ timeout: 10000 });
         });
 
-        test('Add an artifact from the tree via the Entry Points "Add" button', async () => {
+        // Flaky in CI: hovering the "Entry Points" tree item times out (locator
+        // never resolves), even after retries. Skipping until the root cause in the
+        // Project Explorer tree rendering is fixed.
+        // https://github.com/wso2/product-integrator/issues/2188
+        test.skip('Add an artifact from the tree via the Entry Points "Add" button', async () => {
             logStep('Hovering "Entry Points" and clicking "Add Entry Point"');
             const entryPoints = treeItem('Entry Points');
             await entryPoints.hover();


### PR DESCRIPTION
## Purpose
Three Ballerina e2e tests are failing/flaky in CI, blocking unrelated PRs from getting green checks:

- `Flow Nodes builds Statement and Control nodes from diagram` (Group 1)
- `Editing RabbitMQ Integration` (Group 2)
- `Add an artifact from the tree via the Entry Points "Add" button` (Group 2)

## Goals
Unblock CI by temporarily skipping these three tests until their root causes are fixed, without masking the failures — each skip links back to the tracking issue.

## Approach
Marked each test with `test.skip` and added a comment describing the observed failure:

- `flow-nodes.spec.ts`: the flow node form doesn't close after saving a Log Debug node — side panel stays visible past the 60s timeout, with an `undefined symbol 'msg'` diagnostic shown, pointing to an issue in the expression-save flow.
- `rabbitmq.spec.ts`: `ProjectExplorer.findItem` times out waiting for a tree item to appear.
- `project-explorer.spec.ts`: hovering the "Entry Points" tree item times out (locator never resolves), failing across all retries.

The latter two both point at the Project Explorer tree not populating/rendering in time in CI, and may share a root cause — tracked together in the linked issue.

## Automation tests
- Integration tests
  > No new tests added. Three existing e2e tests are disabled (`test.skip`) pending investigation; tracked in wso2/product-integrator#2188.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A (test-only change)
- Ran FindSecurityBugs plugin and verified report? N/A
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes