### PR TITLE
Support multiple listeners per trigger connector

### DIFF
--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/trigger/models/TriggerUISchemaModel.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/trigger/models/TriggerUISchemaModel.java
@@ -45,6 +45,10 @@ import java.util.Map;
  *                     {@code SINGLE_SELECT_LISTENER} / {@code MULTIPLE_SELECT_LISTENER}); defaults to
  *                     {@code SINGLE_SELECT_LISTENER} when a model omits it
  * @param initProperties   the init/listener form fields, keyed by property name
+ * @param listenerForm presentation text for the derived listener field; absent → generic defaults
+ * @param listeners    the listener(s) a service may attach to, each with its own configuration set. The
+ *                     init form's listener field is derived from this rather than authored. Absent → the
+ *                     connector authored that field directly under {@code initProperties}
  * @param serviceTypes     the service type(s) this trigger offers
  * @param readOnlyMetadata read-only summary chips shown on the service card
  * @param importStatements extra import statements required by generated code
@@ -68,10 +72,57 @@ public record TriggerUISchemaModel(
         String kind,
         String listenerKind,
         Map<String, Property> initProperties,
+        ListenerFormModel listenerForm,
+        List<ListenerModel> listeners,
         List<ServiceTypeModel> serviceTypes,
         List<ReadOnlyMetadata> readOnlyMetadata,
         List<String> importStatements,
         String importPrefix) {
+
+    /**
+     * Presentation text for the derived listener field, so a connector can name the section and the switch
+     * in its own terms. Both optional, falling back to generic wording.
+     *
+     * @param section      the group a listener's constructor fields sit in; defaults to
+     *                     "Listener Configuration"
+     * @param typeSelector the switch between listener kinds. Its {@code description} is what the form
+     *                     renders above the options; defaults to "Listener Type"
+     */
+    public record ListenerFormModel(
+            Metadata section,
+            Metadata typeSelector) {
+    }
+
+    /**
+     * One listener a service may attach to, and the configuration set that listener alone takes. A connector
+     * may declare more than one — {@code ballerina/mcp} offers a Streamable HTTP listener plus an older one
+     * deprecated in favour of it — and the two need not take the same parameters.
+     *
+     * @param metadata         display metadata; {@code deprecated}/{@code notice} carry a deprecation
+     *                         reason through to the form's badge
+     * @param name             the listener type's simple name, e.g. {@code StreamableHttpListener}
+     * @param ballerinaType    the module-qualified type, e.g. {@code mcp:StreamableHttpListener}. This is
+     *                         what source generation emits and what identifies this listener among its
+     *                         siblings, so it must be distinct across a connector's listeners
+     * @param enabled          whether this is the listener offered by default; absent -> the first
+     *                         non-deprecated entry
+     * @param initProperties    what constructs this listener: its variable name and constructor arguments
+     * @param serviceProperties service-level fields this listener alone gives meaning to, such as a base
+     *                          path an HTTP transport has and one without a URL space does not. Offered,
+     *                          emitted and validated only while this listener is selected. A field every
+     *                          listener shares belongs in the model's {@code initProperties} instead
+     * @param serviceTypes      names of the {@link ServiceTypeModel}s this listener can host; absent or
+     *                          empty means all of them. Carried but not yet acted on
+     */
+    public record ListenerModel(
+            Metadata metadata,
+            String name,
+            String ballerinaType,
+            Boolean enabled,
+            Map<String, Property> initProperties,
+            Map<String, Property> serviceProperties,
+            List<String> serviceTypes) {
+    }
 
     /**
      * A service-object type and its handler functions. {@code functions} are present/locked handlers;

--- a/packages/ballerina-language-server/model-generator-commons/src/test/java/io/ballerina/modelgenerator/commons/trigger/BundledTriggerMetadataTest.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/test/java/io/ballerina/modelgenerator/commons/trigger/BundledTriggerMetadataTest.java
@@ -150,6 +150,46 @@ public class BundledTriggerMetadataTest {
     }
 
     /**
+     * Spec §2: a document may declare more than one listener, and the two invariants the UI schema's
+     * listener branching rests on — a branch is identified by its listener type's simple name, so two
+     * listeners may not share one; and side effects are emitted per document rather than per selected
+     * branch, so every listener in a document must need the same ones.
+     */
+    @Test
+    public void testMultiListenerDocumentsAreDistinctAndAgreeOnSideEffects() {
+        int multiListenerDocuments = 0;
+        for (String module : bundledModules()) {
+            List<TriggerMetadataModel.Listener> listeners = read(module).listeners();
+            if (listeners.size() < 2) {
+                continue;
+            }
+            multiListenerDocuments++;
+            Set<String> typeNames = new HashSet<>();
+            for (TriggerMetadataModel.Listener listener : listeners) {
+                Assert.assertNotNull(listener.type(), module + ": listeners[].type is required");
+                String typeName = listener.type().name();
+                assertProse(typeName, module + ": listeners[].type.name");
+                Assert.assertTrue(typeNames.add(typeName), module + ": two listeners both named `" + typeName
+                        + "`. A listener branch is identified by its type name, so a duplicate makes"
+                        + " matching a declared listener back to its branch ambiguous.");
+            }
+            TriggerMetadataModel.Listener first = listeners.get(0);
+            for (TriggerMetadataModel.Listener listener : listeners) {
+                Assert.assertEquals(asSet(listener.requiredImports()), asSet(first.requiredImports()),
+                        module + ": " + listener.type().name() + " needs different imports than "
+                                + first.type().name() + ". Imports are emitted per document, not per"
+                                + " selected branch, so they must be scoped to the branch first.");
+                Assert.assertEquals(asSet(listener.platformDependencies()), asSet(first.platformDependencies()),
+                        module + ": " + listener.type().name() + " needs different platform dependencies"
+                                + " than " + first.type().name() + ". Same reason as imports.");
+            }
+        }
+        Assert.assertTrue(multiListenerDocuments > 0, "No document in the corpus declares more than one"
+                + " listener, so this test would pass even if the invariants it pins were violated."
+                + " ballerina/mcp is the instance: StreamableHttpListener plus a deprecated Listener.");
+    }
+
+    /**
      * Spec §0: a handler, its params and its return carry hierarchical ids scoped under their owner.
      *
      * <p>Also pins the containment rule the spec states in prose — "built by appending the child's own name
@@ -452,6 +492,11 @@ public class BundledTriggerMetadataTest {
 
     private static List<TriggerMetadataModel.Subject> safeSubjects(List<TriggerMetadataModel.Subject> subjects) {
         return subjects == null ? List.of() : subjects;
+    }
+
+    /** A list compared by membership rather than order; absent and empty are the same thing here. */
+    private static <T> Set<T> asSet(List<T> values) {
+        return values == null ? Set.of() : new HashSet<>(values);
     }
 
     private static void assertId(String id, String where) {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/SchemaDrivenServiceBuilder.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/SchemaDrivenServiceBuilder.java
@@ -282,29 +282,44 @@ public class SchemaDrivenServiceBuilder extends AbstractServiceBuilder {
                 }
             }
         }
+        if (node.getChoices() != null) {
+            for (Value choice : node.getChoices()) {
+                if (hasListenerParams(choice)) {
+                    return true;
+                }
+            }
+        }
         return false;
     }
 
-    /** Replaces the shipped default listener variable name with a project-unique identifier. */
+    /**
+     * Replaces the shipped default listener variable name with a project-unique identifier, on every
+     * listener-name node. The branches are mutually exclusive, so they should all offer the same name.
+     */
     private void refreshListenerName(ServiceInitModel creationModel, GetServiceInitModelContext context) {
-        // Unified model nests it inside the listener CHOICE's create-new branch; v1 has it top-level.
-        Value listenerName = creationModel.getProperties().get(KEY_LISTENER_VAR_NAME);
-        if (listenerName == null) {
-            listenerName = findListenerVarNameNode(creationModel.getProperties());
+        List<Value> listenerNames = new ArrayList<>();
+        Value topLevel = creationModel.getProperties().get(KEY_LISTENER_VAR_NAME);
+        if (topLevel != null) {
+            listenerNames.add(topLevel);
+        } else {
+            collectListenerVarNameNodes(creationModel.getProperties(), listenerNames);
         }
-        if (listenerName == null) {
+        if (listenerNames.isEmpty()) {
             return;
         }
         String baseName = LISTENER_VAR_NAME.formatted(getProtocol(context.moduleName()));
-        Codedata codedata = listenerName.getCodedata();
-        String shippedName = listenerName.getValue();
-        if (codedata != null && Boolean.TRUE.equals(codedata.getPreserveValue())
-                && shippedName != null && !shippedName.isBlank()) {
-            baseName = shippedName.trim();
+        for (Value listenerName : listenerNames) {
+            Codedata codedata = listenerName.getCodedata();
+            String shippedName = listenerName.getValue();
+            if (codedata != null && Boolean.TRUE.equals(codedata.getPreserveValue())
+                    && shippedName != null && !shippedName.isBlank()) {
+                baseName = shippedName.trim();
+                break;
+            }
         }
         String uniqueName = Utils.generateVariableIdentifier(context.semanticModel(), context.document(),
                 context.document().syntaxTree().rootNode().lineRange().endLine(), baseName);
-        listenerName.setValue(uniqueName);
+        listenerNames.forEach(listenerName -> listenerName.setValue(uniqueName));
     }
 
     /** Locates the listener create/reuse CHOICE, by the v1 key or by {@code codedata.type == LISTENER_CONFIG}. */
@@ -322,10 +337,10 @@ public class SchemaDrivenServiceBuilder extends AbstractServiceBuilder {
         return null;
     }
 
-    /** Recursively locates the listener-variable-name node ({@code codedata.type == LISTENER_VAR_NAME}). */
-    private static Value findListenerVarNameNode(Map<String, Value> properties) {
+    /** Every {@code LISTENER_VAR_NAME} node in the subtree, in document order. */
+    static void collectListenerVarNameNodes(Map<String, Value> properties, List<Value> into) {
         if (properties == null) {
-            return null;
+            return;
         }
         for (Value value : properties.values()) {
             if (value == null) {
@@ -333,21 +348,16 @@ public class SchemaDrivenServiceBuilder extends AbstractServiceBuilder {
             }
             Codedata codedata = value.getCodedata();
             if (codedata != null && ARG_TYPE_LISTENER_VAR_NAME.equals(codedata.getType())) {
-                return value;
+                into.add(value);
             }
-            Value nested = findListenerVarNameNode(value.getProperties());
-            if (nested != null) {
-                return nested;
-            }
+            collectListenerVarNameNodes(value.getProperties(), into);
             if (value.getChoices() != null) {
                 for (Value choice : value.getChoices()) {
-                    Value found = findListenerVarNameNode(choice.getProperties());
-                    if (found != null) {
-                        return found;
+                    if (choice != null) {
+                        collectListenerVarNameNodes(choice.getProperties(), into);
                     }
                 }
             }
         }
-        return null;
     }
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/ExistingListenerResolver.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/ExistingListenerResolver.java
@@ -49,6 +49,7 @@ import io.ballerina.tools.text.TextRange;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,8 @@ import static io.ballerina.servicemodelgenerator.extension.util.Constants.ARG_TY
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.ARG_TYPE_LISTENER_PARAM_INCLUDED_FIELD;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.ARG_TYPE_LISTENER_PARAM_REQUIRED;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_ENUM_VALUE;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_TYPE;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_VAR_NAME;
 
 /**
  * Builds the "use existing" listener selector for the schema-driven path, resolving each existing
@@ -87,13 +90,19 @@ public final class ExistingListenerResolver {
      */
     public static Value buildSelector(Value createNewBranch, List<String> listenerNames,
                                       SemanticModel semanticModel, Project project, String protocol) {
-        ListenerTemplate template = collectTemplate(createNewBranch);
-        Map<String, Value> createNewProps = createNewBranch == null ? null : createNewBranch.getProperties();
         // Resolved once for every name here, instead of each parseListener call re-scanning every
-        // module symbol -- O(listenerNames + moduleSymbols) instead of O(listenerNames * moduleSymbols).
+        // module symbol — O(listenerNames + moduleSymbols) instead of O(listenerNames * moduleSymbols).
         Map<String, VariableSymbol> listenerSymbolsByName = listenerSymbolsByName(semanticModel);
+        List<Value> typeBranches = listenerTypeBranches(createNewBranch);
+        Map<Value, ListenerTemplate> templatesByBranch = new IdentityHashMap<>();
+        ListenerTemplate singleTemplate = typeBranches.isEmpty() ? collectTemplate(createNewBranch) : null;
         Map<String, Value> perListenerConfigs = new LinkedHashMap<>();
         for (String name : listenerNames) {
+            Value branch = typeBranches.isEmpty() ? createNewBranch
+                    : matchByListenerType(typeBranches, declaredTypeOf(listenerSymbolsByName.get(name)));
+            ListenerTemplate template = typeBranches.isEmpty() ? singleTemplate
+                    : templatesByBranch.computeIfAbsent(branch, ExistingListenerResolver::collectTemplate);
+            Map<String, Value> createNewProps = branch == null ? null : branch.getProperties();
             Map<String, Value> fields = new LinkedHashMap<>();
             parseListener(name, listenerSymbolsByName, project).ifPresent(parsed -> {
                 fields.putAll(buildFieldsFromParsed(parsed, template));
@@ -156,6 +165,108 @@ public final class ExistingListenerResolver {
                 .setItems(new ArrayList<>(listenerNames))
                 .setProperties(perListenerConfigs)
                 .build();
+    }
+
+    /** The per-listener-type branches, or empty when the connector declares one listener. */
+    static List<Value> listenerTypeBranches(Value createNewBranch) {
+        if (createNewBranch == null) {
+            return List.of();
+        }
+        Value selector = findListenerTypeSelector(createNewBranch.getProperties());
+        return selector == null || selector.getChoices() == null ? List.of() : selector.getChoices();
+    }
+
+    private static Value findListenerTypeSelector(Map<String, Value> properties) {
+        if (properties == null) {
+            return null;
+        }
+        for (Value value : properties.values()) {
+            if (value == null) {
+                continue;
+            }
+            Codedata codedata = value.getCodedata();
+            if (codedata != null && CD_TYPE_LISTENER_TYPE.equals(codedata.getType())) {
+                return value;
+            }
+            if (isGroup(value)) {
+                Value nested = findListenerTypeSelector(value.getProperties());
+                if (nested != null) {
+                    return nested;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The type a declared listener was written as, e.g. {@code StreamableHttpListener} for
+     * {@code listener mcp:StreamableHttpListener l = ...}. Null when it cannot be read.
+     */
+    private static String declaredTypeOf(VariableSymbol symbol) {
+        if (symbol == null || symbol.typeDescriptor() == null) {
+            return null;
+        }
+        return symbol.typeDescriptor().getName()
+                .orElseGet(() -> {
+                    String signature = symbol.typeDescriptor().signature();
+                    return signature == null || signature.isBlank()
+                            ? null : TriggerModelSynthesizer.simpleName(signature);
+                });
+    }
+
+    /**
+     * The branch describing {@code typeSimpleName}, matched on the listener type its name field states. An
+     * unreadable or unrecognised type falls back to the selected branch, then the first.
+     */
+    static Value matchByListenerType(List<Value> branches, String typeSimpleName) {
+        if (typeSimpleName != null) {
+            for (Value branch : branches) {
+                String branchType = branchListenerType(branch);
+                if (branchType != null && branchType.equalsIgnoreCase(typeSimpleName)) {
+                    return branch;
+                }
+            }
+        }
+        for (Value branch : branches) {
+            if (branch.isEnabled()) {
+                return branch;
+            }
+        }
+        return branches.isEmpty() ? null : branches.getFirst();
+    }
+
+    /** The listener type one branch describes, from its {@code LISTENER_VAR_NAME} field's declared type. */
+    private static String branchListenerType(Value branch) {
+        Value varName = findListenerVarName(branch == null ? null : branch.getProperties());
+        if (varName == null || varName.getTypes() == null) {
+            return null;
+        }
+        for (PropertyType type : varName.getTypes()) {
+            if (type.ballerinaType() != null && !type.ballerinaType().isBlank()) {
+                return TriggerModelSynthesizer.simpleName(type.ballerinaType());
+            }
+        }
+        return null;
+    }
+
+    private static Value findListenerVarName(Map<String, Value> properties) {
+        if (properties == null) {
+            return null;
+        }
+        for (Value value : properties.values()) {
+            if (value == null) {
+                continue;
+            }
+            Codedata codedata = value.getCodedata();
+            if (codedata != null && CD_TYPE_LISTENER_VAR_NAME.equals(codedata.getType())) {
+                return value;
+            }
+            Value nested = findListenerVarName(value.getProperties());
+            if (nested != null) {
+                return nested;
+            }
+        }
+        return null;
     }
 
     /** The listener-parameter field template derived from the create-new branch. */

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/ListenerChoiceDeriver.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/ListenerChoiceDeriver.java
@@ -1,0 +1,227 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.servicemodelgenerator.extension.connector;
+
+import io.ballerina.modelgenerator.commons.trigger.models.TriggerUISchemaModel;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_EXISTING_LISTENER;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_CONFIG;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_TYPE;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.PROP_KEY_LISTENER;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.PROP_KEY_LISTENER_TYPE;
+
+/**
+ * Builds the init form's listener field from a connector's declared
+ * {@link TriggerUISchemaModel.ListenerModel}s.
+ *
+ * <pre>
+ * listener                        CHOICE (LISTENER_CONFIG)
+ *   [0] Create New Listener
+ *         listenerType            CHOICE (LISTENER_TYPE) — only when there is more than one listener
+ *           [i] &lt;listener&gt;
+ *                 listenerConfig  GROUP_SECTION — what constructs the listener
+ *                 &lt;service&gt;       this listener's own service-level fields, after the section
+ *   [1] Use Existing Listener
+ *         listener                the existing-listener selector
+ * </pre>
+ *
+ * <p>With one listener no {@code listenerType} level is emitted at all, so the result is what a
+ * single-listener connector produced before this existed.
+ *
+ * @since 1.10.0
+ */
+public final class ListenerChoiceDeriver {
+
+    /** Reserved: an entry's {@code initProperties} may not use this key. */
+    static final String LISTENER_CONFIG_GROUP_KEY = "listenerConfig";
+
+    /** The widget for the use-existing selector when a model states none. */
+    static final String DEFAULT_EXISTING_LISTENER_FIELD_TYPE = "SINGLE_SELECT_LISTENER";
+
+    private ListenerChoiceDeriver() {
+    }
+
+    /**
+     * The {@code LISTENER_CONFIG} choice for {@code listeners}, or empty when there are none to describe.
+     *
+     * @param listeners                 the connector's declared listeners, in declaration order
+     * @param existingListenerFieldType the widget for the use-existing selector; null falls back to
+     *                                  {@link #DEFAULT_EXISTING_LISTENER_FIELD_TYPE}
+     * @param form                      presentation text for the section and the switch; null takes the
+     *                                  generic defaults
+     */
+    public static Optional<TriggerUISchemaModel.Property> derive(
+            List<TriggerUISchemaModel.ListenerModel> listeners, String existingListenerFieldType,
+            TriggerUISchemaModel.ListenerFormModel form) {
+        if (listeners == null || listeners.isEmpty()) {
+            return Optional.empty();
+        }
+        List<TriggerUISchemaModel.ListenerModel> ordered = deprecatedLast(listeners);
+        int defaultIndex = defaultIndex(ordered);
+
+        Map<String, TriggerUISchemaModel.Property> createNewProps = new LinkedHashMap<>();
+        if (ordered.size() == 1) {
+            createNewProps.putAll(branchProperties(ordered.get(0), form));
+        } else {
+            createNewProps.put(PROP_KEY_LISTENER_TYPE, listenerTypeChoice(ordered, defaultIndex, form));
+        }
+
+        Map<String, TriggerUISchemaModel.Property> useExistingProps = new LinkedHashMap<>();
+        useExistingProps.put(PROP_KEY_LISTENER, existingListenerSelector(existingListenerFieldType));
+
+        TriggerUISchemaModel.Property createNew = formBranch(
+                metadata("Create New Listener", "Create a new listener"), true, true, createNewProps);
+        TriggerUISchemaModel.Property useExisting = formBranch(
+                metadata("Use Existing Listener", "Attach to an already-declared listener"), false, false,
+                useExistingProps);
+
+        return Optional.of(new TriggerUISchemaModel.Property(
+                metadata("Listener", "The listener this service attaches to"),
+                true, true, false, false, null, null, List.of(choiceType()), null,
+                List.of(createNew, useExisting), null, codedata(CD_TYPE_LISTENER_CONFIG), null));
+    }
+
+    /** The per-listener selector; its branches carry whatever deprecation each listener declares. */
+    private static TriggerUISchemaModel.Property listenerTypeChoice(
+            List<TriggerUISchemaModel.ListenerModel> ordered, int defaultIndex,
+            TriggerUISchemaModel.ListenerFormModel form) {
+        List<TriggerUISchemaModel.Property> branches = new ArrayList<>();
+        for (int i = 0; i < ordered.size(); i++) {
+            TriggerUISchemaModel.ListenerModel listener = ordered.get(i);
+            branches.add(formBranch(branchMetadata(listener), i == defaultIndex, true,
+                    branchProperties(listener, form)));
+        }
+        return new TriggerUISchemaModel.Property(
+                orDefault(form == null ? null : form.typeSelector(),
+                        "Listener Type", "The type of listener to create"),
+                true, true, false, false, null, String.valueOf(defaultIndex), List.of(choiceType()), null,
+                branches, null, codedata(CD_TYPE_LISTENER_TYPE), null);
+    }
+
+    /**
+     * The section that constructs one listener, then any service-level fields it alone gives meaning to.
+     * Those sit outside the section: they configure the service, not the listener.
+     */
+    private static Map<String, TriggerUISchemaModel.Property> branchProperties(
+            TriggerUISchemaModel.ListenerModel listener, TriggerUISchemaModel.ListenerFormModel form) {
+        Map<String, TriggerUISchemaModel.Property> properties = new LinkedHashMap<>();
+        properties.put(LISTENER_CONFIG_GROUP_KEY, section(
+                listener.initProperties() == null ? Map.of() : listener.initProperties(), form));
+        if (listener.serviceProperties() != null) {
+            properties.putAll(listener.serviceProperties());
+        }
+        return properties;
+    }
+
+    /** The section a listener's constructor fields are presented in. */
+    private static TriggerUISchemaModel.Property section(
+            Map<String, TriggerUISchemaModel.Property> fields, TriggerUISchemaModel.ListenerFormModel form) {
+        TriggerUISchemaModel.PropertyType type = new TriggerUISchemaModel.PropertyType(
+                "GROUP_SECTION", true, null, null, null, null, null, null);
+        return new TriggerUISchemaModel.Property(
+                orDefault(form == null ? null : form.section(),
+                        "Listener Configuration", "Configure the listener."),
+                true, true, false, false, null, null, List.of(type), null, null,
+                new LinkedHashMap<>(fields), null, null);
+    }
+
+    /** {@code declared} where it states a label, else the generic wording. */
+    private static TriggerUISchemaModel.Metadata orDefault(TriggerUISchemaModel.Metadata declared, String label,
+                                                           String description) {
+        if (declared == null || declared.label() == null || declared.label().isBlank()) {
+            return metadata(label, description);
+        }
+        return declared;
+    }
+
+    private static TriggerUISchemaModel.Property existingListenerSelector(String fieldType) {
+        TriggerUISchemaModel.PropertyType type = new TriggerUISchemaModel.PropertyType(
+                fieldType == null || fieldType.isBlank() ? DEFAULT_EXISTING_LISTENER_FIELD_TYPE : fieldType,
+                true, null, null, null, null, null, null);
+        return new TriggerUISchemaModel.Property(
+                metadata("Listener", "The existing listener to attach to"),
+                true, true, false, false, null, null, List.of(type), null, null, null,
+                codedata(CD_TYPE_EXISTING_LISTENER), null);
+    }
+
+    /** Non-deprecated listeners first, each group keeping its declaration order. */
+    private static List<TriggerUISchemaModel.ListenerModel> deprecatedLast(
+            List<TriggerUISchemaModel.ListenerModel> listeners) {
+        List<TriggerUISchemaModel.ListenerModel> ordered = new ArrayList<>();
+        listeners.stream().filter(listener -> !isDeprecated(listener)).forEach(ordered::add);
+        listeners.stream().filter(ListenerChoiceDeriver::isDeprecated).forEach(ordered::add);
+        return ordered;
+    }
+
+    /** The branch selected when the form opens: an explicit {@code enabled}, else the first entry. */
+    private static int defaultIndex(List<TriggerUISchemaModel.ListenerModel> ordered) {
+        for (int i = 0; i < ordered.size(); i++) {
+            if (Boolean.TRUE.equals(ordered.get(i).enabled())) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    private static boolean isDeprecated(TriggerUISchemaModel.ListenerModel listener) {
+        return listener.metadata() != null && Boolean.TRUE.equals(listener.metadata().deprecated());
+    }
+
+    /** A branch's metadata, falling back to its humanised type name when it states no label. */
+    private static TriggerUISchemaModel.Metadata branchMetadata(TriggerUISchemaModel.ListenerModel listener) {
+        TriggerUISchemaModel.Metadata declared = listener.metadata();
+        if (declared != null && declared.label() != null && !declared.label().isBlank()) {
+            return declared;
+        }
+        String label = listener.name() == null || listener.name().isBlank()
+                ? "Listener" : TriggerModelSynthesizer.humanize(listener.name());
+        if (declared == null) {
+            return metadata(label, null);
+        }
+        return new TriggerUISchemaModel.Metadata(label, declared.description(), declared.notice(),
+                declared.icon(), declared.subLabel(), declared.addLabel(), declared.groupName(),
+                declared.badge(), declared.deprecated(), declared.addDescription());
+    }
+
+    private static TriggerUISchemaModel.Property formBranch(TriggerUISchemaModel.Metadata metadata,
+                                                           boolean enabled, boolean editable,
+                                                           Map<String, TriggerUISchemaModel.Property> properties) {
+        return new TriggerUISchemaModel.Property(metadata, enabled, editable, false, false, null, null, null,
+                null, null, properties, codedata(null), null);
+    }
+
+    private static TriggerUISchemaModel.PropertyType choiceType() {
+        return new TriggerUISchemaModel.PropertyType("CHOICE", true, null, null, null, null, null, null);
+    }
+
+    private static TriggerUISchemaModel.Metadata metadata(String label, String description) {
+        return new TriggerUISchemaModel.Metadata(label, description, null, null, null, null, null, null, null,
+                null);
+    }
+
+    private static TriggerUISchemaModel.Codedata codedata(String type) {
+        return TriggerUISchemaModel.Codedata.builder().type(type).build();
+    }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerModelReader.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerModelReader.java
@@ -58,6 +58,8 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.PROP_KEY_LISTENER;
+
 /**
  * Reads the unified {@code trigger-ui-schema.json} for a connector, bundled, shipped, or synthesized.
  */
@@ -156,6 +158,10 @@ public class TriggerModelReader {
     }
 
     private final Gson gson = new Gson();
+    /** Static counterpart of {@link #gson}, for the init-form derivation that runs before binding. */
+    private static final Gson DERIVATION_GSON = new Gson();
+    private static final Type LISTENER_MODEL_LIST_TYPE =
+            new TypeToken<List<TriggerUISchemaModel.ListenerModel>>() { }.getType();
     private final Cache<String, Optional<TriggerUISchemaModel>> bundledTriggerCache =
             Caffeine.newBuilder().maximumSize(MAX_CACHE_SIZE).build();
     private final Cache<String, Optional<JsonObject>> bundledInitJsonCache =
@@ -186,8 +192,42 @@ public class TriggerModelReader {
                 remapped.add(key, root.get(key));
             }
         }
-        remapped.add("properties", initProperties);
+        remapped.add("properties", withDerivedListenerField(root, initProperties.getAsJsonObject()));
         return Optional.of(remapped);
+    }
+
+    /**
+     * The init form's properties with the listener field derived from a model's declared {@code listeners}
+     * placed first. An authored listener field wins, so this can be adopted per connector.
+     */
+    private static JsonObject withDerivedListenerField(JsonObject root, JsonObject authored) {
+        JsonElement listeners = root.get("listeners");
+        if (listeners == null || !listeners.isJsonArray() || listeners.getAsJsonArray().isEmpty()
+                || authored.has(PROP_KEY_LISTENER)) {
+            return authored.deepCopy();
+        }
+        JsonElement derived = null;
+        try {
+            List<TriggerUISchemaModel.ListenerModel> declared =
+                    DERIVATION_GSON.fromJson(listeners, LISTENER_MODEL_LIST_TYPE);
+            JsonElement listenerKind = root.get("listenerKind");
+            derived = ListenerChoiceDeriver.derive(declared,
+                            listenerKind == null || listenerKind.isJsonNull()
+                                    ? null : listenerKind.getAsString(),
+                            DERIVATION_GSON.fromJson(root.get("listenerForm"),
+                                    TriggerUISchemaModel.ListenerFormModel.class))
+                    .map(DERIVATION_GSON::toJsonTree)
+                    .orElse(null);
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.WARNING, "Could not derive the listener field from `listeners`", e);
+        }
+        if (derived == null) {
+            return authored.deepCopy();
+        }
+        JsonObject ordered = new JsonObject();
+        ordered.add(PROP_KEY_LISTENER, derived);
+        authored.entrySet().forEach(entry -> ordered.add(entry.getKey(), entry.getValue()));
+        return ordered;
     }
 
     /** A fresh {@link ServiceInitModel} bound from {@link #initFormJson}; never a shared instance. */
@@ -422,13 +462,13 @@ public class TriggerModelReader {
         Map<String, TriggerLibraryFacts> crossModuleFacts =
                 resolveCrossModuleFacts(metadata, resolvedOrg, resolvedPackageName);
 
-        Listener listenerModel = resolveListenerModel(metadata, semanticModel, resolvedOrg,
+        Map<String, Listener> listenerModels = resolveListenerModels(metadata, semanticModel, resolvedOrg,
                 resolvedPackageName, moduleName, resolvedVersion);
 
         String displayName = TriggerModelSynthesizer.humanize(moduleName);
         String icon = CommonUtils.generateIcon(resolvedOrg, resolvedPackageName, resolvedVersion);
 
-        return TriggerModelSynthesizer.synthesize(metadata, facts, crossModuleFacts, listenerModel, moduleName,
+        return TriggerModelSynthesizer.synthesize(metadata, facts, crossModuleFacts, listenerModels, moduleName,
                 displayName, icon, "event", resolvedOrg, resolvedPackageName, moduleName, resolvedVersion);
     }
 
@@ -477,22 +517,37 @@ public class TriggerModelReader {
         }
     }
 
-    /** Resolves the listener init-form template via {@link ListenerUtil#getListenerModelFromConnectorPackage}. */
-    private static Listener resolveListenerModel(TriggerMetadataModel metadata, SemanticModel semanticModel,
-                                                 String orgName, String packageName, String moduleName,
-                                                 String version) {
-        try {
-            String listenerType = metadata.listeners().get(0).type().name();
-            Codedata codedata = new Codedata.Builder()
-                    .setType(listenerType)
-                    .setOrgName(orgName)
-                    .setPackageName(packageName)
-                    .setModuleName(moduleName)
-                    .setVersion(version)
-                    .build();
-            return ListenerUtil.getListenerModelFromConnectorPackage(codedata, semanticModel, null).orElse(null);
-        } catch (Throwable e) {
-            return null;
+    /**
+     * One listener init-form template per declared listener, keyed by its type's simple name. A type that
+     * cannot be introspected is left out, costing only that listener its parameter widgets.
+     */
+    private static Map<String, Listener> resolveListenerModels(TriggerMetadataModel metadata,
+                                                               SemanticModel semanticModel, String orgName,
+                                                               String packageName, String moduleName,
+                                                               String version) {
+        Map<String, Listener> models = new LinkedHashMap<>();
+        if (metadata.listeners() == null) {
+            return models;
         }
+        for (TriggerMetadataModel.Listener listener : metadata.listeners()) {
+            if (listener.type() == null || listener.type().name() == null) {
+                continue;
+            }
+            String listenerType = listener.type().name();
+            try {
+                Codedata codedata = new Codedata.Builder()
+                        .setType(listenerType)
+                        .setOrgName(orgName)
+                        .setPackageName(packageName)
+                        .setModuleName(moduleName)
+                        .setVersion(version)
+                        .build();
+                ListenerUtil.getListenerModelFromConnectorPackage(codedata, semanticModel, null)
+                        .ifPresent(model -> models.put(listenerType, model));
+            } catch (Throwable e) {
+                LOGGER.log(Level.FINE, "Could not resolve the listener model for " + listenerType, e);
+            }
+        }
+        return models;
     }
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerModelSynthesizer.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerModelSynthesizer.java
@@ -41,13 +41,13 @@ import java.util.Set;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.ARG_TYPE_SERVICE_TYPE_DESCRIPTOR;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_ANNOTATION_ATTACHMENT;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_EXISTING_LISTENER;
-import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_CONFIG;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_VAR_NAME;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_PAYLOAD_MODIFIER;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_PAYLOAD_TYPE;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_PAYLOAD_TYPE_INCLUDED_RECORD;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_SERVICE_ANNOTATION;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.DATA_BINDING;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.DEFAULT_LISTENER_TYPE;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.DB_KIND_OPTIONAL;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.FIELD_TYPE_FLAG;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.KIND_REQUIRED;
@@ -108,6 +108,31 @@ public final class TriggerModelSynthesizer {
                                                      String id, String displayName, String icon, String kind,
                                                      String orgName, String packageName, String moduleName,
                                                      String version) {
+        return synthesize(authoring, facts, crossModuleFacts,
+                singleListenerModel(authoring, listenerModel), id, displayName, icon, kind, orgName,
+                packageName, moduleName, version);
+    }
+
+    /** The one resolved {@code Listener} keyed by the type it describes, for single-listener callers. */
+    private static Map<String, Listener> singleListenerModel(TriggerMetadataModel authoring,
+                                                             Listener listenerModel) {
+        if (listenerModel == null || authoring == null
+                || authoring.listeners() == null || authoring.listeners().isEmpty()) {
+            return Map.of();
+        }
+        return Map.of(listenerTypeName(authoring.listeners().get(0)), listenerModel);
+    }
+
+    /**
+     * As the other overloads, but with one resolved {@code Listener} per declared listener type, keyed by
+     * that type's simple name. A type absent from the map renders with its name alone.
+     */
+    public static Optional<TriggerUISchemaModel> synthesize(TriggerMetadataModel authoring, TriggerLibraryFacts facts,
+                                                     Map<String, TriggerLibraryFacts> crossModuleFacts,
+                                                     Map<String, Listener> listenerModels,
+                                                     String id, String displayName, String icon, String kind,
+                                                     String orgName, String packageName, String moduleName,
+                                                     String version) {
         if (authoring == null || facts == null
                 || authoring.listeners() == null || authoring.listeners().isEmpty()
                 || authoring.serviceTypes() == null || authoring.serviceTypes().isEmpty()) {
@@ -120,12 +145,11 @@ public final class TriggerModelSynthesizer {
         TriggerMetadataModel.ServiceType primary = serviceTypes.get(0);
         ConnectorIdentity identity = new ConnectorIdentity(orgName, packageName, moduleName, version);
 
-        TriggerMetadataModel.Listener primaryListener = authoring.listeners().get(0);
-        TriggerLibraryFacts.Listener listenerFacts = findListener(primaryListener, facts);
-        String listenerTypeName = primaryListener.type() == null || primaryListener.type().name() == null
-                ? "Listener" : primaryListener.type().name();
+        List<TriggerUISchemaModel.ListenerModel> listeners = buildListenerModels(authoring, facts,
+                listenerModels == null ? Map.of() : listenerModels, moduleName);
         Map<String, TriggerUISchemaModel.Property> initProperties = new LinkedHashMap<>();
-        buildListenerChoice(listenerFacts, listenerModel, moduleName, listenerTypeName, initProperties);
+        ListenerChoiceDeriver.derive(listeners, null, null)
+                .ifPresent(listener -> initProperties.put(LISTENER_KEY, listener));
         buildInitServiceAnnotations(primary, authoring, facts, crossFacts, identity, initProperties);
         buildIdentifierField(primary, initProperties);
         if (multiType) {
@@ -144,8 +168,8 @@ public final class TriggerModelSynthesizer {
 
         return Optional.of(new TriggerUISchemaModel(
                 SCHEMA_VERSION, id, displayName, null, "", orgName, packageName, moduleName, version,
-                kind, icon, kind, listenerKind, initProperties, serviceTypeModels, List.of(),
-                importStatements, null));
+                kind, icon, kind, listenerKind, initProperties, null, listeners, serviceTypeModels,
+                List.of(), importStatements, null));
     }
 
     /** The key {@code crossModuleFacts} is looked up by, for a {@link TypeRef.PackageInfo}. */
@@ -246,48 +270,73 @@ public final class TriggerModelSynthesizer {
                 .field(field).nameEditable(true).build();
     }
 
-    private static final String LISTENER_CONFIG_GROUP_KEY = "listenerConfig";
-
     /**
-     * Builds the {@code listener} CHOICE (create-new / use-existing); always includes both branches.
-     * Every create-new field is nested inside one {@code listenerConfig} {@code GROUP_SECTION}. Each
-     * field's widget is looked up by name from {@code listenerModel} (see {@link #enrichListenerParam})
-     * rather than rebuilt; {@code listenerFacts} supplies only the structure needed to assign correct
-     * {@code argType}/position codedata (see {@link #walkListenerParams}).
+     * One {@link TriggerUISchemaModel.ListenerModel} per declared listener, in declaration order;
+     * {@link ListenerChoiceDeriver} turns the list into the init form's listener field. Each field's widget
+     * is looked up by name from that listener's own {@code Listener} model (see
+     * {@link #enrichListenerParam}) rather than rebuilt.
      */
-    private static void buildListenerChoice(TriggerLibraryFacts.Listener listenerFacts, Listener listenerModel,
-                                            String moduleName, String listenerTypeName,
-                                            Map<String, TriggerUISchemaModel.Property> initProperties) {
-        Map<String, TriggerUISchemaModel.Property> groupProps = new LinkedHashMap<>();
-        groupProps.put(LISTENER_VAR_NAME_KEY, listenerVarNameProperty(moduleName, listenerTypeName));
-        if (listenerFacts != null && listenerModel != null && listenerModel.getProperties() != null) {
-            walkListenerParams(listenerFacts.initParams(), listenerModel, 1, groupProps);
+    private static List<TriggerUISchemaModel.ListenerModel> buildListenerModels(
+            TriggerMetadataModel authoring, TriggerLibraryFacts facts, Map<String, Listener> listenerModels,
+            String moduleName) {
+        Map<String, String> serviceTypeNamesById = serviceTypeNamesById(authoring);
+        List<TriggerUISchemaModel.ListenerModel> models = new ArrayList<>();
+        for (TriggerMetadataModel.Listener listener : authoring.listeners()) {
+            String typeName = listenerTypeName(listener);
+            Listener listenerModel = listenerModels.get(typeName);
+            TriggerLibraryFacts.Listener listenerFacts = findListener(listener, facts,
+                    authoring.listeners().size());
+
+            Map<String, TriggerUISchemaModel.Property> fields = new LinkedHashMap<>();
+            fields.put(LISTENER_VAR_NAME_KEY, listenerVarNameProperty(moduleName, typeName));
+            if (listenerFacts != null && listenerModel != null && listenerModel.getProperties() != null) {
+                walkListenerParams(listenerFacts.initParams(), listenerModel, 1, fields);
+            }
+            models.add(new TriggerUISchemaModel.ListenerModel(
+                    new TriggerUISchemaModel.Metadata(humanize(typeName), listener.doc(),
+                            listener.deprecated(), null, null, null, null, null,
+                            listener.deprecated() == null ? null : true, null),
+                    typeName, moduleName + ":" + typeName, null, fields, null,
+                    hostedServiceTypeNames(listener, serviceTypeNamesById)));
         }
-        TriggerUISchemaModel.Property configGroup = groupSectionProperty("Listener Configuration",
-                "Configure the listener.", groupProps);
+        return models;
+    }
 
-        Map<String, TriggerUISchemaModel.Property> createNewProps = new LinkedHashMap<>();
-        createNewProps.put(LISTENER_CONFIG_GROUP_KEY, configGroup);
-        TriggerUISchemaModel.Property createNew = new TriggerUISchemaModel.Property(
-                new TriggerUISchemaModel.Metadata("Create New Listener", "Create a new listener", null, null,
-                        null, null, null, null, null, null),
-                true, true, false, false, null, null, null, null, null, createNewProps, cd(), null);
+    /** A listener's declared type, defaulting to the conventional name when the document states none. */
+    private static String listenerTypeName(TriggerMetadataModel.Listener listener) {
+        return listener.type() == null || listener.type().name() == null
+                ? DEFAULT_LISTENER_TYPE : listener.type().name();
+    }
 
-        Map<String, TriggerUISchemaModel.Property> useExistingProps = new LinkedHashMap<>();
-        useExistingProps.put(LISTENER_KEY, existingListenerSelector());
-        TriggerUISchemaModel.Property useExisting = new TriggerUISchemaModel.Property(
-                new TriggerUISchemaModel.Metadata("Use Existing Listener", "Attach to an already-declared listener",
-                        null, null, null, null, null, null, null, null),
-                false, false, false, false, null, null, null, null, null, useExistingProps, cd(), null);
+    /** Service type ids ({@code $service}) to the type names a {@code ServiceTypeModel} is keyed by. */
+    private static Map<String, String> serviceTypeNamesById(TriggerMetadataModel authoring) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        for (TriggerMetadataModel.ServiceType serviceType : authoring.serviceTypes()) {
+            if (serviceType.id() == null || serviceType.type() == null || serviceType.type().name() == null) {
+                continue;
+            }
+            byId.put(serviceType.id(), serviceType.type().name());
+        }
+        return byId;
+    }
 
-        TriggerUISchemaModel.PropertyType choiceType = new TriggerUISchemaModel.PropertyType(
-                "CHOICE", true, null, null, null, null, null, null);
-        TriggerUISchemaModel.Property choice = new TriggerUISchemaModel.Property(
-                new TriggerUISchemaModel.Metadata("Listener", "The listener this service attaches to", null, null, null,
-                        null, null, null, null, null),
-                true, true, false, false, null, null, List.of(choiceType), null,
-                List.of(createNew, useExisting), null, cdType(CD_TYPE_LISTENER_CONFIG), null);
-        initProperties.put(LISTENER_KEY, choice);
+    /** The service type names one listener can host; null when it hosts every declared type. */
+    private static List<String> hostedServiceTypeNames(TriggerMetadataModel.Listener listener,
+                                                       Map<String, String> serviceTypeNamesById) {
+        if (listener.services() == null || listener.services().isEmpty()) {
+            return null;
+        }
+        List<String> names = new ArrayList<>();
+        for (String id : listener.services()) {
+            String name = serviceTypeNamesById.get(id);
+            if (name != null) {
+                names.add(name);
+            }
+        }
+        if (names.isEmpty() || names.size() == serviceTypeNamesById.size()) {
+            return null;
+        }
+        return names;
     }
 
     private static TriggerUISchemaModel.Property groupSectionProperty(String label, String description,
@@ -522,23 +571,26 @@ public final class TriggerModelSynthesizer {
     }
 
     /**
-     * The introspected listener matching the authoring schema's declared type, or the first one on a
-     * miss (including when the authoring schema declares no type at all).
+     * The introspected listener matching the authoring schema's declared type. On a miss: the first one when
+     * the document declares a single listener, else {@code null} — with several there is no tie-breaker, and
+     * guessing would describe one listener with another's parameters.
      */
     private static TriggerLibraryFacts.Listener findListener(TriggerMetadataModel.Listener listener,
-                                                              TriggerLibraryFacts facts) {
+                                                              TriggerLibraryFacts facts, int declaredCount) {
         if (facts.listeners() == null || facts.listeners().isEmpty()) {
             return null;
         }
         String name = listener.type() == null ? null : listener.type().name();
         if (name != null) {
-            int colon = name.lastIndexOf(':');
-            String simpleName = colon < 0 ? name : name.substring(colon + 1);
+            String simpleName = simpleName(name);
             for (TriggerLibraryFacts.Listener candidate : facts.listeners()) {
                 if (candidate.type().equals(simpleName)) {
                     return candidate;
                 }
             }
+        }
+        if (declaredCount > 1) {
+            return null;
         }
         return facts.listeners().get(0);
     }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/Constants.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/Constants.java
@@ -119,6 +119,7 @@ public class Constants {
     public static final String CD_TYPE_SERVICE_ANNOTATION = "SERVICE_ANNOTATION";
     public static final String CD_TYPE_INCLUDE_RECORD_PARAM = "INCLUDE_RECORD_PARAM";
     public static final String CD_TYPE_LISTENER_CONFIG = "LISTENER_CONFIG";
+    public static final String CD_TYPE_LISTENER_TYPE = "LISTENER_TYPE";
 
     public static final String ARG_TYPE_LISTENER_VAR_NAME = "LISTENER_VAR_NAME";
     public static final String ARG_TYPE_LISTENER_PARAM_REQUIRED = "LISTENER_PARAM_REQUIRED";

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/azure.storage.files.json
@@ -75,7 +75,8 @@
                   "types": [
                     {
                       "fieldType": "IDENTIFIER",
-                      "selected": true
+                      "selected": true,
+                      "ballerinaType": "azure.storage.files:Listener"
                     }
                   ],
                   "value": "azFilesListener",

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/mcp.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/mcp.json
@@ -97,110 +97,221 @@
       "codedata": {
         "type": "SERVICE_TYPE_DESCRIPTOR"
       }
+    }
+  },
+  "listenerForm": {
+    "section": {
+      "label": "Listener Configuration",
+      "description": "The MCP listener this service is exposed on"
     },
-    "listenTo": {
+    "typeSelector": {
+      "label": "Listener Type",
+      "description": "The MCP transport this service is served over"
+    }
+  },
+  "listeners": [
+    {
       "metadata": {
-        "label": "Port",
-        "description": "The port on which the MCP service listens."
+        "label": "Streamable HTTP Listener",
+        "description": "MCP listener over the Streamable HTTP transport, wrapping an http:Listener and dispatching each tool call to the matching method."
       },
-      "placeholder": "8080",
-      "value": "8080",
-      "enabled": true,
-      "editable": true,
-      "optional": false,
-      "advanced": false,
-      "types": [
-        {
-          "fieldType": "NUMBER",
-          "ballerinaType": "int",
-          "selected": true,
+      "name": "StreamableHttpListener",
+      "ballerinaType": "mcp:StreamableHttpListener",
+      "initProperties": {
+        "listenerVarName": {
+          "metadata": {
+            "label": "Listener Name",
+            "description": "Provide a name for the listener being created"
+          },
+          "value": "mcpListener",
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false,
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true,
+              "ballerinaType": "mcp:StreamableHttpListener"
+            }
+          ],
+          "codedata": {
+            "type": "LISTENER_VAR_NAME"
+          },
           "validations": [
             {
-              "rule": "common.validate.port",
-              "severity": "WARNING",
-              "args": {
-                "min": 1,
-                "max": 65535
-              },
-              "message": "Port must be between {min} and {max}"
+              "rule": "common.validate.identifier"
+            },
+            {
+              "rule": "ls.validate.unique.listener.name",
+              "message": "A listener with this name already exists in the project"
             }
           ]
         },
-        {
-          "fieldType": "EXPRESSION",
-          "ballerinaType": "int",
-          "selected": false
+        "listenTo": {
+          "metadata": {
+            "label": "Port",
+            "description": "The port on which the MCP service listens."
+          },
+          "placeholder": "8080",
+          "value": "8080",
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false,
+          "types": [
+            {
+              "fieldType": "NUMBER",
+              "ballerinaType": "int",
+              "selected": true,
+              "validations": [
+                {
+                  "rule": "common.validate.port",
+                  "severity": "WARNING",
+                  "args": {
+                    "min": 1,
+                    "max": 65535
+                  },
+                  "message": "Port must be between {min} and {max}"
+                }
+              ]
+            },
+            {
+              "fieldType": "EXPRESSION",
+              "ballerinaType": "int",
+              "selected": false
+            }
+          ],
+          "codedata": {
+            "argType": "LISTENER_PARAM_REQUIRED",
+            "position": 1,
+            "originalName": "listenTo"
+          },
+          "validations": [
+            {
+              "rule": "common.validate.required"
+            }
+          ]
         }
-      ],
-      "codedata": {
-        "argType": "LISTENER_PARAM_REQUIRED",
-        "position": 1,
-        "originalName": "listenTo"
       },
-      "validations": [
-        {
-          "rule": "common.validate.required"
+      "serviceProperties": {
+        "basePath": {
+          "metadata": {
+            "label": "Base Path",
+            "description": "The base path of the MCP service"
+          },
+          "placeholder": "/mcp",
+          "value": "/mcp",
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false,
+          "types": [
+            {
+              "fieldType": "SERVICE_PATH",
+              "ballerinaType": "string",
+              "selected": true
+            }
+          ],
+          "codedata": {
+            "type": "SERVICE_BASE_PATH"
+          },
+          "validations": [
+            {
+              "rule": "common.validate.required"
+            }
+          ]
         }
-      ]
+      }
     },
-    "basePath": {
+    {
       "metadata": {
-        "label": "Base Path",
-        "description": "The base path of the MCP service"
+        "label": "Listener",
+        "description": "Delegates every call to an internal StreamableHttpListener, so it accepts and dispatches the same service types the same way.",
+        "notice": "Renamed to make the transport explicit. Use mcp:StreamableHttpListener instead.",
+        "deprecated": true
       },
-      "placeholder": "/mcp",
-      "value": "/mcp",
-      "enabled": true,
-      "editable": true,
-      "optional": false,
-      "advanced": false,
-      "types": [
-        {
-          "fieldType": "SERVICE_PATH",
-          "ballerinaType": "string",
-          "selected": true
-        }
-      ],
-      "codedata": {
-        "type": "SERVICE_BASE_PATH"
-      },
-      "validations": [
-        {
-          "rule": "common.validate.required"
-        }
-      ]
-    },
-    "listenerVarName": {
-      "metadata": {
-        "label": "Listener Name",
-        "description": "Provide a name for the listener being created"
-      },
-      "value": "mcpListener",
-      "enabled": true,
-      "editable": true,
-      "optional": false,
-      "advanced": true,
-      "types": [
-        {
-          "fieldType": "IDENTIFIER",
-          "selected": true,
-          "ballerinaType": "mcp:StreamableHttpListener"
-        }
-      ],
-      "codedata": {
-        "type": "LISTENER_VAR_NAME"
-      },
-      "validations": [
-        {
-          "rule": "common.validate.identifier"
+      "name": "Listener",
+      "ballerinaType": "mcp:Listener",
+      "initProperties": {
+        "listenerVarName": {
+          "metadata": {
+            "label": "Listener Name",
+            "description": "Provide a name for the listener being created"
+          },
+          "value": "mcpListener",
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false,
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true,
+              "ballerinaType": "mcp:Listener"
+            }
+          ],
+          "codedata": {
+            "type": "LISTENER_VAR_NAME"
+          },
+          "validations": [
+            {
+              "rule": "common.validate.identifier"
+            },
+            {
+              "rule": "ls.validate.unique.listener.name",
+              "message": "A listener with this name already exists in the project"
+            }
+          ]
         },
-        {
-          "rule": "ls.validate.unique.listener.name",
-          "message": "A listener with this name already exists in the project"
+        "listenTo": {
+          "metadata": {
+            "label": "Port",
+            "description": "The port on which the MCP service listens."
+          },
+          "placeholder": "8080",
+          "value": "8080",
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false,
+          "types": [
+            {
+              "fieldType": "NUMBER",
+              "ballerinaType": "int",
+              "selected": true,
+              "validations": [
+                {
+                  "rule": "common.validate.port",
+                  "severity": "WARNING",
+                  "args": {
+                    "min": 1,
+                    "max": 65535
+                  },
+                  "message": "Port must be between {min} and {max}"
+                }
+              ]
+            },
+            {
+              "fieldType": "EXPRESSION",
+              "ballerinaType": "int",
+              "selected": false
+            }
+          ],
+          "codedata": {
+            "argType": "LISTENER_PARAM_REQUIRED",
+            "position": 1,
+            "originalName": "listenTo"
+          },
+          "validations": [
+            {
+              "rule": "common.validate.required"
+            }
+          ]
         }
-      ]
+      }
     }
-  },
+  ],
   "serviceTypes": [
     {
       "metadata": {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/builder/service/ListenerChoiceSelectionTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/builder/service/ListenerChoiceSelectionTest.java
@@ -30,6 +30,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static io.ballerina.servicemodelgenerator.extension.model.ServiceInitModel.KEY_CONFIGURE_LISTENER;
@@ -94,9 +96,68 @@ public class ListenerChoiceSelectionTest {
         Assert.assertEquals(configureListener.getValue(), "0");
     }
 
+    /**
+     * A connector declaring several listeners nests its params under a per-listener-type branch, so locating
+     * the create-new branch has to look through choices. The branches are reversed first because
+     * {@code indexOfCreateNewBranch} falls back to index 0, which would mask a broken search.
+     */
+    @Test
+    public void testCreateNewBranchIsFoundWhenParamsAreNestedUnderAListenerTypeChoice() throws Exception {
+        ServiceInitModel model = loadMcpMultiCreationModel();
+        Value listener = model.getProperties().get("listener");
+        Collections.reverse(listener.getChoices());
+        Value useExisting = listener.getChoices().get(0);
+        Value createNew = listener.getChoices().get(1);
+
+        Value prebuiltSelector = new Value.ValueBuilder()
+                .metadata("Select Listener", "Select from the existing mcp listeners")
+                .value("mcpListener")
+                .types(List.of(PropertyType.types(Value.FieldType.SINGLE_SELECT,
+                        Option.of(List.of("mcpListener")))))
+                .enabled(true)
+                .editable(true)
+                .build();
+        SchemaDrivenServiceBuilder.applyListenerChoiceSelection(listener, prebuiltSelector);
+
+        Value nested = useExisting.getProperties().get("listenerConfig").getProperties()
+                .get(KEY_EXISTING_LISTENER);
+        Assert.assertSame(nested, prebuiltSelector,
+                "the selector belongs in the use-existing branch; landing in create-new means the"
+                        + " create-new branch was located by its index rather than by its params");
+        Assert.assertEquals(listener.getValue(), "0", "use-existing is at index 0 in this fixture");
+        Assert.assertFalse(createNew.isEnabled(), "create-new must be deselected once a listener exists");
+        Assert.assertTrue(useExisting.isEnabled());
+    }
+
+    /**
+     * Every listener-name node is collected, not just the first: a branch left holding the shipped default
+     * would offer a name that may already be taken in the project.
+     */
+    @Test
+    public void testEveryListenerVarNameNodeIsCollectedAcrossListenerTypeBranches() throws Exception {
+        ServiceInitModel model = loadMcpMultiCreationModel();
+        List<Value> nodes = new ArrayList<>();
+        SchemaDrivenServiceBuilder.collectListenerVarNameNodes(model.getProperties(), nodes);
+
+        Assert.assertEquals(nodes.size(), 2,
+                "the fixture declares one listener name per listener-type branch");
+        List<String> types = nodes.stream()
+                .map(node -> node.getTypes().getFirst().ballerinaType())
+                .toList();
+        Assert.assertEquals(types, List.of("mcp:StreamableHttpListener", "mcp:Listener"),
+                "collected in document order, each branch naming its own listener type");
+    }
+
     private ServiceInitModel loadHubspotCreationModel() throws Exception {
-        Path path = Paths.get(getClass().getClassLoader()
-                .getResource("connector_models/hubspot/resources/service-creation.json").toURI());
+        return load("connector_models/hubspot/resources/service-creation.json");
+    }
+
+    private ServiceInitModel loadMcpMultiCreationModel() throws Exception {
+        return load("connector_models/mcp_multi/resources/service-creation.json");
+    }
+
+    private ServiceInitModel load(String resource) throws Exception {
+        Path path = Paths.get(getClass().getClassLoader().getResource(resource).toURI());
         return gson.fromJson(Files.readString(path, StandardCharsets.UTF_8), ServiceInitModel.class);
     }
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/ExistingListenerResolverTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/ExistingListenerResolverTest.java
@@ -346,9 +346,57 @@ public class ExistingListenerResolverTest {
         return model.getProperties().get("listener").getChoices().getFirst().getProperties();
     }
 
+    /** A single-listener connector has no selector, so an existing listener reads against create-new. */
+    @Test
+    public void testSingleListenerConnectorHasNoTypeBranches() throws Exception {
+        Value createNewBranch = loadHubspotCreationModel().getProperties()
+                .get("configureListener").getChoices().get(0);
+        Assert.assertTrue(ExistingListenerResolver.listenerTypeBranches(createNewBranch).isEmpty(),
+                "hubspot declares one listener, so there is nothing to match a declared listener against");
+    }
+
+    /**
+     * An existing listener is read against the branch describing its own type; the branches do not agree on
+     * parameters, so the wrong one would map its arguments onto the wrong fields.
+     */
+    @Test
+    public void testExistingListenerIsMatchedToItsOwnTypeBranch() throws Exception {
+        Value createNewBranch = loadMcpMultiCreationModel().getProperties()
+                .get("listener").getChoices().get(0);
+        List<Value> branches = ExistingListenerResolver.listenerTypeBranches(createNewBranch);
+        Assert.assertEquals(branches.size(), 2, "the fixture declares two listener types");
+
+        Assert.assertSame(ExistingListenerResolver.matchByListenerType(branches, "StreamableHttpListener"),
+                branches.get(0));
+        Assert.assertSame(ExistingListenerResolver.matchByListenerType(branches, "Listener"),
+                branches.get(1));
+        Assert.assertSame(ExistingListenerResolver.matchByListenerType(branches, "streamablehttplistener"),
+                branches.get(0), "matched case-insensitively, as Ballerina type names reach us verbatim");
+    }
+
+    /** An unreadable or unknown type degrades to the selected branch rather than resolving nothing. */
+    @Test
+    public void testAnUnknownListenerTypeFallsBackToTheSelectedBranch() throws Exception {
+        Value createNewBranch = loadMcpMultiCreationModel().getProperties()
+                .get("listener").getChoices().get(0);
+        List<Value> branches = ExistingListenerResolver.listenerTypeBranches(createNewBranch);
+
+        Assert.assertSame(ExistingListenerResolver.matchByListenerType(branches, null), branches.get(0),
+                "an unreadable type falls back to the selected branch");
+        Assert.assertSame(ExistingListenerResolver.matchByListenerType(branches, "SomeOtherListener"),
+                branches.get(0), "so does a type no branch describes");
+    }
+
     private ServiceInitModel loadHubspotCreationModel() throws Exception {
-        Path path = Paths.get(getClass().getClassLoader()
-                .getResource("connector_models/hubspot/resources/service-creation.json").toURI());
+        return load("connector_models/hubspot/resources/service-creation.json");
+    }
+
+    private ServiceInitModel loadMcpMultiCreationModel() throws Exception {
+        return load("connector_models/mcp_multi/resources/service-creation.json");
+    }
+
+    private ServiceInitModel load(String resource) throws Exception {
+        Path path = Paths.get(getClass().getClassLoader().getResource(resource).toURI());
         return new Gson().fromJson(Files.readString(path, StandardCharsets.UTF_8), ServiceInitModel.class);
     }
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/ListenerChoiceDeriverTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/ListenerChoiceDeriverTest.java
@@ -1,0 +1,265 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.servicemodelgenerator.extension.connector;
+
+import io.ballerina.modelgenerator.commons.trigger.models.TriggerUISchemaModel;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.ballerina.servicemodelgenerator.extension.connector.ListenerChoiceDeriver.LISTENER_CONFIG_GROUP_KEY;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.ARG_TYPE_SERVICE_BASE_PATH;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_EXISTING_LISTENER;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_CONFIG;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_TYPE;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_VAR_NAME;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.PROP_KEY_LISTENER;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.PROP_KEY_LISTENER_TYPE;
+
+/**
+ * Unit tests for {@link ListenerChoiceDeriver}, exercised directly against hand-built listener lists. The
+ * collapse rule matters most, and is asserted as an absence — no {@code listenerType} key at all — since a
+ * single-branch selector would still render a control the user has no reason to see.
+ *
+ * @since 1.10.0
+ */
+public class ListenerChoiceDeriverTest {
+
+    @Test
+    public void testNothingIsDerivedWithoutListeners() {
+        Assert.assertTrue(ListenerChoiceDeriver.derive(null, null, null).isEmpty(),
+                "a model declaring no `listeners` authored its listener field itself");
+        Assert.assertTrue(ListenerChoiceDeriver.derive(List.of(), null, null).isEmpty(),
+                "an empty `listeners` is the same as none: nothing to derive from");
+    }
+
+    @Test
+    public void testSingleListenerEmitsNoListenerTypeLevel() {
+        TriggerUISchemaModel.Property listener = derive(listener("Listener", "ftp:Listener", null, null));
+
+        Assert.assertEquals(listener.codedata().type(), CD_TYPE_LISTENER_CONFIG);
+        Assert.assertEquals(listener.types().getFirst().fieldType(), "CHOICE");
+        Assert.assertEquals(listener.choices().size(), 2, "create-new and use-existing, always both");
+
+        Map<String, TriggerUISchemaModel.Property> createNew = listener.choices().getFirst().properties();
+        Assert.assertFalse(createNew.containsKey(PROP_KEY_LISTENER_TYPE),
+                "with one listener there is nothing to choose between, so no switch may be emitted");
+        Assert.assertEquals(createNew.keySet(), java.util.Set.of(LISTENER_CONFIG_GROUP_KEY));
+        Assert.assertEquals(varNameType(createNew.get(LISTENER_CONFIG_GROUP_KEY)), "ftp:Listener");
+    }
+
+    @Test
+    public void testSeveralListenersEachGetTheirOwnBranchAndType() {
+        TriggerUISchemaModel.Property listener = derive(
+                listener("StreamableHttpListener", "mcp:StreamableHttpListener", null, null),
+                listener("Listener", "mcp:Listener", null, null));
+
+        TriggerUISchemaModel.Property selector = selector(listener);
+        Assert.assertNotNull(selector, "more than one listener means the user must be able to pick one");
+        Assert.assertEquals(selector.codedata().type(), CD_TYPE_LISTENER_TYPE);
+        Assert.assertEquals(selector.types().getFirst().fieldType(), "CHOICE");
+        Assert.assertEquals(selector.value(), "0", "the first branch is selected when the form opens");
+        Assert.assertEquals(selector.choices().size(), 2);
+
+        Assert.assertEquals(varNameType(config(selector, 0)), "mcp:StreamableHttpListener");
+        Assert.assertEquals(varNameType(config(selector, 1)), "mcp:Listener");
+        Assert.assertTrue(selector.choices().get(0).enabled(), "branch 0 is the selected one");
+        Assert.assertFalse(selector.choices().get(1).enabled());
+        Assert.assertEquals(selector.choices().get(0).metadata().label(), "Streamable Http Listener",
+                "a branch is labelled from its listener type when the connector states no label");
+    }
+
+    @Test
+    public void testDeprecatedListenersSortLastAndKeepTheirReason() {
+        TriggerUISchemaModel.Property listener = derive(
+                listener("Listener", "mcp:Listener", "Use mcp:StreamableHttpListener instead.", null),
+                listener("StreamableHttpListener", "mcp:StreamableHttpListener", null, null));
+
+        TriggerUISchemaModel.Property selector = selector(listener);
+        Assert.assertEquals(varNameType(config(selector, 0)), "mcp:StreamableHttpListener",
+                "the listener still in favour comes first even though it is declared second");
+        Assert.assertEquals(varNameType(config(selector, 1)), "mcp:Listener");
+        Assert.assertTrue(selector.choices().get(0).enabled(), "a deprecated listener is never the default");
+
+        TriggerUISchemaModel.Property deprecated = selector.choices().get(1);
+        Assert.assertEquals(deprecated.metadata().deprecated(), Boolean.TRUE);
+        Assert.assertEquals(deprecated.metadata().notice(), "Use mcp:StreamableHttpListener instead.",
+                "the reason reaches the form, so the badge can say why");
+        Assert.assertTrue(deprecated.editable(),
+                "a deprecated listener stays pickable; deprecated is not the same as unavailable");
+    }
+
+    @Test
+    public void testAnExplicitlyEnabledListenerBecomesTheDefault() {
+        TriggerUISchemaModel.Property listener = derive(
+                listener("First", "x:First", null, null),
+                listener("Second", "x:Second", null, true));
+
+        TriggerUISchemaModel.Property selector = selector(listener);
+        Assert.assertEquals(selector.value(), "1");
+        Assert.assertFalse(selector.choices().get(0).enabled());
+        Assert.assertTrue(selector.choices().get(1).enabled());
+    }
+
+    @Test
+    public void testUseExistingSelectorWidget() {
+        TriggerUISchemaModel.Property defaulted = derive(listener("Listener", "ftp:Listener", null, null));
+        TriggerUISchemaModel.Property selector = defaulted.choices().get(1).properties().get(PROP_KEY_LISTENER);
+        Assert.assertEquals(selector.codedata().type(), CD_TYPE_EXISTING_LISTENER);
+        Assert.assertEquals(selector.types().getFirst().fieldType(), "SINGLE_SELECT_LISTENER",
+                "a model stating no widget attaches to one listener at a time");
+
+        Optional<TriggerUISchemaModel.Property> multi = ListenerChoiceDeriver.derive(
+                List.of(listener("Listener", "smb:Listener", null, null)), "MULTI_SELECT_LISTENER", null);
+        Assert.assertEquals(multi.orElseThrow().choices().get(1).properties().get(PROP_KEY_LISTENER)
+                .types().getFirst().fieldType(), "MULTI_SELECT_LISTENER");
+    }
+
+    /**
+     * A service-level field only one listener gives meaning to lives in that listener's branch, outside the
+     * section. Generation and validation walk only the enabled branch, so it applies exactly while selected.
+     */
+    @Test
+    public void testAListenerMayContributeItsOwnServiceLevelFields() {
+        TriggerUISchemaModel.Property listener = derive(
+                listener("StreamableHttpListener", "mcp:StreamableHttpListener", null, null, basePath()),
+                listener("StdioListener", "mcp:StdioListener", null, null));
+
+        TriggerUISchemaModel.Property selector = selector(listener);
+        Map<String, TriggerUISchemaModel.Property> httpBranch = selector.choices().get(0).properties();
+        Map<String, TriggerUISchemaModel.Property> stdioBranch = selector.choices().get(1).properties();
+
+        Assert.assertTrue(httpBranch.containsKey("basePath"),
+                "the transport with a URL space offers a base path");
+        Assert.assertFalse(stdioBranch.containsKey("basePath"),
+                "the transport without one must not, or the user would be asked for a meaningless value");
+        Assert.assertEquals(httpBranch.get("basePath").codedata().type(), ARG_TYPE_SERVICE_BASE_PATH);
+        Assert.assertEquals(List.copyOf(httpBranch.keySet()), List.of(LISTENER_CONFIG_GROUP_KEY, "basePath"));
+        Assert.assertFalse(httpBranch.get(LISTENER_CONFIG_GROUP_KEY).properties().containsKey("basePath"),
+                "a service-level field must never end up inside the listener's own section");
+    }
+
+    /** A lone listener still contributes its service-level fields; there is just no selector above it. */
+    @Test
+    public void testASingleListenerStillContributesItsServiceLevelFields() {
+        TriggerUISchemaModel.Property listener = derive(
+                listener("Listener", "mcp:Listener", null, null, basePath()));
+
+        Map<String, TriggerUISchemaModel.Property> createNew = listener.choices().getFirst().properties();
+        Assert.assertFalse(createNew.containsKey(PROP_KEY_LISTENER_TYPE), "still nothing to choose between");
+        Assert.assertEquals(List.copyOf(createNew.keySet()), List.of(LISTENER_CONFIG_GROUP_KEY, "basePath"));
+    }
+
+    /** The section and the switch are named by the model; the defaults cannot be connector-specific. */
+    @Test
+    public void testTheSectionAndSwitchAreNamedByTheModel() {
+        TriggerUISchemaModel.ListenerFormModel form = new TriggerUISchemaModel.ListenerFormModel(
+                new TriggerUISchemaModel.Metadata("Transport", "How this service is reached", null, null, null,
+                        null, null, null, null, null),
+                new TriggerUISchemaModel.Metadata("Transport Kind", "Pick the transport to serve over", null,
+                        null, null, null, null, null, null, null));
+        TriggerUISchemaModel.Property listener = ListenerChoiceDeriver.derive(
+                List.of(listener("StreamableHttpListener", "mcp:StreamableHttpListener", null, null),
+                        listener("Listener", "mcp:Listener", null, null)), null, form).orElseThrow();
+
+        TriggerUISchemaModel.Property selector = selector(listener);
+        TriggerUISchemaModel.Property section = selector.choices().getFirst().properties()
+                .get(LISTENER_CONFIG_GROUP_KEY);
+        Assert.assertEquals(section.metadata().label(), "Transport");
+        Assert.assertEquals(section.metadata().description(), "How this service is reached");
+        Assert.assertEquals(selector.metadata().label(), "Transport Kind");
+        Assert.assertEquals(selector.metadata().description(), "Pick the transport to serve over",
+                "the description is what the form renders above the options");
+    }
+
+    @Test
+    public void testTheGenericWordingIsUsedWhenTheModelStatesNone() {
+        TriggerUISchemaModel.Property listener = derive(
+                listener("StreamableHttpListener", "mcp:StreamableHttpListener", null, null),
+                listener("Listener", "mcp:Listener", null, null));
+        TriggerUISchemaModel.Property selector = selector(listener);
+        Assert.assertEquals(selector.metadata().label(), "Listener Type");
+        Assert.assertEquals(selector.choices().getFirst().properties().get(LISTENER_CONFIG_GROUP_KEY)
+                .metadata().label(), "Listener Configuration");
+    }
+
+    // ---- helpers -------------------------------------------------------------------------------
+
+    private TriggerUISchemaModel.Property derive(TriggerUISchemaModel.ListenerModel... listeners) {
+        return ListenerChoiceDeriver.derive(List.of(listeners), null, null)
+                .orElseThrow(() -> new AssertionError("expected a derived listener field"));
+    }
+
+    private TriggerUISchemaModel.ListenerModel listener(String name, String ballerinaType, String deprecated,
+                                                        Boolean enabled) {
+        return listener(name, ballerinaType, deprecated, enabled, null);
+    }
+
+    private TriggerUISchemaModel.ListenerModel listener(String name, String ballerinaType, String deprecated,
+                                                        Boolean enabled,
+                                                        Map<String, TriggerUISchemaModel.Property> service) {
+        Map<String, TriggerUISchemaModel.Property> fields = new LinkedHashMap<>();
+        fields.put("listenerVarName", new TriggerUISchemaModel.Property(
+                new TriggerUISchemaModel.Metadata("Listener Name", null, null, null, null, null, null, null,
+                        null, null),
+                true, true, false, false, null, "aListener",
+                List.of(new TriggerUISchemaModel.PropertyType("IDENTIFIER", true, ballerinaType, null, null,
+                        null, null, null)),
+                null, null, null,
+                TriggerUISchemaModel.Codedata.builder().type(CD_TYPE_LISTENER_VAR_NAME).build(), null));
+        return new TriggerUISchemaModel.ListenerModel(
+                new TriggerUISchemaModel.Metadata(null, "doc", deprecated, null, null, null, null, null,
+                        deprecated == null ? null : true, null),
+                name, ballerinaType, enabled, fields, service, null);
+    }
+
+    /** A base-path field, the canonical service-level field only some transports give meaning to. */
+    private Map<String, TriggerUISchemaModel.Property> basePath() {
+        Map<String, TriggerUISchemaModel.Property> service = new LinkedHashMap<>();
+        service.put("basePath", new TriggerUISchemaModel.Property(
+                new TriggerUISchemaModel.Metadata("Base Path", null, null, null, null, null, null, null, null,
+                        null),
+                true, true, false, false, null, "/mcp",
+                List.of(new TriggerUISchemaModel.PropertyType("SERVICE_PATH", true, "string", null, null, null,
+                        null, null)),
+                null, null, null,
+                TriggerUISchemaModel.Codedata.builder().type(ARG_TYPE_SERVICE_BASE_PATH).build(), null));
+        return service;
+    }
+
+    /** The listener-kind switch, which sits above the section it configures. */
+    private TriggerUISchemaModel.Property selector(TriggerUISchemaModel.Property listener) {
+        return listener.choices().getFirst().properties().get(PROP_KEY_LISTENER_TYPE);
+    }
+
+    /** The construction section of one listener-type branch. */
+    private TriggerUISchemaModel.Property config(TriggerUISchemaModel.Property selector, int branch) {
+        return selector.choices().get(branch).properties().get(LISTENER_CONFIG_GROUP_KEY);
+    }
+
+    /** The listener type a section's name field states. */
+    private String varNameType(TriggerUISchemaModel.Property section) {
+        Assert.assertEquals(section.types().getFirst().fieldType(), "GROUP_SECTION");
+        return section.properties().get("listenerVarName").types().getFirst().ballerinaType();
+    }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/SchemaDrivenSourceGeneratorTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/SchemaDrivenSourceGeneratorTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -302,6 +303,32 @@ public class SchemaDrivenSourceGeneratorTest {
 
     private static Value selectedChoice(Value choiceField) {
         return choiceField.getChoices().stream().filter(Value::isEnabled).findFirst().orElseThrow();
+    }
+
+    /**
+     * Selecting a listener type emits that type, with no generator change: {@code collect} already descends
+     * the enabled branch and {@code listenerTypeOf} already reads {@code ballerinaType} off the name field.
+     */
+    @Test
+    public void testSelectedListenerTypeDecidesTheEmittedDeclaration() throws Exception {
+        ServiceInitModel creation = loadMcpMulti();
+        Assert.assertEquals(SchemaDrivenSourceGenerator.buildListenerDeclaration(creation),
+                "listener mcp:StreamableHttpListener mcpListener = new (8080);",
+                "the fixture ships the Streamable HTTP branch selected");
+
+        ServiceInitModel deprecated = loadMcpMulti();
+        List<Value> branches = deprecated.getProperties().get("listener").getChoices().getFirst()
+                .getProperties().get("listenerType").getChoices();
+        branches.get(0).setEnabled(false);
+        branches.get(1).setEnabled(true);
+        Assert.assertEquals(SchemaDrivenSourceGenerator.buildListenerDeclaration(deprecated),
+                "listener mcp:Listener mcpListener = new (8080);",
+                "selecting the other listener type must emit that type, with the same arguments");
+    }
+
+    private ServiceInitModel loadMcpMulti() throws Exception {
+        Path path = resource("connector_models/mcp_multi/resources/service-creation.json");
+        return gson.fromJson(Files.readString(path, StandardCharsets.UTF_8), ServiceInitModel.class);
     }
 
     private Path resource(String name) throws Exception {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerListenerChoiceTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerListenerChoiceTest.java
@@ -1,0 +1,239 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.servicemodelgenerator.extension.connector;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+import io.ballerina.modelgenerator.commons.trigger.models.TriggerUISchemaModel;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_CONFIG;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_TYPE;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.CD_TYPE_LISTENER_VAR_NAME;
+
+/**
+ * Corpus guard over every bundled trigger model's authored listener form. Companion to
+ * {@link TriggerLayoutTest}, and for the same reason: the init form is resolved by string-matched
+ * {@code codedata}, so a mis-shaped tree degrades silently where a build failure would have named the file.
+ *
+ * <p>Four invariants: one listener form per model, since {@code findListenerChoice} takes the first; every
+ * {@code LISTENER_VAR_NAME} states its {@code ballerinaType}, which is what the generator emits; listener-type
+ * branches are pairwise distinct, since that name is how a declared listener is matched to its branch; and no
+ * key is declared both inside and outside the listener form, which would render two inputs for one field.
+ *
+ * @since 1.10.0
+ */
+public class TriggerListenerChoiceTest {
+
+    private static final String BUNDLED_REGISTRY_RESOURCE = "bundled_trigger_models.json";
+    private static final Type REGISTRY_TYPE = new TypeToken<Map<String, JsonElement>>() { }.getType();
+
+    /** Every bundled module key, read off the registry. Fails hard on an empty registry. */
+    @DataProvider(name = "bundledModules")
+    public Object[][] bundledModules() {
+        Map<String, JsonElement> registry;
+        try (InputStream stream = TriggerModelReader.class.getClassLoader()
+                .getResourceAsStream(BUNDLED_REGISTRY_RESOURCE)) {
+            Assert.assertNotNull(stream, "bundled trigger model registry not found on the classpath");
+            registry = new Gson().fromJson(
+                    new InputStreamReader(stream, StandardCharsets.UTF_8), REGISTRY_TYPE);
+        } catch (Exception e) {
+            throw new AssertionError("could not read " + BUNDLED_REGISTRY_RESOURCE, e);
+        }
+        Assert.assertNotNull(registry, "bundled trigger model registry did not parse");
+        Assert.assertFalse(registry.isEmpty(), "bundled trigger model registry is empty");
+        return registry.keySet().stream().map(key -> new Object[]{key}).toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "bundledModules")
+    public void testAtMostOneListenerFormPerModel(String moduleName) {
+        List<TriggerUISchemaModel.Property> found = new ArrayList<>();
+        collectByCodedataType(initProperties(moduleName), CD_TYPE_LISTENER_CONFIG, found);
+        Assert.assertTrue(found.size() <= 1, moduleName + ": " + found.size() + " `" + CD_TYPE_LISTENER_CONFIG
+                + "` nodes. findListenerChoice takes the first, so any other is authored and never wired up"
+                + " to the project's existing listeners.");
+    }
+
+    @Test(dataProvider = "bundledModules")
+    public void testEveryListenerVarNameNamesItsType(String moduleName) {
+        List<TriggerUISchemaModel.Property> varNames = new ArrayList<>();
+        collectByCodedataType(initProperties(moduleName), CD_TYPE_LISTENER_VAR_NAME, varNames);
+        for (TriggerUISchemaModel.Property varName : varNames) {
+            Assert.assertNotNull(ballerinaTypeOf(varName), moduleName + ": a `" + CD_TYPE_LISTENER_VAR_NAME
+                    + "` field states no `ballerinaType`, so the generator would fall back to a bare"
+                    + " `<protocol>:Listener` — a type this connector may not have.");
+        }
+    }
+
+    @Test(dataProvider = "bundledModules")
+    public void testListenerTypeBranchesAreDistinct(String moduleName) {
+        List<TriggerUISchemaModel.Property> selectors = new ArrayList<>();
+        collectByCodedataType(initProperties(moduleName), CD_TYPE_LISTENER_TYPE, selectors);
+        for (TriggerUISchemaModel.Property selector : selectors) {
+            List<TriggerUISchemaModel.Property> branches = orEmpty(selector.choices());
+            Assert.assertTrue(branches.size() >= 2, moduleName + ": a `" + CD_TYPE_LISTENER_TYPE + "` choice"
+                    + " with " + branches.size() + " branch(es) is a selector with nothing to select."
+                    + " A single-listener connector must omit it entirely.");
+            Set<String> seen = new LinkedHashSet<>();
+            for (TriggerUISchemaModel.Property branch : branches) {
+                List<TriggerUISchemaModel.Property> varNames = new ArrayList<>();
+                collectByCodedataType(branch.properties(), CD_TYPE_LISTENER_VAR_NAME, varNames);
+                collectInChoices(branch, CD_TYPE_LISTENER_VAR_NAME, varNames);
+                Assert.assertEquals(varNames.size(), 1, moduleName + ": a `" + CD_TYPE_LISTENER_TYPE
+                        + "` branch holds " + varNames.size() + " listener-name fields; it must hold exactly"
+                        + " one, since that field is what identifies the branch.");
+                String type = simpleName(ballerinaTypeOf(varNames.get(0)));
+                Assert.assertNotNull(type, moduleName + ": a `" + CD_TYPE_LISTENER_TYPE + "` branch states no"
+                        + " `ballerinaType`, so it cannot be told apart from its siblings.");
+                Assert.assertTrue(seen.add(type), moduleName + ": two `" + CD_TYPE_LISTENER_TYPE
+                        + "` branches both describe `" + type + "`. Matching a declared listener back to its"
+                        + " branch would be ambiguous with no way to break the tie.");
+            }
+        }
+    }
+
+    @Test(dataProvider = "bundledModules")
+    public void testNoFieldIsDeclaredBothInsideAndOutsideTheListenerForm(String moduleName) {
+        Map<String, TriggerUISchemaModel.Property> initProperties = initProperties(moduleName);
+        List<TriggerUISchemaModel.Property> listenerForms = new ArrayList<>();
+        collectByCodedataType(initProperties, CD_TYPE_LISTENER_CONFIG, listenerForms);
+        if (listenerForms.isEmpty()) {
+            return;
+        }
+        Set<String> outside = new LinkedHashSet<>(initProperties.keySet());
+        outside.removeIf(key -> {
+            TriggerUISchemaModel.Codedata codedata = initProperties.get(key).codedata();
+            return codedata != null && CD_TYPE_LISTENER_CONFIG.equals(codedata.type());
+        });
+        for (TriggerUISchemaModel.Property listenerForm : listenerForms) {
+            for (String key : keysWithin(listenerForm)) {
+                Assert.assertFalse(outside.contains(key), moduleName + ": `" + key + "` is declared both"
+                        + " inside the listener form and beside it. The form would show two inputs for one"
+                        + " field, and generation would quietly use the one inside. Pick one: beside the"
+                        + " choice if every listener shares it, inside a listener's branch if only that"
+                        + " listener gives it meaning.");
+            }
+        }
+    }
+
+    // ---- helpers -------------------------------------------------------------------------------
+
+    /** Every property key anywhere inside a subtree, choices included. */
+    private Set<String> keysWithin(TriggerUISchemaModel.Property root) {
+        Set<String> keys = new LinkedHashSet<>();
+        collectKeys(root.properties(), keys);
+        for (TriggerUISchemaModel.Property choice : orEmpty(root.choices())) {
+            if (choice != null) {
+                keys.addAll(keysWithin(choice));
+            }
+        }
+        return keys;
+    }
+
+    private void collectKeys(Map<String, TriggerUISchemaModel.Property> properties, Set<String> keys) {
+        if (properties == null) {
+            return;
+        }
+        properties.forEach((key, property) -> {
+            keys.add(key);
+            if (property != null) {
+                keys.addAll(keysWithin(property));
+            }
+        });
+    }
+
+    private Map<String, TriggerUISchemaModel.Property> initProperties(String moduleName) {
+        TriggerUISchemaModel model = TriggerModelReader.getInstance().getBundledTriggerModel(moduleName)
+                .orElseThrow(() -> new AssertionError(moduleName + ": bundled model failed to load"));
+        Assert.assertNotNull(model.initProperties(), moduleName + ": a bundled model states an init form");
+        return model.initProperties();
+    }
+
+    /** Every node in the subtree whose {@code codedata.type} or {@code codedata.argType} matches. */
+    private void collectByCodedataType(Map<String, TriggerUISchemaModel.Property> properties, String wanted,
+                                       List<TriggerUISchemaModel.Property> into) {
+        if (properties == null) {
+            return;
+        }
+        for (TriggerUISchemaModel.Property property : properties.values()) {
+            if (property == null) {
+                continue;
+            }
+            TriggerUISchemaModel.Codedata codedata = property.codedata();
+            if (codedata != null
+                    && (wanted.equals(codedata.type()) || wanted.equals(codedata.argType()))) {
+                into.add(property);
+            }
+            collectByCodedataType(property.properties(), wanted, into);
+            collectInChoices(property, wanted, into);
+        }
+    }
+
+    private void collectInChoices(TriggerUISchemaModel.Property property, String wanted,
+                                  List<TriggerUISchemaModel.Property> into) {
+        for (TriggerUISchemaModel.Property choice : orEmpty(property.choices())) {
+            if (choice == null) {
+                continue;
+            }
+            TriggerUISchemaModel.Codedata codedata = choice.codedata();
+            if (codedata != null
+                    && (wanted.equals(codedata.type()) || wanted.equals(codedata.argType()))) {
+                into.add(choice);
+            }
+            collectByCodedataType(choice.properties(), wanted, into);
+            collectInChoices(choice, wanted, into);
+        }
+    }
+
+    /** The first non-blank {@code ballerinaType} among a field's rendering candidates, as the generator reads it. */
+    private String ballerinaTypeOf(TriggerUISchemaModel.Property property) {
+        for (TriggerUISchemaModel.PropertyType type : orEmpty(property.types())) {
+            if (type != null && type.ballerinaType() != null && !type.ballerinaType().isBlank()) {
+                return type.ballerinaType();
+            }
+        }
+        return null;
+    }
+
+    /** {@code mcp:StreamableHttpListener -> StreamableHttpListener}, matching the generator's own trim. */
+    private String simpleName(String qualified) {
+        if (qualified == null) {
+            return null;
+        }
+        int colon = qualified.lastIndexOf(':');
+        return colon < 0 ? qualified : qualified.substring(colon + 1);
+    }
+
+    private <T> List<T> orEmpty(List<T> list) {
+        return list == null ? List.of() : list;
+    }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/add_service_and_listener/config/mcp_service_model_multi_listener.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/add_service_and_listener/config/mcp_service_model_multi_listener.json
@@ -1,0 +1,333 @@
+{
+  "filePath": "sample1/main.bal",
+  "description": "Test adding an MCP service with the deprecated mcp:Listener transport selected: it offers no base path, so the descriptor carries none",
+  "serviceInitModel": {
+    "id": "8",
+    "displayName": "MCP Service",
+    "description": "Create MCP service",
+    "orgName": "ballerina",
+    "packageName": "mcp",
+    "moduleName": "mcp",
+    "version": "1.2.0",
+    "type": "mcp",
+    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_mcp_1.2.0.png",
+    "properties": {
+      "listener": {
+        "metadata": {
+          "label": "Listener",
+          "description": "The listener this service attaches to"
+        },
+        "types": [
+          {
+            "fieldType": "CHOICE",
+            "selected": true
+          }
+        ],
+        "codedata": {
+          "type": "LISTENER_CONFIG"
+        },
+        "value": "0",
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false,
+        "choices": [
+          {
+            "metadata": {
+              "label": "Create New Listener",
+              "description": "Create a new listener"
+            },
+            "types": [
+              {
+                "fieldType": "FORM",
+                "selected": true
+              }
+            ],
+            "enabled": true,
+            "editable": true,
+            "optional": false,
+            "advanced": false,
+            "properties": {
+              "listenerType": {
+                "metadata": {
+                  "label": "Listener Type",
+                  "description": "The type of listener to create"
+                },
+                "types": [
+                  {
+                    "fieldType": "CHOICE",
+                    "selected": true
+                  }
+                ],
+                "codedata": {
+                  "type": "LISTENER_TYPE"
+                },
+                "value": "1",
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false,
+                "choices": [
+                  {
+                    "metadata": {
+                      "label": "Streamable HTTP Listener",
+                      "description": ""
+                    },
+                    "types": [
+                      {
+                        "fieldType": "FORM",
+                        "selected": true
+                      }
+                    ],
+                    "enabled": false,
+                    "editable": true,
+                    "optional": false,
+                    "advanced": false,
+                    "properties": {
+                      "listenerConfig": {
+                        "metadata": {
+                          "label": "Listener Configuration",
+                          "description": "The MCP listener this service is exposed on"
+                        },
+                        "types": [
+                          {
+                            "fieldType": "GROUP_SECTION",
+                            "selected": true
+                          }
+                        ],
+                        "enabled": true,
+                        "editable": true,
+                        "optional": false,
+                        "advanced": false,
+                        "properties": {
+                          "listenerVarName": {
+                            "metadata": {
+                              "label": "Listener Name",
+                              "description": "Provide a name for the listener being created"
+                            },
+                            "codedata": {
+                              "type": "LISTENER_VAR_NAME"
+                            },
+                            "value": "mcpListener",
+                            "enabled": true,
+                            "editable": true,
+                            "optional": false,
+                            "advanced": false,
+                            "types": [
+                              {
+                                "fieldType": "IDENTIFIER",
+                                "selected": true,
+                                "ballerinaType": "mcp:StreamableHttpListener"
+                              }
+                            ]
+                          },
+                          "listenTo": {
+                            "metadata": {
+                              "label": "Port",
+                              "description": "The port on which the MCP service listens"
+                            },
+                            "codedata": {
+                              "argType": "LISTENER_PARAM_REQUIRED"
+                            },
+                            "placeholder": "8080",
+                            "value": "8080",
+                            "items": [],
+                            "enabled": true,
+                            "editable": true,
+                            "optional": false,
+                            "advanced": false
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "metadata": {
+                      "label": "Listener",
+                      "description": "",
+                      "notice": "Renamed to make the transport explicit. Use mcp:StreamableHttpListener instead."
+                    },
+                    "types": [
+                      {
+                        "fieldType": "FORM",
+                        "selected": true
+                      }
+                    ],
+                    "enabled": true,
+                    "editable": true,
+                    "optional": false,
+                    "advanced": false,
+                    "properties": {
+                      "listenerConfig": {
+                        "metadata": {
+                          "label": "Listener Configuration",
+                          "description": "The MCP listener this service is exposed on"
+                        },
+                        "types": [
+                          {
+                            "fieldType": "GROUP_SECTION",
+                            "selected": true
+                          }
+                        ],
+                        "enabled": true,
+                        "editable": true,
+                        "optional": false,
+                        "advanced": false,
+                        "properties": {
+                          "listenerVarName": {
+                            "metadata": {
+                              "label": "Listener Name",
+                              "description": "Provide a name for the listener being created"
+                            },
+                            "codedata": {
+                              "type": "LISTENER_VAR_NAME"
+                            },
+                            "value": "mcpListener",
+                            "enabled": true,
+                            "editable": true,
+                            "optional": false,
+                            "advanced": false,
+                            "types": [
+                              {
+                                "fieldType": "IDENTIFIER",
+                                "selected": true,
+                                "ballerinaType": "mcp:Listener"
+                              }
+                            ]
+                          },
+                          "listenTo": {
+                            "metadata": {
+                              "label": "Port",
+                              "description": "The port on which the MCP service listens"
+                            },
+                            "codedata": {
+                              "argType": "LISTENER_PARAM_REQUIRED"
+                            },
+                            "placeholder": "8080",
+                            "value": "8080",
+                            "items": [],
+                            "enabled": true,
+                            "editable": true,
+                            "optional": false,
+                            "advanced": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "metadata": {
+              "label": "Use Existing Listener",
+              "description": "Attach to an already-declared listener"
+            },
+            "types": [
+              {
+                "fieldType": "FORM",
+                "selected": true
+              }
+            ],
+            "enabled": false,
+            "editable": false,
+            "optional": false,
+            "advanced": false,
+            "properties": {}
+          }
+        ]
+      },
+      "serviceName": {
+        "metadata": {
+          "label": "Service Name",
+          "description": "The name of the mcp service"
+        },
+        "codedata": {
+          "argType": "SOURCE_ANNOTATION"
+        },
+        "placeholder": "MCP Service",
+        "value": "\"Health Care MCP\"",
+        "items": [],
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false
+      },
+      "version": {
+        "metadata": {
+          "label": "Version",
+          "description": "The version of the mcp service"
+        },
+        "codedata": {
+          "argType": "SOURCE_ANNOTATION"
+        },
+        "placeholder": "\"1.0.0\"",
+        "value": "\"1.0.0\"",
+        "items": [],
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false
+      },
+      "serviceType": {
+        "metadata": {
+          "label": "Service Type",
+          "description": "The MCP service type."
+        },
+        "codedata": {
+          "type": "SERVICE_TYPE_DESCRIPTOR"
+        },
+        "types": [
+          {
+            "fieldType": "SINGLE_SELECT",
+            "selected": true,
+            "ballerinaType": "mcp:StreamableHttpService",
+            "options": [
+              {
+                "label": "Streamable HTTP Service",
+                "value": "StreamableHttpService"
+              }
+            ]
+          }
+        ],
+        "value": "StreamableHttpService",
+        "enabled": true,
+        "editable": false,
+        "optional": false,
+        "advanced": false,
+        "hidden": true
+      }
+    }
+  },
+  "output": {
+    "sample1/main.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "\nimport ballerina/mcp;\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 57,
+            "character": 3
+          },
+          "end": {
+            "line": 57,
+            "character": 3
+          }
+        },
+        "newText": "\nlistener mcp:Listener mcpListener = new (8080);\nservice mcp:StreamableHttpService on mcpListener {\n\n}\n"
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/connector_models/mcp_multi/resources/service-creation.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/connector_models/mcp_multi/resources/service-creation.json
@@ -1,0 +1,294 @@
+{
+  "schemaVersion": "1.0",
+  "id": "mcp",
+  "displayName": "MCP Service",
+  "description": "Create a service that exposes tools to MCP clients.",
+  "orgName": "ballerina",
+  "packageName": "mcp",
+  "moduleName": "mcp",
+  "version": "1.2.0",
+  "type": "mcp",
+  "icon": "docs/icon.png",
+  "properties": {
+    "listener": {
+      "metadata": {
+        "label": "Configure MCP Listener",
+        "description": "Select an existing MCP listener or create a new one"
+      },
+      "value": "0",
+      "types": [
+        {
+          "fieldType": "CHOICE",
+          "selected": true
+        }
+      ],
+      "codedata": {
+        "type": "LISTENER_CONFIG"
+      },
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false,
+      "choices": [
+        {
+          "metadata": {
+            "label": "Create new",
+            "description": "Create a new MCP listener"
+          },
+          "types": [
+            {
+              "fieldType": "FORM",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false,
+          "properties": {
+            "listenerType": {
+              "metadata": {
+                "label": "Listener Type",
+                "description": "The MCP transport this listener serves"
+              },
+              "value": "0",
+              "types": [
+                {
+                  "fieldType": "CHOICE",
+                  "selected": true
+                }
+              ],
+              "codedata": {
+                "type": "LISTENER_TYPE"
+              },
+              "enabled": true,
+              "editable": true,
+              "optional": false,
+              "advanced": false,
+              "choices": [
+                {
+                  "metadata": {
+                    "label": "Streamable HTTP Listener",
+                    "description": "MCP listener over the Streamable HTTP transport."
+                  },
+                  "types": [
+                    {
+                      "fieldType": "FORM",
+                      "selected": true
+                    }
+                  ],
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "properties": {
+                    "listenerConfig": {
+                      "metadata": {
+                        "label": "Listener Configuration",
+                        "description": "Configure the MCP listener"
+                      },
+                      "types": [
+                        {
+                          "fieldType": "GROUP_SECTION",
+                          "selected": true
+                        }
+                      ],
+                      "enabled": true,
+                      "editable": true,
+                      "optional": false,
+                      "advanced": false,
+                      "properties": {
+                        "listenerVarName": {
+                          "metadata": {
+                            "label": "Listener Name",
+                            "description": "Provide a name for the listener being created"
+                          },
+                          "codedata": {
+                            "type": "LISTENER_VAR_NAME"
+                          },
+                          "value": "mcpListener",
+                          "types": [
+                            {
+                              "fieldType": "IDENTIFIER",
+                              "selected": true,
+                              "ballerinaType": "mcp:StreamableHttpListener"
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false
+                        },
+                        "listenTo": {
+                          "metadata": {
+                            "label": "Port",
+                            "description": "The port on which the MCP service listens."
+                          },
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_REQUIRED",
+                            "originalName": "listenTo",
+                            "position": 1
+                          },
+                          "value": "8080",
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "int",
+                              "selected": true
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false
+                        }
+                      }
+                    },
+                    "basePath": {
+                      "metadata": {
+                        "label": "Base Path",
+                        "description": "The base path of the MCP service"
+                      },
+                      "codedata": {
+                        "type": "SERVICE_BASE_PATH"
+                      },
+                      "value": "/mcp",
+                      "types": [
+                        {
+                          "fieldType": "SERVICE_PATH",
+                          "ballerinaType": "string",
+                          "selected": true
+                        }
+                      ],
+                      "enabled": true,
+                      "editable": true,
+                      "optional": false,
+                      "advanced": false
+                    }
+                  }
+                },
+                {
+                  "metadata": {
+                    "label": "Listener",
+                    "description": "Delegates every call to an internal StreamableHttpListener.",
+                    "notice": "Renamed to make the transport explicit. Use mcp:StreamableHttpListener instead.",
+                    "deprecated": true
+                  },
+                  "types": [
+                    {
+                      "fieldType": "FORM",
+                      "selected": true
+                    }
+                  ],
+                  "enabled": false,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "properties": {
+                    "listenerConfig": {
+                      "metadata": {
+                        "label": "Listener Configuration",
+                        "description": "Configure the MCP listener"
+                      },
+                      "types": [
+                        {
+                          "fieldType": "GROUP_SECTION",
+                          "selected": true
+                        }
+                      ],
+                      "enabled": true,
+                      "editable": true,
+                      "optional": false,
+                      "advanced": false,
+                      "properties": {
+                        "listenerVarName": {
+                          "metadata": {
+                            "label": "Listener Name",
+                            "description": "Provide a name for the listener being created"
+                          },
+                          "codedata": {
+                            "type": "LISTENER_VAR_NAME"
+                          },
+                          "value": "mcpListener",
+                          "types": [
+                            {
+                              "fieldType": "IDENTIFIER",
+                              "selected": true,
+                              "ballerinaType": "mcp:Listener"
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false
+                        },
+                        "listenTo": {
+                          "metadata": {
+                            "label": "Port",
+                            "description": "The port on which the MCP service listens."
+                          },
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_REQUIRED",
+                            "originalName": "listenTo",
+                            "position": 1
+                          },
+                          "value": "8080",
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "int",
+                              "selected": true
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "Use existing",
+            "description": "Attach to an already-declared MCP listener"
+          },
+          "types": [
+            {
+              "fieldType": "FORM",
+              "selected": true
+            }
+          ],
+          "enabled": false,
+          "editable": false,
+          "optional": false,
+          "advanced": false,
+          "properties": {
+            "listenerConfig": {
+              "metadata": {
+                "label": "Listener Configurations",
+                "description": "Configuration of the selected listener."
+              },
+              "types": [
+                {
+                  "fieldType": "GROUP_SECTION",
+                  "selected": true
+                }
+              ],
+              "enabled": true,
+              "editable": true,
+              "optional": false,
+              "advanced": false,
+              "properties": {}
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/mcp_service_model.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/mcp_service_model.json
@@ -15,6 +15,335 @@
       "type": "mcp",
       "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_mcp_1.2.0.png",
       "properties": {
+        "listener": {
+          "metadata": {
+            "label": "Listener",
+            "description": "The listener this service attaches to"
+          },
+          "codedata": {
+            "type": "LISTENER_CONFIG"
+          },
+          "value": "0",
+          "choices": [
+            {
+              "metadata": {
+                "label": "Create New Listener",
+                "description": "Create a new listener"
+              },
+              "codedata": {},
+              "properties": {
+                "listenerType": {
+                  "metadata": {
+                    "label": "Listener Type",
+                    "description": "The MCP transport this service is served over"
+                  },
+                  "codedata": {
+                    "type": "LISTENER_TYPE"
+                  },
+                  "value": "0",
+                  "choices": [
+                    {
+                      "metadata": {
+                        "label": "Streamable HTTP Listener",
+                        "description": "MCP listener over the Streamable HTTP transport, wrapping an http:Listener and dispatching each tool call to the matching method."
+                      },
+                      "codedata": {},
+                      "properties": {
+                        "listenerConfig": {
+                          "metadata": {
+                            "label": "Listener Configuration",
+                            "description": "The MCP listener this service is exposed on"
+                          },
+                          "properties": {
+                            "listenerVarName": {
+                              "metadata": {
+                                "label": "Listener Name",
+                                "description": "Provide a name for the listener being created"
+                              },
+                              "codedata": {
+                                "type": "LISTENER_VAR_NAME"
+                              },
+                              "value": "mcpListener",
+                              "types": [
+                                {
+                                  "fieldType": "IDENTIFIER",
+                                  "ballerinaType": "mcp:StreamableHttpListener",
+                                  "selected": true
+                                }
+                              ],
+                              "validations": [
+                                {
+                                  "rule": "common.validate.identifier"
+                                },
+                                {
+                                  "rule": "ls.validate.unique.listener.name",
+                                  "message": "A listener with this name already exists in the project"
+                                }
+                              ],
+                              "enabled": true,
+                              "editable": true,
+                              "optional": false,
+                              "advanced": false
+                            },
+                            "listenTo": {
+                              "metadata": {
+                                "label": "Port",
+                                "description": "The port on which the MCP service listens."
+                              },
+                              "codedata": {
+                                "argType": "LISTENER_PARAM_REQUIRED",
+                                "originalName": "listenTo",
+                                "position": 1
+                              },
+                              "placeholder": "8080",
+                              "value": "8080",
+                              "types": [
+                                {
+                                  "fieldType": "NUMBER",
+                                  "ballerinaType": "int",
+                                  "selected": true,
+                                  "validations": [
+                                    {
+                                      "rule": "common.validate.port",
+                                      "args": {
+                                        "min": 1.0,
+                                        "max": 65535.0
+                                      },
+                                      "message": "Port must be between {min} and {max}",
+                                      "severity": "WARNING"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "fieldType": "EXPRESSION",
+                                  "ballerinaType": "int",
+                                  "selected": false
+                                }
+                              ],
+                              "validations": [
+                                {
+                                  "rule": "common.validate.required"
+                                }
+                              ],
+                              "enabled": true,
+                              "editable": true,
+                              "optional": false,
+                              "advanced": false
+                            }
+                          },
+                          "types": [
+                            {
+                              "fieldType": "GROUP_SECTION",
+                              "selected": true
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false
+                        },
+                        "basePath": {
+                          "metadata": {
+                            "label": "Base Path",
+                            "description": "The base path of the MCP service"
+                          },
+                          "codedata": {
+                            "type": "SERVICE_BASE_PATH"
+                          },
+                          "placeholder": "/mcp",
+                          "value": "/mcp",
+                          "types": [
+                            {
+                              "fieldType": "SERVICE_PATH",
+                              "ballerinaType": "string",
+                              "selected": true
+                            }
+                          ],
+                          "validations": [
+                            {
+                              "rule": "common.validate.required"
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false
+                        }
+                      },
+                      "enabled": true,
+                      "editable": true,
+                      "optional": false,
+                      "advanced": false
+                    },
+                    {
+                      "metadata": {
+                        "label": "Listener",
+                        "description": "Delegates every call to an internal StreamableHttpListener, so it accepts and dispatches the same service types the same way.",
+                        "notice": "Renamed to make the transport explicit. Use mcp:StreamableHttpListener instead."
+                      },
+                      "codedata": {},
+                      "properties": {
+                        "listenerConfig": {
+                          "metadata": {
+                            "label": "Listener Configuration",
+                            "description": "The MCP listener this service is exposed on"
+                          },
+                          "properties": {
+                            "listenerVarName": {
+                              "metadata": {
+                                "label": "Listener Name",
+                                "description": "Provide a name for the listener being created"
+                              },
+                              "codedata": {
+                                "type": "LISTENER_VAR_NAME"
+                              },
+                              "value": "mcpListener",
+                              "types": [
+                                {
+                                  "fieldType": "IDENTIFIER",
+                                  "ballerinaType": "mcp:Listener",
+                                  "selected": true
+                                }
+                              ],
+                              "validations": [
+                                {
+                                  "rule": "common.validate.identifier"
+                                },
+                                {
+                                  "rule": "ls.validate.unique.listener.name",
+                                  "message": "A listener with this name already exists in the project"
+                                }
+                              ],
+                              "enabled": true,
+                              "editable": true,
+                              "optional": false,
+                              "advanced": false
+                            },
+                            "listenTo": {
+                              "metadata": {
+                                "label": "Port",
+                                "description": "The port on which the MCP service listens."
+                              },
+                              "codedata": {
+                                "argType": "LISTENER_PARAM_REQUIRED",
+                                "originalName": "listenTo",
+                                "position": 1
+                              },
+                              "placeholder": "8080",
+                              "value": "8080",
+                              "types": [
+                                {
+                                  "fieldType": "NUMBER",
+                                  "ballerinaType": "int",
+                                  "selected": true,
+                                  "validations": [
+                                    {
+                                      "rule": "common.validate.port",
+                                      "args": {
+                                        "min": 1.0,
+                                        "max": 65535.0
+                                      },
+                                      "message": "Port must be between {min} and {max}",
+                                      "severity": "WARNING"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "fieldType": "EXPRESSION",
+                                  "ballerinaType": "int",
+                                  "selected": false
+                                }
+                              ],
+                              "validations": [
+                                {
+                                  "rule": "common.validate.required"
+                                }
+                              ],
+                              "enabled": true,
+                              "editable": true,
+                              "optional": false,
+                              "advanced": false
+                            }
+                          },
+                          "types": [
+                            {
+                              "fieldType": "GROUP_SECTION",
+                              "selected": true
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false
+                        }
+                      },
+                      "enabled": false,
+                      "editable": true,
+                      "optional": false,
+                      "advanced": false
+                    }
+                  ],
+                  "types": [
+                    {
+                      "fieldType": "CHOICE",
+                      "selected": true
+                    }
+                  ],
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false
+                }
+              },
+              "enabled": true,
+              "editable": true,
+              "optional": false,
+              "advanced": false
+            },
+            {
+              "metadata": {
+                "label": "Use existing (none available)",
+                "description": "No compatible listener of this type is present in the project."
+              },
+              "codedata": {},
+              "properties": {
+                "listener": {
+                  "metadata": {
+                    "label": "Listener",
+                    "description": "The existing listener to attach to"
+                  },
+                  "codedata": {
+                    "type": "KEY_EXISTING_LISTENER"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "SINGLE_SELECT_LISTENER",
+                      "selected": true
+                    }
+                  ],
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false
+                }
+              },
+              "enabled": false,
+              "editable": false,
+              "optional": false,
+              "advanced": false
+            }
+          ],
+          "types": [
+            {
+              "fieldType": "CHOICE",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
         "serviceName": {
           "metadata": {
             "label": "Service Name",
@@ -102,108 +431,6 @@
           "optional": false,
           "advanced": false,
           "hidden": true
-        },
-        "listenTo": {
-          "metadata": {
-            "label": "Port",
-            "description": "The port on which the MCP service listens."
-          },
-          "codedata": {
-            "argType": "LISTENER_PARAM_REQUIRED",
-            "originalName": "listenTo",
-            "position": 1
-          },
-          "placeholder": "8080",
-          "value": "8080",
-          "types": [
-            {
-              "fieldType": "NUMBER",
-              "ballerinaType": "int",
-              "selected": true,
-              "validations": [
-                {
-                  "rule": "common.validate.port",
-                  "args": {
-                    "min": 1.0,
-                    "max": 65535.0
-                  },
-                  "message": "Port must be between {min} and {max}",
-                  "severity": "WARNING"
-                }
-              ]
-            },
-            {
-              "fieldType": "EXPRESSION",
-              "ballerinaType": "int",
-              "selected": false
-            }
-          ],
-          "validations": [
-            {
-              "rule": "common.validate.required"
-            }
-          ],
-          "enabled": true,
-          "editable": true,
-          "optional": false,
-          "advanced": false
-        },
-        "basePath": {
-          "metadata": {
-            "label": "Base Path",
-            "description": "The base path of the MCP service"
-          },
-          "codedata": {
-            "type": "SERVICE_BASE_PATH"
-          },
-          "placeholder": "/mcp",
-          "value": "/mcp",
-          "types": [
-            {
-              "fieldType": "SERVICE_PATH",
-              "ballerinaType": "string",
-              "selected": true
-            }
-          ],
-          "validations": [
-            {
-              "rule": "common.validate.required"
-            }
-          ],
-          "enabled": true,
-          "editable": true,
-          "optional": false,
-          "advanced": false
-        },
-        "listenerVarName": {
-          "metadata": {
-            "label": "Listener Name",
-            "description": "Provide a name for the listener being created"
-          },
-          "codedata": {
-            "type": "LISTENER_VAR_NAME"
-          },
-          "value": "mcpListener",
-          "types": [
-            {
-              "fieldType": "IDENTIFIER",
-              "ballerinaType": "mcp:StreamableHttpListener",
-              "selected": true
-            }
-          ],
-          "validations": [
-            {
-              "rule": "common.validate.identifier"
-            },
-            {
-              "rule": "ls.validate.unique.listener.name",
-              "message": "A listener with this name already exists in the project"
-            }
-          ],
-          "enabled": true,
-          "editable": true,
-          "optional": false,
-          "advanced": true
         }
       }
     }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/testng.xml
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/testng.xml
@@ -54,6 +54,7 @@ under the License.
             <class name="io.ballerina.servicemodelgenerator.extension.connector.PayloadComposerTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerFunctionAdapterTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerLayoutTest"/>
+            <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerListenerChoiceTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.AnnotationEmitterTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerImportTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.util.ModuleAliasResolverTest"/>

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/testng.xml
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/testng.xml
@@ -55,6 +55,7 @@ under the License.
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerFunctionAdapterTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerLayoutTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerListenerChoiceTest"/>
+            <class name="io.ballerina.servicemodelgenerator.extension.connector.ListenerChoiceDeriverTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.AnnotationEmitterTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerImportTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.util.ModuleAliasResolverTest"/>

--- a/packages/ballerina-side-panel/src/components/editors/ChoiceForm.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/ChoiceForm.tsx
@@ -57,6 +57,14 @@ const ChoiceLabel = styled.span<{ selected: boolean }>`
     font-weight: ${(props: { selected: boolean }) => (props.selected ? 500 : 400)};
 `;
 
+/** A choice's own callout, shown on every option — e.g. why one is deprecated and what supersedes it. */
+const ChoiceNotice = styled.span`
+    display: block;
+    font-size: 11px;
+    opacity: 0.8;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+`;
+
 export function ChoiceForm(props: ChoiceFormProps) {
     const { field, recordTypeFields } = props;
     const { form } = useFormContext();
@@ -187,9 +195,14 @@ export function ChoiceForm(props: ChoiceFormProps) {
                         id: index.toString(),
                         value: index + 1,
                         content: (
-                            <ChoiceLabel selected={selectedOption === index + 1}>
-                                {choice.metadata.label}
-                            </ChoiceLabel>
+                            <>
+                                <ChoiceLabel selected={selectedOption === index + 1}>
+                                    {choice.metadata.label}
+                                </ChoiceLabel>
+                                {choice.metadata.notice && (
+                                    <ChoiceNotice>{choice.metadata.notice}</ChoiceNotice>
+                                )}
+                            </>
                         ),
                         disabled: field.editable === false || !choice.editable
                     }))}

--- a/packages/ballerina-side-panel/src/test/ChoiceForm.test.tsx
+++ b/packages/ballerina-side-panel/src/test/ChoiceForm.test.tsx
@@ -27,7 +27,7 @@ import type { FormField } from "../components/Form/types";
 import { renderWithForm } from "./formHarness";
 import { ChoiceForm } from "../components/editors/ChoiceForm";
 
-const choiceField = (labels: string[], enabledIndex = 0): FormField =>
+const choiceField = (labels: string[], enabledIndex = 0, notices: (string | undefined)[] = []): FormField =>
     ({
         key: "payload",
         label: "Payload type",
@@ -38,7 +38,7 @@ const choiceField = (labels: string[], enabledIndex = 0): FormField =>
         documentation: "",
         choices: labels.map((label, i) => ({
             enabled: i === enabledIndex,
-            metadata: { label, description: "" },
+            metadata: { label, description: "", notice: notices[i] },
             properties: {},
         })),
     } as unknown as FormField);
@@ -63,5 +63,22 @@ describe("ChoiceForm", () => {
     ])("renders without throwing (%s)", (_desc, labels) => {
         const { container } = renderChoice(choiceField(labels as string[]));
         expect(container.textContent).toContain("JSON");
+    });
+
+    it("shows a choice's notice, on unselected options too", () => {
+        const { container } = renderChoice(
+            choiceField(["Streamable HTTP Listener", "Listener"], 0, [
+                undefined,
+                "Renamed to make the transport explicit. Use mcp:StreamableHttpListener instead.",
+            ])
+        );
+        expect(container.textContent).toContain(
+            "Renamed to make the transport explicit. Use mcp:StreamableHttpListener instead."
+        );
+    });
+
+    it("renders nothing extra when a choice states no notice", () => {
+        const { container } = renderChoice(choiceField(["JSON", "XML"]));
+        expect(container.textContent).toBe("JSONXML");
     });
 });


### PR DESCRIPTION
## Purpose

A connector's `trigger-metadata.json` may declare more than one listener, but the trigger UI schema modelled exactly one — `TriggerModelSynthesizer.synthesize` and `TriggerModelReader.resolveListenerModel` both took `listeners().get(0)`. `ballerina/mcp` is the first connector to hit this: it declares `StreamableHttpListener` plus a `Listener` deprecated in favour of it, and everything past the first entry was dropped, so the init form could neither offer the transport choice nor express that the two take different configuration.

## Approach

`TriggerUISchemaModel` gains a first-class `listeners` list, each entry carrying its own configuration set, and `ListenerChoiceDeriver` turns that list into the create-new/use-existing `CHOICE` every consumer already understands:

```
listener                        CHOICE (LISTENER_CONFIG)
  [0] Create New Listener
        listenerType            CHOICE (LISTENER_TYPE) — only when there is more than one listener
          [i] <listener>
                listenerConfig  GROUP_SECTION — what constructs the listener
                <service>       this listener's own service-level fields, after the section
  [1] Use Existing Listener
        listener                the existing-listener selector
```

Deriving rather than authoring is what keeps this additive. With one listener no `listenerType` level is emitted at all, so all 25 existing single-listener models produce byte-identical output and route through the same code. `SchemaDrivenSourceGenerator` needed no change: `collect` already descends the enabled branch and `listenerTypeOf` already reads the emitted type off the branch's `LISTENER_VAR_NAME`. The webview needed no change either, beyond rendering a choice's `notice`.

`serviceProperties` covers a service-level field only some listeners give meaning to — a base path an HTTP transport has and one without a URL space does not. It sits inside that listener's branch but outside the configuration section, so it is offered, generated and validated exactly while its listener is selected, since `findBasePath`, `findServiceType`, `collectAnnotationFields` and `ValidationEngine` all walk only the enabled branch. `listenerForm` lets a connector name the section and the switch in its own terms.

For `mcp`, both transports are offered with the deprecated one badged and sorted last, and only the Streamable HTTP transport offers a base path:

![MCP service init form](https://raw.githubusercontent.com/LakshanWeerasinghe/ballerina-vscode/pr-assets/docs/mcp-listener-form.png)

## Two latent bugs fixed

Both were correct only by luck, and both are now covered by tests that fail without the fix:

- `hasListenerParams` never recursed `getChoices()`, so `indexOfCreateNewBranch` silently fell through to its index-0 default.
- `refreshListenerName` renamed only the first `LISTENER_VAR_NAME` node, leaving other branches offering a name that may already be taken.

## Deliberately out of scope

Recorded rather than half-built: per-listener service-type narrowing (`ListenerModel.serviceTypes` is carried but not yet acted on, and is blocked on `buildInitServiceAnnotations`'s own `serviceTypes.get(0)`); per-listener import scoping, guarded instead by a corpus assertion that multi-listener documents agree on their side effects; and `Metadata.deprecated`, which never crosses the wire, so deprecation is surfaced through `notice`.

## Testing

- Two new corpus guards over every bundled model: the listener form's structural contract, and the metadata invariants the branching rests on.
- Unit tests for the deriver, per-type template matching, and the two bug fixes.
- A golden test proving a submission with the deprecated transport selected emits `listener mcp:Listener mcpListener = new (8080);` with no base path, while the Streamable HTTP transport keeps `/mcp`.
- 627 service-model-generator, 79 model-generator-commons and 176 ballerina-side-panel tests pass; checkstyle clean.
- Verified in the Extension Development Host, per the screenshot above.

> Stacked on #940 (`handler-ordering`), so the diff includes that branch's commits until it merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added support for connectors with multiple listener types and listener-specific configuration.
- Added listener choice derivation for create-new and use-existing flows.
- Preserved existing single-listener behavior.
- Added MCP support for Streamable HTTP and deprecated Listener options, with correct ordering and fields.
- Fixed listener branch traversal and listener-name updates across nested branches.
- Added schema, resolver, generator, corpus, UI, and golden submission tests.
- Updated choice forms to display optional notices.
- Confirmed test suites pass and checkstyle is clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->