### PR TITLE
Serialize shared sample-project package resolution and metadata queries

### DIFF
--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -84,16 +84,8 @@ import io.ballerina.modelgenerator.commons.PackageUtil;
 import io.ballerina.projects.DependenciesToml;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Package;
-import io.ballerina.projects.PackageDescriptor;
-import io.ballerina.projects.PackageName;
-import io.ballerina.projects.PackageOrg;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.TomlDocument;
-import io.ballerina.projects.environment.PackageMetadataResponse;
-import io.ballerina.projects.environment.PackageResolver;
-import io.ballerina.projects.environment.ResolutionOptions;
-import io.ballerina.projects.environment.ResolutionRequest;
-import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
@@ -105,7 +97,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -633,21 +624,7 @@ public class AiUtils {
     }
 
     public static Optional<String> resolvePackageVersion(String org, String packageName) {
-        try {
-            PackageResolver resolver = PackageUtil.getSampleProject()
-                    .projectEnvironmentContext().getService(PackageResolver.class);
-            ResolutionRequest resolutionRequest = ResolutionRequest.from(
-                    PackageDescriptor.from(PackageOrg.from(org), PackageName.from(packageName)));
-            Collection<PackageMetadataResponse> metadataResponses = resolver.resolvePackageMetadata(
-                    Collections.singletonList(resolutionRequest),
-                    ResolutionOptions.builder().setOffline(true).build());
-            return metadataResponses.stream().findFirst()
-                    .filter(meta -> meta.resolutionStatus() != ResolutionResponse.ResolutionStatus.UNRESOLVED)
-                    .map(PackageMetadataResponse::resolvedDescriptor)
-                    .map(descriptor -> descriptor.version().value().toString());
-        } catch (RuntimeException e) {
-            return Optional.empty();
-        }
+        return Optional.ofNullable(PackageUtil.cachedVersion(org, packageName));
     }
 
     private static synchronized void ensureDependentModulesResolved() {

--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -117,8 +117,9 @@ public class PackageUtil {
             new ConcurrentHashMap<>();
 
     /**
-     * Serializes cache-miss resolutions: before caching, every call built its own sample project
-     * (and resolver), so the shared resolver was never used concurrently. Keep that property.
+     * Serializes access to the shared sample project's non-thread-safe resolver — cache-miss
+     * resolutions, offline resolutions, and metadata queries — so concurrent Language Server
+     * requests cannot corrupt it.
      */
     private static final Object SAMPLE_RESOLUTION_LOCK = new Object();
 
@@ -164,21 +165,24 @@ public class PackageUtil {
      * i.e. the version the build has provisioned. Returns null if not cached.
      */
     public static String cachedVersion(String org, String name) {
-        try {
-            PackageResolver resolver = SAMPLE_PROJECT.projectEnvironmentContext().getService(PackageResolver.class);
-            Collection<PackageMetadataResponse> responses = resolver.resolvePackageMetadata(
-                    Collections.singletonList(ResolutionRequest.from(
-                            PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name)))),
-                    ResolutionOptions.builder().setOffline(true).build());
-            Optional<PackageMetadataResponse> first = responses.stream().findFirst();
-            if (first.isPresent()
-                    && first.get().resolutionStatus() != ResolutionResponse.ResolutionStatus.UNRESOLVED) {
-                return first.get().resolvedDescriptor().version().toString();
+        synchronized (SAMPLE_RESOLUTION_LOCK) {
+            try {
+                PackageResolver resolver = SAMPLE_PROJECT.projectEnvironmentContext()
+                        .getService(PackageResolver.class);
+                Collection<PackageMetadataResponse> responses = resolver.resolvePackageMetadata(
+                        Collections.singletonList(ResolutionRequest.from(
+                                PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name)))),
+                        ResolutionOptions.builder().setOffline(true).build());
+                Optional<PackageMetadataResponse> first = responses.stream().findFirst();
+                if (first.isPresent()
+                        && first.get().resolutionStatus() != ResolutionResponse.ResolutionStatus.UNRESOLVED) {
+                    return first.get().resolvedDescriptor().version().toString();
+                }
+            } catch (RuntimeException ignored) {
+                // fall through to null
             }
-        } catch (RuntimeException ignored) {
-            // fall through to null
+            return null;
         }
-        return null;
     }
 
     /**
@@ -398,42 +402,48 @@ public class PackageUtil {
      * {@link #pullModuleAndNotify}) rather than pulling it silently as a side effect of a read.
      */
     public static Optional<Package> getModulePackageOffline(BuildProject buildProject, String org, String name) {
-        ResolutionRequest resolutionRequest = ResolutionRequest.from(
-                PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name)));
-        PackageResolver packageResolver = buildProject.projectEnvironmentContext().getService(PackageResolver.class);
-        Collection<PackageMetadataResponse> packageMetadataResponses = packageResolver.resolvePackageMetadata(
-                Collections.singletonList(resolutionRequest),
-                ResolutionOptions.builder().setOffline(true).build());
-        Optional<PackageMetadataResponse> pkgMetadata = packageMetadataResponses.stream().findFirst();
-        if (pkgMetadata.isEmpty() ||
-                pkgMetadata.get().resolutionStatus() == ResolutionResponse.ResolutionStatus.UNRESOLVED) {
-            return Optional.empty();
-        }
+        synchronized (SAMPLE_RESOLUTION_LOCK) {
+            ResolutionRequest resolutionRequest = ResolutionRequest.from(
+                    PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name)));
+            PackageResolver packageResolver = buildProject.projectEnvironmentContext()
+                    .getService(PackageResolver.class);
+            Collection<PackageMetadataResponse> packageMetadataResponses = packageResolver.resolvePackageMetadata(
+                    Collections.singletonList(resolutionRequest),
+                    ResolutionOptions.builder().setOffline(true).build());
+            Optional<PackageMetadataResponse> pkgMetadata = packageMetadataResponses.stream().findFirst();
+            if (pkgMetadata.isEmpty() ||
+                    pkgMetadata.get().resolutionStatus() == ResolutionResponse.ResolutionStatus.UNRESOLVED) {
+                return Optional.empty();
+            }
 
-        Collection<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(
-                Collections.singletonList(ResolutionRequest.from(pkgMetadata.get().resolvedDescriptor())),
-                ResolutionOptions.builder().setOffline(true).build());
-        Optional<ResolutionResponse> resolutionResponse = resolutionResponses.stream().findFirst();
-        if (resolutionResponse.isEmpty()) {
-            return Optional.empty();
-        }
+            Collection<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(
+                    Collections.singletonList(ResolutionRequest.from(pkgMetadata.get().resolvedDescriptor())),
+                    ResolutionOptions.builder().setOffline(true).build());
+            Optional<ResolutionResponse> resolutionResponse = resolutionResponses.stream().findFirst();
+            if (resolutionResponse.isEmpty()) {
+                return Optional.empty();
+            }
 
-        Path balaPath = resolutionResponse.get().resolvedPackage().project().sourceRoot();
-        ProjectEnvironmentBuilder defaultBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
-        defaultBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
-        BalaProject balaProject = BalaProject.loadProject(defaultBuilder, balaPath);
-        return Optional.ofNullable(balaProject.currentPackage());
+            Path balaPath = resolutionResponse.get().resolvedPackage().project().sourceRoot();
+            ProjectEnvironmentBuilder defaultBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
+            defaultBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
+            BalaProject balaProject = BalaProject.loadProject(defaultBuilder, balaPath);
+            return Optional.ofNullable(balaProject.currentPackage());
+        }
     }
 
     public static boolean isModuleUnresolved(String org, String name, String version) {
-        ResolutionRequest resolutionRequest = ResolutionRequest.from(
-                PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name), PackageVersion.from(version)));
-        PackageResolver packageResolver = SAMPLE_PROJECT.projectEnvironmentContext().getService(PackageResolver.class);
-        return packageResolver.resolvePackageMetadata(Collections.singletonList(resolutionRequest),
-                        ResolutionOptions.builder().setOffline(true).build()).stream()
-                .findFirst()
-                .map(response -> response.resolutionStatus() == ResolutionResponse.ResolutionStatus.UNRESOLVED)
-                .orElse(false);
+        synchronized (SAMPLE_RESOLUTION_LOCK) {
+            ResolutionRequest resolutionRequest = ResolutionRequest.from(
+                    PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name), PackageVersion.from(version)));
+            PackageResolver packageResolver = SAMPLE_PROJECT.projectEnvironmentContext()
+                    .getService(PackageResolver.class);
+            return packageResolver.resolvePackageMetadata(Collections.singletonList(resolutionRequest),
+                            ResolutionOptions.builder().setOffline(true).build()).stream()
+                    .findFirst()
+                    .map(response -> response.resolutionStatus() == ResolutionResponse.ResolutionStatus.UNRESOLVED)
+                    .orElse(false);
+        }
     }
 
     private static Path getPath(Path path) {


### PR DESCRIPTION
Serializes all access to the singleton sample project's non-thread-safe `PackageResolver` behind `SAMPLE_RESOLUTION_LOCK` (offline resolutions now route through the memoized cache; `cachedVersion`/`isModuleUnresolved` are synchronized), preventing concurrent HashMap corruption in the compiler's `EnvironmentPackageCache` during parallel Language Server requests.

Fixes wso2/product-integrator#2193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Serialized shared sample-project `PackageResolver` access with `SAMPLE_RESOLUTION_LOCK` to improve stability during parallel Language Server requests.
- Updated offline resolution and unresolved-module checks to use synchronized resolver operations and memoized version data.
- Simplified `AiUtils` by using `PackageUtil.cachedVersion` directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->