### PR TITLE
Move optional fields under advanced configs in sqs trigger

### DIFF
--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/sqs.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/sqs.json
@@ -189,6 +189,67 @@
                             }
                           ]
                         },
+                        "region": {
+                          "metadata": {
+                            "label": "Region",
+                            "description": "AWS region for the SQS connection"
+                          },
+                          "value": "\"us-east-1\"",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false,
+                          "types": [
+                            {
+                              "fieldType": "SINGLE_SELECT",
+                              "ballerinaType": "string",
+                              "selected": true,
+                              "options": [
+                                { "label": "US East (N. Virginia) - us-east-1", "value": "\"us-east-1\"" },
+                                { "label": "US East (Ohio) - us-east-2", "value": "\"us-east-2\"" },
+                                { "label": "US West (N. California) - us-west-1", "value": "\"us-west-1\"" },
+                                { "label": "US West (Oregon) - us-west-2", "value": "\"us-west-2\"" },
+                                { "label": "Africa (Cape Town) - af-south-1", "value": "\"af-south-1\"" },
+                                { "label": "Asia Pacific (Hong Kong) - ap-east-1", "value": "\"ap-east-1\"" },
+                                { "label": "Asia Pacific (Mumbai) - ap-south-1", "value": "\"ap-south-1\"" },
+                                { "label": "Asia Pacific (Hyderabad) - ap-south-2", "value": "\"ap-south-2\"" },
+                                { "label": "Asia Pacific (Singapore) - ap-southeast-1", "value": "\"ap-southeast-1\"" },
+                                { "label": "Asia Pacific (Sydney) - ap-southeast-2", "value": "\"ap-southeast-2\"" },
+                                { "label": "Asia Pacific (Jakarta) - ap-southeast-3", "value": "\"ap-southeast-3\"" },
+                                { "label": "Asia Pacific (Tokyo) - ap-northeast-1", "value": "\"ap-northeast-1\"" },
+                                { "label": "Asia Pacific (Seoul) - ap-northeast-2", "value": "\"ap-northeast-2\"" },
+                                { "label": "Asia Pacific (Osaka) - ap-northeast-3", "value": "\"ap-northeast-3\"" },
+                                { "label": "Canada (Central) - ca-central-1", "value": "\"ca-central-1\"" },
+                                { "label": "Europe (Frankfurt) - eu-central-1", "value": "\"eu-central-1\"" },
+                                { "label": "Europe (Zurich) - eu-central-2", "value": "\"eu-central-2\"" },
+                                { "label": "Europe (Ireland) - eu-west-1", "value": "\"eu-west-1\"" },
+                                { "label": "Europe (London) - eu-west-2", "value": "\"eu-west-2\"" },
+                                { "label": "Europe (Paris) - eu-west-3", "value": "\"eu-west-3\"" },
+                                { "label": "Europe (Stockholm) - eu-north-1", "value": "\"eu-north-1\"" },
+                                { "label": "Europe (Milan) - eu-south-1", "value": "\"eu-south-1\"" },
+                                { "label": "Europe (Spain) - eu-south-2", "value": "\"eu-south-2\"" },
+                                { "label": "Middle East (UAE) - me-central-1", "value": "\"me-central-1\"" },
+                                { "label": "Middle East (Bahrain) - me-south-1", "value": "\"me-south-1\"" },
+                                { "label": "South America (São Paulo) - sa-east-1", "value": "\"sa-east-1\"" }
+                              ]
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "sqs:Region|string",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "region"
+                          },
+                          "validations": [
+                            {
+                              "rule": "common.validate.required"
+                            }
+                          ]
+                        },
                         "sessionToken": {
                           "metadata": {
                             "label": "Session Token",
@@ -209,11 +270,121 @@
                           "enabled": true,
                           "editable": true,
                           "optional": true,
-                          "advanced": false,
+                          "advanced": true,
                           "codedata": {
                             "argType": "LISTENER_PARAM_CONFIG_FIELD",
                             "position": 1,
                             "path": "auth.sessionToken"
+                          }
+                        },
+                        "endpoint": {
+                          "metadata": {
+                            "label": "Endpoint",
+                            "description": "Optional endpoint options: FIPS/dualstack variants, or a custom endpoint override (e.g. LocalStack, VPC interface endpoints)"
+                          },
+                          "value": "",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "sqs:EndpointConfig",
+                              "selected": true
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "endpoint"
+                          }
+                        },
+                        "pollInterval": {
+                          "metadata": {
+                            "label": "Poll Interval",
+                            "description": "Interval between polling attempts in seconds"
+                          },
+                          "placeholder": "30",
+                          "value": "1",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "decimal",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "decimal",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 2,
+                            "path": "pollInterval"
+                          }
+                        },
+                        "waitTime": {
+                          "metadata": {
+                            "label": "Wait Time",
+                            "description": "Duration in seconds for which the polling waits for messages"
+                          },
+                          "placeholder": "20",
+                          "value": "20",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "int",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "int",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 2,
+                            "path": "waitTime"
+                          }
+                        },
+                        "visibilityTimeout": {
+                          "metadata": {
+                            "label": "Visibility Timeout",
+                            "description": "Duration in seconds for which the received message remains invisible to other consumers"
+                          },
+                          "placeholder": "30",
+                          "value": "30",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "int",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "int",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 2,
+                            "path": "visibilityTimeout"
                           }
                         }
                       }
@@ -256,6 +427,67 @@
                             "path": "auth.profileName"
                           }
                         },
+                        "region": {
+                          "metadata": {
+                            "label": "Region",
+                            "description": "AWS region for the SQS connection"
+                          },
+                          "value": "\"us-east-1\"",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false,
+                          "types": [
+                            {
+                              "fieldType": "SINGLE_SELECT",
+                              "ballerinaType": "string",
+                              "selected": true,
+                              "options": [
+                                { "label": "US East (N. Virginia) - us-east-1", "value": "\"us-east-1\"" },
+                                { "label": "US East (Ohio) - us-east-2", "value": "\"us-east-2\"" },
+                                { "label": "US West (N. California) - us-west-1", "value": "\"us-west-1\"" },
+                                { "label": "US West (Oregon) - us-west-2", "value": "\"us-west-2\"" },
+                                { "label": "Africa (Cape Town) - af-south-1", "value": "\"af-south-1\"" },
+                                { "label": "Asia Pacific (Hong Kong) - ap-east-1", "value": "\"ap-east-1\"" },
+                                { "label": "Asia Pacific (Mumbai) - ap-south-1", "value": "\"ap-south-1\"" },
+                                { "label": "Asia Pacific (Hyderabad) - ap-south-2", "value": "\"ap-south-2\"" },
+                                { "label": "Asia Pacific (Singapore) - ap-southeast-1", "value": "\"ap-southeast-1\"" },
+                                { "label": "Asia Pacific (Sydney) - ap-southeast-2", "value": "\"ap-southeast-2\"" },
+                                { "label": "Asia Pacific (Jakarta) - ap-southeast-3", "value": "\"ap-southeast-3\"" },
+                                { "label": "Asia Pacific (Tokyo) - ap-northeast-1", "value": "\"ap-northeast-1\"" },
+                                { "label": "Asia Pacific (Seoul) - ap-northeast-2", "value": "\"ap-northeast-2\"" },
+                                { "label": "Asia Pacific (Osaka) - ap-northeast-3", "value": "\"ap-northeast-3\"" },
+                                { "label": "Canada (Central) - ca-central-1", "value": "\"ca-central-1\"" },
+                                { "label": "Europe (Frankfurt) - eu-central-1", "value": "\"eu-central-1\"" },
+                                { "label": "Europe (Zurich) - eu-central-2", "value": "\"eu-central-2\"" },
+                                { "label": "Europe (Ireland) - eu-west-1", "value": "\"eu-west-1\"" },
+                                { "label": "Europe (London) - eu-west-2", "value": "\"eu-west-2\"" },
+                                { "label": "Europe (Paris) - eu-west-3", "value": "\"eu-west-3\"" },
+                                { "label": "Europe (Stockholm) - eu-north-1", "value": "\"eu-north-1\"" },
+                                { "label": "Europe (Milan) - eu-south-1", "value": "\"eu-south-1\"" },
+                                { "label": "Europe (Spain) - eu-south-2", "value": "\"eu-south-2\"" },
+                                { "label": "Middle East (UAE) - me-central-1", "value": "\"me-central-1\"" },
+                                { "label": "Middle East (Bahrain) - me-south-1", "value": "\"me-south-1\"" },
+                                { "label": "South America (São Paulo) - sa-east-1", "value": "\"sa-east-1\"" }
+                              ]
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "sqs:Region|string",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "region"
+                          },
+                          "validations": [
+                            {
+                              "rule": "common.validate.required"
+                            }
+                          ]
+                        },
                         "credentialsFilePath": {
                           "metadata": {
                             "label": "Credentials File Path",
@@ -272,11 +504,121 @@
                           "enabled": true,
                           "editable": true,
                           "optional": true,
-                          "advanced": false,
+                          "advanced": true,
                           "codedata": {
                             "argType": "LISTENER_PARAM_CONFIG_FIELD",
                             "position": 1,
                             "path": "auth.credentialsFilePath"
+                          }
+                        },
+                        "endpoint": {
+                          "metadata": {
+                            "label": "Endpoint",
+                            "description": "Optional endpoint options: FIPS/dualstack variants, or a custom endpoint override (e.g. LocalStack, VPC interface endpoints)"
+                          },
+                          "value": "",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "sqs:EndpointConfig",
+                              "selected": true
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "endpoint"
+                          }
+                        },
+                        "pollInterval": {
+                          "metadata": {
+                            "label": "Poll Interval",
+                            "description": "Interval between polling attempts in seconds"
+                          },
+                          "placeholder": "30",
+                          "value": "1",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "decimal",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "decimal",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 2,
+                            "path": "pollInterval"
+                          }
+                        },
+                        "waitTime": {
+                          "metadata": {
+                            "label": "Wait Time",
+                            "description": "Duration in seconds for which the polling waits for messages"
+                          },
+                          "placeholder": "20",
+                          "value": "20",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "int",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "int",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 2,
+                            "path": "waitTime"
+                          }
+                        },
+                        "visibilityTimeout": {
+                          "metadata": {
+                            "label": "Visibility Timeout",
+                            "description": "Duration in seconds for which the received message remains invisible to other consumers"
+                          },
+                          "placeholder": "30",
+                          "value": "30",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "int",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "int",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 2,
+                            "path": "visibilityTimeout"
                           }
                         }
                       }
@@ -318,154 +660,181 @@
                             "position": 1,
                             "path": "auth"
                           }
+                        },
+                        "region": {
+                          "metadata": {
+                            "label": "Region",
+                            "description": "AWS region for the SQS connection"
+                          },
+                          "value": "\"us-east-1\"",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false,
+                          "types": [
+                            {
+                              "fieldType": "SINGLE_SELECT",
+                              "ballerinaType": "string",
+                              "selected": true,
+                              "options": [
+                                { "label": "US East (N. Virginia) - us-east-1", "value": "\"us-east-1\"" },
+                                { "label": "US East (Ohio) - us-east-2", "value": "\"us-east-2\"" },
+                                { "label": "US West (N. California) - us-west-1", "value": "\"us-west-1\"" },
+                                { "label": "US West (Oregon) - us-west-2", "value": "\"us-west-2\"" },
+                                { "label": "Africa (Cape Town) - af-south-1", "value": "\"af-south-1\"" },
+                                { "label": "Asia Pacific (Hong Kong) - ap-east-1", "value": "\"ap-east-1\"" },
+                                { "label": "Asia Pacific (Mumbai) - ap-south-1", "value": "\"ap-south-1\"" },
+                                { "label": "Asia Pacific (Hyderabad) - ap-south-2", "value": "\"ap-south-2\"" },
+                                { "label": "Asia Pacific (Singapore) - ap-southeast-1", "value": "\"ap-southeast-1\"" },
+                                { "label": "Asia Pacific (Sydney) - ap-southeast-2", "value": "\"ap-southeast-2\"" },
+                                { "label": "Asia Pacific (Jakarta) - ap-southeast-3", "value": "\"ap-southeast-3\"" },
+                                { "label": "Asia Pacific (Tokyo) - ap-northeast-1", "value": "\"ap-northeast-1\"" },
+                                { "label": "Asia Pacific (Seoul) - ap-northeast-2", "value": "\"ap-northeast-2\"" },
+                                { "label": "Asia Pacific (Osaka) - ap-northeast-3", "value": "\"ap-northeast-3\"" },
+                                { "label": "Canada (Central) - ca-central-1", "value": "\"ca-central-1\"" },
+                                { "label": "Europe (Frankfurt) - eu-central-1", "value": "\"eu-central-1\"" },
+                                { "label": "Europe (Zurich) - eu-central-2", "value": "\"eu-central-2\"" },
+                                { "label": "Europe (Ireland) - eu-west-1", "value": "\"eu-west-1\"" },
+                                { "label": "Europe (London) - eu-west-2", "value": "\"eu-west-2\"" },
+                                { "label": "Europe (Paris) - eu-west-3", "value": "\"eu-west-3\"" },
+                                { "label": "Europe (Stockholm) - eu-north-1", "value": "\"eu-north-1\"" },
+                                { "label": "Europe (Milan) - eu-south-1", "value": "\"eu-south-1\"" },
+                                { "label": "Europe (Spain) - eu-south-2", "value": "\"eu-south-2\"" },
+                                { "label": "Middle East (UAE) - me-central-1", "value": "\"me-central-1\"" },
+                                { "label": "Middle East (Bahrain) - me-south-1", "value": "\"me-south-1\"" },
+                                { "label": "South America (São Paulo) - sa-east-1", "value": "\"sa-east-1\"" }
+                              ]
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "sqs:Region|string",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "region"
+                          },
+                          "validations": [
+                            {
+                              "rule": "common.validate.required"
+                            }
+                          ]
+                        },
+                        "endpoint": {
+                          "metadata": {
+                            "label": "Endpoint",
+                            "description": "Optional endpoint options: FIPS/dualstack variants, or a custom endpoint override (e.g. LocalStack, VPC interface endpoints)"
+                          },
+                          "value": "",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "sqs:EndpointConfig",
+                              "selected": true
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "endpoint"
+                          }
+                        },
+                        "pollInterval": {
+                          "metadata": {
+                            "label": "Poll Interval",
+                            "description": "Interval between polling attempts in seconds"
+                          },
+                          "placeholder": "30",
+                          "value": "1",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "decimal",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "decimal",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 2,
+                            "path": "pollInterval"
+                          }
+                        },
+                        "waitTime": {
+                          "metadata": {
+                            "label": "Wait Time",
+                            "description": "Duration in seconds for which the polling waits for messages"
+                          },
+                          "placeholder": "20",
+                          "value": "20",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "int",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "int",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 2,
+                            "path": "waitTime"
+                          }
+                        },
+                        "visibilityTimeout": {
+                          "metadata": {
+                            "label": "Visibility Timeout",
+                            "description": "Duration in seconds for which the received message remains invisible to other consumers"
+                          },
+                          "placeholder": "30",
+                          "value": "30",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "int",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "int",
+                              "selected": false
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 2,
+                            "path": "visibilityTimeout"
+                          }
                         }
                       }
                     }
                   ]
-                },
-                "region": {
-                  "metadata": {
-                    "label": "Region",
-                    "description": "AWS region (e.g. us-east-1)"
-                  },
-                  "placeholder": "us-east-1",
-                  "value": "\"us-east-1\"",
-                  "enabled": true,
-                  "editable": true,
-                  "optional": false,
-                  "advanced": false,
-                  "types": [
-                    {
-                      "fieldType": "TEXT",
-                      "ballerinaType": "string",
-                      "selected": true
-                    },
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "sqs:Region|string",
-                      "selected": false
-                    }
-                  ],
-                  "codedata": {
-                    "argType": "LISTENER_PARAM_CONFIG_FIELD",
-                    "position": 1,
-                    "path": "region"
-                  },
-                  "validations": [
-                    {
-                      "rule": "common.validate.required"
-                    }
-                  ]
-                },
-                "endpoint": {
-                  "metadata": {
-                    "label": "Endpoint",
-                    "description": "Optional endpoint options: FIPS/dualstack variants, or a custom endpoint override (e.g. LocalStack, VPC interface endpoints)"
-                  },
-                  "value": "",
-                  "enabled": true,
-                  "editable": true,
-                  "optional": true,
-                  "advanced": true,
-                  "types": [
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "sqs:EndpointConfig",
-                      "selected": true
-                    }
-                  ],
-                  "codedata": {
-                    "argType": "LISTENER_PARAM_CONFIG_FIELD",
-                    "position": 1,
-                    "path": "endpoint"
-                  }
-                },
-                "pollInterval": {
-                  "metadata": {
-                    "label": "Poll Interval",
-                    "description": "Interval between polling attempts in seconds"
-                  },
-                  "placeholder": "1",
-                  "value": "1",
-                  "enabled": true,
-                  "editable": true,
-                  "optional": true,
-                  "advanced": true,
-                  "types": [
-                    {
-                      "fieldType": "NUMBER",
-                      "ballerinaType": "decimal",
-                      "selected": true
-                    },
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "decimal",
-                      "selected": false
-                    }
-                  ],
-                  "codedata": {
-                    "argType": "LISTENER_PARAM_CONFIG_FIELD",
-                    "position": 2,
-                    "path": "pollInterval"
-                  }
-                },
-                "waitTime": {
-                  "metadata": {
-                    "label": "Wait Time",
-                    "description": "Duration in seconds for which the polling waits for messages"
-                  },
-                  "placeholder": "20",
-                  "value": "20",
-                  "enabled": true,
-                  "editable": true,
-                  "optional": true,
-                  "advanced": true,
-                  "types": [
-                    {
-                      "fieldType": "NUMBER",
-                      "ballerinaType": "int",
-                      "selected": true
-                    },
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "int",
-                      "selected": false
-                    }
-                  ],
-                  "codedata": {
-                    "argType": "LISTENER_PARAM_CONFIG_FIELD",
-                    "position": 2,
-                    "path": "waitTime"
-                  }
-                },
-                "visibilityTimeout": {
-                  "metadata": {
-                    "label": "Visibility Timeout",
-                    "description": "Duration in seconds for which the received message remains invisible to other consumers"
-                  },
-                  "placeholder": "30",
-                  "value": "30",
-                  "enabled": true,
-                  "editable": true,
-                  "optional": true,
-                  "advanced": true,
-                  "types": [
-                    {
-                      "fieldType": "NUMBER",
-                      "ballerinaType": "int",
-                      "selected": true
-                    },
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "int",
-                      "selected": false
-                    }
-                  ],
-                  "codedata": {
-                    "argType": "LISTENER_PARAM_CONFIG_FIELD",
-                    "position": 2,
-                    "path": "visibilityTimeout"
-                  }
                 }
               }
             }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/sqs.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/sqs.json
@@ -277,10 +277,56 @@
                             "path": "auth.sessionToken"
                           }
                         },
-                        "endpoint": {
+                        "fips": {
                           "metadata": {
-                            "label": "Endpoint",
-                            "description": "Optional endpoint options: FIPS/dualstack variants, or a custom endpoint override (e.g. LocalStack, VPC interface endpoints)"
+                            "label": "FIPS",
+                            "description": "Use the FIPS 140-validated endpoint variant"
+                          },
+                          "value": false,
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "FLAG",
+                              "ballerinaType": "boolean",
+                              "selected": true
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "endpoint.fips"
+                          }
+                        },
+                        "dualstack": {
+                          "metadata": {
+                            "label": "Dualstack",
+                            "description": "Use the dualstack (IPv4/IPv6) endpoint variant"
+                          },
+                          "value": false,
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "FLAG",
+                              "ballerinaType": "boolean",
+                              "selected": true
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "endpoint.dualstack"
+                          }
+                        },
+                        "customEndpoint": {
+                          "metadata": {
+                            "label": "Custom Endpoint",
+                            "description": "Full endpoint URL override (e.g. http://localhost:4566). When set, FIPS and Dualstack options are ignored."
                           },
                           "value": "",
                           "enabled": true,
@@ -289,15 +335,20 @@
                           "advanced": true,
                           "types": [
                             {
-                              "fieldType": "EXPRESSION",
-                              "ballerinaType": "sqs:EndpointConfig",
+                              "fieldType": "TEXT",
+                              "ballerinaType": "string",
                               "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "string",
+                              "selected": false
                             }
                           ],
                           "codedata": {
                             "argType": "LISTENER_PARAM_CONFIG_FIELD",
                             "position": 1,
-                            "path": "endpoint"
+                            "path": "endpoint.customEndpoint"
                           }
                         },
                         "pollInterval": {
@@ -511,10 +562,56 @@
                             "path": "auth.credentialsFilePath"
                           }
                         },
-                        "endpoint": {
+                        "fips": {
                           "metadata": {
-                            "label": "Endpoint",
-                            "description": "Optional endpoint options: FIPS/dualstack variants, or a custom endpoint override (e.g. LocalStack, VPC interface endpoints)"
+                            "label": "FIPS",
+                            "description": "Use the FIPS 140-validated endpoint variant"
+                          },
+                          "value": false,
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "FLAG",
+                              "ballerinaType": "boolean",
+                              "selected": true
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "endpoint.fips"
+                          }
+                        },
+                        "dualstack": {
+                          "metadata": {
+                            "label": "Dualstack",
+                            "description": "Use the dualstack (IPv4/IPv6) endpoint variant"
+                          },
+                          "value": false,
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "FLAG",
+                              "ballerinaType": "boolean",
+                              "selected": true
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "endpoint.dualstack"
+                          }
+                        },
+                        "customEndpoint": {
+                          "metadata": {
+                            "label": "Custom Endpoint",
+                            "description": "Full endpoint URL override (e.g. http://localhost:4566). When set, FIPS and Dualstack options are ignored."
                           },
                           "value": "",
                           "enabled": true,
@@ -523,15 +620,20 @@
                           "advanced": true,
                           "types": [
                             {
-                              "fieldType": "EXPRESSION",
-                              "ballerinaType": "sqs:EndpointConfig",
+                              "fieldType": "TEXT",
+                              "ballerinaType": "string",
                               "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "string",
+                              "selected": false
                             }
                           ],
                           "codedata": {
                             "argType": "LISTENER_PARAM_CONFIG_FIELD",
                             "position": 1,
-                            "path": "endpoint"
+                            "path": "endpoint.customEndpoint"
                           }
                         },
                         "pollInterval": {
@@ -722,10 +824,56 @@
                             }
                           ]
                         },
-                        "endpoint": {
+                        "fips": {
                           "metadata": {
-                            "label": "Endpoint",
-                            "description": "Optional endpoint options: FIPS/dualstack variants, or a custom endpoint override (e.g. LocalStack, VPC interface endpoints)"
+                            "label": "FIPS",
+                            "description": "Use the FIPS 140-validated endpoint variant"
+                          },
+                          "value": false,
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "FLAG",
+                              "ballerinaType": "boolean",
+                              "selected": true
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "endpoint.fips"
+                          }
+                        },
+                        "dualstack": {
+                          "metadata": {
+                            "label": "Dualstack",
+                            "description": "Use the dualstack (IPv4/IPv6) endpoint variant"
+                          },
+                          "value": false,
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "types": [
+                            {
+                              "fieldType": "FLAG",
+                              "ballerinaType": "boolean",
+                              "selected": true
+                            }
+                          ],
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_CONFIG_FIELD",
+                            "position": 1,
+                            "path": "endpoint.dualstack"
+                          }
+                        },
+                        "customEndpoint": {
+                          "metadata": {
+                            "label": "Custom Endpoint",
+                            "description": "Full endpoint URL override (e.g. http://localhost:4566). When set, FIPS and Dualstack options are ignored."
                           },
                           "value": "",
                           "enabled": true,
@@ -734,15 +882,20 @@
                           "advanced": true,
                           "types": [
                             {
-                              "fieldType": "EXPRESSION",
-                              "ballerinaType": "sqs:EndpointConfig",
+                              "fieldType": "TEXT",
+                              "ballerinaType": "string",
                               "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "string",
+                              "selected": false
                             }
                           ],
                           "codedata": {
                             "argType": "LISTENER_PARAM_CONFIG_FIELD",
                             "position": 1,
-                            "path": "endpoint"
+                            "path": "endpoint.customEndpoint"
                           }
                         },
                         "pollInterval": {


### PR DESCRIPTION
## Purpose

The updated SQS trigger form look like this.

<img width="703" height="743" alt="Screenshot 2026-08-23 at 18 23 51" src="https://github.com/user-attachments/assets/257673bb-bb2b-4173-a6be-77c49e5a930c" />

<img width="684" height="745" alt="Screenshot 2026-08-23 at 18 24 01" src="https://github.com/user-attachments/assets/b12e0dd3-7639-478e-8a8e-4fc4023f8823" />
