### PR TITLE
Update the Azure Files trigger model for the 1.0.0 data binding contract

### DIFF
--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
@@ -7,9 +7,9 @@
   "orgName": "ballerinax",
   "packageName": "azure.storage.files",
   "moduleName": "azure.storage.files",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "files",
-  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_azure.storage.files_1.0.0.png",
+  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_azure.storage.files_1.0.1.png",
   "kind": "file",
   "listenerKind": "SINGLE_SELECT_LISTENER",
   "initProperties": {
@@ -1213,7 +1213,7 @@
               "typeMembers": [
                 {
                   "type": "ServiceConfiguration",
-                  "packageInfo": "ballerinax:azure.storage.files:1.0.0",
+                  "packageInfo": "ballerinax:azure.storage.files:1.0.1",
                   "packageName": "azure.storage.files",
                   "kind": "RECORD_TYPE",
                   "selected": true
@@ -1320,17 +1320,28 @@
                       "label": "Row Schema",
                       "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
-                    "value": "record {}[]",
-                    "enabled": false,
-                    "editable": false,
+                    "value": "string[][]",
+                    "enabled": true,
+                    "editable": true,
                     "optional": false,
                     "advanced": false,
                     "types": [
                       {
                         "fieldType": "PAYLOAD_TYPE",
                         "selected": true,
-                        "ballerinaType": "record {}[]",
-                        "template": "{{type}}"
+                        "formats": [
+                          {
+                            "supported": [
+                              "schema",
+                              "browse",
+                              "json",
+                              "xml"
+                            ],
+                            "defaultFormat": "schema"
+                          }
+                        ],
+                        "ballerinaType": "string[][]",
+                        "template": "{{type}}[]"
                       }
                     ],
                     "codedata": {
@@ -1339,7 +1350,7 @@
                       "boundType": "",
                       "typeConstraint": "anydata",
                       "bindingKind": "USER_SELECTED",
-                      "defaultType": "record {}",
+                      "defaultType": "string[]",
                       "template": "{{type}}[]"
                     }
                   }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
@@ -7,9 +7,9 @@
   "orgName": "ballerinax",
   "packageName": "azure.storage.files",
   "moduleName": "azure.storage.files",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "type": "files",
-  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_azure.storage.files_0.9.0.png",
+  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_azure.storage.files_1.0.0.png",
   "kind": "file",
   "listenerKind": "SINGLE_SELECT_LISTENER",
   "initProperties": {
@@ -1213,7 +1213,7 @@
               "typeMembers": [
                 {
                   "type": "ServiceConfiguration",
-                  "packageInfo": "ballerinax:azure.storage.files:0.9.0",
+                  "packageInfo": "ballerinax:azure.storage.files:1.0.0",
                   "packageName": "azure.storage.files",
                   "kind": "RECORD_TYPE",
                   "selected": true
@@ -1293,7 +1293,7 @@
                       "label": "Row Schema",
                       "description": "Create a record type describing one row of the file. Each row arrives as one record."
                     },
-                    "value": "string[][]",
+                    "value": "record {}[]",
                     "enabled": false,
                     "editable": false,
                     "optional": false,
@@ -1302,7 +1302,7 @@
                       {
                         "fieldType": "PAYLOAD_TYPE",
                         "selected": true,
-                        "ballerinaType": "string[][]",
+                        "ballerinaType": "record {}[]",
                         "template": "{{type}}"
                       }
                     ],
@@ -1312,7 +1312,7 @@
                       "boundType": "",
                       "typeConstraint": "anydata",
                       "bindingKind": "USER_SELECTED",
-                      "defaultType": "string[]",
+                      "defaultType": "record {}",
                       "template": "{{type}}[]"
                     }
                   }
@@ -1627,7 +1627,7 @@
                 "afterError": {
                   "metadata": {
                     "label": "On Error",
-                    "description": "Action when the handler fails or the file content does not match the expected format."
+                    "description": "Action when the handler returns an error. Also applies when the file content does not match the expected format, unless an onError handler is declared."
                   },
                   "types": [
                     {
@@ -1818,9 +1818,9 @@
                   "payload": {
                     "metadata": {
                       "label": "Content Schema",
-                      "description": "Create a record type describing the file content. Defaults to map<json>; bare json is not supported."
+                      "description": "Create a record type describing the file content. Defaults to json."
                     },
-                    "value": "map<json>",
+                    "value": "json",
                     "enabled": true,
                     "editable": true,
                     "optional": false,
@@ -1829,7 +1829,7 @@
                       {
                         "fieldType": "PAYLOAD_TYPE",
                         "selected": true,
-                        "ballerinaType": "map<json>",
+                        "ballerinaType": "json",
                         "formats": [
                           {
                             "supported": [
@@ -1849,7 +1849,7 @@
                       "boundType": "",
                       "typeConstraint": "anydata",
                       "bindingKind": "USER_SELECTED",
-                      "defaultType": "map<json>",
+                      "defaultType": "json",
                       "template": "{{type}}"
                     }
                   }
@@ -2164,7 +2164,7 @@
                 "afterError": {
                   "metadata": {
                     "label": "On Error",
-                    "description": "Action when the handler fails or the file content does not match the expected format."
+                    "description": "Action when the handler returns an error. Also applies when the file content does not match the expected format, unless an onError handler is declared."
                   },
                   "types": [
                     {
@@ -2691,7 +2691,7 @@
                 "afterError": {
                   "metadata": {
                     "label": "On Error",
-                    "description": "Action when the handler fails or the file content does not match the expected format."
+                    "description": "Action when the handler returns an error. Also applies when the file content does not match the expected format, unless an onError handler is declared."
                   },
                   "types": [
                     {
@@ -3214,7 +3214,7 @@
                 "afterError": {
                   "metadata": {
                     "label": "On Error",
-                    "description": "Action when the handler fails or the file content does not match the expected format."
+                    "description": "Action when the handler returns an error. Also applies when the file content does not match the expected format, unless an onError handler is declared."
                   },
                   "types": [
                     {
@@ -3737,7 +3737,7 @@
                 "afterError": {
                   "metadata": {
                     "label": "On Error",
-                    "description": "Action when the handler fails or the file content does not match the expected format."
+                    "description": "Action when the handler returns an error. Also applies when the file content does not match the expected format, unless an onError handler is declared."
                   },
                   "types": [
                     {
@@ -3876,7 +3876,7 @@
         {
           "metadata": {
             "label": "On Error",
-            "description": "Invoked when an error occurs while processing a file in the monitored directory.",
+            "description": "Invoked when a poll fails or a file's content does not match the expected format. Errors returned by the other handlers are not sent here.",
             "addLabel": "Add On Error Handler",
             "badge": "onError"
           },
@@ -3901,7 +3901,7 @@
             {
               "metadata": {
                 "label": "Azure Files Error",
-                "description": "The error that occurred while processing the file."
+                "description": "The error reported by the listener: a failed poll, or content that does not match the expected format."
               },
               "kind": "REQUIRED",
               "type": {
@@ -3925,7 +3925,7 @@
               "name": {
                 "metadata": {
                   "label": "err",
-                  "description": "The error that occurred while processing the file."
+                  "description": "The error reported by the listener: a failed poll, or content that does not match the expected format."
                 },
                 "placeholder": "err",
                 "value": "err",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
@@ -1288,6 +1288,33 @@
                 "optional": false,
                 "advanced": false,
                 "properties": {
+                  "stream": {
+                    "metadata": {
+                      "label": "Stream (Large Files)",
+                      "description": "Process the file content in chunks."
+                    },
+                    "value": false,
+                    "types": [
+                      {
+                        "fieldType": "FLAG",
+                        "selected": true,
+                        "template": "stream<{{type}}, error?>"
+                      }
+                    ],
+                    "enabled": true,
+                    "editable": true,
+                    "optional": false,
+                    "advanced": false,
+                    "codedata": {
+                      "type": "PAYLOAD_MODIFIER",
+                      "modifier": "stream",
+                      "template": "stream<{{type}}, error?>",
+                      "supersedes": [
+                        "base"
+                      ],
+                      "targetParam": "payload"
+                    }
+                  },
                   "payload": {
                     "metadata": {
                       "label": "Row Schema",
@@ -3402,6 +3429,33 @@
                 "optional": false,
                 "advanced": false,
                 "properties": {
+                  "stream": {
+                    "metadata": {
+                      "label": "Stream (Large Files)",
+                      "description": "Process the file content in chunks."
+                    },
+                    "value": false,
+                    "types": [
+                      {
+                        "fieldType": "FLAG",
+                        "selected": true,
+                        "template": "stream<{{type}}, error?>"
+                      }
+                    ],
+                    "enabled": true,
+                    "editable": true,
+                    "optional": false,
+                    "advanced": false,
+                    "codedata": {
+                      "type": "PAYLOAD_MODIFIER",
+                      "modifier": "stream",
+                      "template": "stream<{{type}}, error?>",
+                      "supersedes": [
+                        "base"
+                      ],
+                      "targetParam": "payload"
+                    }
+                  },
                   "payload": {
                     "metadata": {
                       "label": "Content",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
@@ -341,8 +341,8 @@
       "event"
     ],
     "triggerName": "Azure Files",
-    "version": "0.9.0",
-    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_azure.storage.files_0.9.0.png",
+    "version": "1.0.0",
+    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_azure.storage.files_1.0.0.png",
     "kind": "file"
   }
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
@@ -341,8 +341,8 @@
       "event"
     ],
     "triggerName": "Azure Files",
-    "version": "1.0.0",
-    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_azure.storage.files_1.0.0.png",
+    "version": "1.0.1",
+    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_azure.storage.files_1.0.1.png",
     "kind": "file"
   }
 }


### PR DESCRIPTION
PRAM https://github.com/wso2/product-integrator/issues/2234

## Purpose

Aligns the bundled Azure Files trigger model with the connector's 1.0.0 data binding contract. The 1.0.0 compiler plugin narrowed what the typed content handlers accept, so the handlers generated by the current model no longer compile. This also adds the stream toggle that the other file listeners already have.

## Changes

- `onFileJson`: the generated content parameter is now `json` instead of `map<json>`. The 1.0.0 plugin accepts only `json` or a record type, and `map<json>` is rejected, so an Add Handler action produced code that failed to build.
- `onFileCsv`: the generated content parameter is now `record {}[]` instead of `string[][]`. CSV binding is records only in 1.0.0. The row schema button still applies the `{{type}}[]` template, so choosing a record `R` yields `R[]`.
- Added the `Stream (Large Files)` toggle to `onFile` and `onFileCsv`, matching the `ftp` and `smb` models. Azure Files was the only file listener without it, although the connector accepts both stream forms. With the toggle on, the composed parameter is `stream<byte[], error?>` for `onFile` and `stream<record {}, error?>` for `onFileCsv`, which are the forms the 1.0.0 `ContentFunctionValidator` accepts. The remaining handlers are unchanged, since the connector takes no stream for them.
- Version references moved from 0.9.0 to 1.0.0 (three in the trigger model, two in the Azure Files entry of `trigger_properties.json`, including the version stamped icon URL).
- Help text corrections, all describing existing 1.0.0 behaviour:
  - The `On Error` post-processing action no longer claims to cover content binding failures unconditionally. With an `onError` handler declared, the binding failure is disposed of by `onError`'s own annotation instead.
  - The `onError` description no longer implies that errors returned by a handler are delivered to it. They are not.
  - The `err` parameter description now covers failed polls as well as content binding failures.

## Merge gate

Ballerina Central currently publishes `ballerinax/azure.storage.files` 0.9.0 only. Because the model now declares 1.0.0, this should merge together with or after the 1.0.0 release, otherwise the wizard cannot resolve the package.

## Validation

- `TriggerModelReaderTest` (12/12) and `PayloadComposerTest` (5/5) pass.
- Type changes verified against the 1.0.0 `ContentFunctionValidator`, and the help text against the connector spec sections 5.4 and 5.5.
- The stream node mirrors the `ftp` and `smb` shape exactly: a `PAYLOAD_MODIFIER` sibling of `payload` inside the parameter's `COMPLEX_PAYLOAD` container.

## Note for reviewers

The `onError` node has no File Handling Options group, so its `@files:FunctionConfig` cannot be set from the editor. In 1.0.0 that annotation is what disposes of a file after a content binding failure when `onError` is declared, so a service built in the editor leaves such a file in place and it is picked up again on the next poll. Happy to add the group in this PR or a follow-up if you would like it exposed.


## Dependencies

The latest commit points the model at `ballerinax/azure.storage.files` **1.0.1**, which restores the string CSV row forms (`string[][]` and `stream<string[], error?>`) in the connector's compiler plugin. Depends on [module-ballerinax-azure.storage.files#9](https://github.com/ballerina-platform/module-ballerinax-azure.storage.files/pull/9) merging and the 1.0.1 patch reaching Ballerina Central; please merge this PR only after that release.
