### PR TITLE
Set up AI from the Agent Builder overview

### DIFF
--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -52,6 +52,15 @@ export function shortAssistantName(mode: ProductMode): string {
     return SHORT_ASSISTANT_NAMES[mode];
 }
 
+const ASSISTANT_TAGLINES: Record<ProductMode, string> = {
+    [ProductMode.INTEGRATOR]: 'Your AI pair programmer for integration development',
+    [ProductMode.AGENT_BUILDER]: 'Your AI partner for building agents'
+};
+
+export function assistantTagline(mode: ProductMode): string {
+    return ASSISTANT_TAGLINES[mode];
+}
+
 export type MachineStateValue =
     | 'initialize'
     | 'lsError'

--- a/packages/ballerina-extension/src/RPCLayer.ts
+++ b/packages/ballerina-extension/src/RPCLayer.ts
@@ -77,6 +77,9 @@ export class RPCLayer {
             window.onDidChangeActiveColorTheme((theme) => {
                 RPCLayer._messenger.sendNotification(currentThemeChanged, { type: 'webview', webviewType: VisualizerWebview.viewType }, theme.kind);
             });
+            AIStateMachine.service().onTransition((state) => {
+                RPCLayer._messenger.sendNotification(aiStateChanged, { type: 'webview', webviewType: VisualizerWebview.viewType }, state.value);
+            });
         } else if (isMigrationPanel(webViewPanel)) {
             // Migration panel is a WebviewPanel but does not use the AI state machine.
             RPCLayer._messenger.registerWebviewPanel(webViewPanel as WebviewPanel);

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -339,6 +339,56 @@ export const IconOverlay = styled.div`
     pointer-events: none;
 `;
 
+const auraBreathe = keyframes`
+    0%, 100% { transform: scale(1); opacity: 0.4; }
+    50% { transform: scale(1.15); opacity: 0.7; }
+`;
+
+const ACTIVE_GLOW: AmbientGlowSpec = { outerSize: 40, outerStrength: 48, innerSize: 20, innerStrength: 30 };
+
+interface OrbAuraProps {
+    $active?: boolean;
+    $colors: [string, string, string];
+}
+
+export const OrbAura = styled.div<OrbAuraProps>`
+    position: relative;
+    width: ${ORB_SIZE}px;
+    height: ${ORB_SIZE}px;
+    flex: none;
+    border-radius: 50%;
+    box-shadow: ${(props: OrbAuraProps) =>
+        ambientGlow(props.$colors, props.$active ? ACTIVE_GLOW : HERO_GLOW)};
+    transform: scale(${(props: OrbAuraProps) => (props.$active ? 1.12 : 1)});
+    transition: transform 620ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 620ms ease;
+
+    &::before {
+        content: "";
+        position: absolute;
+        inset: -75%;
+        border-radius: 50%;
+        background: ${(props: OrbAuraProps) => `radial-gradient(
+            circle,
+            color-mix(in srgb, ${props.$colors[1]} 32%, transparent) 0%,
+            color-mix(in srgb, ${props.$colors[0]} 12%, transparent) 45%,
+            transparent 70%
+        )`};
+        filter: blur(12px);
+        animation: ${auraBreathe} ${(props: OrbAuraProps) => (props.$active ? "2.6s" : "5.5s")} ease-in-out
+            infinite;
+        pointer-events: none;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        transition: none;
+
+        &::before {
+            animation: none;
+            opacity: 0.75;
+        }
+    }
+`;
+
 // ---------------------------------------------------------------------------
 // Agent-run-status fan-out.
 //

--- a/packages/ballerina-visualizer/src/components/PopupModal/index.tsx
+++ b/packages/ballerina-visualizer/src/components/PopupModal/index.tsx
@@ -49,11 +49,15 @@ const Backdrop = styled(PopupOverlay)`
     }
 `;
 
-const Box = styled(PopupContainer) <{ $expanded?: boolean }>`
-    width: ${(props: { $expanded?: boolean }) => props.$expanded ? "90%" : "80%"};
-    max-width: ${(props: { $expanded?: boolean }) => props.$expanded ? "1000px" : "800px"};
-    height: ${(props: { $expanded?: boolean }) => props.$expanded ? "90vh" : "80vh"};
-    max-height: ${(props: { $expanded?: boolean }) => props.$expanded ? "none" : "800px"};
+type BoxProps = { $expanded?: boolean; $autoHeight?: boolean; $maxWidth?: number };
+
+const Box = styled(PopupContainer) <BoxProps>`
+    width: ${(props: BoxProps) => props.$expanded ? "90%" : "80%"};
+    max-width: ${(props: BoxProps) => props.$maxWidth ? `${props.$maxWidth}px` : props.$expanded ? "1000px" : "800px"};
+    transition: max-height 180ms ease, max-width 180ms ease;
+    height: ${(props: BoxProps) => props.$autoHeight ? "auto" : props.$expanded ? "90vh" : "80vh"};
+    max-height: ${(props: BoxProps) => props.$autoHeight ? "80vh" : props.$expanded ? "none" : "800px"};
+    min-height: ${(props: BoxProps) => props.$autoHeight ? "0" : "480px"};
     animation: ${popIn} ${ENTER_MS}ms cubic-bezier(0.16, 1, 0.3, 1) both;
     &.closing {
         animation-duration: ${EXIT_MS}ms;
@@ -98,13 +102,15 @@ export interface PopupModalProps {
     dismissOnBackdropClick?: boolean;
     dismissOnEscape?: boolean;
     expanded?: boolean;
+    autoHeight?: boolean;
+    maxWidth?: number;
     zIndexBase?: number;
     ariaLabelledBy?: string;
     children: (close: () => void) => ReactNode;
 }
 
 export function PopupModal(props: PopupModalProps) {
-    const { onClose, dismissOnBackdropClick, dismissOnEscape, expanded, zIndexBase, ariaLabelledBy, children } = props;
+    const { onClose, dismissOnBackdropClick, dismissOnEscape, expanded, autoHeight, maxWidth, zIndexBase, ariaLabelledBy, children } = props;
     const [closing, setClosing] = useState(false);
     const exitTimer = useRef<ReturnType<typeof setTimeout>>(null);
 
@@ -145,6 +151,8 @@ export function PopupModal(props: PopupModalProps) {
                 aria-modal="true"
                 aria-labelledby={ariaLabelledBy}
                 $expanded={expanded}
+                $autoHeight={autoHeight}
+                $maxWidth={maxWidth}
                 className={closingClass}
                 style={zIndexBase ? { zIndex: zIndexBase + 1 } : undefined}
             >

--- a/packages/ballerina-visualizer/src/hooks/useProductMode.ts
+++ b/packages/ballerina-visualizer/src/hooks/useProductMode.ts
@@ -18,7 +18,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { BallerinaRpcClient, useRpcContext } from "@wso2/ballerina-rpc-client";
-import { ProductMode, assistantName, shortAssistantName } from "@wso2/ballerina-core";
+import { ProductMode, assistantName, assistantTagline, shortAssistantName } from "@wso2/ballerina-core";
 
 function seededMode(): ProductMode | undefined {
     const seed = (window as unknown as { productMode?: string }).productMode;
@@ -126,4 +126,8 @@ export function useTracingStatus(rpcClient: BallerinaRpcClient, projectPath: str
     }, [isToggling, isTracingEnabled, rpcClient, checkTracingStatus]);
 
     return { isTracingEnabled, isToggling, toggleTracing };
+}
+
+export function useAssistantTagline(): string {
+    return assistantTagline(useProductMode());
 }

--- a/packages/ballerina-visualizer/src/views/AIPanel/AlertBox.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/AlertBox.tsx
@@ -4,34 +4,39 @@ import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import { Codicon } from "@wso2/ui-toolkit";
 
 
-const Container = styled.div<{ variant: 'primary' | 'secondary' }>`
-    border-left: 0.3rem solid var(${(props: { variant: string; }) => props.variant === 'secondary' ? '--vscode-editorWidget-border' : '--vscode-focusBorder'});
-    background: var(${(props: { variant: string; }) => props.variant === 'secondary' ? 'transparent' : '--vscode-inputValidation-infoBackground'});
+export const AuthPanel = styled.div`
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    padding: 1rem;
+    align-items: stretch;
+    width: 100%;
+    max-width: 420px;
     gap: 12px;
-    margin-bottom: 15px;
-    width: -webkit-fill-available;
+`;
+
+export const AuthTitle = styled.div`
+    color: var(--vscode-foreground);
+    font-size: 20px;
+    font-weight: 400;
+`;
+
+export const AuthSubTitle = styled.div`
+    color: var(--vscode-descriptionForeground);
+    font-size: 13px;
+    font-weight: 400;
+    line-height: 1.55;
+    margin: 0 0 12px;
+`;
+
+export const AuthActions = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
 `;
 
 const WideVSCodeButton = styled(VSCodeButton as React.ComponentType)`
     width: 100%;
     max-width: 300px;
     align-self: center;
-`;
-
-const Title = styled.div`
-    color: var(--vscode-foreground);
-    font-weight: 500;
-`;
-
-const SubTitle = styled.div`
-    color: var(--vscode-descriptionForeground);
-    font-size: 12px;
-    font-weight: 400;
-    line-height: 1.5;
 `;
 
 interface Props {
@@ -48,17 +53,19 @@ interface Props {
 export const AlertBox = (props: Props) => {
     const { title, buttonTitle, subTitle, iconName, variant = 'primary', buttonDisabled = false, onClick, buttonId } = props;
     return (
-        <Container variant={variant}>
-            {title && <Title>{title}</Title>}
-            {subTitle && <SubTitle>{subTitle}</SubTitle>}
-            <VSCodeButton onClick={onClick} appearance={variant} id={`alert-btn${buttonId ? `-${buttonId}` : ''}`}>
-                {iconName && (
-                    <>
-                        <Codicon name={iconName} /> &nbsp;{" "}
-                    </>
-                )}
-                {buttonTitle}
-            </VSCodeButton>
-        </Container>
+        <AuthPanel>
+            {title && <AuthTitle>{title}</AuthTitle>}
+            {subTitle && <AuthSubTitle>{subTitle}</AuthSubTitle>}
+            <AuthActions>
+                <VSCodeButton onClick={onClick} appearance={variant} id={`alert-btn${buttonId ? `-${buttonId}` : ''}`}>
+                    {iconName && (
+                        <>
+                            <Codicon name={iconName} /> &nbsp;{" "}
+                        </>
+                    )}
+                    {buttonTitle}
+                </VSCodeButton>
+            </AuthActions>
+        </AuthPanel>
     );
 };

--- a/packages/ballerina-visualizer/src/views/AIPanel/DisabledSection/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/DisabledSection/index.tsx
@@ -26,9 +26,10 @@ import { useAssistantName } from "../../../hooks/useProductMode";
 const Container = styled.div`
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    padding: 10px;
-    gap: 8px;
+    align-items: center;
+    width: 100%;
+    padding: 16px;
+    box-sizing: border-box;
 `;
 
 export const DisabledWindow = () => {

--- a/packages/ballerina-visualizer/src/views/AIPanel/LoginPanel/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/LoginPanel/index.tsx
@@ -23,14 +23,25 @@ import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Icon, ThemeColors, Typography } from "@wso2/ui-toolkit";
 import React from "react";
 import { Banner } from "../../../components/Banner";
-import { useAssistantName, useShortAssistantName } from "../../../hooks/useProductMode";
+import {
+    ACCENT_CORE,
+    ACCENT_SPHERE,
+    frameTriple,
+    IconOverlay,
+    OrbAura,
+    ORB_ENERGY,
+    Sphere,
+} from "../../../components/AgentStatusOrb/shared";
+import { useAssistantName, useAssistantTagline } from "../../../hooks/useProductMode";
 
-const PanelWrapper = styled.div`
+const WIDE = "@media (min-width: 940px)";
+
+const PanelWrapper = styled.div<{ $embedded?: boolean }>`
     display: flex;
     flex-direction: column;
-    height: 100vh;
-    overflow-y: auto;
-    padding: 24px 16px;
+    height: ${(props: { $embedded?: boolean }) => (props.$embedded ? "auto" : "100vh")};
+    overflow-y: ${(props: { $embedded?: boolean }) => (props.$embedded ? "visible" : "auto")};
+    padding: ${(props: { $embedded?: boolean }) => (props.$embedded ? "0" : "24px 16px")};
 `;
 
 const TopSpacer = styled.div`
@@ -47,15 +58,22 @@ const HeaderContent = styled.div`
     flex-direction: column;
     align-items: center;
     text-align: center;
-    margin-bottom: 32px;
+    margin-bottom: 40px;
 `;
 
 const Title = styled.h2`
-    display: inline-flex;
-    margin-top: 24px;
-    margin-bottom: 8px;
-    font-size: 18px;
-    font-weight: 700;
+    margin: 20px 0 0;
+    font-size: 24px;
+    font-weight: 400;
+    color: var(--vscode-foreground);
+`;
+
+const Subtitle = styled.p`
+    margin: 8px 0 0;
+    max-width: 420px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--vscode-descriptionForeground);
 `;
 
 const BodyContent = styled.div`
@@ -66,6 +84,10 @@ const BodyContent = styled.div`
     max-width: 380px;
     align-self: center;
     gap: 0;
+
+    ${WIDE} {
+        max-width: 680px;
+    }
 `;
 
 const WSO2LoginButton = styled.button`
@@ -74,6 +96,8 @@ const WSO2LoginButton = styled.button`
     justify-content: center;
     gap: 12px;
     width: 100%;
+    max-width: 420px;
+    align-self: center;
     padding: 14px 20px;
     background-color: ${ThemeColors.PRIMARY};
     color: ${ThemeColors.ON_PRIMARY};
@@ -92,8 +116,7 @@ const WSO2LoginButton = styled.button`
 `;
 
 const RecommendedBadge = styled.div`
-    margin-top: 8px;
-    padding: 4px 0;
+    margin-top: 12px;
     font-size: 12px;
     color: ${ThemeColors.ON_SURFACE_VARIANT};
     text-align: center;
@@ -105,13 +128,25 @@ const SectionDivider = styled.div`
     color: var(--vscode-descriptionForeground);
     font-size: 12px;
     width: 100%;
-    margin: 28px 0 16px;
+    margin: 40px 0 16px;
     &::before,
     &::after {
         content: "";
         flex: 1;
         border-bottom: 1px solid var(--vscode-widget-border);
         margin: 0 10px;
+    }
+`;
+
+const ProviderGrid = styled.div`
+    display: grid;
+    grid-template-columns: 1fr;
+    align-items: stretch;
+    gap: 8px;
+    width: 100%;
+
+    ${WIDE} {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 `;
 
@@ -123,16 +158,20 @@ const ProviderCard = styled.button`
     padding: 14px 16px;
     background: none;
     border: 1px solid var(--vscode-widget-border);
-    border-radius: 6px;
+    border-radius: 8px;
     cursor: pointer;
     text-align: left;
-    margin-bottom: 8px;
     color: var(--vscode-foreground);
     &:hover {
         background-color: var(--vscode-list-hoverBackground);
     }
-    &:last-child {
-        margin-bottom: 0;
+
+    ${WIDE} {
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 16px;
     }
 `;
 
@@ -143,16 +182,27 @@ const ProviderLogoWrapper = styled.div`
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
+
+    ${WIDE} {
+        width: auto;
+        height: 24px;
+        justify-content: flex-start;
+    }
 `;
 
 const ProviderInfo = styled.div`
     flex: 1;
     min-width: 0;
+
+    ${WIDE} {
+        flex: 0 0 auto;
+        width: 100%;
+    }
 `;
 
 const ProviderName = styled.div`
     font-size: 14px;
-    font-weight: 600;
+    font-weight: 500;
     color: var(--vscode-foreground);
 `;
 
@@ -166,17 +216,25 @@ const ChevronIcon = styled.span`
     color: ${ThemeColors.PRIMARY};
     font-size: 16px;
     flex-shrink: 0;
+
+    ${WIDE} {
+        display: none;
+    }
 `;
 
 const Footer = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 12px;
-    margin-top: 24px;
+    gap: 10px;
+    margin-top: 40px;
     width: 100%;
     max-width: 380px;
     align-self: center;
+
+    ${WIDE} {
+        max-width: 560px;
+    }
 `;
 
 const FooterDisclaimer = styled.div`
@@ -219,6 +277,8 @@ const InstallingContainer = styled.div`
     align-items: center;
     gap: 8px;
     width: 100%;
+    max-width: 420px;
+    align-self: center;
 `;
 
 const InstallButton = styled.button`
@@ -240,10 +300,10 @@ const InstallButton = styled.button`
 `;
 
 
-const LoginPanel: React.FC = () => {
+const LoginPanel: React.FC<{ embedded?: boolean; subtitle?: React.ReactNode }> = ({ embedded, subtitle }) => {
     const { rpcClient } = useRpcContext();
     const assistantName = useAssistantName();
-    const shortName = useShortAssistantName();
+    const tagline = useAssistantTagline();
 
     const { data: isPlatformAvailable, refetch: refetchPlatformAvailability } = useQuery({
         queryKey: ["platform-availability"],
@@ -280,26 +340,21 @@ const LoginPanel: React.FC = () => {
     };
 
     return (
-        <PanelWrapper>
-            <TopSpacer />
+        <PanelWrapper $embedded={embedded}>
+            {!embedded && <TopSpacer />}
             <HeaderContent>
-                <Icon
-                    name="bi-ai-chat"
-                    sx={{ width: 54, height: 54 }}
-                    iconSx={{ fontSize: "54px", color: "var(--vscode-foreground)", cursor: "default" }}
-                />
-                <Title>Welcome to {assistantName}</Title>
-                <Typography
-                    variant="body1"
-                    sx={{
-                        color: "var(--vscode-descriptionForeground)",
-                        textAlign: "center",
-                        maxWidth: 350,
-                        fontSize: 14,
-                    }}
-                >
-                    Your AI pair programmer for integration development
-                </Typography>
+                <OrbAura $colors={frameTriple(ACCENT_SPHERE[0])}>
+                    <Sphere colors={ACCENT_SPHERE} energy={ORB_ENERGY.idle} highlightColor={ACCENT_CORE} />
+                    <IconOverlay>
+                        <Icon
+                            name="bi-ai-chat"
+                            sx={{ width: 26, height: 26 }}
+                            iconSx={{ fontSize: "26px", color: "#ffffff", cursor: "default" }}
+                        />
+                    </IconOverlay>
+                </OrbAura>
+                <Title>{assistantName}</Title>
+                <Subtitle>{subtitle ?? tagline}</Subtitle>
             </HeaderContent>
 
             <BodyContent>
@@ -333,40 +388,42 @@ const LoginPanel: React.FC = () => {
                     </InstallingContainer>
                 )}
 
-                <SectionDivider>Use your own AI provider</SectionDivider>
+                <SectionDivider>Or use your own AI provider</SectionDivider>
 
-                <ProviderCard onClick={handleAnthropicKeyClick}>
-                    <ProviderLogoWrapper>
-                        <Icon name="bi-anthropic" sx={{ width: 24, height: 24 }} iconSx={{ fontSize: "24px" }} />
-                    </ProviderLogoWrapper>
-                    <ProviderInfo>
-                        <ProviderName>Anthropic API Key</ProviderName>
-                        <ProviderDesc>Use your Anthropic API key to power {shortName}</ProviderDesc>
-                    </ProviderInfo>
-                    <ChevronIcon>›</ChevronIcon>
-                </ProviderCard>
+                <ProviderGrid>
+                    <ProviderCard onClick={handleAnthropicKeyClick}>
+                        <ProviderLogoWrapper>
+                            <Icon name="bi-anthropic" sx={{ width: 20, height: 20 }} iconSx={{ fontSize: "20px" }} />
+                        </ProviderLogoWrapper>
+                        <ProviderInfo>
+                            <ProviderName>Anthropic API Key</ProviderName>
+                            <ProviderDesc>Use your Anthropic API key</ProviderDesc>
+                        </ProviderInfo>
+                        <ChevronIcon>›</ChevronIcon>
+                    </ProviderCard>
 
-                <ProviderCard onClick={handleAwsClick}>
-                    <ProviderLogoWrapper>
-                        <Icon name="bi-aws" sx={{ width: 28, height: 28 }} iconSx={{ fontSize: "28px" }} />
-                    </ProviderLogoWrapper>
-                    <ProviderInfo>
-                        <ProviderName>AWS Bedrock</ProviderName>
-                        <ProviderDesc>Use your AWS Bedrock account</ProviderDesc>
-                    </ProviderInfo>
-                    <ChevronIcon>›</ChevronIcon>
-                </ProviderCard>
+                    <ProviderCard onClick={handleAwsClick}>
+                        <ProviderLogoWrapper>
+                            <Icon name="bi-aws" sx={{ width: 24, height: 24 }} iconSx={{ fontSize: "24px" }} />
+                        </ProviderLogoWrapper>
+                        <ProviderInfo>
+                            <ProviderName>AWS Bedrock</ProviderName>
+                            <ProviderDesc>Use your AWS Bedrock account</ProviderDesc>
+                        </ProviderInfo>
+                        <ChevronIcon>›</ChevronIcon>
+                    </ProviderCard>
 
-                <ProviderCard onClick={handleVertexAiClick}>
-                    <ProviderLogoWrapper>
-                        <Icon name="bi-vertex-ai" sx={{ width: 28, height: 28 }} iconSx={{ fontSize: "28px" }} />
-                    </ProviderLogoWrapper>
-                    <ProviderInfo>
-                        <ProviderName>Google Vertex AI</ProviderName>
-                        <ProviderDesc>Use your Google Vertex AI account</ProviderDesc>
-                    </ProviderInfo>
-                    <ChevronIcon>›</ChevronIcon>
-                </ProviderCard>
+                    <ProviderCard onClick={handleVertexAiClick}>
+                        <ProviderLogoWrapper>
+                            <Icon name="bi-vertex-ai" sx={{ width: 24, height: 24 }} iconSx={{ fontSize: "24px" }} />
+                        </ProviderLogoWrapper>
+                        <ProviderInfo>
+                            <ProviderName>Google Vertex AI</ProviderName>
+                            <ProviderDesc>Use your Google Vertex AI account</ProviderDesc>
+                        </ProviderInfo>
+                        <ChevronIcon>›</ChevronIcon>
+                    </ProviderCard>
+                </ProviderGrid>
             </BodyContent>
 
             <Footer>
@@ -384,7 +441,7 @@ const LoginPanel: React.FC = () => {
                 </FooterLinks>
             </Footer>
 
-            <EndSpacer />
+            {!embedded && <EndSpacer />}
         </PanelWrapper>
     );
 };

--- a/packages/ballerina-visualizer/src/views/AIPanel/WaitingForLoginSection/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/WaitingForLoginSection/index.tsx
@@ -20,66 +20,38 @@ import styled from "@emotion/styled";
 import { AIMachineEventType, LoginMethod } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 
-import { AlertBox } from "../AlertBox";
+import { AlertBox, AuthActions, AuthPanel, AuthSubTitle, AuthTitle } from "../AlertBox";
 import { useEffect, useState } from "react";
-import { Codicon, RadioButtonGroup } from "@wso2/ui-toolkit";
+import { Codicon, RadioButtonGroup, ThemeColors } from "@wso2/ui-toolkit";
 import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import { useAssistantName } from "../../../hooks/useProductMode";
 
-const Container = styled.div`
+const Container = styled.div<{ $embedded?: boolean }>`
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    padding: 10px;
-    gap: 8px;
-`;
-
-// AlertBox-style container for consistency
-const AlertContainer = styled.div<{ variant: "primary" | "secondary" }>`
-    border-left: 0.3rem solid
-        var(
-            ${(props: { variant: string }) =>
-        props.variant === "secondary" ? "--vscode-editorWidget-border" : "--vscode-focusBorder"}
-        );
-    background: var(
-        ${(props: { variant: string }) =>
-        props.variant === "secondary" ? "transparent" : "--vscode-inputValidation-infoBackground"}
-    );
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    padding: 1rem;
-    gap: 12px;
-    margin-bottom: 15px;
-    width: -webkit-fill-available;
-`;
-
-const Title = styled.div`
-    color: var(--vscode-foreground);
-    font-weight: 500;
-`;
-
-const SubTitle = styled.div`
-    color: var(--vscode-descriptionForeground);
-    font-size: 12px;
-    font-weight: 400;
-    line-height: 1.5;
+    align-items: center;
+    justify-content: ${(props: { $embedded?: boolean }) => (props.$embedded ? "flex-start" : "safe center")};
+    height: ${(props: { $embedded?: boolean }) => (props.$embedded ? "auto" : "100vh")};
+    overflow-y: ${(props: { $embedded?: boolean }) => (props.$embedded ? "visible" : "auto")};
+    padding: ${(props: { $embedded?: boolean }) => (props.$embedded ? "0" : "16px")};
+    width: 100%;
+    box-sizing: border-box;
 `;
 
 const InputContainer = styled.div`
     display: flex;
     flex-direction: column;
     gap: 4px;
-    padding: 2px 4px;
-    border: 1px solid var(--vscode-editorWidget-border);
-    border-radius: 4px;
-    background-color: var(--vscode-editor-background);
-    color: var(--vscode-editor-foreground);
+    padding: 2px 6px;
+    border: 1px solid var(--vscode-widget-border);
+    border-radius: 6px;
+    background-color: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
     width: 100%;
     box-sizing: border-box;
-    min-height: 32px;
+    min-height: 36px;
     &:focus-within {
-        border-color: var(--vscode-button-background);
+        border-color: ${ThemeColors.PRIMARY};
     }
 `;
 
@@ -154,10 +126,8 @@ const EyeButton = styled.button`
     }
 `;
 
-const ButtonContainer = styled.div`
-    display: flex;
-    gap: 8px;
-    align-self: flex-start;
+const ButtonContainer = styled(AuthActions)`
+    margin-top: 8px;
 `;
 
 const ErrorMessage = styled.div`
@@ -173,21 +143,23 @@ const ErrorMessage = styled.div`
 
 const AuthModeToggle = styled.div`
     display: flex;
-    gap: 0;
-    border: 1px solid var(--vscode-editorWidget-border);
-    border-radius: 4px;
-    overflow: hidden;
+    gap: 4px;
+    padding: 4px;
+    border: 1px solid var(--vscode-widget-border);
+    border-radius: 8px;
     width: 100%;
+    box-sizing: border-box;
 `;
 
 const AuthModeButton = styled.button<{ active: boolean }>`
     flex: 1;
-    padding: 5px 8px;
+    padding: 7px 10px;
     font-size: 12px;
+    border-radius: 5px;
     cursor: pointer;
     border: none;
-    background: ${(props: { active: boolean }) => props.active ? 'var(--vscode-button-background)' : 'transparent'};
-    color: ${(props: { active: boolean }) => props.active ? 'var(--vscode-button-foreground)' : 'var(--vscode-foreground)'};
+    background: ${(props: { active: boolean }) => props.active ? ThemeColors.PRIMARY : 'transparent'};
+    color: ${(props: { active: boolean }) => props.active ? ThemeColors.ON_PRIMARY : 'var(--vscode-foreground)'};
     &:hover {
         background: ${(props: { active: boolean }) => props.active ? 'var(--vscode-button-hoverBackground)' : 'var(--vscode-toolbar-hoverBackground)'};
     }
@@ -201,9 +173,10 @@ interface WaitingForLoginProps {
     loginMethod?: LoginMethod;
     isValidating?: boolean;
     errorMessage?: string;
+    embedded?: boolean;
 }
 
-const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: WaitingForLoginProps) => {
+const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage, embedded }: WaitingForLoginProps) => {
     const { rpcClient } = useRpcContext();
     const assistantName = useAssistantName();
     const [apiKey, setApiKey] = useState("");
@@ -361,13 +334,13 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
 
     if (loginMethod === LoginMethod.ANTHROPIC_KEY) {
         return (
-            <Container>
-                <AlertContainer variant="primary">
-                    <Title>Connect with Anthropic API Key</Title>
-                    <SubTitle>
+            <Container $embedded={embedded}>
+                <AuthPanel>
+                    <AuthTitle>Connect with Anthropic API Key</AuthTitle>
+                    <AuthSubTitle>
                         Enter your Anthropic API key to connect to {assistantName}. Your API key will be securely stored
                         and used for authentication.
-                    </SubTitle>
+                    </AuthSubTitle>
 
                     <InputContainer>
                         <InputRow>
@@ -398,21 +371,21 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
 
                     <ButtonContainer>
                         <VSCodeButton
+                            appearance="secondary"
+                            onClick={cancelLogin}
+                            disabled={isValidating}
+                        >
+                            Back
+                        </VSCodeButton>
+                        <VSCodeButton
                             appearance="primary"
                             onClick={connectWithKey}
                             disabled={isValidating || !apiKey || apiKey.trim().length === 0}
                         >
                             {isValidating ? "Validating..." : "Connect with Key"}
                         </VSCodeButton>
-                        <VSCodeButton
-                            appearance="secondary"
-                            onClick={cancelLogin}
-                            disabled={isValidating}
-                        >
-                            Cancel
-                        </VSCodeButton>
                     </ButtonContainer>
-                </AlertContainer>
+                </AuthPanel>
             </Container>
         );
     }
@@ -433,13 +406,13 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
         const isFormValid = awsServiceMode === 'bedrock' ? isBedrockFormValid : isAnthropicAwsFormValid;
 
         return (
-            <Container>
-                <AlertContainer variant="primary">
-                    <Title>Connect with AWS</Title>
-                    <SubTitle>
+            <Container $embedded={embedded}>
+                <AuthPanel>
+                    <AuthTitle>Connect with AWS</AuthTitle>
+                    <AuthSubTitle>
                         Choose your AWS-based AI provider. Use AWS Bedrock to access Claude via Amazon's inference service,
                         or Claude Platform on AWS for Anthropic's native API with same-day feature parity.
-                    </SubTitle>
+                    </AuthSubTitle>
 
                     <AuthModeToggle>
                         <AuthModeButton
@@ -667,6 +640,13 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
 
                     <ButtonContainer>
                         <VSCodeButton
+                            appearance="secondary"
+                            onClick={cancelLogin}
+                            disabled={isValidating}
+                        >
+                            Back
+                        </VSCodeButton>
+                        <VSCodeButton
                             appearance="primary"
                             onClick={awsServiceMode === 'bedrock' ? connectWithAwsCredentials : connectWithAnthropicAwsCredentials}
                             disabled={isValidating || !isFormValid}
@@ -677,15 +657,8 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
                                     ? "Connect with AWS Bedrock"
                                     : "Connect with Claude Platform on AWS"}
                         </VSCodeButton>
-                        <VSCodeButton
-                            appearance="secondary"
-                            onClick={cancelLogin}
-                            disabled={isValidating}
-                        >
-                            Cancel
-                        </VSCodeButton>
                     </ButtonContainer>
-                </AlertContainer>
+                </AuthPanel>
             </Container>
         );
     }
@@ -696,13 +669,13 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
             awsCredentials.region.trim();
 
         return (
-            <Container>
-                <AlertContainer variant="primary">
-                    <Title>Connect with AWS Bedrock</Title>
-                    <SubTitle>
+            <Container $embedded={embedded}>
+                <AuthPanel>
+                    <AuthTitle>Connect with AWS Bedrock</AuthTitle>
+                    <AuthSubTitle>
                         Enter your AWS credentials to connect to {assistantName} via AWS Bedrock. Your credentials will be securely stored
                         and used for authentication.
-                    </SubTitle>
+                    </AuthSubTitle>
 
                     <InputContainer>
                         <InputRow>
@@ -785,21 +758,21 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
 
                     <ButtonContainer>
                         <VSCodeButton
+                            appearance="secondary"
+                            onClick={cancelLogin}
+                            disabled={isValidating}
+                        >
+                            Back
+                        </VSCodeButton>
+                        <VSCodeButton
                             appearance="primary"
                             onClick={connectWithAwsCredentials}
                             disabled={isValidating || !isFormValid}
                         >
                             {isValidating ? "Validating..." : "Connect with AWS Bedrock"}
                         </VSCodeButton>
-                        <VSCodeButton
-                            appearance="secondary"
-                            onClick={cancelLogin}
-                            disabled={isValidating}
-                        >
-                            Cancel
-                        </VSCodeButton>
                     </ButtonContainer>
-                </AlertContainer>
+                </AuthPanel>
             </Container>
         );
     }
@@ -811,13 +784,13 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
         const submitDisabled = isValidating || !isFormValid;
 
         return (
-            <Container>
-                <AlertContainer variant="primary">
-                    <Title>Connect with Google Vertex AI</Title>
-                    <SubTitle>
+            <Container $embedded={embedded}>
+                <AuthPanel>
+                    <AuthTitle>Connect with Google Vertex AI</AuthTitle>
+                    <AuthSubTitle>
                         Select the GCP service account JSON key file to authenticate {assistantName} with Google Vertex AI.
                         The path is stored locally and read on each request, so the file must remain accessible at this location.
-                    </SubTitle>
+                    </AuthSubTitle>
 
                     <InputContainer>
                         <InputRow>
@@ -864,21 +837,21 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
 
                     <ButtonContainer>
                         <VSCodeButton
+                            appearance="secondary"
+                            onClick={cancelLogin}
+                            disabled={isValidating}
+                        >
+                            Back
+                        </VSCodeButton>
+                        <VSCodeButton
                             appearance="primary"
                             onClick={connectWithVertexAi}
                             disabled={submitDisabled}
                         >
                             {isValidating ? "Validating..." : "Validate & Connect"}
                         </VSCodeButton>
-                        <VSCodeButton
-                            appearance="secondary"
-                            onClick={cancelLogin}
-                            disabled={isValidating}
-                        >
-                            Cancel
-                        </VSCodeButton>
                     </ButtonContainer>
-                </AlertContainer>
+                </AuthPanel>
             </Container>
         );
     }
@@ -893,13 +866,13 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
         );
 
         return (
-            <Container>
-                <AlertContainer variant="primary">
-                    <Title>Connect with Claude Platform on AWS</Title>
-                    <SubTitle>
+            <Container $embedded={embedded}>
+                <AuthPanel>
+                    <AuthTitle>Connect with Claude Platform on AWS</AuthTitle>
+                    <AuthSubTitle>
                         Anthropic's native API through AWS with same-day feature parity and AWS Marketplace billing.
                         Use IAM credentials or an API key provisioned by your Anthropic account representative.
-                    </SubTitle>
+                    </AuthSubTitle>
 
                     <InputContainer>
                         <InputRow>
@@ -1037,21 +1010,21 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
 
                     <ButtonContainer>
                         <VSCodeButton
+                            appearance="secondary"
+                            onClick={cancelLogin}
+                            disabled={isValidating}
+                        >
+                            Back
+                        </VSCodeButton>
+                        <VSCodeButton
                             appearance="primary"
                             onClick={connectWithAnthropicAwsCredentials}
                             disabled={isValidating || !isFormValid}
                         >
                             {isValidating ? "Validating..." : "Connect with Claude Platform on AWS"}
                         </VSCodeButton>
-                        <VSCodeButton
-                            appearance="secondary"
-                            onClick={cancelLogin}
-                            disabled={isValidating}
-                        >
-                            Cancel
-                        </VSCodeButton>
                     </ButtonContainer>
-                </AlertContainer>
+                </AuthPanel>
             </Container>
         );
     }
@@ -1059,7 +1032,7 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
     // Default: BI_INTEL login method
 
     return (
-        <Container>
+        <Container $embedded={embedded}>
             <AlertBox
                 buttonTitle="Cancel"
                 onClick={cancelLogin}

--- a/packages/ballerina-visualizer/src/views/BI/AgentBuilderOverview/EmptyState.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AgentBuilderOverview/EmptyState.tsx
@@ -16,10 +16,10 @@
  * under the License.
  */
 
-import { CSSProperties, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { CSSProperties, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
-import { AgentRunStatus } from "@wso2/ballerina-core";
+import { AgentRunStatus, AIMachineSnapshot, AIMachineStateValue } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Button, Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
 import {
@@ -29,13 +29,11 @@ import {
     ACCENT_FRAME,
     ACCENT_SPHERE,
     SpinArc,
-    HERO_GLOW,
-    ambientGlow,
     frameTriple,
     IconOverlay,
     AGENT_BUILDER_ORB_COLORS,
     ORB_ENERGY,
-    ORB_SIZE,
+    OrbAura,
     Sphere,
     subscribeAgentRunStatus,
     useAiPanelOpen,
@@ -43,14 +41,46 @@ import {
 } from "../../../components/AgentStatusOrb/shared";
 import { openCopilotPanel, submitPromptToCopilot } from "../../../components/AgentStatusOrb/CopilotHeroBox";
 import { useProductMode, useAssistantName } from "../../../hooks/useProductMode";
+import { LoadingRing } from "../../../components/Loader";
+import LoginPanel from "../../AIPanel/LoginPanel";
+import WaitingForLogin from "../../AIPanel/WaitingForLoginSection";
+import { DisabledWindow } from "../../AIPanel/DisabledSection";
+import { PopupModal } from "../../../components/PopupModal";
+import { CloseButton } from "../Connection/styles";
 
 const CONTENT_WIDTH = 760;
 
 const INPUT_MIN_HEIGHT = 46;
-const INPUT_MAX_HEIGHT = 220;
+const INPUT_MAX_HEIGHT = 100;
 
 const EXIT_MS = 680;
 const RUN_START_TIMEOUT_MS = 10000;
+
+type AuthState = "unknown" | "authenticated" | "unauthenticated" | "connecting" | "disabled";
+
+const VALIDATING_SUBSTATES = [
+    "validatingApiKey",
+    "validatingAwsCredentials",
+    "validatingVertexAiCredentials",
+    "validatingAnthropicAwsCredentials",
+];
+
+function authenticatingSubstate(state: AIMachineStateValue | undefined): string | undefined {
+    return typeof state === "object" && state !== null ? state.Authenticating : undefined;
+}
+
+function toAuthState(state: AIMachineStateValue | undefined): AuthState {
+    if (state === undefined || state === "Initialize") {
+        return "unknown";
+    }
+    if (state === "Authenticated") {
+        return "authenticated";
+    }
+    if (state === "Disabled") {
+        return "disabled";
+    }
+    return authenticatingSubstate(state) ? "connecting" : "unauthenticated";
+}
 
 interface Example {
     name: string;
@@ -177,56 +207,6 @@ const Intro = styled.div`
     align-items: center;
     gap: 8px;
     margin-top: 8px;
-`;
-
-const auraBreathe = keyframes`
-    0%, 100% { transform: scale(1); opacity: 0.4; }
-    50% { transform: scale(1.15); opacity: 0.7; }
-`;
-
-const ACTIVE_GLOW = { outerSize: 40, outerStrength: 48, innerSize: 20, innerStrength: 30 };
-
-interface OrbHolderProps {
-    $active?: boolean;
-    $colors: [string, string, string];
-}
-
-const OrbHolder = styled.div<OrbHolderProps>`
-    position: relative;
-    width: ${ORB_SIZE}px;
-    height: ${ORB_SIZE}px;
-    flex: none;
-    border-radius: 50%;
-    box-shadow: ${(props: OrbHolderProps) =>
-        ambientGlow(props.$colors, props.$active ? ACTIVE_GLOW : HERO_GLOW)};
-    transform: scale(${(props: OrbHolderProps) => (props.$active ? 1.12 : 1)});
-    transition: transform 620ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 620ms ease;
-
-    &::before {
-        content: "";
-        position: absolute;
-        inset: -75%;
-        border-radius: 50%;
-        background: ${(props: OrbHolderProps) => `radial-gradient(
-            circle,
-            color-mix(in srgb, ${props.$colors[1]} 32%, transparent) 0%,
-            color-mix(in srgb, ${props.$colors[0]} 12%, transparent) 45%,
-            transparent 70%
-        )`};
-        filter: blur(12px);
-        animation: ${auraBreathe} ${(props: OrbHolderProps) => (props.$active ? "2.6s" : "5.5s")} ease-in-out
-            infinite;
-        pointer-events: none;
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-        transition: none;
-
-        &::before {
-            animation: none;
-            opacity: 0.75;
-        }
-    }
 `;
 
 const riseIn = keyframes`
@@ -398,6 +378,53 @@ const RoundButton = styled.button<{ primary?: boolean }>`
     }
 `;
 
+const FooterLeft = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+`;
+
+const FooterHint = styled.span`
+    color: var(--vscode-descriptionForeground);
+    font-size: 12px;
+`;
+
+const SetupModalHeader = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    padding: 12px 12px 0;
+`;
+
+const SetupModalBody = styled.div`
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: safe center;
+    padding: 32px 24px 32px;
+`;
+
+const LoginSlot = styled.div`
+    width: 100%;
+    padding-top: 12px;
+`;
+
+const NarrowSlot = styled.div`
+    width: 100%;
+    max-width: 520px;
+`;
+
+const Notice = styled.div`
+    width: 100%;
+    max-width: ${CONTENT_WIDTH}px;
+    margin-top: 16px;
+    color: var(--vscode-descriptionForeground);
+    font-size: 13px;
+    text-align: center;
+`;
+
 const ExamplesBlock = styled.div`
     width: 100%;
     max-width: ${CONTENT_WIDTH}px;
@@ -520,6 +547,10 @@ export function EmptyState({ onCreateFromScratch, isLibrary }: EmptyStateProps) 
     const [status, setStatus] = useState<AgentRunStatus | null>(null);
     const [text, setText] = useState("");
     const [submittedPrompt, setSubmittedPrompt] = useState<string>();
+    const [aiSnapshot, setAiSnapshot] = useState<AIMachineSnapshot>();
+    const [pendingPrompt, setPendingPrompt] = useState<string>();
+    const [setupRequested, setSetupRequested] = useState(false);
+    const [startFailed, setStartFailed] = useState(false);
     const [idleMounted, setIdleMounted] = useState(true);
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const focusOnTextRef = useRef(false);
@@ -535,6 +566,22 @@ export function EmptyState({ onCreateFromScratch, isLibrary }: EmptyStateProps) 
         }
         return subscribeAgentRunStatus(rpcClient, setStatus);
     }, [rpcClient]);
+
+    const refreshAiSnapshot = useCallback(() => {
+        rpcClient
+            ?.getAiPanelRpcClient()
+            .getAIMachineSnapshot()
+            .then(setAiSnapshot)
+            .catch((): void => undefined);
+    }, [rpcClient]);
+
+    useEffect(() => {
+        if (!rpcClient) {
+            return;
+        }
+        refreshAiSnapshot();
+        rpcClient.onAIPanelStateChanged(refreshAiSnapshot);
+    }, [rpcClient, refreshAiSnapshot]);
 
     useLayoutEffect(() => {
         const input = inputRef.current;
@@ -570,7 +617,11 @@ export function EmptyState({ onCreateFromScratch, isLibrary }: EmptyStateProps) 
             setSubmittedPrompt(undefined);
             return;
         }
-        const timer = setTimeout(() => setSubmittedPrompt(undefined), RUN_START_TIMEOUT_MS);
+        const timer = setTimeout(() => {
+            setSubmittedPrompt(undefined);
+            setText(submittedPrompt);
+            setStartFailed(true);
+        }, RUN_START_TIMEOUT_MS);
         return () => clearTimeout(timer);
     }, [working, submittedPrompt]);
 
@@ -597,10 +648,14 @@ export function EmptyState({ onCreateFromScratch, isLibrary }: EmptyStateProps) 
     const runDetail =
         state === "completed" ? undefined : status?.label ?? (running ? "Working on it…" : undefined);
     const showOpenCopilot = !aiPanelOpen;
+    const authState = toAuthState(aiSnapshot?.state);
+    const substate = authenticatingSubstate(aiSnapshot?.state);
+    const showSetup =
+        authState !== "authenticated" && (pendingPrompt !== undefined || setupRequested);
 
     const openCopilot = () => openCopilotPanel(rpcClient);
 
-    const send = (prompt: string) => {
+    const dispatch = (prompt: string) => {
         const trimmed = prompt.trim();
         if (submitPromptToCopilot(rpcClient, trimmed, { newThread: true, hiddenContext: copy.hiddenContext })) {
             setSubmittedPrompt(trimmed);
@@ -608,137 +663,253 @@ export function EmptyState({ onCreateFromScratch, isLibrary }: EmptyStateProps) 
         }
     };
 
+    const send = async (prompt: string) => {
+        const trimmed = prompt.trim();
+        if (!trimmed) {
+            openCopilot();
+            return;
+        }
+        setStartFailed(false);
+        const authenticated =
+            authState === "authenticated" ||
+            (await rpcClient?.getAiPanelRpcClient().isUserAuthenticated().catch(() => false));
+        if (!authenticated) {
+            refreshAiSnapshot();
+            setPendingPrompt(trimmed);
+            return;
+        }
+        dispatch(trimmed);
+    };
+
+    const openSetup = () => {
+        refreshAiSnapshot();
+        setSetupRequested(true);
+    };
+
+    const dismissSetup = () => {
+        setSetupRequested(false);
+        setPendingPrompt(undefined);
+    };
+
+    useEffect(() => {
+        if (authState !== "authenticated" || pendingPrompt === undefined) {
+            return;
+        }
+        setPendingPrompt(undefined);
+        dispatch(text.trim() || pendingPrompt);
+    }, [authState, pendingPrompt, text]);
+
     const fillExample = (prompt: string) => {
         focusOnTextRef.current = true;
         setText(prompt);
     };
 
+    const setupModal = showSetup && (
+        <PopupModal
+            onClose={dismissSetup}
+            dismissOnBackdropClick={authState !== "connecting"}
+            dismissOnEscape
+            autoHeight
+            maxWidth={authState === "unauthenticated" ? undefined : 560}
+        >
+            {(close) => (
+                <>
+                    <SetupModalHeader>
+                        <CloseButton appearance="icon" onClick={close}>
+                            <Codicon name="close" />
+                        </CloseButton>
+                    </SetupModalHeader>
+                    <SetupModalBody>
+                        {authState === "unknown" || substate === "determineFlow" ? (
+                            <LoadingRing />
+                        ) : authState === "disabled" ? (
+                            <NarrowSlot>
+                                <DisabledWindow />
+                            </NarrowSlot>
+                        ) : authState === "connecting" ? (
+                            <NarrowSlot>
+                                <WaitingForLogin
+                                    embedded
+                                    loginMethod={aiSnapshot?.context?.loginMethod}
+                                    isValidating={!!substate && VALIDATING_SUBSTATES.includes(substate)}
+                                    errorMessage={aiSnapshot?.context?.errorMessage}
+                                />
+                            </NarrowSlot>
+                        ) : (
+                            <LoginSlot>
+                                <LoginPanel
+                                    embedded
+                                    subtitle={
+                                        pendingPrompt
+                                            ? "Your prompt is saved and will be sent once setup is complete."
+                                            : undefined
+                                    }
+                                />
+                            </LoginSlot>
+                        )}
+                    </SetupModalBody>
+                </>
+            )}
+        </PopupModal>
+    );
+
     return (
-        <Wrap>
-            <OrbHolder $active={showRun} $colors={orbGlow}>
-                <Sphere
-                    colors={orbColors}
-                    energy={ORB_ENERGY[state]}
-                    highlightColor={orbHighlight}
-                />
-                <IconOverlay>
-                    <Icon
-                        name="bi-ai-chat"
-                        sx={{ width: 26, height: 26 }}
-                        iconSx={{ fontSize: "26px", color: "#ffffff" }}
+        <>
+            {setupModal}
+            <Wrap>
+                <OrbAura $active={showRun} $colors={orbGlow}>
+                    <Sphere
+                        colors={orbColors}
+                        energy={ORB_ENERGY[state]}
+                        highlightColor={orbHighlight}
                     />
-                </IconOverlay>
-                {(running || (showRun && !working)) && <SpinArc color={orbGlow[1]} />}
-            </OrbHolder>
+                    <IconOverlay>
+                        <Icon
+                            name="bi-ai-chat"
+                            sx={{ width: 26, height: 26 }}
+                            iconSx={{ fontSize: "26px", color: "#ffffff" }}
+                        />
+                    </IconOverlay>
+                    {(running || (showRun && !working)) && <SpinArc color={orbGlow[1]} />}
+                </OrbAura>
 
-            {showRun && (
-                <RunBlock>
-                    <Intro>
-                        <Heading>{runHeading}</Heading>
-                        {runDetail && <Subtitle live>{runDetail}</Subtitle>}
-                    </Intro>
-                    {submittedPrompt && <PromptEcho>{submittedPrompt}</PromptEcho>}
-                    {showOpenCopilot && (
-                        <ScratchLine>
-                            <LinkButton type="button" onClick={openCopilot}>
-                                Open {assistantName}
-                            </LinkButton>
-                        </ScratchLine>
-                    )}
-                </RunBlock>
-            )}
+                {showRun && (
+                    <RunBlock>
+                        <Intro>
+                            <Heading>{runHeading}</Heading>
+                            {runDetail && <Subtitle live>{runDetail}</Subtitle>}
+                        </Intro>
+                        {submittedPrompt && <PromptEcho>{submittedPrompt}</PromptEcho>}
+                        {showOpenCopilot && (
+                            <ScratchLine>
+                                <LinkButton type="button" onClick={openCopilot}>
+                                    Open {assistantName}
+                                </LinkButton>
+                            </ScratchLine>
+                        )}
+                    </RunBlock>
+                )}
 
-            {idleMounted && (
-                <IdleBlock $out={showRun}>
-                    <div>
-                        <ExitGroup $out={showRun}>
-                            <CopilotName>{assistantName}</CopilotName>
-                            <Intro>
-                                <Heading>{copy.heading}</Heading>
-                            </Intro>
-                        </ExitGroup>
+                {idleMounted && (
+                    <IdleBlock $out={showRun}>
+                        <div>
+                            <ExitGroup $out={showRun}>
+                                <CopilotName>{assistantName}</CopilotName>
+                                <Intro>
+                                    <Heading>{copy.heading}</Heading>
+                                </Intro>
+                            </ExitGroup>
 
-                        <ExitGroup $out={showRun} $delay={110}>
-                            <ComposerRow>
-                                <ComposerFrame $variant="hero" $state={state} $agentBuilder $colors={ACCENT_FRAME}>
-                                    <Composer>
-                                        <PromptInput
-                                            ref={inputRef}
-                                            rows={2}
-                                            value={text}
-                                            onChange={(event) => setText(event.target.value)}
-                                            onKeyDown={(event) => {
-                                                if (event.key === "Enter" && !event.shiftKey) {
-                                                    event.preventDefault();
-                                                    send(text);
-                                                }
-                                            }}
-                                            placeholder={copy.placeholder}
-                                            aria-label={copy.inputLabel}
-                                        />
-                                        <ComposerFooter>
-                                            <RoundButton
-                                                type="button"
-                                                title={`Open ${assistantName}`}
-                                                onClick={openCopilot}
-                                            >
-                                                <Codicon name="add" />
-                                            </RoundButton>
-                                            <RoundButton
-                                                type="button"
-                                                title={`Send to ${assistantName}`}
-                                                aria-label={`Send to ${assistantName}`}
-                                                disabled={!text.trim()}
-                                                onClick={() => send(text)}
-                                                primary={true}
-                                            >
-                                                <Codicon name="arrow-up" />
-                                            </RoundButton>
-                                        </ComposerFooter>
-                                    </Composer>
-                                </ComposerFrame>
-                            </ComposerRow>
-                        </ExitGroup>
-
-                        <ExitGroup $out={showRun}>
-                            <ExamplesBlock>
-                                <ExamplesLabel>Examples</ExamplesLabel>
-                                <Cards>
-                                    {copy.examples.map((example) => (
-                                        <Card
-                                            key={example.name}
-                                            type="button"
-                                            onClick={() => fillExample(example.prompt)}
-                                        >
-                                            <Icon
-                                                name={example.icon}
-                                                isCodicon={example.isCodicon}
-                                                sx={{ color: "var(--vscode-foreground)" }}
-                                                iconSx={{ fontSize: "18px", color: "var(--vscode-foreground)" }}
+                            <ExitGroup $out={showRun} $delay={110}>
+                                <ComposerRow>
+                                    <ComposerFrame $variant="hero" $state={state} $agentBuilder $colors={ACCENT_FRAME}>
+                                        <Composer>
+                                            <PromptInput
+                                                ref={inputRef}
+                                                rows={2}
+                                                value={text}
+                                                onChange={(event) => setText(event.target.value)}
+                                                onKeyDown={(event) => {
+                                                    if (event.key === "Enter" && !event.shiftKey) {
+                                                        event.preventDefault();
+                                                        void send(text);
+                                                    }
+                                                }}
+                                                placeholder={copy.placeholder}
+                                                aria-label={copy.inputLabel}
                                             />
-                                            <CardText>
-                                                <CardName>{example.name}</CardName>
-                                                <CardDescription>{example.description}</CardDescription>
-                                            </CardText>
-                                        </Card>
-                                    ))}
-                                </Cards>
-                            </ExamplesBlock>
+                                            <ComposerFooter>
+                                                <FooterLeft>
+                                                    <RoundButton
+                                                        type="button"
+                                                        title={`Open ${assistantName}`}
+                                                        onClick={openCopilot}
+                                                    >
+                                                        <Codicon name="add" />
+                                                    </RoundButton>
+                                                    {authState === "unauthenticated" && (
+                                                        <FooterHint>
+                                                            <LinkButton type="button" onClick={openSetup}>
+                                                                Set up AI
+                                                            </LinkButton>{" "}
+                                                            to generate
+                                                        </FooterHint>
+                                                    )}
+                                                    {authState === "connecting" && (
+                                                        <FooterHint>
+                                                            <LinkButton type="button" onClick={openSetup}>
+                                                                Finish setting up AI
+                                                            </LinkButton>
+                                                        </FooterHint>
+                                                    )}
+                                                </FooterLeft>
+                                                <RoundButton
+                                                    type="button"
+                                                    title={`Send to ${assistantName}`}
+                                                    aria-label={`Send to ${assistantName}`}
+                                                    disabled={!text.trim()}
+                                                    onClick={() => void send(text)}
+                                                    primary={true}
+                                                >
+                                                    <Codicon name="arrow-up" />
+                                                </RoundButton>
+                                            </ComposerFooter>
+                                        </Composer>
+                                    </ComposerFrame>
+                                </ComposerRow>
 
-                            <ManualRow>
-                                or
-                                <Button
-                                    appearance="secondary"
-                                    onClick={onCreateFromScratch}
-                                    buttonSx={MANUAL_BUTTON_SX}
-                                >
-                                    {copy.manualLabel}
-                                </Button>
-                            </ManualRow>
-                        </ExitGroup>
-                    </div>
-                </IdleBlock>
-            )}
-        </Wrap>
+                                {startFailed && (
+                                    <Notice>
+                                        {assistantName} didn’t start. Try again, or{" "}
+                                        <LinkButton type="button" onClick={openCopilot}>
+                                            open {assistantName}
+                                        </LinkButton>
+                                        .
+                                    </Notice>
+                                )}
+
+                            </ExitGroup>
+
+                            <ExitGroup $out={showRun}>
+                                <ExamplesBlock>
+                                    <ExamplesLabel>Examples</ExamplesLabel>
+                                    <Cards>
+                                        {copy.examples.map((example) => (
+                                            <Card
+                                                key={example.name}
+                                                type="button"
+                                                onClick={() => fillExample(example.prompt)}
+                                            >
+                                                <Icon
+                                                    name={example.icon}
+                                                    isCodicon={example.isCodicon}
+                                                    sx={{ color: "var(--vscode-foreground)" }}
+                                                    iconSx={{ fontSize: "18px", color: "var(--vscode-foreground)" }}
+                                                />
+                                                <CardText>
+                                                    <CardName>{example.name}</CardName>
+                                                    <CardDescription>{example.description}</CardDescription>
+                                                </CardText>
+                                            </Card>
+                                        ))}
+                                    </Cards>
+                                </ExamplesBlock>
+
+                                <ManualRow>
+                                    or
+                                    <Button
+                                        appearance="secondary"
+                                        onClick={onCreateFromScratch}
+                                        buttonSx={MANUAL_BUTTON_SX}
+                                    >
+                                        {copy.manualLabel}
+                                    </Button>
+                                </ManualRow>
+                            </ExitGroup>
+                        </div>
+                    </IdleBlock>
+                )}
+            </Wrap>
+        </>
     );
 }


### PR DESCRIPTION
### Purpose

Sending a prompt from the Agent Builder overview silently did nothing when the AI panel was not authenticated. This PR lets the user complete AI setup from the overview itself, then sends the held prompt.

### Goals

- The composer checks the AI machine state before it dispatches a prompt.
- If setup is incomplete, the login flow opens in a `PopupModal` and the prompt is held. When the state reaches `Authenticated`, the prompt is dispatched.
- A footer link opens the same modal on demand: **Set up AI to generate** when unauthenticated, **Finish setting up AI** while a provider flow is open.
- A notice appears if the run never starts, so the prompt is not lost.

### Approach

**Overview (`AgentBuilderOverview/EmptyState.tsx`)**
- Reads `getAIMachineSnapshot()` and refreshes on `onAIPanelStateChanged`, mapping the machine state to `unknown | authenticated | unauthenticated | connecting | disabled`.
- Renders `LoginPanel`, `WaitingForLogin`, or `DisabledWindow` inside the modal, per that state.

**Shared auth surfaces**
- `LoginPanel` and `WaitingForLogin` take an `embedded` prop, so they drop the full-viewport wrapper when they render inside the modal.
- `AlertBox` now exports `AuthPanel` / `AuthTitle` / `AuthSubTitle` / `AuthActions`. `WaitingForLogin` uses them instead of its own duplicated `AlertContainer`, and its cancel button becomes a leading **Back** action.
- `LoginPanel` shows the orb in its header and lays the provider cards out in a grid on wide viewports.

**Supporting changes**
- `OrbHolder` moves from `EmptyState` into `AgentStatusOrb/shared` as `OrbAura`, so the login header can reuse it.
- `PopupModal` gains `autoHeight` and `maxWidth` for the shorter auth forms.
- `assistantTagline` / `useAssistantTagline` replace the hardcoded Integrator tagline in the login header.
- `RPCLayer` forwards AI state transitions to the visualizer webview. Before, only the AI panel webview received them.