### PR TITLE
Fix branch rendering when a comment is the only child

### DIFF
--- a/packages/bi-diagram/src/test/__snapshots__/comment-only-branches.test.ts.snap
+++ b/packages/bi-diagram/src/test/__snapshots__/comment-only-branches.test.ts.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`comment-only branches — layout graph error handler: comment-only body is placeheld and wired 1`] = `
+"nodes:
+  start
+  eh1-startContainer
+  eh1-startContainer
+  eh1
+  eh1-Body
+  eh1-lastNode
+links:
+  eh1-startContainer -> eh1-Body  [no-add-button]
+  eh1-Body -> eh1  [no-add-button]
+  eh1 -> eh1-lastNode
+comment chips:
+  start <- c1"
+`;
+
+exports[`comment-only branches — layout graph if: comment-only then branch is placeheld and wired 1`] = `
+"nodes:
+  start
+  if1
+  if1-endif
+  if1-Then
+  if1-Else
+  if1-lastNode
+links:
+  start -> if1
+  if1 -> if1-Then  [label=Then, no-add-button]
+  if1-Then -> if1-endif  [broken, no-add-button]
+  if1 -> if1-Else  [broken, no-add-button]
+  if1-Else -> if1-endif  [broken, no-add-button]
+  if1-endif -> if1-lastNode
+comment chips:
+  if1 <- c1"
+`;
+
+exports[`comment-only branches — layout graph match: comment-only case branch is placeheld and wired 1`] = `
+"nodes:
+  start
+  match1
+  match1-endif
+  match1-1
+  match1-_
+  match1-lastNode
+links:
+  start -> match1
+  match1 -> match1-1  [label=1, no-add-button]
+  match1-1 -> match1-endif  [broken, no-add-button]
+  match1 -> match1-_  [broken, no-add-button]
+  match1-_ -> match1-endif  [broken, no-add-button]
+  match1-endif -> match1-lastNode
+comment chips:
+  match1 <- c1"
+`;
+
+exports[`comment-only branches — layout graph while: comment-only body is placeheld and wired 1`] = `
+"nodes:
+  start
+  while1
+  while1-endContainer
+  while1-Body
+  while1-lastNode
+links:
+  start -> while1
+  while1 -> while1-Body  [no-add-button]
+  while1-Body -> while1-endContainer  [no-add-button]
+  while1-endContainer -> while1-lastNode
+comment chips:
+  while1 <- c1"
+`;
+
+exports[`comments alongside real nodes — layout graph if: branch with a comment and a real node links to the real node 1`] = `
+"nodes:
+  start
+  if3
+  stmt
+  if3-endif
+  if3-Else
+  if3-lastNode
+links:
+  start -> if3
+  if3 -> stmt  [label=Then]
+  stmt -> if3-endif
+  if3 -> if3-Else  [broken, no-add-button]
+  if3-Else -> if3-endif  [broken, no-add-button]
+  if3-endif -> if3-lastNode
+comment chips:
+  stmt <- c1"
+`;
+
+exports[`comments alongside real nodes — layout graph if: trailing comment does not mask a returning last statement 1`] = `
+"nodes:
+  start
+  if2
+  ret
+  if2-endif
+  if2-Else
+  if2-lastNode
+links:
+  start -> if2
+  if2 -> ret  [label=Then]
+  ret -> if2-endif  [broken, no-add-button]
+  if2 -> if2-Else  [broken, no-add-button]
+  if2-Else -> if2-endif  [broken, no-add-button]
+  if2-endif -> if2-lastNode
+comment chips:
+  ret <- c1"
+`;

--- a/packages/bi-diagram/src/test/comment-only-branches.test.ts
+++ b/packages/bi-diagram/src/test/comment-only-branches.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Comments render as note chips on another node, never as widgets of their own, so a branch
+// whose only children are comments has no renderable content. It used to be treated as
+// non-empty, so it got no placeholder and no links — the branch silently vanished from the
+// canvas and the connector ran straight past it (e.g. `if true { // Hi }`).
+//
+// These snapshot the visitor pipeline's OUTPUT GRAPH (nodes + links + the link flags that
+// drive rendering) rather than the DOM: the defect was missing links, which a "renders
+// without throwing" assertion cannot see. Diagram.semantic.test.tsx already had a
+// comment-in-else case and this bug still shipped past it.
+
+import { InitVisitor } from "../visitors/InitVisitor";
+import { SizingVisitor } from "../visitors/SizingVisitor";
+import { PositionVisitor } from "../visitors/PositionVisitor";
+import { NodeFactoryVisitor } from "../visitors/NodeFactoryVisitor";
+import { traverseFlow } from "@wso2/ballerina-core";
+import { Flow, FlowNode } from "../utils/types";
+
+const viewState = () => ({ x: 0, y: 0, lw: 0, rw: 0, h: 0, clw: 0, crw: 0, ch: 0 });
+
+function node(id: string, kind: string, extra: Record<string, any> = {}): any {
+    return {
+        id,
+        metadata: { label: kind, description: "" },
+        codedata: { node: kind },
+        branches: [],
+        returning: false,
+        viewState: viewState(),
+        ...extra,
+    };
+}
+
+const comment = (id: string) => node(id, "COMMENT", { properties: { comment: { value: "Hi" } } });
+
+function branch(label: string, kind: string, children: any[], properties: Record<string, any> = {}) {
+    return { label, kind: "BLOCK", codedata: { node: kind }, repeatable: "ONE", properties, children };
+}
+
+// A match case's pattern list, as the LS emits it (InitVisitor reads value[0].value).
+const patterns = (value: string) => ({ patterns: { value: [{ value }] } });
+
+/**
+ * Run the real layout pipeline (the same chain Diagram.tsx drives) and serialize the
+ * resulting graph. Non-default link flags are appended so a branch drawn as a dangling
+ * "returning" line is distinguishable from a normal one.
+ */
+function graph(nodes: any[]): string {
+    const flow = { fileName: "test.bal", nodes: JSON.parse(JSON.stringify(nodes)), connections: [] } as unknown as Flow;
+    traverseFlow(flow, new InitVisitor(flow));
+    traverseFlow(flow, new SizingVisitor());
+    traverseFlow(flow, new PositionVisitor());
+    const factory = new NodeFactoryVisitor();
+    traverseFlow(flow, factory);
+
+    const links = factory.getLinks().map((link: any) => {
+        const from = link.getSourcePort()?.getNode()?.getID();
+        const to = link.getTargetPort()?.getNode()?.getID();
+        const flags = [
+            link.label ? `label=${link.label}` : "",
+            link.brokenLine ? "broken" : "",
+            link.showAddButton ? "" : "no-add-button",
+        ].filter(Boolean);
+        return `  ${from} -> ${to}${flags.length ? `  [${flags.join(", ")}]` : ""}`;
+    });
+
+    const comments = [...factory.getNodeComments()].map(
+        ([target, notes]: any) => `  ${target} <- ${notes.map((c: any) => c.id).join(", ")}`
+    );
+
+    return [
+        "nodes:",
+        ...factory.getNodes().map((n: any) => `  ${n.getID()}`),
+        "links:",
+        ...links,
+        "comment chips:",
+        ...(comments.length ? comments : ["  (none)"]),
+    ].join("\n");
+}
+
+const start = () => node("start", "EVENT_START");
+
+describe("comment-only branches — layout graph", () => {
+    // `if true { // Hi }` — the reported case. Before the fix the Then branch produced no
+    // node and no links at all, so only the synthetic dashed Else path reached the endif.
+    it("if: comment-only then branch is placeheld and wired", () => {
+        const ifNode = node("if1", "IF", {
+            branches: [branch("Then", "CONDITIONAL", [comment("c1")])],
+        });
+        expect(graph([start(), ifNode])).toMatchSnapshot();
+    });
+
+    it("match: comment-only case branch is placeheld and wired", () => {
+        const matchNode = node("match1", "MATCH", {
+            branches: [branch("1", "CONDITIONAL", [comment("c1")], patterns("1"))],
+        });
+        expect(graph([start(), matchNode])).toMatchSnapshot();
+    });
+
+    it("while: comment-only body is placeheld and wired", () => {
+        const whileNode = node("while1", "WHILE", {
+            branches: [branch("Body", "BODY", [comment("c1")])],
+        });
+        expect(graph([start(), whileNode])).toMatchSnapshot();
+    });
+
+    // The worst case: before the fix the whole body branch was unwired, leaving the error
+    // handler with nothing but its trailing link.
+    it("error handler: comment-only body is placeheld and wired", () => {
+        const errorHandler = node("eh1", "ERROR_HANDLER", {
+            branches: [
+                branch("Body", "BODY", [comment("c1")]),
+                branch("On Failure", "ON_FAILURE", [node("log", "FUNCTION_CALL")]),
+            ],
+        });
+        expect(graph([start(), errorHandler])).toMatchSnapshot();
+    });
+});
+
+describe("comments alongside real nodes — layout graph", () => {
+    // A trailing comment used to be read as the branch's last node, so a `return` looked
+    // non-returning: the out-link lost `broken` and wrongly kept its add button.
+    it("if: trailing comment does not mask a returning last statement", () => {
+        const ifNode = node("if2", "IF", {
+            branches: [branch("Then", "CONDITIONAL", [node("ret", "RETURN", { returning: true }), comment("c1")])],
+        });
+        expect(graph([start(), ifNode])).toMatchSnapshot();
+    });
+
+    // Guard against over-correcting: a branch holding a real node is NOT empty, so it must
+    // link to that node and gain no placeholder, with the comment still surfacing as a chip.
+    it("if: branch with a comment and a real node links to the real node", () => {
+        const ifNode = node("if3", "IF", {
+            branches: [branch("Then", "CONDITIONAL", [comment("c1"), node("stmt", "EXPRESSION")])],
+        });
+        expect(graph([start(), ifNode])).toMatchSnapshot();
+    });
+});
+
+describe("comment-only branches — comment preservation", () => {
+    // The branch must not be "fixed" by dropping the comment: it still has to reach the
+    // canvas as a note chip.
+    it("keeps the comment as a note chip", () => {
+        const ifNode = node("if4", "IF", {
+            branches: [branch("Then", "CONDITIONAL", [comment("only-comment")])],
+        });
+        const flow = {
+            fileName: "test.bal",
+            nodes: JSON.parse(JSON.stringify([start(), ifNode])),
+            connections: [],
+        } as unknown as Flow;
+        traverseFlow(flow, new InitVisitor(flow));
+        traverseFlow(flow, new SizingVisitor());
+        traverseFlow(flow, new PositionVisitor());
+        const factory = new NodeFactoryVisitor();
+        traverseFlow(flow, factory);
+
+        const chips = [...factory.getNodeComments().values()].flat() as FlowNode[];
+        expect(chips.map((c) => c.id)).toContain("only-comment");
+    });
+});

--- a/packages/bi-diagram/src/visitors/InitVisitor.ts
+++ b/packages/bi-diagram/src/visitors/InitVisitor.ts
@@ -51,6 +51,12 @@ export class InitVisitor implements BaseVisitor {
         return true;
     }
 
+    // Comments render as note chips on another node, not as widgets of their own, so a branch
+    // whose children are all comments has nothing to link to and must be treated as empty too.
+    private isBranchEmpty(branch: Branch): boolean {
+        return !branch.children || branch.children.every((child) => child.codedata.node === "COMMENT");
+    }
+
     beginVisitNode(node: FlowNode, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
         node.viewState = this.getDefaultViewState();
@@ -109,8 +115,8 @@ export class InitVisitor implements BaseVisitor {
                 }
             }
 
-            // if branch is empty add empty node
-            if (!branch.children || branch.children.length === 0) {
+            // if branch is empty (or only holds comments) add empty node
+            if (this.isBranchEmpty(branch)) {
                 // empty branch
                 // add empty node as `add new node` button
                 const emptyNode: FlowNode = {
@@ -180,8 +186,8 @@ export class InitVisitor implements BaseVisitor {
                 }
             }
 
-            // if branch is empty add empty node
-            if (!branch.children || branch.children.length === 0) {
+            // if branch is empty (or only holds comments) add empty node
+            if (this.isBranchEmpty(branch)) {
                 // empty branch
                 // add empty node as `add new node` button
                 const emptyNode: FlowNode = {
@@ -282,8 +288,8 @@ export class InitVisitor implements BaseVisitor {
             }
         }
 
-        // add empty node if the branch is empty
-        if (!branch.children || branch.children.length === 0) {
+        // add empty node if the branch is empty (or only holds comments)
+        if (this.isBranchEmpty(branch)) {
             // empty branch
             // add empty node as `add new node` button
             const emptyNode: FlowNode = {
@@ -347,8 +353,8 @@ export class InitVisitor implements BaseVisitor {
             }
         }
 
-        // add empty node if the body branch is empty
-        if (!bodyBranch.children || bodyBranch.children.length === 0) {
+        // add empty node if the body branch is empty (or only holds comments)
+        if (this.isBranchEmpty(bodyBranch)) {
             // add empty node as `add new node` button
             const emptyNode: FlowNode = {
                 id: getCustomNodeId(node.id, bodyBranch.label),

--- a/packages/bi-diagram/src/visitors/InitVisitor.ts
+++ b/packages/bi-diagram/src/visitors/InitVisitor.ts
@@ -53,8 +53,8 @@ export class InitVisitor implements BaseVisitor {
 
     // Comments render as note chips on another node, not as widgets of their own, so a branch
     // whose children are all comments has nothing to link to and must be treated as empty too.
-    private isBranchEmpty(branch: Branch): boolean {
-        return !branch.children || branch.children.every((child) => child.codedata.node === "COMMENT");
+    private isEmptyBranchOrOnlyComments(branch: Branch): boolean {
+        return !branch.children || branch.children.length === 0 || branch.children.every((child) => child.codedata.node === "COMMENT");
     }
 
     beginVisitNode(node: FlowNode, parent?: FlowNode): void {
@@ -116,7 +116,7 @@ export class InitVisitor implements BaseVisitor {
             }
 
             // if branch is empty (or only holds comments) add empty node
-            if (this.isBranchEmpty(branch)) {
+            if (this.isEmptyBranchOrOnlyComments(branch)) {
                 // empty branch
                 // add empty node as `add new node` button
                 const emptyNode: FlowNode = {
@@ -187,7 +187,7 @@ export class InitVisitor implements BaseVisitor {
             }
 
             // if branch is empty (or only holds comments) add empty node
-            if (this.isBranchEmpty(branch)) {
+            if (this.isEmptyBranchOrOnlyComments(branch)) {
                 // empty branch
                 // add empty node as `add new node` button
                 const emptyNode: FlowNode = {
@@ -289,7 +289,7 @@ export class InitVisitor implements BaseVisitor {
         }
 
         // add empty node if the branch is empty (or only holds comments)
-        if (this.isBranchEmpty(branch)) {
+        if (this.isEmptyBranchOrOnlyComments(branch)) {
             // empty branch
             // add empty node as `add new node` button
             const emptyNode: FlowNode = {
@@ -354,7 +354,7 @@ export class InitVisitor implements BaseVisitor {
         }
 
         // add empty node if the body branch is empty (or only holds comments)
-        if (this.isBranchEmpty(bodyBranch)) {
+        if (this.isEmptyBranchOrOnlyComments(bodyBranch)) {
             // add empty node as `add new node` button
             const emptyNode: FlowNode = {
                 id: getCustomNodeId(node.id, bodyBranch.label),

--- a/packages/bi-diagram/src/visitors/NodeFactoryVisitor.ts
+++ b/packages/bi-diagram/src/visitors/NodeFactoryVisitor.ts
@@ -182,7 +182,7 @@ export class NodeFactoryVisitor implements BaseVisitor {
     }
 
     // Comments render as note chips on another node, so they never count as branch content.
-    private getRenderableChildren(branch: Branch): FlowNode[] {
+    private getRenderableBranchChildren(branch: Branch): FlowNode[] {
         return branch.children?.filter((child) => child.codedata.node !== "COMMENT") ?? [];
     }
 
@@ -334,7 +334,7 @@ export class NodeFactoryVisitor implements BaseVisitor {
             }
 
             // get last child node model
-            const renderableChildren = this.getRenderableChildren(branch);
+            const renderableChildren = this.getRenderableBranchChildren(branch);
             const lastNode = renderableChildren.at(-1);
             if (!lastNode) {
                 console.error("Branch has no renderable children", branch);
@@ -548,7 +548,7 @@ export class NodeFactoryVisitor implements BaseVisitor {
         endContainerEmptyNode.setParentFlowNode(node);
         this.lastNodeModel = endContainerEmptyNode;
 
-        const renderableChildren = this.getRenderableChildren(branch);
+        const renderableChildren = this.getRenderableBranchChildren(branch);
         if (renderableChildren.length === 1 && renderableChildren[0].codedata.node === "EMPTY") {
             const branchEmptyNodeModel = renderableChildren[0];
 
@@ -703,7 +703,7 @@ export class NodeFactoryVisitor implements BaseVisitor {
             this.lastNodeModel = containerNodeModel;
         }
 
-        const bodyRenderableChildren = this.getRenderableChildren(bodyBranch);
+        const bodyRenderableChildren = this.getRenderableBranchChildren(bodyBranch);
         if (bodyRenderableChildren.at(0)?.codedata.node === "EMPTY") {
             const branchEmptyNodeModel = bodyRenderableChildren.at(0);
             if (!branchEmptyNodeModel || !branchEmptyNodeModel.viewState) {

--- a/packages/bi-diagram/src/visitors/NodeFactoryVisitor.ts
+++ b/packages/bi-diagram/src/visitors/NodeFactoryVisitor.ts
@@ -181,6 +181,11 @@ export class NodeFactoryVisitor implements BaseVisitor {
         }
     }
 
+    // Comments render as note chips on another node, so they never count as branch content.
+    private getRenderableChildren(branch: Branch): FlowNode[] {
+        return branch.children?.filter((child) => child.codedata.node !== "COMMENT") ?? [];
+    }
+
     private getBranchStartNode(branch: Branch): NodeModel | undefined {
         // Comments render as note chips on the following node, not as widgets — skip them
         const firstChild = branch.children.find((child) => child.codedata.node !== "COMMENT");
@@ -329,20 +334,21 @@ export class NodeFactoryVisitor implements BaseVisitor {
             }
 
             // get last child node model
-            const lastNode = branch.children.at(-1);
+            const renderableChildren = this.getRenderableChildren(branch);
+            const lastNode = renderableChildren.at(-1);
+            if (!lastNode) {
+                console.error("Branch has no renderable children", branch);
+                return;
+            }
             // check last node is a returning node
             if (!lastNode.returning) {
                 allBranchesReturn = false;
             }
 
             // handle empty nodes in empty branches
-            if (
-                branch.children &&
-                branch.children.length === 1 &&
-                branch.children.find((n) => n.codedata.node === "EMPTY")
-            ) {
+            if (renderableChildren.length === 1 && lastNode.codedata.node === "EMPTY") {
                 // empty branch
-                const branchEmptyNodeModel = branch.children.at(0);
+                const branchEmptyNodeModel = lastNode;
                 let branchEmptyNode = this.createEmptyNode(
                     branchEmptyNodeModel.id,
                     branchEmptyNodeModel.viewState.x,
@@ -542,12 +548,9 @@ export class NodeFactoryVisitor implements BaseVisitor {
         endContainerEmptyNode.setParentFlowNode(node);
         this.lastNodeModel = endContainerEmptyNode;
 
-        if (
-            branch.children &&
-            branch.children.length === 1 &&
-            branch.children.find((n) => n.codedata.node === "EMPTY")
-        ) {
-            const branchEmptyNodeModel = branch.children.at(0);
+        const renderableChildren = this.getRenderableChildren(branch);
+        if (renderableChildren.length === 1 && renderableChildren[0].codedata.node === "EMPTY") {
+            const branchEmptyNodeModel = renderableChildren[0];
 
             let branchEmptyNode = this.createEmptyNode(
                 branchEmptyNodeModel.id,
@@ -569,9 +572,9 @@ export class NodeFactoryVisitor implements BaseVisitor {
             return;
         }
 
-        const lastNode = branch.children.at(-1);
+        const lastNode = renderableChildren.at(-1);
         const lastChildNodeModel = this.getBranchEndNode(branch);
-        if (!lastChildNodeModel) {
+        if (!lastNode || !lastChildNodeModel) {
             console.error("Cannot find last child node model in branch", branch);
             return;
         }
@@ -700,8 +703,9 @@ export class NodeFactoryVisitor implements BaseVisitor {
             this.lastNodeModel = containerNodeModel;
         }
 
-        if (bodyBranch.children && bodyBranch.children.at(0)?.codedata.node === "EMPTY") {
-            const branchEmptyNodeModel = bodyBranch.children.at(0);
+        const bodyRenderableChildren = this.getRenderableChildren(bodyBranch);
+        if (bodyRenderableChildren.at(0)?.codedata.node === "EMPTY") {
+            const branchEmptyNodeModel = bodyRenderableChildren.at(0);
             if (!branchEmptyNodeModel || !branchEmptyNodeModel.viewState) {
                 console.error("Branch empty node model not found", bodyBranch);
                 return;


### PR DESCRIPTION
Fixes : https://github.com/wso2/product-integrator/issues/2223
### Problem

A branch whose only child is a comment rendered as nothing — no widget, no links — so the diagram drew a connector straight past it. Repro:

```ballerina
do {
    if true {
        // Hi
    }
} on fail error e {
    log:printError("Error occurred", 'error = e);
    return e;
}
```

The `Then` branch disappears and the dashed line runs from the `If` diamond to the Error Handler.

### Cause

Comments render as note chips on another node rather than as widgets, so a comment-only branch has no renderable content — but it was not treated as empty:

- `InitVisitor` — empty-branch checks used `children.length === 0`, so no `EMPTY` placeholder was inserted.
- `NodeFactoryVisitor` — the branch placeholder widget is created only behind checks a `COMMENT` sibling breaks (`children.length === 1`, `children.at(0)`), so even with a placeholder present nothing was created.

Both layers had to change; fixing only the first is a no-op.

### Fix

Adds `getRenderableChildren()` to skip `COMMENT` children in those checks, and uses it for the last-child lookups so a trailing comment is no longer mistaken for a branch's last node. Covers If/Match, While/Foreach/Lock and the ErrorHandler body branch.

### Verification

Ran the visitor pipeline over the reported flow model and compared against the unfixed baseline:

```
before:  36031 -> 36031-Else -> 36031-endif          (Else only)
after:   36031 -> 36031-Then -> 36031-endif          (Then now wired)
         36031 -> 36031-Else -> 36031-endif
```

The `before` run reproduces the reported diagram. Also checked while-loop with comment-only body, if with a trailing comment, a normal if, and a genuinely empty if — all correct. `diff.test.ts` and `WorkflowNodeCompatibility.test.ts` pass (36 tests).

### Not covered

The note chip still attaches to the `If` node rather than inside the branch, since comments flush to the last real node and the placeholder is an `EMPTY` node with no chip support. Existing behaviour, left as-is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed rendering for branches whose only child is a comment.
- Excluded `COMMENT` nodes from branch emptiness checks and final-node lookup.
- Added `EMPTY` placeholders for comment-only branches in conditional, loop, container, and error-handler branches.
- Added snapshot tests for layout nodes, links, and rendering flags.
- Verified normal, empty, comment-only, loop, and trailing-comment cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->