### PR TITLE
Filter out KBs from connections + Refactoring KB filter

### DIFF
--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/CloudKnowledgeBasePage.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/CloudKnowledgeBasePage.tsx
@@ -24,11 +24,7 @@ import ButtonCard from "../../../../components/ButtonCard";
 import { BodyTinyInfo } from "../../../styles";
 import { usePlatformExtContext } from "../../../../providers/platform-ext-ctx-provider";
 import { ConnectorsGrid, Section, SectionHeader, SectionTitle } from "../AddConnectionPopup/styles";
-import { ProgressWrap } from "./utils";
-
-// Devant tags knowledge base services with this tag.
-const KB_TAG = "knowledge-base-as-service";
-const isKnowledgeBase = (item: MarketplaceItem) => item.tags?.includes(KB_TAG) ?? false;
+import { isKnowledgeBaseService, ProgressWrap } from "./utils";
 
 interface CloudKnowledgeBasePageProps {
     // Opens a blank CloudKnowledgeBase create form (manual entry, no Devant service pre-selected).
@@ -68,7 +64,7 @@ export function CloudKnowledgeBasePage(props: CloudKnowledgeBasePageProps) {
                 request: getMarketPlaceParams,
             }),
         enabled: isSignedIn,
-        select: (data) => ({ ...data, data: (data?.data || []).filter(isKnowledgeBase) }),
+        select: (data) => ({ ...data, data: (data?.data || []).filter(isKnowledgeBaseService) }),
     });
 
     const items: MarketplaceItem[] = knowledgeBases?.data || [];

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantConnectorList.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantConnectorList.tsx
@@ -34,7 +34,7 @@ import {
     SectionHeader,
     SectionTitle,
 } from "../AddConnectionPopup/styles";
-import { DevantConnectionFlow, getKnownAvailableNode, isKnowledgeBaseService, ProgressWrap } from "./utils";
+import { DevantConnectionFlow, filterConnectionMarketplaceItems, getKnownAvailableNode, ProgressWrap } from "./utils";
 
 // Target number of connections to show. Knowledge base services can only be filtered out client-side
 // (the marketplace tag filter is include-only), so over-fetch and trim to this size so filtered-out
@@ -165,18 +165,12 @@ export function DevantConnectorList(props: DevantConnectorListProps) {
             filterType !== "databases" && platformExtState.isLoggedIn && !!platformExtState?.selectedContext?.project,
         select: (data) => ({
             ...data,
-            data: data.data
-                .filter((item) => {
-                    // Knowledge base services are listed under "Add Knowledge Base", not here.
-                    if (isKnowledgeBaseService(item)) {
-                        return false;
-                    }
-                    if (filterType === "internal-services") {
-                        return item.component?.componentId !== platformExtState?.selectedComponent?.metadata?.id;
-                    }
-                    return true;
-                })
-                .slice(0, CONNECTIONS_PAGE_SIZE),
+            data: filterConnectionMarketplaceItems(
+                data.data,
+                filterType,
+                platformExtState?.selectedComponent?.metadata?.id,
+                CONNECTIONS_PAGE_SIZE,
+            ),
         }),
     });
 

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantConnectorList.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantConnectorList.tsx
@@ -34,7 +34,7 @@ import {
     SectionHeader,
     SectionTitle,
 } from "../AddConnectionPopup/styles";
-import { DevantConnectionFlow, getKnownAvailableNode, ProgressWrap } from "./utils";
+import { DevantConnectionFlow, getKnownAvailableNode, isKnowledgeBaseService, ProgressWrap } from "./utils";
 
 interface DevantConnectorListProps {
     onItemSelect: (
@@ -160,6 +160,10 @@ export function DevantConnectorList(props: DevantConnectorListProps) {
         select: (data) => ({
             ...data,
             data: data.data.filter((item) => {
+                // Knowledge base services are listed under "Add Knowledge Base", not here.
+                if (isKnowledgeBaseService(item)) {
+                    return false;
+                }
                 if (filterType === "internal-services") {
                     return item.component?.componentId !== platformExtState?.selectedComponent?.metadata?.id;
                 }

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantConnectorList.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantConnectorList.tsx
@@ -36,6 +36,12 @@ import {
 } from "../AddConnectionPopup/styles";
 import { DevantConnectionFlow, getKnownAvailableNode, isKnowledgeBaseService, ProgressWrap } from "./utils";
 
+// Target number of connections to show. Knowledge base services can only be filtered out client-side
+// (the marketplace tag filter is include-only), so over-fetch and trim to this size so filtered-out
+// KBs don't shrink the visible connections list (or search results).
+const CONNECTIONS_PAGE_SIZE = 24;
+const MARKETPLACE_OVERFETCH_LIMIT = 100;
+
 interface DevantConnectorListProps {
     onItemSelect: (
         flow: DevantConnectionFlow | null,
@@ -131,7 +137,7 @@ export function DevantConnectorList(props: DevantConnectorListProps) {
     };
 
     const getMarketPlaceParams: GetMarketplaceItemsParams = {
-        limit: 24,
+        limit: MARKETPLACE_OVERFETCH_LIMIT,
         offset: 0,
         networkVisibilityFilter: "all",
         networkVisibilityprojectId: platformExtState?.selectedContext?.project?.id,
@@ -159,16 +165,18 @@ export function DevantConnectorList(props: DevantConnectorListProps) {
             filterType !== "databases" && platformExtState.isLoggedIn && !!platformExtState?.selectedContext?.project,
         select: (data) => ({
             ...data,
-            data: data.data.filter((item) => {
-                // Knowledge base services are listed under "Add Knowledge Base", not here.
-                if (isKnowledgeBaseService(item)) {
-                    return false;
-                }
-                if (filterType === "internal-services") {
-                    return item.component?.componentId !== platformExtState?.selectedComponent?.metadata?.id;
-                }
-                return true;
-            }),
+            data: data.data
+                .filter((item) => {
+                    // Knowledge base services are listed under "Add Knowledge Base", not here.
+                    if (isKnowledgeBaseService(item)) {
+                        return false;
+                    }
+                    if (filterType === "internal-services") {
+                        return item.component?.componentId !== platformExtState?.selectedComponent?.metadata?.id;
+                    }
+                    return true;
+                })
+                .slice(0, CONNECTIONS_PAGE_SIZE),
         }),
     });
 

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantConnectorList.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/DevantConnectorList.tsx
@@ -34,13 +34,26 @@ import {
     SectionHeader,
     SectionTitle,
 } from "../AddConnectionPopup/styles";
-import { DevantConnectionFlow, filterConnectionMarketplaceItems, getKnownAvailableNode, ProgressWrap } from "./utils";
+import {
+    ConnectionFilterType,
+    DevantConnectionFlow,
+    filterConnectionMarketplaceItems,
+    getKnownAvailableNode,
+    INTERNAL_SERVICES,
+    ProgressWrap,
+} from "./utils";
 
-// Target number of connections to show. Knowledge base services can only be filtered out client-side
-// (the marketplace tag filter is include-only), so over-fetch and trim to this size so filtered-out
-// KBs don't shrink the visible connections list (or search results).
+// Number of connections rendered in the list.
 const CONNECTIONS_PAGE_SIZE = 24;
-const MARKETPLACE_OVERFETCH_LIMIT = 100;
+
+// Knowledge base services have to be filtered out client-side to keep the visible count stable we over-fetch a fixed multiple of
+// the page size and trim back to CONNECTIONS_PAGE_SIZE.
+//
+// Note: If more than (LIMIT - CONNECTIONS_PAGE_SIZE) of the first fetched items get filtered out, 
+// the list renders FEWER than CONNECTIONS_PAGE_SIZE and there is no "load more" to recover the rest.
+// Also every (debounced) search request also fetches this many items.
+const MARKETPLACE_OVERFETCH_MULTIPLIER = 4;
+const MARKETPLACE_OVERFETCH_LIMIT = CONNECTIONS_PAGE_SIZE * MARKETPLACE_OVERFETCH_MULTIPLIER;
 
 interface DevantConnectorListProps {
     onItemSelect: (
@@ -57,9 +70,7 @@ export function DevantConnectorList(props: DevantConnectorListProps) {
     const { onItemSelect, fileName, target, searchText } = props;
     const { platformExtState, platformRpcClient } = usePlatformExtContext();
     const { rpcClient } = useRpcContext();
-    const [filterType, setFilterType] = useState<"all" | "internal-services" | "third-party-services" | "databases">(
-        "all",
-    );
+    const [filterType, setFilterType] = useState<ConnectionFilterType>("all");
 
     const [debouncedSearchText, setDebouncedSearchText] = useState(searchText || "");
 
@@ -146,7 +157,7 @@ export function DevantConnectorList(props: DevantConnectorListProps) {
         searchContent: false,
     };
 
-    if (filterType === "internal-services") {
+    if (filterType === INTERNAL_SERVICES) {
         getMarketPlaceParams.isThirdParty = false;
     }
     if (filterType === "third-party-services") {
@@ -205,7 +216,7 @@ export function DevantConnectorList(props: DevantConnectorListProps) {
     }
 
     let emptyText = "No resources in WSO2 Cloud";
-    if (filterType === "internal-services") {
+    if (filterType === INTERNAL_SERVICES) {
         emptyText = "No services running";
     } else if (filterType === "third-party-services") {
         emptyText = "No third party services configured";
@@ -228,8 +239,8 @@ export function DevantConnectorList(props: DevantConnectorListProps) {
                         </FilterButton>
                         <FilterButton
                             title="Services running in WSO2 Cloud"
-                            active={filterType === "internal-services"}
-                            onClick={() => setFilterType("internal-services")}
+                            active={filterType === INTERNAL_SERVICES}
+                            onClick={() => setFilterType(INTERNAL_SERVICES)}
                         >
                             Internal Services
                         </FilterButton>

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { MarketplaceItem } from "@wso2/wso2-platform-core";
+import { KB_SERVICE_TAG, filterConnectionMarketplaceItems } from "./utils";
+
+const PAGE_SIZE = 24;
+
+// Minimal MarketplaceItem stub; the filter only reads name, tags, and component.componentId.
+const svc = (name: string, tags: string[] = [], componentId?: string): MarketplaceItem =>
+    ({ name, tags, ...(componentId ? { component: { componentId } } : {}) } as unknown as MarketplaceItem);
+
+const names = (items: MarketplaceItem[]) => items.map((item) => item.name);
+
+describe("filterConnectionMarketplaceItems", () => {
+    it("excludes knowledge base services", () => {
+        const items = [svc("a"), svc("kb-1", [KB_SERVICE_TAG]), svc("b"), svc("kb-2", [KB_SERVICE_TAG])];
+
+        const result = filterConnectionMarketplaceItems(items, "all", undefined, PAGE_SIZE);
+
+        expect(names(result)).toEqual(["a", "b"]);
+        expect(result.some((item) => item.tags?.includes(KB_SERVICE_TAG))).toBe(false);
+    });
+
+    it("preserves the order of the remaining items", () => {
+        const items = [svc("c"), svc("kb", [KB_SERVICE_TAG]), svc("a"), svc("b")];
+
+        const result = filterConnectionMarketplaceItems(items, "all", undefined, PAGE_SIZE);
+
+        expect(names(result)).toEqual(["c", "a", "b"]);
+    });
+
+    it("caps the result at the page size", () => {
+        const items = Array.from({ length: 30 }, (_, i) => svc(`svc-${i}`));
+
+        const result = filterConnectionMarketplaceItems(items, "all", undefined, PAGE_SIZE);
+
+        expect(result).toHaveLength(PAGE_SIZE);
+        expect(result[0].name).toBe("svc-0");
+        expect(result[PAGE_SIZE - 1].name).toBe("svc-23");
+    });
+
+    it("keeps a full page of connections even when knowledge bases are mixed in", () => {
+        // Interleave knowledge bases with connections; KBs must not consume page slots.
+        const items: MarketplaceItem[] = [];
+        for (let i = 0; i < 30; i++) {
+            items.push(svc(`svc-${i}`));
+            if (i % 3 === 0) {
+                items.push(svc(`kb-${i}`, [KB_SERVICE_TAG]));
+            }
+        }
+
+        const result = filterConnectionMarketplaceItems(items, "all", undefined, PAGE_SIZE);
+
+        expect(result).toHaveLength(PAGE_SIZE);
+        expect(result.some((item) => item.tags?.includes(KB_SERVICE_TAG))).toBe(false);
+        expect(result[0].name).toBe("svc-0");
+    });
+
+    it("excludes the selected component's own service in internal-services mode", () => {
+        const items = [svc("own", [], "comp-1"), svc("other", [], "comp-2")];
+
+        const result = filterConnectionMarketplaceItems(items, "internal-services", "comp-1", PAGE_SIZE);
+
+        expect(names(result)).toEqual(["other"]);
+    });
+});

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.test.ts
@@ -79,4 +79,14 @@ describe("filterConnectionMarketplaceItems", () => {
 
         expect(names(result)).toEqual(["other"]);
     });
+
+    it("keeps componentless services in internal-services mode when no component is selected", () => {
+        // Regression: with selectedComponentId undefined, `componentId !== undefined` used to drop
+        // every componentless item. With no component to exclude, all non-KB items should be kept.
+        const items = [svc("no-comp-1"), svc("has-comp", [], "comp-2"), svc("no-comp-2")];
+
+        const result = filterConnectionMarketplaceItems(items, "internal-services", undefined, PAGE_SIZE);
+
+        expect(names(result)).toEqual(["no-comp-1", "has-comp", "no-comp-2"]);
+    });
 });

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
@@ -27,6 +27,10 @@ export const ProgressWrap = styled.div`
     padding: 40px;
 `;
 
+// Devant tags knowledge base services with this tag.
+export const KB_SERVICE_TAG = "knowledge-base-as-service";
+export const isKnowledgeBaseService = (item: MarketplaceItem) => item.tags?.includes(KB_SERVICE_TAG) ?? false;
+
 export enum DevantConnectionFlow {
     // Create related flows
     CREATE_INTERNAL_OAS = "CREATE_INTERNAL_OAS",

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
@@ -31,6 +31,32 @@ export const ProgressWrap = styled.div`
 export const KB_SERVICE_TAG = "knowledge-base-as-service";
 export const isKnowledgeBaseService = (item: MarketplaceItem) => item.tags?.includes(KB_SERVICE_TAG) ?? false;
 
+/**
+ * Filters marketplace items for the connections list: drops knowledge base services (they belong
+ * under "Add Knowledge Base"), applies the internal-services component filter, and trims to the
+ * page size. Order is preserved. The list is over-fetched because knowledge base services can only
+ * be excluded client-side, so trimming keeps the visible count independent of how many KBs are in
+ * the fetched page.
+ */
+export function filterConnectionMarketplaceItems(
+    items: MarketplaceItem[],
+    filterType: string,
+    selectedComponentId: string | undefined,
+    pageSize: number,
+): MarketplaceItem[] {
+    return items
+        .filter((item) => {
+            if (isKnowledgeBaseService(item)) {
+                return false;
+            }
+            if (filterType === "internal-services") {
+                return item.component?.componentId !== selectedComponentId;
+            }
+            return true;
+        })
+        .slice(0, pageSize);
+}
+
 export enum DevantConnectionFlow {
     // Create related flows
     CREATE_INTERNAL_OAS = "CREATE_INTERNAL_OAS",

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
@@ -29,6 +29,7 @@ export const ProgressWrap = styled.div`
 
 // Devant tags knowledge base services with this tag.
 export const KB_SERVICE_TAG = "knowledge-base-as-service";
+export const INTERNAL_SERVICES = "internal-services";
 export const isKnowledgeBaseService = (item: MarketplaceItem) => item.tags?.includes(KB_SERVICE_TAG) ?? false;
 
 /**
@@ -49,7 +50,7 @@ export function filterConnectionMarketplaceItems(
             if (isKnowledgeBaseService(item)) {
                 return false;
             }
-            if (filterType === "internal-services") {
+            if (filterType === INTERNAL_SERVICES) {
                 return item.component?.componentId !== selectedComponentId;
             }
             return true;

--- a/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/DevantConnections/utils.ts
@@ -32,6 +32,9 @@ export const KB_SERVICE_TAG = "knowledge-base-as-service";
 export const INTERNAL_SERVICES = "internal-services";
 export const isKnowledgeBaseService = (item: MarketplaceItem) => item.tags?.includes(KB_SERVICE_TAG) ?? false;
 
+// The filter tabs on the WSO2 Cloud connections list.
+export type ConnectionFilterType = "all" | "internal-services" | "third-party-services" | "databases";
+
 /**
  * Filters marketplace items for the connections list: drops knowledge base services (they belong
  * under "Add Knowledge Base"), applies the internal-services component filter, and trims to the
@@ -41,7 +44,7 @@ export const isKnowledgeBaseService = (item: MarketplaceItem) => item.tags?.incl
  */
 export function filterConnectionMarketplaceItems(
     items: MarketplaceItem[],
-    filterType: string,
+    filterType: ConnectionFilterType,
     selectedComponentId: string | undefined,
     pageSize: number,
 ): MarketplaceItem[] {
@@ -50,7 +53,7 @@ export function filterConnectionMarketplaceItems(
             if (isKnowledgeBaseService(item)) {
                 return false;
             }
-            if (filterType === INTERNAL_SERVICES) {
+            if (filterType === INTERNAL_SERVICES && selectedComponentId) {
                 return item.component?.componentId !== selectedComponentId;
             }
             return true;


### PR DESCRIPTION
## Purpose
> Previously Devant Knowledge Base services were listed in both under WSO2 cloud Connections and Knowledge Bases. Even though when we click a Devant Knowledge Base service under Knowledge Bases, it goes to a specified pre filled form, when user clicks a Devant Knowledge Base service under WSO2 cloud Connections, it just makes a regular connection. For now, we remove the Devant Knowledge Base services from WSO2 cloud Connections.

> Solves the issue https://github.com/wso2/product-integrator/issues/2221

## Approach
> Adds a filter for Marketplace items shown under WSO2 cloud Connections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added shared logic to identify Marketplace items tagged `"knowledge-base-as-a-service"`.
- Filtered Knowledge Base services from the WSO2 cloud Connections list.
- Updated the Knowledge Base page to use the shared filtering logic.
- Over-fetched Marketplace results before filtering to preserve the requested page size.
- Added tests for filtering, ordering, pagination, and internal service handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->