### PR TITLE
Language server cleanup

### DIFF
--- a/.github/actions/ls-test/action.yml
+++ b/.github/actions/ls-test/action.yml
@@ -15,6 +15,20 @@ inputs:
   package-pat:
     description: Token for maven.pkg.github.com authentication
     required: true
+  codecov-token:
+    description: >-
+      Codecov upload token. When empty the upload is attempted tokenless, which
+      works for public repositories. Either way it never fails the job.
+    required: false
+    default: ''
+  codecov-branch:
+    description: >-
+      Branch to attribute the coverage upload to. Set this only when the workflow
+      checked out a ref other than the one that triggered it (schedule.yml's
+      multi-branch matrix); leave empty to let the Codecov action derive branch
+      and commit from the event, which is what PR builds need.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -64,3 +78,63 @@ runs:
         else
           "$GRADLE" test
         fi
+
+    # Coverage is aggregated and published from Linux only. The Windows leg runs the
+    # same suite over the same sources, so a second upload would only duplicate the
+    # report, and its Windows paths do not map onto the repository layout.
+    #
+    # always(): a failing suite still wrote JaCoCo execution data for everything that
+    # did run, and the coverage number for it is more useful than none. createCodeCoverageReport
+    # declares no task dependencies, so this re-reads build outputs instead of rebuilding.
+    - name: Generate aggregated coverage report
+      if: ${{ always() && runner.os == 'Linux' }}
+      shell: bash
+      working-directory: packages/ballerina-language-server
+      env:
+        packageUser: ${{ inputs.package-user }}
+        packagePAT: ${{ inputs.package-pat }}
+      run: ./gradlew createCodeCoverageReport
+
+    - name: Resolve coverage upload metadata
+      if: ${{ always() && runner.os == 'Linux' }}
+      id: coverage
+      shell: bash
+      env:
+        CODECOV_BRANCH: ${{ inputs.codecov-branch }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        # Override the commit only alongside an explicit branch: on a pull_request event
+        # the Codecov action's own detection is correct, and HEAD is a merge commit that
+        # would be attributed to the wrong place.
+        if [ -n "$CODECOV_BRANCH" ]; then
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        fi
+        # Artifact names cannot contain '/', which both branch names ('builds/nightly')
+        # and PR refs ('123/merge') do.
+        echo "label=$(echo "${CODECOV_BRANCH:-$REF_NAME}" | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+    - name: Upload coverage to Codecov
+      if: ${{ always() && runner.os == 'Linux' }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        token: ${{ inputs.codecov-token }}
+        files: packages/ballerina-language-server/.jacoco/reports/jacoco/report.xml
+        flags: language-server
+        name: ballerina-language-server
+        disable_search: true
+        override_branch: ${{ inputs.codecov-branch }}
+        override_commit: ${{ steps.coverage.outputs.commit }}
+        # Coverage is informational (see codecov.yml); a Codecov outage or a missing
+        # token must never fail the build.
+        fail_ci_if_error: false
+
+    # The XML is what Codecov consumes; the HTML report next to it is how a developer
+    # finds which classes are uncovered without re-running the suite locally.
+    - name: Upload coverage report
+      if: ${{ always() && runner.os == 'Linux' }}
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: ls-coverage-${{ steps.coverage.outputs.label }}
+        path: packages/ballerina-language-server/.jacoco/reports/jacoco/
+        if-no-files-found: warn
+        retention-days: 5

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -332,6 +332,31 @@ Gradle's `mavenJava` publication and does not run Gradle's `release` task: that 
 rewrote the `version=` key in `gradle.properties`, which no longer exists now that the
 extension manifest owns the version.
 
+## Language server test coverage
+
+Every LS test run reports coverage to [Codecov](https://codecov.io/gh/ballerina-platform/ballerina-vscode)
+under the `language-server` flag. `.github/actions/ls-test` owns the whole flow, so any
+workflow that runs LS tests gets it: after `./gradlew test` it runs
+`./gradlew createCodeCoverageReport` (defined in the LS root `build.gradle`, modelled on
+ballerina-lang's task of the same name), which merges every module's JaCoCo execution data
+into `.jacoco/reports/jacoco/report.xml`, then uploads that file and attaches the report
+directory as the `ls-coverage-<branch>` artifact.
+
+Three details worth knowing:
+
+- **Linux only.** The Windows matrix leg runs the same suite over the same sources, so a
+  second upload would only duplicate the report and its paths do not map onto the repo layout.
+- **Runs even when tests fail** (`if: always()`), because a partial number beats none.
+- **`schedule.yml` passes `codecov-branch`.** Its matrix checks out `matrix.branch` rather
+  than the ref the schedule fired on, so the upload has to be attributed explicitly. These
+  nightly runs are what give `main` and each release line the baseline that PR comparisons
+  need — PR builds only run LS tests when language server files change.
+
+Coverage thresholds are informational in `codecov.yml` (repository root — Codecov reads it
+from nowhere else): coverage is reported but never fails a build. To flip it to a merge gate,
+set `informational: false` on the statuses there — worth doing only after the first full CI
+run establishes the real baseline, since the `range` there is currently a placeholder.
+
 ## Required GitHub secrets for publishing and notifications
 
 - `BALLERINA_BOT_USERNAME` / `BALLERINA_BOT_TOKEN` — `release-pre-release.yml`, when
@@ -349,6 +374,10 @@ extension manifest owns the version.
 - `COPILOT_ROOT_URL` / `COPILOT_DEV_ROOT_URL` / `APPINSIGHTS_INSTRUMENTATION_KEY` —
   `schedule.yml`, `devBuild.yml`, and `release-pre-release.yml`: optional build-time
   endpoint and telemetry configuration. Pull-request builds receive none of these secrets.
+- `CODECOV_TOKEN` — every workflow that runs LS tests: authenticates the language server
+  coverage upload. Unset, the upload falls back to Codecov's tokenless flow for public
+  repositories; either way it never fails a build. See
+  [Language server test coverage](#language-server-test-coverage).
 
 Configure these in the new repo's settings before triggering anything.
 
@@ -369,6 +398,7 @@ configured.
 | Action | Used by |
 |---|---|
 | `build` | `reusable-build.yml` — runs rush install + `rush build --to ballerina` |
+| `ls-test` | `reusable-build.yml`, `schedule.yml` — runs the LS gradle suite, then aggregates and uploads coverage (see [Language server test coverage](#language-server-test-coverage)) |
 | `setup-ballerina` | Build and LS workflows — installs the distribution version declared by the LS `gradle.properties`; accepts an optional `gradlePropertiesRef` to read that file from a git tag instead of the checkout (used by `e2e-scheduled.yml` to pin to the `nightly` tag) |
 | `updateVersion` | `build`, `schedule.yml` — resolves and writes the version in the extension manifest |
 | `resolve-source-branch` | `schedule.yml` — the latest-`staging/*`-else-`main` resolution described under [The nightly branch](#the-nightly-branch) |

--- a/.github/workflows/devBuild.yml
+++ b/.github/workflows/devBuild.yml
@@ -40,6 +40,8 @@ on:
         required: false
       APPINSIGHTS_INSTRUMENTATION_KEY:
         required: false
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   Build:
@@ -49,6 +51,7 @@ jobs:
       COPILOT_ROOT_URL: ${{ secrets.COPILOT_ROOT_URL }}
       COPILOT_DEV_ROOT_URL: ${{ secrets.COPILOT_DEV_ROOT_URL }}
       APPINSIGHTS_INSTRUMENTATION_KEY: ${{ secrets.APPINSIGHTS_INSTRUMENTATION_KEY }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       ref: ${{ inputs.ref }}
       runOnAWS: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -51,6 +51,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.build == 'true'
     uses: ./.github/workflows/reusable-build.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       runOnAWS: ${{ contains(github.event.pull_request.labels.*.name, 'Runner/AWS') }}
       # Always run the e2e suite for a PR into a release line ('5.14.x'), where a regression

--- a/.github/workflows/release-pre-release.yml
+++ b/.github/workflows/release-pre-release.yml
@@ -35,6 +35,7 @@ jobs:
       COPILOT_ROOT_URL: ${{ secrets.COPILOT_ROOT_URL }}
       COPILOT_DEV_ROOT_URL: ${{ secrets.COPILOT_DEV_ROOT_URL }}
       APPINSIGHTS_INSTRUMENTATION_KEY: ${{ secrets.APPINSIGHTS_INSTRUMENTATION_KEY }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       runOnAWS: false
       isPreRelease: ${{ inputs.isPreRelease }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -67,6 +67,10 @@ on:
         required: false
       APPINSIGHTS_INSTRUMENTATION_KEY:
         required: false
+      CODECOV_TOKEN:
+        # Optional: language server coverage uploads fall back to Codecov's
+        # tokenless flow for public repositories when this is not set.
+        required: false
 
 jobs:
   Build_Stage:
@@ -324,3 +328,4 @@ jobs:
           cache-branch: ${{ github.base_ref || github.ref_name }}
           package-user: ${{ github.actor }}
           package-pat: ${{ secrets.GITHUB_TOKEN }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -267,12 +267,6 @@ jobs:
           gradle-version: ${{ matrix.version }}
           package-user: ${{ github.actor }}
           package-pat: ${{ secrets.GITHUB_TOKEN }}
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          # This job checks out matrix.branch, not the ref the schedule fired on, so
-          # the coverage upload must be attributed explicitly. These nightly runs are
-          # what give each tracked branch — main included — a Codecov baseline for PRs
-          # to compare against.
-          codecov-branch: ${{ matrix.branch }}
 
   ls-windows-build:
     name: LS Windows build (${{ matrix.branch }})

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -267,6 +267,12 @@ jobs:
           gradle-version: ${{ matrix.version }}
           package-user: ${{ github.actor }}
           package-pat: ${{ secrets.GITHUB_TOKEN }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          # This job checks out matrix.branch, not the ref the schedule fired on, so
+          # the coverage upload must be attributed explicitly. These nightly runs are
+          # what give each tracked branch — main included — a Codecov baseline for PRs
+          # to compare against.
+          codecov-branch: ${{ matrix.branch }}
 
   ls-windows-build:
     name: LS Windows build (${{ matrix.branch }})
@@ -378,6 +384,7 @@ jobs:
       COPILOT_ROOT_URL: ${{ secrets.COPILOT_ROOT_URL }}
       COPILOT_DEV_ROOT_URL: ${{ secrets.COPILOT_DEV_ROOT_URL }}
       APPINSIGHTS_INSTRUMENTATION_KEY: ${{ secrets.APPINSIGHTS_INSTRUMENTATION_KEY }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       # Pin the nightly commit SHA rather than the branch name: the branch is
       # force-pushed every run, so a name would let a concurrent run swap the tree

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,65 @@
+# Codecov configuration for the ballerina-vscode monorepo.
+#
+# Codecov only reads this file from the repository root, so it configures every
+# package. Today the only upload is the Ballerina language server's aggregated
+# JaCoCo report, produced by
+# `packages/ballerina-language-server` -> ./gradlew test createCodeCoverageReport
+# and uploaded under the `language-server` flag by .github/actions/ls-test.
+#
+# All statuses are informational: coverage is reported on the PR and the
+# dashboard but never fails a build. Flip `informational` to false once the
+# numbers have settled and the team wants coverage to gate merges.
+
+codecov:
+  require_ci_to_pass: false
+  # LS tests only run when language server files change, so a PR that touches
+  # nothing there has no fresh upload. Without this, Codecov would discard the
+  # carried-forward report as stale.
+  max_report_age: off
+  notify:
+    # Coverage arrives from a single job; report as soon as it lands rather than
+    # waiting for the rest of the build matrix.
+    wait_for_ci: false
+
+coverage:
+  precision: 2
+  round: down
+  # Red below 30%, green at 80%. Adjust once the first full CI run establishes
+  # where the language server actually sits.
+  range: "30...80"
+  status:
+    project:
+      default:
+        informational: true
+      language-server:
+        flags:
+          - language-server
+        target: auto
+        # Tolerate sub-1% drops: which LS tests run varies slightly between runs.
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+flags:
+  language-server:
+    paths:
+      - packages/ballerina-language-server/
+    # LS tests are conditional on changed paths (see .github/workflows/pull-request.yml).
+    # When they do not run, reuse the base commit's report instead of reporting 0%.
+    carryforward: true
+
+# Coverage is measured on production sources only; these never appear in the
+# JaCoCo report but are listed so a stray upload cannot skew the number.
+ignore:
+  - "**/src/test/**"
+  - "**/build/**"
+  - "**/node_modules/**"
+  - "**/*.bal"
+  - "packages/ballerina-language-server/langserver-stdlib/**"
+
+comment:
+  layout: "condensed_header, diff, flags, components"
+  behavior: default
+  require_changes: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -57,14 +57,23 @@ flags:
     # When they do not run, reuse the base commit's report instead of reporting 0%.
     carryforward: true
 
-# Coverage is measured on production sources only; these never appear in the
-# JaCoCo report but are listed so a stray upload cannot skew the number.
+# Coverage is measured on production sources only.
+#
+# The entries up to langserver-stdlib never appear in the JaCoCo report in the
+# first place; they are listed so a stray upload cannot skew the number.
 ignore:
   - "**/src/test/**"
   - "**/build/**"
   - "**/node_modules/**"
   - "**/*.bal"
   - "packages/ballerina-language-server/langserver-stdlib/**"
+  # These two do appear in the report, and are excluded on purpose. Both services
+  # are complete and valid, but no frontend consumes them yet, so nothing drives
+  # them end to end and they contribute 543 lines at 0% (edi-service 350,
+  # xsd-service 193). Remove both entries once the frontend is plugged in — the
+  # code is production code and should be measured then.
+  - "packages/ballerina-language-server/xsd-service/**"
+  - "packages/ballerina-language-server/edi-service/**"
 
 comment:
   layout: "condensed_header, diff, flags, components"

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,9 +28,12 @@ coverage:
   # where the language server actually sits.
   range: "30...80"
   status:
+    # Codecov posts an unscoped 'default' status for each type whether or not it is
+    # configured. Both are off here: with a single uploading package they would only
+    # duplicate the flagged statuses below under a name that does not say what it
+    # measures. Add a second flag's statuses here when another package starts uploading.
     project:
-      default:
-        informational: true
+      default: off
       language-server:
         flags:
           - language-server
@@ -39,7 +42,11 @@ coverage:
         threshold: 1%
         informational: true
     patch:
-      default:
+      default: off
+      language-server:
+        flags:
+          - language-server
+        target: auto
         informational: true
 
 flags:

--- a/packages/ballerina-language-server/.gitignore
+++ b/packages/ballerina-language-server/.gitignore
@@ -45,6 +45,9 @@ target/
 **/bin/
 .cache/
 
+# Aggregated JaCoCo coverage report (createCodeCoverageReport)
+.jacoco/
+
 # macOS metadata files
 .DS_Store
 .claude

--- a/packages/ballerina-language-server/README.md
+++ b/packages/ballerina-language-server/README.md
@@ -1,5 +1,7 @@
 # Ballerina Language Server
 
+[![codecov](https://codecov.io/gh/ballerina-platform/ballerina-vscode/branch/main/graph/badge.svg?flag=language-server)](https://codecov.io/gh/ballerina-platform/ballerina-vscode?flags%5B0%5D=language-server)
+
 A Language Server Implementation for [Ballerina](https://ballerina.io/); a general purpose, concurrent and strongly typed programming language with both textual and graphical syntax, optimized for integration. With this implementation we expose the language support for Ballerina in various IDEs by adhering to the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/).
 
 ## Features
@@ -34,6 +36,36 @@ You can find the Language Server User Guide [here](https://github.com/ballerina-
 
 ## Language Server Extensions Development Guide
 You can find the Language Server Extensions Development Guide [here](https://github.com/ballerina-platform/ballerina-lang/blob/master/docs/language-server/ExtensionPoints.md)
+
+## Test Coverage
+
+Every module's `test` task emits JaCoCo execution data. `createCodeCoverageReport` merges
+all of it into one report and logs the overall percentage:
+
+```bash
+./gradlew test createCodeCoverageReport   # full suite, then the report
+./gradlew createCodeCoverageReport        # report from the last run's data, no rebuild
+```
+
+The output looks like this (illustrative figures — a report only reflects the tests that
+actually ran, so only a full `test` run gives the project's real coverage):
+
+```
+INSTRUCTION  coverage:  nn.nn% (171187/375097)
+BRANCH       coverage:  nn.nn% (14382/38765)
+LINE         coverage:  nn.nn% (36348/84510)
+```
+
+Modules whose tests did not run still contribute their lines to the denominator with nothing
+covered, which is correct for a full run but means a partial run under-reports.
+
+The report lands in `.jacoco/reports/jacoco/` — `report.xml` is what CI uploads to Codecov
+under the `language-server` flag, and `html/index.html` is the browsable per-class breakdown.
+Because the task never depends on `test`, a suite that fails partway still yields a report
+for whatever ran. CI also attaches the whole directory as the `ls-coverage-<branch>` artifact.
+
+Codecov thresholds are informational (see `codecov.yml` at the repository root): coverage is
+reported on pull requests but never fails a build.
 
 ## How to Contribute
 Ballerina Language Server is currently work in progress and feel free to follow the [issue tracker](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aopen+is%3Aissue+label%3AComponent%2FLanguageServer) for up coming features and feature requests.

--- a/packages/ballerina-language-server/build.gradle
+++ b/packages/ballerina-language-server/build.gradle
@@ -429,6 +429,89 @@ task buildCommons {
     dependsOn(":model-generator-commons:build")
 }
 
+// Aggregated test coverage across every module, mirroring the createCodeCoverageReport
+// task in ballerina-lang. gradle/javaProject.gradle already makes each module's test task
+// emit JaCoCo execution data into build/coverage-reports/jacoco.exec; modules that only
+// get the base jacoco plugin from allprojects use JaCoCo's default build/jacoco/*.exec.
+// Merging both into one report gives a single coverage percentage for the language server,
+// which is what CI hands to Codecov.
+//
+// Usage: ./gradlew test createCodeCoverageReport  (or run it after a `test`/`build`, since
+// it reads existing build outputs). It deliberately declares no task dependencies so CI can
+// still publish coverage from a run where some tests failed.
+def coverageExcludedProjects = [
+        ':checkstyle',                                      // downloads the checkstyle config, no sources
+        ':langserver-stdlib',                               // Ballerina mock stdlib — a test fixture
+        ':flow-model-generator:flow-model-index-generator', // build-time index generators
+        ':service-model-generator:service-model-index-generator',
+]
+
+tasks.register('createCodeCoverageReport', JacocoReport) {
+    description 'Merges the JaCoCo execution data of all modules into a single coverage report'
+    group 'verification'
+
+    def reportDir = file("$rootDir/.jacoco/reports/jacoco")
+    def xmlReport = new File(reportDir, 'report.xml')
+
+    // Ordering only, deliberately not dependsOn: when tests are part of the same
+    // invocation the report has to come last, but `./gradlew createCodeCoverageReport`
+    // on its own — what CI runs after a suite that failed — must not rebuild or re-run
+    // anything. Without this, Gradle 8 rejects the task for reading compileJava and
+    // test outputs it never declared a dependency on.
+    mustRunAfter subprojects.collect { it.tasks.withType(JavaCompile) }
+    mustRunAfter subprojects.collect { it.tasks.withType(Test) }
+
+    // Asking for this task always produces a report and always logs the percentage;
+    // an UP-TO-DATE skip would silently print nothing. Regeneration is seconds against
+    // a suite that takes tens of minutes.
+    outputs.upToDateWhen { false }
+
+    subprojects.each { subproject ->
+        // fileTree resolves at execution time, so exec files written earlier in the same
+        // invocation (./gradlew test createCodeCoverageReport) are picked up too.
+        executionData fileTree(subproject.buildDir) {
+            include 'coverage-reports/*.exec', 'jacoco/*.exec'
+        }
+
+        if (coverageExcludedProjects.contains(subproject.path)) {
+            return
+        }
+        additionalClassDirs fileTree("${subproject.buildDir}/classes/java/main") {
+            exclude '**/module-info.class'
+        }
+        additionalSourceDirs files("${subproject.projectDir}/src/main/java")
+    }
+
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+        xml.outputLocation = xmlReport
+        html.outputLocation = new File(reportDir, 'html')
+    }
+
+    doLast {
+        // JaCoCo's own XML carries the totals; echo them so the percentage is visible in
+        // the build log and not only on Codecov.
+        def parser = new groovy.xml.XmlSlurper()
+        parser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+        parser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+        def report = parser.parse(xmlReport)
+        ['INSTRUCTION', 'BRANCH', 'LINE'].each { type ->
+            def counter = report.counter.find { it.@type == type }
+            if (counter.isEmpty()) {
+                return
+            }
+            def missed = counter.@missed.toInteger()
+            def covered = counter.@covered.toInteger()
+            def total = missed + covered
+            def percentage = total == 0 ? 0 : (covered * 100.0d / total)
+            logger.lifecycle(String.format('%-12s coverage: %6.2f%% (%d/%d)', type, percentage, covered, total))
+        }
+        logger.lifecycle("Coverage report: ${xmlReport}")
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) { publication ->


### PR DESCRIPTION
Draft to track LS cleanup work, seeded with the coverage tooling from #862 so every push reports to Codecov under the `language-server` flag.

- Cherry-picks the three commits of #862 (`-x` references retained). Base is `staging/5.14.0`, the same base as #862, so this diff collapses to just the cleanup work once #862 merges.
- One conflict, in `.github/workflows/README.md`: kept the new `ls-test` row from #862 alongside this branch's `setup-ballerina` description, which documents `gradlePropertiesRef` and postdates #862.
- Verified locally: `./gradlew createCodeCoverageReport` configures and runs. It reported LINE 10.93% against stale partial exec data; `./gradlew test createCodeCoverageReport` gives the real figure.

Follow-ups: cleanup commits to come. `staging/5.14.0` has no coverage baseline yet, so the first comparison has nothing to diff against; and `.github/workflows/README.md:350` still documents `schedule.yml` passing `codecov-branch`, which the third commit of #862 removed.