### PR TITLE
Fix unpublished mssql version in trigger metadata

### DIFF
--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/mssql.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/mssql.json
@@ -6,9 +6,9 @@
   "orgName": "ballerinax",
   "packageName": "mssql",
   "moduleName": "mssql",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "type": "mssql",
-  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_mssql_1.18.1.png",
+  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_mssql_1.19.0.png",
   "kind": "event",
   "listenerKind": "MULTIPLE_SELECT_LISTENER",
   "initProperties": {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
@@ -144,7 +144,7 @@
       "event"
     ],
     "triggerName": "CDC for Microsoft SQL Server",
-    "version": "1.18.1",
+    "version": "1.19.0",
     "kind": "event"
   },
   "12": {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/connector_models/mssql_cdc/resources/service-creation.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/connector_models/mssql_cdc/resources/service-creation.json
@@ -5,7 +5,7 @@
   "orgName": "ballerinax",
   "packageName": "mssql",
   "moduleName": "mssql",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "type": "mssql",
   "icon": "",
   "properties": {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/cdc_mssql_service_model.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/cdc_mssql_service_model.json
@@ -12,9 +12,9 @@
       "orgName": "ballerinax",
       "packageName": "mssql",
       "moduleName": "mssql",
-      "version": "1.18.1",
+      "version": "1.19.0",
       "type": "mssql",
-      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_mssql_1.18.1.png",
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_mssql_1.19.0.png",
       "properties": {
         "listener": {
           "metadata": {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/cdc_service_model.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/cdc_service_model.json
@@ -16,10 +16,10 @@
     "displayName": "Microsoft SQL Server CDC",
     "moduleName": "mssql",
     "orgName": "ballerinax",
-    "version": "1.18.1",
+    "version": "1.19.0",
     "packageName": "mssql",
     "listenerProtocol": "mssql",
-    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_mssql_1.18.1.png",
+    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_mssql_1.19.0.png",
     "properties": {
       "listener": {
         "metadata": {
@@ -331,7 +331,7 @@
           "orgName": "ballerinax",
           "packageName": "mssql",
           "moduleName": "mssql",
-          "version": "1.18.1"
+          "version": "1.19.0"
         },
         "properties": {},
         "group": "onRead",
@@ -568,7 +568,7 @@
           "orgName": "ballerinax",
           "packageName": "mssql",
           "moduleName": "mssql",
-          "version": "1.18.1"
+          "version": "1.19.0"
         },
         "properties": {},
         "group": "onUpdate",
@@ -737,7 +737,7 @@
           "orgName": "ballerinax",
           "packageName": "mssql",
           "moduleName": "mssql",
-          "version": "1.18.1"
+          "version": "1.19.0"
         },
         "properties": {},
         "group": "onCreate",
@@ -904,7 +904,7 @@
           "orgName": "ballerinax",
           "packageName": "mssql",
           "moduleName": "mssql",
-          "version": "1.18.1"
+          "version": "1.19.0"
         },
         "properties": {},
         "group": "onDelete",
@@ -1014,7 +1014,7 @@
           "orgName": "ballerinax",
           "packageName": "mssql",
           "moduleName": "mssql",
-          "version": "1.18.1"
+          "version": "1.19.0"
         },
         "properties": {},
         "group": "onError",


### PR DESCRIPTION
Fixes : https://github.com/wso2/product-integrator/issues/2104
### Problem
Picking the **CDC for Microsoft SQL Server** trigger showed `Failed to pull the module: ballerinax/mssql:1.18.1`. That version was never published to Central (1.18.0 and 1.19.0 exist), and `Utils.resolveModule` pins the pull to the requested version with no fallback.

The bad version came from the bundled trigger metadata, which the picker passes to `getServiceInitModel`.

### Fix
Pin `ballerinax/mssql` to `1.19.0` in `trigger_properties.json` and `trigger-models/mssql.json` (including the icon URL, which also 404'd), and update the goldens that mirror it.

### Tests
`GetServiceInitModelTest`, `GetServiceModelFromSourceTest`, `SchemaDrivenSourceGeneratorTest`, `AddServiceAndListenerTest`, `AddFunctionTest`, `UpdateFunctionTest` — all pass.