### PR TITLE
Resolve the backend URL from the selected platform environment

### DIFF
--- a/packages/ballerina-extension/src/features/ai/utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils.ts
@@ -40,8 +40,15 @@ import { BallerinaProject, LoginMethod, AuthCredentials, DefaultProviderKind } f
 import { BallerinaExtension } from 'src/core';
 
 const config = workspace.getConfiguration('ballerina');
-const isDevantDev = process.env.CLOUD_ENV === "dev";
-export const BACKEND_URL: string = config.get('rootUrl') || (isDevantDev ? process.env.COPILOT_DEV_ROOT_URL : process.env.COPILOT_ROOT_URL);
+const PLATFORM_ENV_SETTING = "WSO2.WSO2-Platform.Advanced.ChoreoEnvironment";
+// Same order the WSO2 Platform extension resolves its environment in.
+const devantEnv = (process.env.CHOREO_ENV || process.env.CLOUD_ENV
+    || workspace.getConfiguration().get<string>(PLATFORM_ENV_SETTING) || "").trim().toLowerCase();
+const COPILOT_ROOT_URLS = new Map<string, string>([
+    ["dev", process.env.COPILOT_DEV_ROOT_URL],
+    ["stage", process.env.COPILOT_STAGE_ROOT_URL || process.env.COPILOT_DEV_ROOT_URL],
+]);
+export const BACKEND_URL: string = config.get('rootUrl') || COPILOT_ROOT_URLS.get(devantEnv) || process.env.COPILOT_ROOT_URL;
 
 export const DEVANT_TOKEN_EXCHANGE_URL: string = BACKEND_URL + "/auth-api/v1.0/auth/token-exchange";
 


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2192

- Select the Copilot backend based on the environment the user is signed in to, instead of always assuming production
- Add support for the staging environment, falling back to the development backend when no staging URL is configured
- Resolve the environment the same way the WSO2 Platform extension does, so both its environment variables and its environment setting are honoured
- Keep the `ballerina.rootUrl` setting as an explicit override
- Fall back to production for any unrecognised value


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Resolve the Copilot backend URL from the selected platform environment.
- Support development and staging URLs, with staging falling back to development and then the default URL.
- Preserve `ballerina.rootUrl` as an explicit override.
- Extend `addConfigFile` with optional `signOutOnFailure` control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->