### PR TITLE
Lower the Copilot orb below side panels and modals

### DIFF
--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/MiniChat.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/MiniChat.tsx
@@ -355,7 +355,8 @@ const spin = keyframes`
 
 const Panel = styled.div`
     position: fixed;
-    z-index: 10001;
+    /* One above the orb, still below panels/modals so an open panel takes priority. */
+    z-index: 1801;
     width: ${PANEL_WIDTH}px;
     max-width: calc(100vw - ${EDGE_MARGIN * 2}px);
     height: min(520px, calc(100vh - 150px));

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
@@ -126,7 +126,8 @@ const haloPulse = keyframes`
 
 const Wrapper = styled.div`
     position: fixed;
-    z-index: 10000;
+    /* Below side panels and modals (>=1900) so an open form keeps its controls reachable; above diagram content. */
+    z-index: 1800;
     display: flex;
     align-items: center;
     gap: 10px;

--- a/packages/data-mapper/src/components/DataMapper/SidePanel/ImportData/ImportDataForm.tsx
+++ b/packages/data-mapper/src/components/DataMapper/SidePanel/ImportData/ImportDataForm.tsx
@@ -117,7 +117,7 @@ export function ImportDataForm(props: ImportDataWizardProps) {
         <SidePanel
             isOpen={isOpen}
             alignment="right"
-            width={312}
+            width={400}
             overlay={false}
         >
             <SidePanelTitleContainer>


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2155

The floating orb rendered at z-index 10000, above every side panel and modal (1900–2100), so it covered the save/cancel buttons at the bottom of side-panel forms.

- Lower the orb from z-index 10000 to 1800 and the mini chat from 10001 to 1801, so an open side panel, popup or modal renders over them and its controls stay reachable — panels take priority when open
- Widen the data mapper import panel to 400 (matching every other panel) so the orb's idle invite box no longer pokes past its edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Lowered the Copilot floating orb z-index to `1800` and the mini chat z-index to `1801`.
- Allows side panels, popups, and modals with higher z-index values to remain accessible.
- Increased the data mapper import panel width to `400` so the orb invite box stays within the panel boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->