### PR TITLE
Re-land review-mode empty-diff fix (#855) and fix PackageUtil sample-project concurrency

### DIFF
--- a/packages/ballerina-core/src/interfaces/extended-lang-client.ts
+++ b/packages/ballerina-core/src/interfaces/extended-lang-client.ts
@@ -854,6 +854,8 @@ export interface ProjectDiagnosticsRequest {
 
 export interface ProjectDiagnosticsResponse {
     errorDiagnosticMap?: Map<string, Diagnostic[]>;
+    /** Why diagnostics could not be produced (e.g. the package failed to compile). */
+    errorMsg?: string;
 }
 
 export interface MainFunctionParamsRequest {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -416,6 +416,20 @@ export interface EnsureAiBaselineResponse {
     errorMsg?: string;
 }
 
+/**
+ * Request to warm the LS module-package caches for a package's direct dependencies,
+ * so the first review-diff flow-model fetch does not pay the one-time dependency
+ * resolution/compilation cost interactively. Fired in the background at run start.
+ */
+export interface PrewarmDependenciesRequest {
+    projectPath: string;
+}
+
+export interface PrewarmDependenciesResponse {
+    warmedDependencyCount?: number;
+    errorMsg?: string;
+}
+
 // Numeric enum values from the API
 export enum ChangeTypeEnum {
     ADDITION = 0,

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -425,6 +425,14 @@ export interface SemanticDiff {
 export interface SemanticDiffResponse {
     loadDesignDiagrams: boolean;
     semanticDiffs: SemanticDiff[];
+    /** Set when diff computation failed entirely; semanticDiffs is absent in that case. */
+    errorMsg?: string;
+    /**
+     * Set when the syntax-level diffs succeeded but the package failed to compile
+     * (design-model comparison). The diffs are still usable, but flow diagrams
+     * will likely be unavailable for the same reason.
+     */
+    compilationError?: string;
 }
 
 export interface RevertGenerationRequest {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -393,6 +393,29 @@ export interface SemanticDiffRequest {
     projectPath: string;
 }
 
+/** One file's frozen baseline content, relative to the package root. */
+export interface AiBaselineFile {
+    filePath: string;
+    content: string;
+}
+
+/**
+ * Request to (re)establish a package's ai:// frozen baseline from explicit file contents.
+ * Unlike the didOpen/didChange notification protocol, the LS applies everything before
+ * responding, so callers can await the baseline being in place.
+ */
+export interface EnsureAiBaselineRequest {
+    projectPath: string;
+    files: AiBaselineFile[];
+}
+
+export interface EnsureAiBaselineResponse {
+    seededFileCount: number;
+    /** Files whose baseline content could not be applied; the rest are in place. */
+    failedFiles?: string[];
+    errorMsg?: string;
+}
+
 // Numeric enum values from the API
 export enum ChangeTypeEnum {
     ADDITION = 0,
@@ -401,10 +424,34 @@ export enum ChangeTypeEnum {
 
 }
 
+/**
+ * Mirrors the LS NodeKind wire ordinals
+ * (io.ballerina.copilotagent.core.models.NodeKind) — the single TS copy.
+ */
+export enum NodeKindEnum {
+    MODULE_FUNCTION = 0,
+    OBJECT_FUNCTION = 1,
+    TYPE_DEFINITION = 2,
+    DATA_MAPPING_FUNCTION = 3,
+    MODULE_VARIABLE = 4,
+    CONSTANT = 5,
+    LISTENER = 6,
+    CLASS_DEFINITION = 7,
+    ENUM_DECLARATION = 8,
+    IMPORT_DECLARATION = 9,
+}
+
 export type ChangeType = "ADDITION" | "MODIFICATION" | "DELETION";
 
 export interface IdentifierMetadata {
     name: string;
+    /**
+     * Before/after source text, present on construct kinds the review UI renders as
+     * source blocks (module vars, constants, listeners, classes, enums, imports).
+     * Either side is absent for a pure addition/deletion.
+     */
+    oldSource?: string;
+    newSource?: string;
 }
 
 export interface ResourceMetadata {

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -257,6 +257,8 @@ export interface ReviewModeData {
     modifiedFiles?: string[];
     tempProjectPath?: string;
     isWorkspace?: boolean;
+    /** Compile/diff failure to surface in the review UI instead of a silent empty review. */
+    semanticDiffError?: string;
 }
 
 // --- Evalset Trace Types ---
@@ -852,6 +854,8 @@ export interface GenerationReviewState {
         semanticDiffs: object[];
         loadDesignDiagrams: boolean;
         isWorkspace: boolean;
+        /** Compile/diff failure to surface in the review UI instead of a silent empty review. */
+        semanticDiffError?: string;
     };
 }
 

--- a/packages/ballerina-extension/src/core/extended-language-client.ts
+++ b/packages/ballerina-extension/src/core/extended-language-client.ts
@@ -292,6 +292,8 @@ import {
     ClausePositionRequest,
     SemanticDiffRequest,
     SemanticDiffResponse,
+    EnsureAiBaselineRequest,
+    EnsureAiBaselineResponse,
     ConvertExpressionRequest,
     ConvertExpressionResponse,
     IntrospectDatabaseRequest,
@@ -499,6 +501,7 @@ enum EXTENDED_APIS {
     BI_AI_GEN_AGENT_DEFINITION = 'agentManager/genAgentDefinition',
     BI_AI_GET_PACKAGE_VERSION = 'agentManager/getPackageVersion',
     BI_GET_SEMANTIC_DIFF = 'copilotAgentService/getSemanticDiff',
+    BI_ENSURE_AI_BASELINE = 'copilotAgentService/ensureAiBaseline',
     BI_IS_ICP_ENABLED = 'icpService/isIcpEnabled',
     BI_ADD_ICP = 'icpService/addICP',
     BI_DISABLE_ICP = 'icpService/disableICP',
@@ -1619,6 +1622,10 @@ export class ExtendedLangClient extends LanguageClient implements ExtendedLangCl
 
     async getSemanticDiff(params: SemanticDiffRequest): Promise<SemanticDiffResponse> {
         return this.sendRequest<SemanticDiffResponse>(EXTENDED_APIS.BI_GET_SEMANTIC_DIFF, params);
+    }
+
+    async ensureAiBaseline(params: EnsureAiBaselineRequest): Promise<EnsureAiBaselineResponse> {
+        return this.sendRequest<EnsureAiBaselineResponse>(EXTENDED_APIS.BI_ENSURE_AI_BASELINE, params);
     }
 
     // <------------ BI APIS END --------------->

--- a/packages/ballerina-extension/src/core/extended-language-client.ts
+++ b/packages/ballerina-extension/src/core/extended-language-client.ts
@@ -294,6 +294,8 @@ import {
     SemanticDiffResponse,
     EnsureAiBaselineRequest,
     EnsureAiBaselineResponse,
+    PrewarmDependenciesRequest,
+    PrewarmDependenciesResponse,
     ConvertExpressionRequest,
     ConvertExpressionResponse,
     IntrospectDatabaseRequest,
@@ -502,6 +504,7 @@ enum EXTENDED_APIS {
     BI_AI_GET_PACKAGE_VERSION = 'agentManager/getPackageVersion',
     BI_GET_SEMANTIC_DIFF = 'copilotAgentService/getSemanticDiff',
     BI_ENSURE_AI_BASELINE = 'copilotAgentService/ensureAiBaseline',
+    BI_PREWARM_DEPENDENCIES = 'copilotAgentService/prewarmDependencies',
     BI_IS_ICP_ENABLED = 'icpService/isIcpEnabled',
     BI_ADD_ICP = 'icpService/addICP',
     BI_DISABLE_ICP = 'icpService/disableICP',
@@ -1626,6 +1629,10 @@ export class ExtendedLangClient extends LanguageClient implements ExtendedLangCl
 
     async ensureAiBaseline(params: EnsureAiBaselineRequest): Promise<EnsureAiBaselineResponse> {
         return this.sendRequest<EnsureAiBaselineResponse>(EXTENDED_APIS.BI_ENSURE_AI_BASELINE, params);
+    }
+
+    async prewarmDependencies(params: PrewarmDependenciesRequest): Promise<PrewarmDependenciesResponse> {
+        return this.sendRequest<PrewarmDependenciesResponse>(EXTENDED_APIS.BI_PREWARM_DEPENDENCIES, params);
     }
 
     // <------------ BI APIS END --------------->

--- a/packages/ballerina-extension/src/features/ai/activator.ts
+++ b/packages/ballerina-extension/src/features/ai/activator.ts
@@ -182,7 +182,7 @@ export function activateAIFeatures(ballerinaExternalInstance: BallerinaExtension
         });
 
         commands.registerCommand('ballerina.test.ai.restoreCheckpoint', async (checkpoint: Checkpoint, skipArtifactWait?: boolean): Promise<void> => {
-            return await restoreWorkspaceSnapshot(checkpoint, skipArtifactWait);
+            await restoreWorkspaceSnapshot(checkpoint, skipArtifactWait);
         });
 
         commands.registerCommand('ballerina.test.ai.integrateCodeToWorkspace', async (tempProjectPath: string, modifiedFiles: string[], ctx: ExecutionContext): Promise<void> => {

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -23,6 +23,7 @@ import { ModelMessage, stepCountIs, streamText, TextStreamPart } from 'ai';
 import { getAnthropicClient, getProviderCacheControl, getProviderModelOptions, addCacheControlToMessages, ANTHROPIC_SONNET } from '../utils/ai-client';
 import { populateHistoryForAgent, getErrorMessage, getErrorCode, buildChatError } from '../utils/ai-utils';
 import { seedAiBaselines } from '../utils/project/ls-schema-notifications';
+import { mapWithConcurrency } from '../utils/concurrency';
 import { getSystemPrompt, getUserPrompt } from './prompts';
 import { FollowupSituation, startFollowupSuggestions } from './followups';
 import { prepareAgentsMdForTurn } from './agents-md';
@@ -307,6 +308,18 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                 await seedAiBaselines(tempProjectPath, projects);
             } else {
                 console.log(`[AgentExecutor] Skipping ai:// baseline seed (skipFreshProjectSetup)`);
+            }
+
+            // Fire-and-forget: warm the LS module-package caches for each package's
+            // dependencies while the generation streams, so the first review-diff diagram
+            // does not pay the one-time dependency resolution/compilation cost (seconds)
+            // interactively. Failures are irrelevant — the fetch path pays the cost lazily.
+            for (const project of projects) {
+                const pkgRoot = project.packagePath
+                    ? path.join(tempProjectPath, project.packagePath)
+                    : tempProjectPath;
+                StateMachine.langClient().prewarmDependencies({ projectPath: pkgRoot })
+                    .catch(() => { /* best-effort warm-up only */ });
             }
 
             const workspaceId = this.config.executionContext.workspacePath || this.config.executionContext.projectPath;
@@ -1073,9 +1086,15 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
             const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
             let semanticDiffError: string | undefined;
             let diffedPackageCount = 0;
-            for (const pkg of affectedPackages) {
+            // Each package's diff is an independent LS request against its own project root,
+            // so fetch them concurrently; results are folded back in affectedPackages order
+            // below to keep diffPackageMap/semanticDiffs alignment and error-message order
+            // deterministic. Bounded, because each request can trigger two full package
+            // compilations and migration turns can touch many packages at once.
+            const diffPackages = affectedPackages.filter(
                 // Skip workspace root — it only contains Ballerina.toml, not a real package
-                if (isWorkspace && pkg === workingProjectPath) { continue; }
+                pkg => !(isWorkspace && pkg === workingProjectPath));
+            const packageResults = await mapWithConcurrency(diffPackages, 3, async pkg => {
                 const pkgName = path.basename(pkg);
                 try {
                     const res = await langClient.getSemanticDiff({ projectPath: pkg });
@@ -1085,23 +1104,29 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                     if (res?.errorMsg) {
                         throw new Error(res.errorMsg);
                     }
-                    if (res) {
-                        diffedPackageCount++;
-                        diffPackageMap.push(...Array(res.semanticDiffs.length).fill(pkgName));
-                        semanticDiffs.push(...res.semanticDiffs);
-                        loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
-                        // Partial success: diffs are valid but the package failed to compile,
-                        // so flow diagrams will likely be unavailable. Keep the diffs and
-                        // surface the reason as a warning.
-                        semanticDiffError = semanticDiffError ?? res.compilationError ?? undefined;
-                    }
+                    return { pkgName, res, error: undefined as string | undefined };
                 } catch (err) {
-                    // One package failing must not discard the diffs already collected for
-                    // its siblings — keep going and report the failure alongside them.
+                    // One package failing must not discard the diffs collected for its
+                    // siblings — record the failure and report it alongside them.
                     console.error(`[AgentExecutor] getSemanticDiff failed for package ${pkg}; keeping other packages' diffs`, err);
                     const message = err instanceof Error ? err.message : String(err);
-                    const packageError = isWorkspace ? `${pkgName}: ${message}` : message;
-                    semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${packageError}` : packageError;
+                    return { pkgName, res: undefined, error: isWorkspace ? `${pkgName}: ${message}` : message };
+                }
+            });
+            for (const { pkgName, res, error } of packageResults) {
+                if (error !== undefined) {
+                    semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${error}` : error;
+                    continue;
+                }
+                if (res) {
+                    diffedPackageCount++;
+                    diffPackageMap.push(...Array(res.semanticDiffs.length).fill(pkgName));
+                    semanticDiffs.push(...res.semanticDiffs);
+                    loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
+                    // Partial success: diffs are valid but the package failed to compile,
+                    // so flow diagrams will likely be unavailable. Keep the diffs and
+                    // surface the reason as a warning.
+                    semanticDiffError = semanticDiffError ?? res.compilationError ?? undefined;
                 }
             }
 

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -1085,6 +1085,9 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                 : await determineAffectedPackages(accumulatedModifiedFiles, context.projects, context.ctx, workingProjectPath);
             const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
             let semanticDiffError: string | undefined;
+            const appendDiffError = (msg: string) => {
+                semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${msg}` : msg;
+            };
             let diffedPackageCount = 0;
             // Each package's diff is an independent LS request against its own project root,
             // so fetch them concurrently; results are folded back in affectedPackages order
@@ -1115,7 +1118,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
             });
             for (const { pkgName, res, error } of packageResults) {
                 if (error !== undefined) {
-                    semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${error}` : error;
+                    appendDiffError(error);
                     continue;
                 }
                 if (res) {
@@ -1125,8 +1128,11 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                     loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
                     // Partial success: diffs are valid but the package failed to compile,
                     // so flow diagrams will likely be unavailable. Keep the diffs and
-                    // surface the reason as a warning.
-                    semanticDiffError = semanticDiffError ?? res.compilationError ?? undefined;
+                    // surface the reason as a warning — appended so no package's reason
+                    // is dropped.
+                    if (res.compilationError) {
+                        appendDiffError(res.compilationError);
+                    }
                 }
             }
 

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -1040,22 +1040,34 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                 ? cachedAffectedPackages
                 : await determineAffectedPackages(accumulatedModifiedFiles, context.projects, context.ctx, workingProjectPath);
             const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
+            let semanticDiffError: string | undefined;
             for (const pkg of affectedPackages) {
                 // Skip workspace root — it only contains Ballerina.toml, not a real package
                 if (isWorkspace && pkg === workingProjectPath) { continue; }
                 const pkgName = path.basename(pkg);
                 try {
                     const res = await langClient.getSemanticDiff({ projectPath: pkg });
+                    // errorMsg means the LS could not compute diffs at all (e.g. the package
+                    // fails to compile) — semanticDiffs is absent, so treat it as a failure
+                    // instead of reading past it.
+                    if (res?.errorMsg) {
+                        throw new Error(res.errorMsg);
+                    }
                     if (res) {
                         diffPackageMap.push(...Array(res.semanticDiffs.length).fill(pkgName));
                         semanticDiffs.push(...res.semanticDiffs);
                         loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
+                        // Partial success: diffs are valid but the package failed to compile,
+                        // so flow diagrams will likely be unavailable. Keep the diffs and
+                        // surface the reason as a warning.
+                        semanticDiffError = semanticDiffError ?? res.compilationError ?? undefined;
                     }
                 } catch (err) {
                     console.error(`[AgentExecutor] getSemanticDiff failed for package ${pkg}, falling back to plain modifiedFiles`, err);
                     semanticDiffs.length = 0;
                     diffPackageMap.length = 0;
                     loadDesignDiagrams = false;
+                    semanticDiffError = err instanceof Error ? err.message : String(err);
                     break;
                 }
             }
@@ -1070,6 +1082,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                 modifiedFiles: accumulatedModifiedFiles,
                 tempProjectPath: workingProjectPath,
                 isWorkspace,
+                semanticDiffError,
             };
 
             approvalViewManager.openReviewMode(context.messageId, reviewData, false);
@@ -1082,7 +1095,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                 tempProjectPath: workingProjectPath,
                 modifiedFiles: accumulatedModifiedFiles,
                 affectedPackagePaths: affectedPackages,
-                reviewView: { semanticDiffs, loadDesignDiagrams, isWorkspace },
+                reviewView: { semanticDiffs, loadDesignDiagrams, isWorkspace, semanticDiffError },
             });
 
             context.eventHandler({

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -22,7 +22,7 @@ import { StateMachine } from '../../../stateMachine';
 import { ModelMessage, stepCountIs, streamText, TextStreamPart } from 'ai';
 import { getAnthropicClient, getProviderCacheControl, getProviderModelOptions, addCacheControlToMessages, ANTHROPIC_SONNET } from '../utils/ai-client';
 import { populateHistoryForAgent, getErrorMessage, getErrorCode, buildChatError } from '../utils/ai-utils';
-import { sendAgentDidOpenForFreshProjects } from '../utils/project/ls-schema-notifications';
+import { seedAiBaselines } from '../utils/project/ls-schema-notifications';
 import { getSystemPrompt, getUserPrompt } from './prompts';
 import { FollowupSituation, startFollowupSuggestions } from './followups';
 import { prepareAgentsMdForTurn } from './agents-md';
@@ -147,6 +147,18 @@ function computeTokenBreakdown(
 }
 
 /**
+ * Normalizes a relative path for package-membership comparison: trims, collapses `.`
+ * segments, converts backslashes, and strips leading `./` and trailing slashes. The two
+ * sides being compared come from different authors (the workspace toml's `packages` list
+ * vs the LLM's verbatim tool `file_path` args), so raw string comparison misses trivially
+ * equivalent forms like `./orders` vs `orders/main.bal`.
+ */
+export function normalizeRelativePath(p: string): string {
+    const normalized = path.normalize(p.trim()).replace(/\\/g, '/').replace(/\/+$/, '');
+    return normalized === '.' ? '' : normalized;
+}
+
+/**
  * Determines which packages have been affected by analyzing modified files
  * Returns temp directory package paths for use with Language Server semantic diff API
  * @param modifiedFiles Array of relative file paths that were modified
@@ -173,18 +185,23 @@ async function determineAffectedPackages(
         return Array.from(affectedPackages);
     }
 
-    // Re-read workspace Ballerina.toml from temp to get the current package list
-    // (the agent may have added new packages during the session)
+    // Union of the current workspace Ballerina.toml package list (re-read so packages the
+    // agent added mid-run are present) and the generation-start ProjectSource packages.
+    // An empty toml `packages` array must fall back too — `??` alone doesn't cover it.
     const workspaceToml = await getWorkspaceTomlValues(tempProjectPath);
-    const packagePaths: string[] = workspaceToml?.workspace?.packages ?? projects.map(p => p.packagePath).filter(p => p !== "");
+    const tomlPackages = (workspaceToml?.workspace?.packages ?? []).map(normalizeRelativePath);
+    const sourcePackages = projects.map(p => normalizeRelativePath(p.packagePath ?? ''));
+    const packagePaths: string[] = Array.from(new Set([...tomlPackages, ...sourcePackages])).filter(p => p !== '');
 
     // For workspace scenario with multiple packages
     // We need to map modified files to their temp package paths
+    const unmatchedFiles: string[] = [];
     for (const modifiedFile of modifiedFiles) {
+        const normalizedFile = normalizeRelativePath(modifiedFile);
         let matched = false;
 
         for (const pkgPath of packagePaths) {
-            if (modifiedFile.startsWith(pkgPath + '/') || modifiedFile === pkgPath) {
+            if (normalizedFile.startsWith(pkgPath + '/') || normalizedFile === pkgPath) {
                 const tempPackagePath = path.join(tempProjectPath, pkgPath);
                 affectedPackages.add(tempPackagePath);
                 matched = true;
@@ -196,8 +213,19 @@ async function determineAffectedPackages(
         if (!matched) {
             // File at workspace root (e.g. root Ballerina.toml)
             affectedPackages.add(tempProjectPath);
+            unmatchedFiles.push(modifiedFile);
             console.log(`[determineAffectedPackages] File '${modifiedFile}' is at workspace root (temp): ${tempProjectPath}`);
         }
+    }
+
+    // Unmatched .bal files are a red flag: the workspace root holds no sources, so their
+    // package's diff would silently never be computed. Loud log so this is diagnosable.
+    const unmatchedBalFiles = unmatchedFiles.filter(f => f.endsWith('.bal'));
+    if (unmatchedBalFiles.length > 0) {
+        console.error(
+            `[determineAffectedPackages] ${unmatchedBalFiles.length} modified .bal file(s) matched no workspace package — their diffs will be missing.`,
+            { unmatchedBalFiles, packagePaths }
+        );
     }
 
     const result = Array.from(affectedPackages);
@@ -271,9 +299,12 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
             );
 
             // 2. Seed the ai:// baseline, unless the caller explicitly asked to skip it
-            // (migration reusing the same directory across sequential stages).
+            // (migration reusing the same directory across sequential stages). Awaited so
+            // the baseline is guaranteed in place before the first edit can touch disk —
+            // the LS-side ensureAiBaseline request applies the pre-edit contents before
+            // responding, unlike the old fire-and-forget didOpen seed.
             if (!this.config.lifecycle?.skipFreshProjectSetup) {
-                sendAgentDidOpenForFreshProjects(tempProjectPath, projects);
+                await seedAiBaselines(tempProjectPath, projects);
             } else {
                 console.log(`[AgentExecutor] Skipping ai:// baseline seed (skipFreshProjectSetup)`);
             }
@@ -1041,6 +1072,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                 : await determineAffectedPackages(accumulatedModifiedFiles, context.projects, context.ctx, workingProjectPath);
             const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
             let semanticDiffError: string | undefined;
+            let diffedPackageCount = 0;
             for (const pkg of affectedPackages) {
                 // Skip workspace root — it only contains Ballerina.toml, not a real package
                 if (isWorkspace && pkg === workingProjectPath) { continue; }
@@ -1054,6 +1086,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                         throw new Error(res.errorMsg);
                     }
                     if (res) {
+                        diffedPackageCount++;
                         diffPackageMap.push(...Array(res.semanticDiffs.length).fill(pkgName));
                         semanticDiffs.push(...res.semanticDiffs);
                         loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
@@ -1063,13 +1096,30 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
                         semanticDiffError = semanticDiffError ?? res.compilationError ?? undefined;
                     }
                 } catch (err) {
-                    console.error(`[AgentExecutor] getSemanticDiff failed for package ${pkg}, falling back to plain modifiedFiles`, err);
-                    semanticDiffs.length = 0;
-                    diffPackageMap.length = 0;
-                    loadDesignDiagrams = false;
-                    semanticDiffError = err instanceof Error ? err.message : String(err);
-                    break;
+                    // One package failing must not discard the diffs already collected for
+                    // its siblings — keep going and report the failure alongside them.
+                    console.error(`[AgentExecutor] getSemanticDiff failed for package ${pkg}; keeping other packages' diffs`, err);
+                    const message = err instanceof Error ? err.message : String(err);
+                    const packageError = isWorkspace ? `${pkgName}: ${message}` : message;
+                    semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${packageError}` : packageError;
                 }
+            }
+
+            // Diagnosability guard: files were modified, yet no package produced (or was
+            // even asked for) a diff and no error was recorded. Without this, a mapping
+            // failure is indistinguishable from a genuine no-op turn.
+            // (diffedPackageCount === 0 implies semanticDiffs is empty — diffs are only
+            // pushed in the branch that increments it.)
+            const modifiedBalFiles = accumulatedModifiedFiles.filter(f => f.endsWith('.bal'));
+            if (!semanticDiffError && modifiedBalFiles.length > 0 && diffedPackageCount === 0) {
+                semanticDiffError =
+                    `The review diff could not be computed: none of the ${modifiedBalFiles.length} modified .bal file(s) ` +
+                    `mapped to a reviewable package. The changes are already applied to your files.`;
+                console.error('[AgentExecutor] Review diff silently empty — modified files mapped to no package.', {
+                    modifiedFiles: accumulatedModifiedFiles,
+                    affectedPackages,
+                    workingProjectPath,
+                });
             }
 
             const reviewData: ReviewModeData = {

--- a/packages/ballerina-extension/src/features/ai/agent/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/index.ts
@@ -31,7 +31,7 @@ import { getProjectMetrics } from "../../telemetry/common/project-metrics";
 import { getHashedProjectId } from "../../telemetry/common/project-id";
 import { runEventStore } from "../utils/run-event-store";
 import { sendSaveChatNotification } from "../utils/ai-utils";
-import { finalizeRevertibleGeneration } from "../utils/generation-response";
+import { finalizeRevertibleGeneration, finalizeRevertibleGenerationsAllThreads } from "../utils/generation-response";
 
 // ==================================
 // Agent Generation Functions
@@ -127,10 +127,14 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
             throw new Error('A generation is already in progress. Please wait for it to finish before starting a new one.');
         }
 
-        // Moving on to a new generation implicitly accepts a still-open previous one.
-        // Nothing to clean up: edits already land directly in the real workspace, and there's
-        // no separate temp copy anymore (see existingTempPath below).
-        finalizeLastGeneration(projectRootPath, threadId);
+        // Moving on to a new generation implicitly accepts a still-open previous one —
+        // on EVERY thread of the project, not just this one: the upcoming ai:// baseline
+        // reseed is a per-package LS slot shared by all threads, so any other thread's
+        // still-open review would be silently invalidated (and its decline would restore
+        // stale content over this run's edits). Nothing to clean up beyond that: edits
+        // already land directly in the real workspace, and there's no separate temp copy
+        // anymore (see existingTempPath below).
+        finalizeRevertibleGenerationsAllThreads(projectRootPath);
 
         // Create config using factory function. existingTempPath makes the agent operate
         // directly on the real project root instead of AICommandExecutor creating a

--- a/packages/ballerina-extension/src/features/ai/agent/tools/diagnostics-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/diagnostics-utils.ts
@@ -1,5 +1,5 @@
 import { DiagnosticEntry, Diagnostics } from '@wso2/ballerina-core';
-import { checkProjectDiagnostics, isModuleNotFoundDiagsExist as resolveModuleNotFoundDiagnostics } from '../../../../rpc-managers/ai-panel/repair-utils';
+import { checkProjectDiagnostics, isModuleNotFoundDiagsExist as resolveModuleNotFoundDiagnostics, PACKAGE_COMPILATION_FAILED_PREFIX } from '../../../../rpc-managers/ai-panel/repair-utils';
 import { StateMachine } from '../../../../stateMachine';
 import * as path from 'path';
 import { Uri } from 'vscode';
@@ -162,12 +162,25 @@ export async function checkCompilationErrors(
         };
     } catch (error) {
         console.error("[DiagnosticsUtils] Error checking compilation errors:", error);
+        const reason = error instanceof Error ? error.message : 'Unknown error';
+        if (reason.startsWith(PACKAGE_COMPILATION_FAILED_PREFIX)) {
+            // The package itself cannot compile (e.g. an unresolvable dependency mix from a
+            // stale sticky Dependencies.toml) — distinct from an LS malfunction. Tell the
+            // agent the real cause so it can inform the user instead of silently finishing.
+            return {
+                diagnostics: [{ message: reason }],
+                message: `<CRITICAL_ERROR> The Ballerina package failed to compile, so diagnostics could not be produced.
+Reason: ${reason}
+This is an environment/dependency problem, not something to fix with code edits. Do not attempt further code changes for it. Inform the user that the project currently fails to compile with the reason above, and suggest running 'bal build' in the project to refresh its dependency resolution (Dependencies.toml) if the reason mentions a module or dependency.
+</CRITICAL_ERROR>`,
+            };
+        }
         return {
             diagnostics: [{
                 message: "Internal error occurred while checking compilation errors."
             }],
             message: `<CRITICAL_ERROR> Failed to check compilation errors due to an internal error. Avoid try to resolve this with code changes. Acknowledge the failure, consider the task is done.
-Reason: ${error instanceof Error ? error.message : 'Unknown error'}
+Reason: ${reason}
 </CRITICAL_ERROR>`,
         };
     }

--- a/packages/ballerina-extension/src/features/ai/agent/tools/text-editor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/text-editor.ts
@@ -24,6 +24,7 @@ import { normalizeInvisibleChars } from "../../utils/string-utils";
 import { normalizeToLf, readAndNormalize, restoreEol } from "../../utils/eol-utils";
 import { addToIntegration } from "../../../../rpc-managers/ai-panel/utils";
 import { recordAiTouchedFile } from "../../../../rpc-managers/diagram-validity";
+import { seedNewPackageBaseline } from "../../utils/project/ls-schema-notifications";
 
 /**
  * Persists a tool's computed content directly into the real workspace file via VS Code's
@@ -45,10 +46,27 @@ async function persistLiveEdit(
     return;
   }
   const workspaceRoot = ctx.workspacePath || ctx.projectPath;
+  const absolutePath = path.join(workspaceRoot, file_path);
+  // A Ballerina.toml that doesn't exist yet means the agent is creating a whole new
+  // package mid-run — its ai:// baseline must be frozen NOW, before more files land,
+  // or the review diff loads the baseline from post-edit disk and shows no changes.
+  const isNewPackageToml = path.basename(file_path) === 'Ballerina.toml' && !fs.existsSync(absolutePath);
   try {
     await addToIntegration(workspaceRoot, [{ filePath: file_path, content }]);
-    recordAiTouchedFile(path.join(workspaceRoot, file_path));
+    recordAiTouchedFile(absolutePath);
     allModifiedFiles?.add(file_path);
+    if (isNewPackageToml) {
+      const packageRoot = path.dirname(absolutePath);
+      // .bal files this generation already wrote into the new package: freeze them as
+      // empty in the baseline so they still register as additions in the review.
+      const alreadyWritten = new Set([...(modifiedFiles ?? []), ...(allModifiedFiles ?? [])]);
+      const preexistingBalFiles = [...alreadyWritten]
+        .filter(f => f.endsWith('.bal'))
+        .map(f => path.resolve(workspaceRoot, f))
+        .filter(abs => abs.startsWith(packageRoot + path.sep))
+        .map(abs => path.relative(packageRoot, abs));
+      await seedNewPackageBaseline(packageRoot, content, preexistingBalFiles);
+    }
   } catch (error) {
     console.error("[TextEditorTool] Live persist failed:", error);
   }

--- a/packages/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
@@ -77,7 +77,7 @@ export interface AICommandConfig<TParams = any> {
          */
         existingTempPath?: string;
         /**
-         * Skip sendAgentDidOpenForFreshProjects (the ai:// baseline seed). Set by callers
+         * Skip seedAiBaselines (the ai:// baseline seed). Set by callers
          * that reuse the same existingTempPath across multiple executions of the same
          * directory (migration's per-stage runs), where the LS already has it open from
          * an earlier execution and re-seeding would overwrite the baseline with
@@ -418,7 +418,13 @@ export abstract class AICommandExecutor<TParams = any> {
         );
     }
 
-    /** Implicitly accepts whichever generation is still in the revertible 'done' window. */
+    /**
+     * Implicitly accepts whichever generation is still in the revertible 'done' window.
+     * Per-thread on purpose: executors on this path (typecreator, data mapper) work in
+     * their own temp copies and do NOT reseed the shared ai:// diff baseline, so another
+     * thread's open review stays valid. The agent entry point (generateAgent) finalizes
+     * ALL threads instead, because its baseline reseed invalidates every open review.
+     */
     protected finalizePreviousGeneration(): void {
         if (!this.config.chatStorage) {
             return;

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -573,12 +573,24 @@ export class ApprovalViewManager {
         }
 
         const tempProjectPath = review.tempProjectPath ?? projectRootPath;
-        sendReviewRestoreDidOpenBatch(
+        const { restoredCount, skippedCount } = sendReviewRestoreDidOpenBatch(
             tempProjectPath,
             review.modifiedFiles,
             undefined,
             generation.checkpoint?.workspaceSnapshot
         );
+
+        // Without original content (no checkpoint — disabled or size-capped), the ai://
+        // baseline could not be re-established, so the "old" side of every diagram is
+        // gone. Surface that instead of silently degrading to New-only views.
+        let semanticDiffError = review.reviewView.semanticDiffError;
+        if (restoredCount === 0 && skippedCount > 0) {
+            const restoreWarning =
+                'The original (pre-change) version of the files could not be restored after the window reload ' +
+                '(no checkpoint snapshot exists for this generation), so only the New view is available.';
+            semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${restoreWarning}` : restoreWarning;
+            console.error(`[ApprovalViewManager] Review restore had no original content for ${generationId} — ${skippedCount} file(s) skipped.`);
+        }
 
         return {
             views: [],
@@ -591,7 +603,7 @@ export class ApprovalViewManager {
             modifiedFiles: review.modifiedFiles,
             tempProjectPath,
             isWorkspace: review.reviewView.isWorkspace,
-            semanticDiffError: review.reviewView.semanticDiffError,
+            semanticDiffError,
         };
     }
 

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -580,16 +580,19 @@ export class ApprovalViewManager {
             generation.checkpoint?.workspaceSnapshot
         );
 
-        // Without original content (no checkpoint — disabled or size-capped), the ai://
-        // baseline could not be re-established, so the "old" side of every diagram is
-        // gone. Surface that instead of silently degrading to New-only views.
+        // A skipped file's ai:// baseline could not be re-established (no checkpoint
+        // snapshot — disabled or size-capped — or the restore itself failed), so its "old"
+        // side is gone. Surface that instead of silently degrading to New-only views,
+        // whether every file was hit or only some.
         let semanticDiffError = review.reviewView.semanticDiffError;
-        if (restoredCount === 0 && skippedCount > 0) {
-            const restoreWarning =
-                'The original (pre-change) version of the files could not be restored after the window reload ' +
-                '(no checkpoint snapshot exists for this generation), so only the New view is available.';
+        if (skippedCount > 0) {
+            const restoreWarning = restoredCount === 0
+                ? 'The original (pre-change) version of the files could not be restored after the window ' +
+                  'reload, so only the New view is available.'
+                : `The original (pre-change) version of ${skippedCount} file(s) could not be restored after ` +
+                  'the window reload; those files show only the New view.';
             semanticDiffError = semanticDiffError ? `${semanticDiffError}\n${restoreWarning}` : restoreWarning;
-            console.error(`[ApprovalViewManager] Review restore had no original content for ${generationId} — ${skippedCount} file(s) skipped.`);
+            console.error(`[ApprovalViewManager] Review restore skipped ${skippedCount} file(s) for ${generationId} (${restoredCount} restored).`);
         }
 
         return {

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -591,6 +591,7 @@ export class ApprovalViewManager {
             modifiedFiles: review.modifiedFiles,
             tempProjectPath,
             isWorkspace: review.reviewView.isWorkspace,
+            semanticDiffError: review.reviewView.semanticDiffError,
         };
     }
 

--- a/packages/ballerina-extension/src/features/ai/utils/concurrency.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/concurrency.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/packages/ballerina-extension/src/features/ai/utils/concurrency.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/concurrency.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Maps items through an async function with at most `limit` invocations in flight,
+ * preserving input order in the result. A flat Promise.all over a workspace-sized
+ * collection can fire dozens of concurrent LS compilations or file reads at once;
+ * this keeps the parallelism win while bounding the fan-out.
+ *
+ * Rejections propagate like Promise.all: the first rejection rejects the whole call.
+ * Callers that need per-item error isolation should catch inside `fn`.
+ */
+export async function mapWithConcurrency<T, R>(
+    items: readonly T[],
+    limit: number,
+    fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+    const results = new Array<R>(items.length);
+    let nextIndex = 0;
+    const workers = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+        while (true) {
+            const index = nextIndex++;
+            if (index >= items.length) {
+                return;
+            }
+            results[index] = await fn(items[index], index);
+        }
+    });
+    await Promise.all(workers);
+    return results;
+}

--- a/packages/ballerina-extension/src/features/ai/utils/generation-response.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/generation-response.ts
@@ -52,6 +52,23 @@ export function finalizeRevertibleGeneration(projectRootPath: string, threadId: 
 }
 
 /**
+ * Finalizes revertible generations across EVERY thread of the project, not just the one
+ * about to run. The ai:// diff baseline is a single per-package slot in the Language
+ * Server — reseeding it at generation start silently invalidates any other thread's
+ * still-open review, whose decline would then restore stale content over the new run's
+ * edits. Same policy as the same-thread implicit accept, applied project-wide.
+ *
+ * @returns true if any generation was finalized
+ */
+export function finalizeRevertibleGenerationsAllThreads(projectRootPath: string): boolean {
+    let finalizedAny = false;
+    for (const thread of chatStateStorage.listThreadsSummary(projectRootPath)) {
+        finalizedAny = finalizeRevertibleGeneration(projectRootPath, thread.id) || finalizedAny;
+    }
+    return finalizedAny;
+}
+
+/**
  * Sends a telemetry event when the user keeps an AI-generated response.
  *
  * @param messageId - The message identifier for the kept generation

--- a/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Uri } from 'vscode';
 import { StateMachine } from "../../../../stateMachine";
-import { ProjectSource, PROJECT_KIND } from "@wso2/ballerina-core";
+import { EnsureAiBaselineResponse, ProjectSource, PROJECT_KIND } from "@wso2/ballerina-core";
 import { mapWithConcurrency } from "../concurrency";
 
 /**
@@ -143,6 +143,23 @@ function collectBaselineFiles(project: ProjectSource): { filePath: string; conte
  * @param tempProjectPath The root path of the project (the real workspace/project root)
  * @param projects Array of project sources containing source files, modules, and tests
  */
+/**
+ * Rejects an ensureAiBaseline response that failed outright or seeded only part of the
+ * baseline. A partially seeded baseline is worse than the racy didOpen fallback the callers'
+ * catch blocks run: the unseeded files would diff against post-edit disk and read as unchanged.
+ */
+function assertBaselineSeeded(res: EnsureAiBaselineResponse | undefined): void {
+  if (!res) {
+    throw new Error('ensureAiBaseline returned no response');
+  }
+  if (res.errorMsg) {
+    throw new Error(res.errorMsg);
+  }
+  if (res.failedFiles?.length) {
+    throw new Error(`could not seed ${res.failedFiles.length} file(s): ${res.failedFiles.join(', ')}`);
+  }
+}
+
 export async function seedAiBaselines(tempProjectPath: string, projects: ProjectSource[]): Promise<void> {
   const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
 
@@ -152,10 +169,11 @@ export async function seedAiBaselines(tempProjectPath: string, projects: Project
     if (fs.existsSync(workspaceTomlPath)) {
       try {
         const content = fs.readFileSync(workspaceTomlPath, 'utf-8');
-        await StateMachine.langClient().ensureAiBaseline({
+        const res = await StateMachine.langClient().ensureAiBaseline({
           projectPath: tempProjectPath,
           files: [{ filePath: 'Ballerina.toml', content }],
         });
+        assertBaselineSeeded(res);
       } catch (error) {
         console.error('[AgentNotification] ensureAiBaseline failed for workspace root, falling back:', error);
         seedAiBaseline(tempProjectPath, 'Ballerina.toml');
@@ -173,12 +191,7 @@ export async function seedAiBaselines(tempProjectPath: string, projects: Project
     const files = collectBaselineFiles(project);
     try {
       const res = await StateMachine.langClient().ensureAiBaseline({ projectPath: packageRoot, files });
-      if (res?.errorMsg) {
-        throw new Error(res.errorMsg);
-      }
-      if (res?.failedFiles?.length) {
-        console.warn(`[AgentNotification] ensureAiBaseline could not seed ${res.failedFiles.length} file(s) in ${packageRoot}:`, res.failedFiles);
-      }
+      assertBaselineSeeded(res);
       console.log(`[AgentNotification] Seeded ai:// baseline (${res?.seededFileCount ?? 0} files) for: ${packageRoot}`);
     } catch (error) {
       // Older LS or request failure: fall back to the racy-but-working notification seed.
@@ -211,9 +224,7 @@ export async function seedNewPackageBaseline(
   ];
   try {
     const res = await StateMachine.langClient().ensureAiBaseline({ projectPath: packageRoot, files });
-    if (res?.errorMsg) {
-      throw new Error(res.errorMsg);
-    }
+    assertBaselineSeeded(res);
     console.log(`[AgentNotification] Seeded ai:// baseline for new package: ${packageRoot}`);
   } catch (error) {
     // Same policy as seedAiBaselines: fall back to the notification seed. Right after the
@@ -353,17 +364,23 @@ export function sendReviewRestoreDidOpenBatch(
   // the package from the live sources on disk and the rest update documents in place, so the
   // batch costs one rebuild instead of one per file — and no file's original is clobbered by
   // the next file's rebuild. See the module notes on the ai:// baseline.
+  let restoredCount = 0;
   for (const { filePath, aiUri, originalContent } of restored) {
     try {
       StateMachine.langClient().didChange({
         textDocument: { uri: aiUri, version: 2 },
         contentChanges: [{ text: originalContent }]
       });
+      restoredCount++;
       console.log(`[AgentNotification] Restored review schemas for: ${filePath}`);
     } catch (error) {
+      // A file whose baseline never landed counts as skipped, not restored — otherwise a
+      // total didChange failure would still report every file restored and suppress the
+      // caller's unavailable-originals warning.
+      skippedCount++;
       console.error(`[AgentNotification] Failed to restore the ai:// baseline for ${filePath}:`, error);
     }
   }
 
-  return { restoredCount: restored.length, skippedCount };
+  return { restoredCount, skippedCount };
 }

--- a/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
@@ -19,6 +19,7 @@ import * as path from 'path';
 import { Uri } from 'vscode';
 import { StateMachine } from "../../../../stateMachine";
 import { ProjectSource, PROJECT_KIND } from "@wso2/ballerina-core";
+import { mapWithConcurrency } from "../concurrency";
 
 /**
  * How the ai:// baseline works, and the Language Server behaviours every caller here depends
@@ -162,7 +163,11 @@ export async function seedAiBaselines(tempProjectPath: string, projects: Project
     }
   }
 
-  for (const project of projects) {
+  // Packages are independent project roots on the LS side (per-project locks), so seed
+  // them concurrently — only the workspace-root toml above must land first. Bounded,
+  // because this runs every turn over every package in the workspace and each request
+  // rebuilds that package's ai:// project.
+  await mapWithConcurrency(projects, 4, async project => {
     const pkgPath = project.packagePath || '';
     const packageRoot = pkgPath ? path.join(tempProjectPath, pkgPath) : tempProjectPath;
     const files = collectBaselineFiles(project);
@@ -181,7 +186,7 @@ export async function seedAiBaselines(tempProjectPath: string, projects: Project
       const tomlRel = pkgPath ? path.join(pkgPath, 'Ballerina.toml') : 'Ballerina.toml';
       seedAiBaseline(tempProjectPath, tomlRel);
     }
-  }
+  });
 }
 
 /**

--- a/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
@@ -294,6 +294,7 @@ export function sendReviewRestoreDidOpenBatch(
       const tempFileFullPath = path.resolve(tempProjectPath, filePath);
       if (tempFileFullPath !== normalizedTempRoot && !tempFileFullPath.startsWith(normalizedTempRoot + path.sep)) {
         console.warn(`[AgentNotification] Review restore path escapes temp project, skipping: ${filePath}`);
+        skippedCount++;
         continue;
       }
 

--- a/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
@@ -106,60 +106,117 @@ function seedAiBaseline(tempProjectPath: string, filePath: string): void {
   }
 }
 
+/** The baseline payload for one package: every .bal/toml file with its pre-edit content. */
+function collectBaselineFiles(project: ProjectSource): { filePath: string; content: string }[] {
+  const files: { filePath: string; content: string }[] = [];
+
+  project.sourceFiles.forEach(f => {
+    if (f.filePath.endsWith('.bal') || f.filePath.endsWith('.toml')) {
+      files.push({ filePath: f.filePath, content: f.content ?? '' });
+    }
+  });
+  project.projectModules?.forEach(module => {
+    module.sourceFiles.forEach(f => {
+      if (f.filePath.endsWith('.bal')) {
+        files.push({
+          filePath: path.join('modules', module.moduleName, f.filePath),
+          content: f.content ?? '',
+        });
+      }
+    });
+  });
+  project.projectTests?.forEach(f => {
+    if (f.filePath.endsWith('.bal')) {
+      files.push({ filePath: path.join('tests', f.filePath), content: f.content ?? '' });
+    }
+  });
+  return files;
+}
+
 /**
- * Seeds the ai:// baseline for every package in the project at generation start, via each
- * package's Ballerina.toml (one seedAiBaseline call per package is enough: dropping and
- * re-opening any of a package's documents makes the LS re-scan the whole package from disk
- * and cache it under ai://).
+ * Establishes the ai:// frozen baseline for every package from the in-hand pre-edit
+ * contents (ProjectSource), via the LS ensureAiBaseline request. Unlike the notification
+ * protocol, the LS applies everything before responding — awaiting this call guarantees
+ * the baseline is in place before the first edit can land, killing the seed↔edit race.
+ * Falls back to the legacy notification seed for a package if the request fails.
  * @param tempProjectPath The root path of the project (the real workspace/project root)
  * @param projects Array of project sources containing source files, modules, and tests
  */
-export function sendAgentDidOpenForFreshProjects(tempProjectPath: string, projects: ProjectSource[]): void {
-  const allFiles: string[] = [];
-
-  // For workspace projects, open the workspace root Ballerina.toml first so the LSP
-  // can resolve cross-package dependencies when checking diagnostics per-package.
+export async function seedAiBaselines(tempProjectPath: string, projects: ProjectSource[]): Promise<void> {
   const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
+
+  // Workspace root first, so the LS can resolve cross-package dependencies.
   if (isWorkspace) {
     const workspaceTomlPath = path.join(tempProjectPath, 'Ballerina.toml');
     if (fs.existsSync(workspaceTomlPath)) {
-      allFiles.push('Ballerina.toml');
+      try {
+        const content = fs.readFileSync(workspaceTomlPath, 'utf-8');
+        await StateMachine.langClient().ensureAiBaseline({
+          projectPath: tempProjectPath,
+          files: [{ filePath: 'Ballerina.toml', content }],
+        });
+      } catch (error) {
+        console.error('[AgentNotification] ensureAiBaseline failed for workspace root, falling back:', error);
+        seedAiBaseline(tempProjectPath, 'Ballerina.toml');
+      }
     }
   }
 
-  projects.forEach(project => {
-    const pkgPath = project.packagePath || ""; // Empty for single package, relative path for workspace
-
-    // Add root-level source files
-    project.sourceFiles.forEach(f => {
-      const relativePath = pkgPath ? path.join(pkgPath, f.filePath) : f.filePath;
-      allFiles.push(relativePath);
-    });
-
-    // Add module files
-    project.projectModules?.forEach(module => {
-      module.sourceFiles.forEach(f => {
-        const relativePath = pkgPath
-          ? path.join(pkgPath, 'modules', module.moduleName, f.filePath)
-          : path.join('modules', module.moduleName, f.filePath);
-        allFiles.push(relativePath);
-      });
-    });
-
-    // Add test files
-    if (project.projectTests) {
-      project.projectTests.forEach(f => {
-        const relativePath = pkgPath
-          ? path.join(pkgPath, 'tests', f.filePath)
-          : path.join('tests', f.filePath);
-        allFiles.push(relativePath);
-      });
+  for (const project of projects) {
+    const pkgPath = project.packagePath || '';
+    const packageRoot = pkgPath ? path.join(tempProjectPath, pkgPath) : tempProjectPath;
+    const files = collectBaselineFiles(project);
+    try {
+      const res = await StateMachine.langClient().ensureAiBaseline({ projectPath: packageRoot, files });
+      if (res?.errorMsg) {
+        throw new Error(res.errorMsg);
+      }
+      if (res?.failedFiles?.length) {
+        console.warn(`[AgentNotification] ensureAiBaseline could not seed ${res.failedFiles.length} file(s) in ${packageRoot}:`, res.failedFiles);
+      }
+      console.log(`[AgentNotification] Seeded ai:// baseline (${res?.seededFileCount ?? 0} files) for: ${packageRoot}`);
+    } catch (error) {
+      // Older LS or request failure: fall back to the racy-but-working notification seed.
+      console.error(`[AgentNotification] ensureAiBaseline failed for ${packageRoot}, falling back to didOpen seed:`, error);
+      const tomlRel = pkgPath ? path.join(pkgPath, 'Ballerina.toml') : 'Ballerina.toml';
+      seedAiBaseline(tempProjectPath, tomlRel);
     }
-  });
+  }
+}
 
-  const tomlFiles = allFiles.filter(f => f.endsWith('Ballerina.toml'));
-  console.log(`[AgentNotification] Sending didOpen for ${tomlFiles.length} Ballerina.toml(s) across ${projects.length} project(s)`);
-  tomlFiles.forEach(file => seedAiBaseline(tempProjectPath, file));
+/**
+ * Freezes the ai:// baseline for a package the agent just created mid-run (it wrote a new
+ * Ballerina.toml). Without this, the package has no cached ai:// project, so the first
+ * getSemanticDiff loads the baseline from post-edit disk and the whole package diffs
+ * against itself as "no changes". The baseline is the just-written toml plus explicit
+ * empty content for any .bal files this generation already wrote into the package —
+ * everything the run adds afterwards then registers as an addition.
+ * @param packageRoot Absolute path of the new package
+ * @param tomlContent The Ballerina.toml content just written
+ * @param preexistingBalFiles Package-relative .bal paths this generation already created
+ */
+export async function seedNewPackageBaseline(
+  packageRoot: string,
+  tomlContent: string,
+  preexistingBalFiles: string[]
+): Promise<void> {
+  const files = [
+    { filePath: 'Ballerina.toml', content: tomlContent },
+    ...preexistingBalFiles.map(filePath => ({ filePath, content: '' })),
+  ];
+  try {
+    const res = await StateMachine.langClient().ensureAiBaseline({ projectPath: packageRoot, files });
+    if (res?.errorMsg) {
+      throw new Error(res.errorMsg);
+    }
+    console.log(`[AgentNotification] Seeded ai:// baseline for new package: ${packageRoot}`);
+  } catch (error) {
+    // Same policy as seedAiBaselines: fall back to the notification seed. Right after the
+    // toml write the disk state is still close to the intended baseline, so a racy seed
+    // beats no baseline at all (which would make the whole package diff as unchanged).
+    console.error(`[AgentNotification] ensureAiBaseline failed for new package ${packageRoot}, falling back to didOpen seed:`, error);
+    seedAiBaseline(packageRoot, 'Ballerina.toml');
+  }
 }
 
 /**
@@ -217,9 +274,10 @@ export function sendReviewRestoreDidOpenBatch(
   modifiedFiles: string[],
   baselineProjectPath: string | undefined,
   fallbackOriginalContents?: Record<string, string>
-): void {
+): { restoredCount: number; skippedCount: number } {
   const normalizedTempRoot = path.resolve(tempProjectPath);
   const baselineAvailable = !!baselineProjectPath && fs.existsSync(baselineProjectPath);
+  let skippedCount = 0;
   const restored: { filePath: string; aiUri: string; originalContent: string }[] = [];
 
   for (const filePath of modifiedFiles) {
@@ -248,13 +306,20 @@ export function sendReviewRestoreDidOpenBatch(
       } else if (baselineAvailable) {
         // The baseline is authoritative: absence means the generation created this file.
         originalContent = '';
+      } else if (fallbackOriginalContents !== undefined) {
+        // A checkpoint snapshot exists but has no entry for this file — it did not exist
+        // when the snapshot was captured, i.e. the generation created it. An empty
+        // original makes it read as an addition, matching the live-run behavior.
+        originalContent = '';
       } else {
         console.warn(`[AgentNotification] Original content unavailable, skipping review restore: ${filePath}`);
+        skippedCount++;
         continue;
       }
 
       if (!tempFileExists && !baselineFileExists && !hasFallbackOriginal) {
         console.warn(`[AgentNotification] File is absent from both review versions, skipping: ${filePath}`);
+        skippedCount++;
         continue;
       }
 
@@ -271,6 +336,9 @@ export function sendReviewRestoreDidOpenBatch(
       evictAiBaseline(tempFileFullPath);
       restored.push({ filePath, aiUri, originalContent });
     } catch (error) {
+      // Counts as skipped: without it a total failure through this path would return
+      // {restoredCount: 0, skippedCount: 0} and read as "nothing needed restoring".
+      skippedCount++;
       console.error(`[AgentNotification] Failed to restore review schemas for ${filePath}:`, error);
     }
   }
@@ -290,4 +358,6 @@ export function sendReviewRestoreDidOpenBatch(
       console.error(`[AgentNotification] Failed to restore the ai:// baseline for ${filePath}:`, error);
     }
   }
+
+  return { restoredCount: restored.length, skippedCount };
 }

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/repair-utils.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/repair-utils.ts
@@ -23,6 +23,9 @@ import { TextDocumentEdit } from "vscode-languageserver-types";
 import { fileURLToPath } from "url";
 import { writeBallerinaFileDidOpenTemp } from "../../utils/modification";
 
+/** Marks errors whose cause is the package failing to compile, not an LS malfunction. */
+export const PACKAGE_COMPILATION_FAILED_PREFIX = "Package compilation failed: ";
+
 export async function attemptRepairProject(langClient: ExtendedLangClient, tempDir: string): Promise<Diagnostics[]> {
     // check project diagnostics
     let projectDiags: Diagnostics[] = await checkProjectDiagnostics(langClient, tempDir);
@@ -58,8 +61,12 @@ export async function checkProjectDiagnostics(langClient: ExtendedLangClient, te
     });
     const _diagDurationMs = Date.now() - _diagStartMs;
     if (!response.errorDiagnosticMap) {
-        console.log(`[DiagTiming] getProjectDiagnostics END — ${_diagDurationMs}ms — no errorDiagnosticMap (internal error)`);
-        throw new Error("Internal error while getting diagnostics from language server");
+        console.log(`[DiagTiming] getProjectDiagnostics END — ${_diagDurationMs}ms — no errorDiagnosticMap (${response.errorMsg ?? "internal error"})`);
+        // errorMsg carries the language server's reason — typically a package-compilation
+        // failure (e.g. unresolvable dependencies), which callers surface to the user.
+        throw new Error(response.errorMsg
+            ? `${PACKAGE_COMPILATION_FAILED_PREFIX}${response.errorMsg}`
+            : "Internal error while getting diagnostics from language server");
     }
     const _fileCount = Object.keys(response.errorDiagnosticMap).length;
     console.log(`[DiagTiming] getProjectDiagnostics END — ${_diagDurationMs}ms, ${_fileCount} files with errors`);

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -551,13 +551,18 @@ export class AiPanelRpcManager implements AIPanelAPI {
 
             console.log(`[Review Actions] Reverting generation ${doneGeneration.id}`);
 
-            // Restore workspace to state before this generation ran
+            // Restore workspace to state before this generation ran. Without a checkpoint
+            // (checkpoints disabled, or the workspace exceeded the snapshot size cap)
+            // nothing can be restored — that must fail loudly rather than mark the
+            // generation reverted and tell the model files were restored when they weren't.
             const checkpoint = doneGeneration.checkpoint;
-            if (checkpoint) {
-                await restoreWorkspaceSnapshot(checkpoint, true);
-            } else {
-                console.warn("[Review Actions] No checkpoint found for generation — workspace changes will not be reverted");
+            if (!checkpoint) {
+                const reason = "No checkpoint exists for this generation (checkpoints may be disabled, or the workspace exceeded the snapshot size limit), so the changes cannot be reverted automatically. Use source control to undo them if needed.";
+                console.error(`[Review Actions] Revert refused for ${doneGeneration.id}: ${reason}`);
+                window.showErrorMessage(`Could not revert the Copilot changes: ${reason}`);
+                throw new Error(reason);
             }
+            await restoreWorkspaceSnapshot(checkpoint, true);
 
             // Append revert notification to model messages so the LLM knows changes were reverted
             const existingMessages = doneGeneration.modelMessages || [];
@@ -575,6 +580,10 @@ User reverted the last made changes. The files have been restored to the state b
 
             chatStateStorage.revertLastGeneration(projectRootPath, threadId);
             console.log(`[Review Actions] Reverted generation: ${doneGeneration.id}`);
+
+            // Drop the manager's cached review for this generation so a queued/late
+            // navigation cannot reopen the just-reverted diff.
+            approvalViewManager.clearReviewData(doneGeneration.id);
 
             sendGenerationDiscardTelemetry(doneGeneration.id);
 

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -562,7 +562,15 @@ export class AiPanelRpcManager implements AIPanelAPI {
                 window.showErrorMessage(`Could not revert the Copilot changes: ${reason}`);
                 throw new Error(reason);
             }
-            await restoreWorkspaceSnapshot(checkpoint, true);
+            // restoreWorkspaceSnapshot reports its own failures to the user but does not throw, so a
+            // failed applyEdit must not fall through to marking the generation reverted and telling
+            // the model the files were restored when they weren't — the same refusal as no checkpoint.
+            const restored = await restoreWorkspaceSnapshot(checkpoint, true);
+            if (!restored) {
+                const reason = "Restoring the workspace to the pre-generation checkpoint failed, so the changes were not reverted. Use source control to undo them if needed.";
+                console.error(`[Review Actions] Revert refused for ${doneGeneration.id}: ${reason}`);
+                throw new Error(reason);
+            }
 
             // Append revert notification to model messages so the LLM knows changes were reverted
             const existingMessages = doneGeneration.modelMessages || [];

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -795,8 +795,14 @@ User reverted the last made changes. The files have been restored to the state b
 
         const { checkpoint } = found;
 
-        // 1. Restore workspace files from checkpoint snapshot
-        await restoreWorkspaceSnapshot(checkpoint);
+        // 1. Restore workspace files from checkpoint snapshot.
+        // restoreWorkspaceSnapshot reports its own failures to the user but does not throw, so a
+        // failed restore must not fall through to truncating the thread history — that loss is
+        // irreversible while the files would stay unchanged.
+        const workspaceRestored = await restoreWorkspaceSnapshot(checkpoint);
+        if (!workspaceRestored) {
+            throw new Error('Restoring the workspace from the checkpoint failed; the conversation was not rewound.');
+        }
 
         // 2. Truncate thread history to this checkpoint
         const restored = chatStateStorage.restoreThreadToCheckpoint(

--- a/packages/ballerina-extension/src/test-support/emitReviewActions.test.ts
+++ b/packages/ballerina-extension/src/test-support/emitReviewActions.test.ts
@@ -67,7 +67,7 @@ for (const m of [
 
 jest.mock('../features/ai/executors/base/AICommandExecutor', () => ({ AICommandExecutor: class { } }));
 
-import { AgentExecutor } from '../features/ai/agent/AgentExecutor';
+import { AgentExecutor, normalizeRelativePath } from '../features/ai/agent/AgentExecutor';
 import { chatStateStorage } from '../views/ai-panel/chatStateStorage';
 
 const ROOT = '/ws';
@@ -160,7 +160,7 @@ describe('emitReviewActions', () => {
         expect(review.data.modifiedFiles).toEqual(['main.bal']);
     });
 
-    it('EDGE: a partial failure discards the diffs already collected', async () => {
+    it('EDGE: a partial failure keeps the diffs already collected and reports the error', async () => {
         seedGeneration('gen-1', ['a.bal', 'b.bal'], [PKG_A, PKG_B]);
         getSemanticDiff
             .mockResolvedValueOnce({ semanticDiffs: [{ a: 1 }], loadDesignDiagrams: true })
@@ -170,9 +170,13 @@ describe('emitReviewActions', () => {
 
         await executor.emitReviewActions(context);
 
-        // Mixing one package's diffs with another's absence would misattribute them.
-        expect(reviewEvent(events).data.semanticDiffs).toEqual([]);
-        expect(reviewEvent(events).data.loadDesignDiagrams).toBe(false);
+        // One package failing must not cost the sibling package its valid diffs; the
+        // failure is surfaced alongside them instead (openReviewMode's reviewData).
+        expect(reviewEvent(events).data.semanticDiffs).toEqual([{ a: 1 }]);
+        expect(reviewEvent(events).data.diffPackageMap).toEqual(['pkg-a']);
+        expect(reviewEvent(events).data.loadDesignDiagrams).toBe(true);
+        const reviewData = openReviewMode.mock.calls[0][1];
+        expect(reviewData.semanticDiffError).toContain('LS died');
     });
 
     it('EDGE: skips the workspace root, which holds no package to diff', async () => {
@@ -217,5 +221,24 @@ describe('emitReviewActions', () => {
         expect(stored?.reviewState.reviewView).toEqual({
             semanticDiffs: [{ a: 1 }], loadDesignDiagrams: true, isWorkspace: false,
         });
+    });
+});
+
+describe('normalizeRelativePath', () => {
+    // The two sides of the package-membership match come from different authors: the
+    // workspace toml's `packages` entries vs the LLM's verbatim tool file_path args.
+    it.each([
+        ['./orders', 'orders'],
+        ['orders/', 'orders'],
+        ['./orders/', 'orders'],
+        ['orders', 'orders'],
+        ['orders\\main.bal', 'orders/main.bal'],
+        ['./orders/main.bal', 'orders/main.bal'],
+        ['orders//main.bal', 'orders/main.bal'],
+        [' orders ', 'orders'],
+        ['.', ''],
+        ['./', ''],
+    ])('normalizes %s to %s', (input, expected) => {
+        expect(normalizeRelativePath(input)).toBe(expected);
     });
 });

--- a/packages/ballerina-extension/src/test-support/emitReviewActions.test.ts
+++ b/packages/ballerina-extension/src/test-support/emitReviewActions.test.ts
@@ -179,6 +179,24 @@ describe('emitReviewActions', () => {
         expect(reviewData.semanticDiffError).toContain('LS died');
     });
 
+    it("EDGE: keeps every package's compilation error, not just the first", async () => {
+        seedGeneration('gen-1', ['a.bal', 'b.bal'], [PKG_A, PKG_B]);
+        getSemanticDiff
+            .mockResolvedValueOnce({ semanticDiffs: [{ a: 1 }], loadDesignDiagrams: false, compilationError: 'pkg-a failed to compile' })
+            .mockResolvedValueOnce({ semanticDiffs: [{ b: 1 }], loadDesignDiagrams: false, compilationError: 'pkg-b failed to compile' });
+        const events: any[] = [];
+        const { executor, context } = makeExecutor(events);
+
+        await executor.emitReviewActions(context);
+
+        // Partial-success compile errors aggregate like request failures — a later
+        // package's reason must not be dropped because an earlier one already failed.
+        expect(reviewEvent(events).data.semanticDiffs).toEqual([{ a: 1 }, { b: 1 }]);
+        const reviewData = openReviewMode.mock.calls[0][1];
+        expect(reviewData.semanticDiffError).toContain('pkg-a failed to compile');
+        expect(reviewData.semanticDiffError).toContain('pkg-b failed to compile');
+    });
+
     it('EDGE: skips the workspace root, which holds no package to diff', async () => {
         projectKind = 'WORKSPACE_PROJECT';
         seedGeneration('gen-1', ['main.bal'], [ROOT, PKG_A]);

--- a/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -56,8 +56,9 @@ export async function captureWorkspaceSnapshot(messageId: string): Promise<Check
 
         // Read in bounded-concurrency chunks: one-at-a-time reads dominate run-start
         // latency on large workspaces, while unbounded Promise.all can exhaust file
-        // handles. Chunks keep fileList in findFiles order and let the size cap abort
-        // between chunks.
+        // handles. Hand-rolled rather than mapWithConcurrency because the size cap must
+        // be able to abort between batches, which that helper cannot express; chunks
+        // also keep fileList in findFiles order.
         const READ_CONCURRENCY = 32;
         for (let i = 0; i < allFiles.length; i += READ_CONCURRENCY) {
             const chunk = allFiles.slice(i, i + READ_CONCURRENCY);

--- a/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -54,27 +54,39 @@ export async function captureWorkspaceSnapshot(messageId: string): Promise<Check
     try {
         const allFiles = await getAllWorkspaceFiles(workspaceRoot, config.ignorePatterns);
 
-        for (const fileUri of allFiles) {
-            try {
-                const fileContent = await vscode.workspace.fs.readFile(fileUri);
-                const content = Buffer.from(fileContent).toString('utf8');
-                const relativePath = path.relative(workspaceRoot.fsPath, fileUri.fsPath).split(path.sep).join('/');
-
-                workspaceSnapshot[relativePath] = content;
-                fileList.push(relativePath);
-                totalSize += content.length;
-
-                if (totalSize > config.maxSnapshotSize) {
-                    // Fail closed rather than save a partial checkpoint that silently leaves
-                    // later-scanned files unrevertible on restore.
-                    console.warn(`[Checkpoint] Snapshot size exceeded max limit (${totalSize} bytes) — aborting capture, no partial checkpoint will be saved`);
-                    vscode.window.showWarningMessage(
-                        `Workspace is too large to checkpoint (exceeds ${Math.round(config.maxSnapshotSize / 1024 / 1024)}MB). This generation will not be revertible.`
-                    );
+        // Read in bounded-concurrency chunks: one-at-a-time reads dominate run-start
+        // latency on large workspaces, while unbounded Promise.all can exhaust file
+        // handles. Chunks keep fileList in findFiles order and let the size cap abort
+        // between chunks.
+        const READ_CONCURRENCY = 32;
+        for (let i = 0; i < allFiles.length; i += READ_CONCURRENCY) {
+            const chunk = allFiles.slice(i, i + READ_CONCURRENCY);
+            const chunkContents = await Promise.all(chunk.map(async fileUri => {
+                try {
+                    const fileContent = await vscode.workspace.fs.readFile(fileUri);
+                    return { fileUri, content: Buffer.from(fileContent).toString('utf8') };
+                } catch (error) {
+                    console.error(`[Checkpoint] Failed to read file ${fileUri.fsPath}:`, error);
                     return null;
                 }
-            } catch (error) {
-                console.error(`[Checkpoint] Failed to read file ${fileUri.fsPath}:`, error);
+            }));
+
+            for (const entry of chunkContents) {
+                if (!entry) { continue; }
+                const relativePath = path.relative(workspaceRoot.fsPath, entry.fileUri.fsPath).split(path.sep).join('/');
+                workspaceSnapshot[relativePath] = entry.content;
+                fileList.push(relativePath);
+                totalSize += entry.content.length;
+            }
+
+            if (totalSize > config.maxSnapshotSize) {
+                // Fail closed rather than save a partial checkpoint that silently leaves
+                // later-scanned files unrevertible on restore.
+                console.warn(`[Checkpoint] Snapshot size exceeded max limit (${totalSize} bytes) — aborting capture, no partial checkpoint will be saved`);
+                vscode.window.showWarningMessage(
+                    `Workspace is too large to checkpoint (exceeds ${Math.round(config.maxSnapshotSize / 1024 / 1024)}MB). This generation will not be revertible.`
+                );
+                return null;
             }
         }
 

--- a/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -107,7 +107,13 @@ export async function captureWorkspaceSnapshot(messageId: string): Promise<Check
     }
 }
 
-export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtifactWait = false): Promise<void> {
+/**
+ * Restores the workspace to a checkpoint snapshot. Returns {@code true} only when the restore
+ * actually applied; callers that mark a generation reverted (and tell the model its changes were
+ * undone) must gate that on the return value, since a failed {@code applyEdit} is reported to the
+ * user here but not thrown.
+ */
+export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtifactWait = false): Promise<boolean> {
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (!workspaceFolders || workspaceFolders.length === 0) {
         throw new Error('No workspace folder found');
@@ -227,7 +233,7 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
         });
 
         // Wait for artifact update notification if any .bal files were restored
-        if (skipArtifactWait) { return; }
+        if (skipArtifactWait) { return true; }
         await new Promise<void>((resolve, reject) => {
             if (!isBalFileRestored) {
                 resolve();
@@ -260,9 +266,11 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
         });
 
         vscode.window.showInformationMessage('Checkpoint restored successfully');
+        return true;
     } catch (error) {
         console.error('[Checkpoint] Failed to restore workspace snapshot:', error);
         vscode.window.showErrorMessage('Failed to restore checkpoint: ' + (error as Error).message);
+        return false;
     }
 }
 

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/NodeRefExtractor.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/NodeRefExtractor.java
@@ -18,7 +18,11 @@
 
 package io.ballerina.copilotagent.core;
 
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
+import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
@@ -47,6 +51,7 @@ public class NodeRefExtractor extends NodeVisitor {
 
     @Override
     public void visit(ModulePartNode modulePartNode) {
+        modulePartNode.imports().forEach(importNode -> importNode.accept(this));
         modulePartNode.members().forEach(member -> member.accept(this));
     }
 
@@ -80,6 +85,42 @@ public class NodeRefExtractor extends NodeVisitor {
         String key = CommonUtils.getVariableName(
                 moduleVariableDeclarationNode.typedBindingPattern().bindingPattern());
         this.nodeRefMap.putModuleVarNode(key, moduleVariableDeclarationNode);
+    }
+
+    @Override
+    public void visit(ConstantDeclarationNode constantDeclarationNode) {
+        String key = constantDeclarationNode.variableName().text().trim();
+        this.nodeRefMap.putConstantNode(key, constantDeclarationNode);
+    }
+
+    @Override
+    public void visit(EnumDeclarationNode enumDeclarationNode) {
+        String key = enumDeclarationNode.identifier().text().trim();
+        this.nodeRefMap.putEnumNode(key, enumDeclarationNode);
+    }
+
+    @Override
+    public void visit(ClassDefinitionNode classDefinitionNode) {
+        String key = classDefinitionNode.className().text().trim();
+        this.nodeRefMap.putClassNode(key, classDefinitionNode);
+    }
+
+    @Override
+    public void visit(ImportDeclarationNode importDeclarationNode) {
+        // Key by the imported module identity plus alias: the same module may legally be
+        // imported more than once under different prefixes, and identity-only keys would
+        // silently overwrite one of them. An alias-only change therefore reads as a
+        // deletion+addition pair rather than a modification — an acceptable trade for
+        // never dropping an import from the diff.
+        String orgName = importDeclarationNode.orgName().map(org -> org.orgName().text() + "/").orElse("");
+        String moduleName = importDeclarationNode.moduleName().stream()
+                .map(identifier -> identifier.text().trim())
+                .collect(Collectors.joining("."));
+        // " as <prefix>" keeps the key readable, since it doubles as the diff's display name.
+        String prefix = importDeclarationNode.prefix()
+                .map(p -> " as " + p.prefix().text().trim())
+                .orElse("");
+        this.nodeRefMap.putImportNode(orgName + moduleName + prefix, importDeclarationNode);
     }
 
     private static String getPath(NodeList<Node> paths) {

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -318,7 +318,7 @@ public class SemanticDiffComputer {
                         buildFunctionMetadata(className + "." + methodEntry.getKey()));
             }
 
-            if (!nonMethodMembersSource(originalClass).equals(nonMethodMembersSource(modifiedClass))) {
+            if (!classHeaderAndMembersSource(originalClass).equals(classHeaderAndMembersSource(modifiedClass))) {
                 addModificationDiff(NodeKind.CLASS_DEFINITION, modifiedClass.lineRange(),
                         originalClass.lineRange(),
                         buildSourceMetadata(className, originalClassSource, modifiedClassSource));
@@ -350,6 +350,24 @@ public class SemanticDiffComputer {
                 .filter(member -> !(member instanceof FunctionDefinitionNode))
                 .map(Node::toSourceCode)
                 .collect(Collectors.joining());
+    }
+
+    /**
+     * Signature used to decide whether a class needs a {@code CLASS_DEFINITION} diff once its methods
+     * have been diffed separately. It combines the class header — metadata, visibility, class-type
+     * qualifiers, the {@code class} keyword and the name — with the non-method members, so a
+     * header-only change (for example adding {@code isolated} or an annotation) is not lost when the
+     * members are unchanged. Qualifier/keyword/name tokens use {@code text()} to stay trivia-insensitive,
+     * matching the trivia-only handling elsewhere in this computer.
+     */
+    private static String classHeaderAndMembersSource(ClassDefinitionNode classNode) {
+        StringBuilder header = new StringBuilder();
+        classNode.metadata().ifPresent(metadata -> header.append(metadata.toSourceCode().trim()));
+        classNode.visibilityQualifier().ifPresent(qualifier -> header.append(qualifier.text().trim()).append(' '));
+        classNode.classTypeQualifiers().forEach(qualifier -> header.append(qualifier.text().trim()).append(' '));
+        header.append(classNode.classKeyword().text().trim()).append(' ');
+        header.append(classNode.className().text().trim());
+        return header + "\n" + nonMethodMembersSource(classNode);
     }
 
     /**

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -39,6 +39,7 @@ import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.OnFailClauseNode;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.StatementNode;
+import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TransactionStatementNode;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import io.ballerina.compiler.syntax.tree.WhileStatementNode;
@@ -239,8 +240,9 @@ public class SemanticDiffComputer {
 
     /**
      * Computes diffs for a construct kind whose changes are reviewed as source text:
-     * name-keyed nodes compared by their source, producing addition/deletion/modification
-     * entries carrying that source in the metadata.
+     * name-keyed nodes compared by their trivia-free source ({@link #triviaFreeSource}, so a
+     * comment that re-attaches to an untouched declaration never reports it as modified),
+     * producing addition/deletion/modification entries carrying the raw source in the metadata.
      *
      * @param originalMap   original map of construct names to their declaration nodes
      * @param modifiedMap   modified map of construct names to their declaration nodes
@@ -261,12 +263,10 @@ public class SemanticDiffComputer {
                 continue;
             }
             T modifiedNode = modifiedMap.remove(name);
-            String originalSource = originalNode.toSourceCode();
-            String modifiedSource = modifiedNode.toSourceCode();
-            if (!originalSource.equals(modifiedSource)) {
+            if (!triviaFreeSource(originalNode).equals(triviaFreeSource(modifiedNode))) {
                 loadDesignDiagrams |= affectsDesign;
                 addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(),
-                        buildSourceMetadata(name, originalSource, modifiedSource));
+                        buildSourceMetadata(name, originalNode.toSourceCode(), modifiedNode.toSourceCode()));
             }
         }
 
@@ -348,8 +348,8 @@ public class SemanticDiffComputer {
     private static String nonMethodMembersSource(ClassDefinitionNode classNode) {
         return classNode.members().stream()
                 .filter(member -> !(member instanceof FunctionDefinitionNode))
-                .map(Node::toSourceCode)
-                .collect(Collectors.joining());
+                .map(SemanticDiffComputer::triviaFreeSource)
+                .collect(Collectors.joining("\n"));
     }
 
     /**
@@ -357,17 +357,43 @@ public class SemanticDiffComputer {
      * have been diffed separately. It combines the class header — metadata, visibility, class-type
      * qualifiers, the {@code class} keyword and the name — with the non-method members, so a
      * header-only change (for example adding {@code isolated} or an annotation) is not lost when the
-     * members are unchanged. Qualifier/keyword/name tokens use {@code text()} to stay trivia-insensitive,
-     * matching the trivia-only handling elsewhere in this computer.
+     * members are unchanged. Built from token text only ({@link #triviaFreeSource}), so a comment or
+     * formatting shuffle around the class or its fields never registers as a modification — the same
+     * trivia-only handling as {@link #computeImportDiffs}. Annotations and markdown documentation are
+     * syntax nodes, not trivia, so genuine changes to them still produce a diff.
      */
     private static String classHeaderAndMembersSource(ClassDefinitionNode classNode) {
         StringBuilder header = new StringBuilder();
-        classNode.metadata().ifPresent(metadata -> header.append(metadata.toSourceCode().trim()));
-        classNode.visibilityQualifier().ifPresent(qualifier -> header.append(qualifier.text().trim()).append(' '));
-        classNode.classTypeQualifiers().forEach(qualifier -> header.append(qualifier.text().trim()).append(' '));
-        header.append(classNode.classKeyword().text().trim()).append(' ');
-        header.append(classNode.className().text().trim());
+        classNode.metadata().ifPresent(metadata -> header.append(triviaFreeSource(metadata)).append(' '));
+        classNode.visibilityQualifier().ifPresent(qualifier -> header.append(qualifier.text()).append(' '));
+        classNode.classTypeQualifiers().forEach(qualifier -> header.append(qualifier.text()).append(' '));
+        header.append(classNode.classKeyword().text()).append(' ');
+        header.append(classNode.className().text());
         return header + "\n" + nonMethodMembersSource(classNode);
+    }
+
+    /**
+     * Source text of a node with all trivia removed: token texts joined by single spaces, so
+     * comments and whitespace never contribute. Only for comparison keys — the joined text is
+     * not valid, displayable source.
+     */
+    private static String triviaFreeSource(Node node) {
+        StringBuilder sb = new StringBuilder();
+        appendTriviaFreeSource(node, sb);
+        return sb.toString();
+    }
+
+    private static void appendTriviaFreeSource(Node node, StringBuilder sb) {
+        if (node instanceof Token token) {
+            if (!sb.isEmpty()) {
+                sb.append(' ');
+            }
+            sb.append(token.text());
+        } else if (node instanceof NonTerminalNode nonTerminal) {
+            for (Node child : nonTerminal.children()) {
+                appendTriviaFreeSource(child, sb);
+            }
+        }
     }
 
     /**

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -65,6 +65,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
 /**
@@ -130,11 +131,32 @@ public class SemanticDiffComputer {
         computeTypeDefDiffs(originalNodeRefMap.getTypeDefNodeMap(), modifiedNodeRefMap.getTypeDefNodeMap());
         computeModuleVarDiffs(originalNodeRefMap.getModuleVarNodeMap(), modifiedNodeRefMap.getModuleVarNodeMap());
 
+        String compilationError = null;
         if (!loadDesignDiagrams) {
-            compareUsingDesignDiagrams();
+            try {
+                compareUsingDesignDiagrams();
+            } catch (Throwable t) {
+                // The design-model comparison is the only step that needs a full package
+                // compilation, which can fail for reasons unrelated to the edit (e.g. an
+                // unresolvable dependency). The syntax-level diffs above are still valid,
+                // so report the failure instead of discarding them.
+                compilationError = rootCauseMessage(t);
+            }
         }
 
-        return new Result(loadDesignDiagrams, this.semanticDiffs);
+        return new Result(loadDesignDiagrams, this.semanticDiffs, compilationError);
+    }
+
+    // Unwraps only async plumbing (CompletionException from join()); the first real
+    // exception's message already carries the full context (e.g. which module failed).
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause instanceof CompletionException
+                && cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        String message = cause.getMessage();
+        return message == null || message.isBlank() ? cause.getClass().getName() : message;
     }
 
     /**

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -19,6 +19,7 @@
 package io.ballerina.copilotagent.core;
 
 import io.ballerina.compiler.syntax.tree.BlockStatementNode;
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
 import io.ballerina.compiler.syntax.tree.DoStatementNode;
 import io.ballerina.compiler.syntax.tree.ExpressionFunctionBodyNode;
 import io.ballerina.compiler.syntax.tree.ForEachStatementNode;
@@ -27,11 +28,9 @@ import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.FunctionBodyNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.IfElseStatementNode;
-import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.LockStatementNode;
 import io.ballerina.compiler.syntax.tree.MatchClauseNode;
 import io.ballerina.compiler.syntax.tree.MatchStatementNode;
-import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.NamedWorkerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeList;
@@ -53,6 +52,7 @@ import io.ballerina.designmodelgenerator.core.model.Connection;
 import io.ballerina.designmodelgenerator.core.model.DesignModel;
 import io.ballerina.designmodelgenerator.core.model.Listener;
 import io.ballerina.projects.Document;
+import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LineRange;
 
@@ -60,10 +60,12 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
@@ -79,6 +81,10 @@ public class SemanticDiffComputer {
     private final Project modifiedProject;
     private final List<SemanticDiff> semanticDiffs = new ArrayList<>();
     private final String rootProjectPath;
+    // Document-name → absolute path for the module currently being diffed. LineRange only
+    // carries the document name, which for module/test documents does not resolve against
+    // the project root; this map recovers the real on-disk path. Rebuilt per module.
+    private final Map<String, Path> currentModuleFilePaths = new HashMap<>();
     private boolean loadDesignDiagrams = false;
 
     public SemanticDiffComputer(Project originalProject,
@@ -91,8 +97,64 @@ public class SemanticDiffComputer {
 
     public Result computeSemanticDiffs() {
 
-        Map<String, Document> originalDocumentMap = collectDocumentMap(originalProject);
-        Map<String, Document> modifiedDocumentMap = collectDocumentMap(modifiedProject);
+        // Diff module by module: name-keyed construct maps are only unique within a module
+        // (the same function name may legally exist in two modules), and per-module passes
+        // keep document names unambiguous. The union covers added/removed modules.
+        Map<String, Module> originalModules = collectModules(originalProject);
+        Map<String, Module> modifiedModules = collectModules(modifiedProject);
+        Set<String> allModuleNames = new LinkedHashSet<>();
+        allModuleNames.addAll(originalModules.keySet());
+        allModuleNames.addAll(modifiedModules.keySet());
+
+        for (String moduleName : allModuleNames) {
+            computeModuleSemanticDiffs(originalModules.get(moduleName), modifiedModules.get(moduleName));
+        }
+
+        String compilationError = null;
+        if (!loadDesignDiagrams) {
+            try {
+                compareUsingDesignDiagrams();
+            } catch (Throwable t) {
+                // The design-model comparison is the only step that needs a full package
+                // compilation, which can fail for reasons unrelated to the edit (e.g. an
+                // unresolvable dependency). The syntax-level diffs above are still valid,
+                // so report the failure instead of discarding them.
+                compilationError = rootCauseMessage(t);
+            }
+        }
+
+        return new Result(loadDesignDiagrams, this.semanticDiffs, compilationError);
+    }
+
+    // Unwraps only async plumbing (CompletionException from join()); the first real
+    // exception's message already carries the full context (e.g. which module failed).
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause instanceof CompletionException
+                && cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        String message = cause.getMessage();
+        return message == null || message.isBlank() ? cause.getClass().getName() : message;
+    }
+
+    private static Map<String, Module> collectModules(Project project) {
+        Map<String, Module> modules = new LinkedHashMap<>();
+        project.currentPackage().modules().forEach(module ->
+                modules.put(module.moduleName().toString(), module));
+        return modules;
+    }
+
+    /**
+     * Computes the semantic diffs contributed by one module. Either side may be null when the
+     * module itself was added or removed; the corresponding document map is then empty, so
+     * every construct on the other side registers as an addition/deletion.
+     */
+    private void computeModuleSemanticDiffs(Module originalModule, Module modifiedModule) {
+
+        this.currentModuleFilePaths.clear();
+        Map<String, Document> originalDocumentMap = collectDocumentMap(originalModule);
+        Map<String, Document> modifiedDocumentMap = collectDocumentMap(modifiedModule);
 
         STNodeRefMap originalNodeRefMap = new STNodeRefMap();
         STNodeRefMap modifiedNodeRefMap = new STNodeRefMap();
@@ -125,119 +187,136 @@ public class SemanticDiffComputer {
             modifiedDoc.syntaxTree().rootNode().accept(modifiedNodeRefExtractor);
         }
 
-        computeListenerDiffs(originalNodeRefMap.getListenerNodeMap(), modifiedNodeRefMap.getListenerNodeMap());
+        // Listeners and module variables (connections) shape the design diagram; the rest don't.
+        computeSourceDiffs(originalNodeRefMap.getListenerNodeMap(), modifiedNodeRefMap.getListenerNodeMap(),
+                NodeKind.LISTENER, true);
         computeServiceDiffs(originalNodeRefMap.getServiceNodeMap(), modifiedNodeRefMap.getServiceNodeMap());
         computeFunctionDiffs(originalNodeRefMap.getFunctionNodeMap(), modifiedNodeRefMap.getFunctionNodeMap());
         computeTypeDefDiffs(originalNodeRefMap.getTypeDefNodeMap(), modifiedNodeRefMap.getTypeDefNodeMap());
-        computeModuleVarDiffs(originalNodeRefMap.getModuleVarNodeMap(), modifiedNodeRefMap.getModuleVarNodeMap());
-
-        String compilationError = null;
-        if (!loadDesignDiagrams) {
-            try {
-                compareUsingDesignDiagrams();
-            } catch (Throwable t) {
-                // The design-model comparison is the only step that needs a full package
-                // compilation, which can fail for reasons unrelated to the edit (e.g. an
-                // unresolvable dependency). The syntax-level diffs above are still valid,
-                // so report the failure instead of discarding them.
-                compilationError = rootCauseMessage(t);
-            }
-        }
-
-        return new Result(loadDesignDiagrams, this.semanticDiffs, compilationError);
-    }
-
-    // Unwraps only async plumbing (CompletionException from join()); the first real
-    // exception's message already carries the full context (e.g. which module failed).
-    private static String rootCauseMessage(Throwable throwable) {
-        Throwable cause = throwable;
-        while (cause instanceof CompletionException
-                && cause.getCause() != null && cause.getCause() != cause) {
-            cause = cause.getCause();
-        }
-        String message = cause.getMessage();
-        return message == null || message.isBlank() ? cause.getClass().getName() : message;
+        computeSourceDiffs(originalNodeRefMap.getModuleVarNodeMap(), modifiedNodeRefMap.getModuleVarNodeMap(),
+                NodeKind.MODULE_VARIABLE, true);
+        computeSourceDiffs(originalNodeRefMap.getConstantNodeMap(), modifiedNodeRefMap.getConstantNodeMap(),
+                NodeKind.CONSTANT, false);
+        computeSourceDiffs(originalNodeRefMap.getEnumNodeMap(), modifiedNodeRefMap.getEnumNodeMap(),
+                NodeKind.ENUM_DECLARATION, false);
+        computeClassDiffs(originalNodeRefMap.getClassNodeMap(), modifiedNodeRefMap.getClassNodeMap());
+        computeSourceDiffs(originalNodeRefMap.getImportNodeMap(), modifiedNodeRefMap.getImportNodeMap(),
+                NodeKind.IMPORT_DECLARATION, false);
     }
 
     /**
-     * Computes listener differences between original and modified projects to determine
-     * if design diagrams need to be reloaded.
+     * Computes diffs for a construct kind whose changes are reviewed as source text:
+     * name-keyed nodes compared by their source, producing addition/deletion/modification
+     * entries carrying that source in the metadata.
      *
-     * <p>This method performs a shallow comparison of listener declarations to detect
-     * structural changes such as listener additions or removals. It sets the
-     * {@code loadDesignDiagrams} flag if any differences are found, which indicates
-     * that the architecture diagram should be regenerated.
-     *
-     * <p>Note: This method does not analyze the expression content of listeners since
-     * only structural changes affect the design diagram. The comparison terminates
-     * early if a difference is already detected to optimize performance.
-     *
-     * @param originalListenerMap map of listener names to their declaration nodes
-     *                            from the original project
-     * @param modifiedListenerMap map of listener names to their declaration nodes
-     *                            from the modified project
+     * @param originalMap   original map of construct names to their declaration nodes
+     * @param modifiedMap   modified map of construct names to their declaration nodes
+     * @param kind          the NodeKind reported on the diffs
+     * @param affectsDesign whether a change to this kind reshapes the design diagram
+     *                      (listeners and module vars/connections do)
      */
-    private void computeListenerDiffs(Map<String, ListenerDeclarationNode> originalListenerMap,
-                                      Map<String, ListenerDeclarationNode> modifiedListenerMap) {
+    private <T extends Node> void computeSourceDiffs(Map<String, T> originalMap, Map<String, T> modifiedMap,
+                                                     NodeKind kind, boolean affectsDesign) {
 
-        if (loadDesignDiagrams) {
-            return;
+        for (Map.Entry<String, T> entry : originalMap.entrySet()) {
+            String name = entry.getKey();
+            T originalNode = entry.getValue();
+            if (!modifiedMap.containsKey(name)) {
+                loadDesignDiagrams |= affectsDesign;
+                addDeletionDiff(kind, originalNode.lineRange(),
+                        buildSourceMetadata(name, originalNode.toSourceCode(), null));
+                continue;
+            }
+            T modifiedNode = modifiedMap.remove(name);
+            String originalSource = originalNode.toSourceCode();
+            String modifiedSource = modifiedNode.toSourceCode();
+            if (!originalSource.equals(modifiedSource)) {
+                loadDesignDiagrams |= affectsDesign;
+                addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(),
+                        buildSourceMetadata(name, originalSource, modifiedSource));
+            }
         }
 
-        for (Map.Entry<String, ListenerDeclarationNode> entry : originalListenerMap.entrySet()) {
-            String listenerName = entry.getKey();
-            if (!modifiedListenerMap.containsKey(listenerName)) {
-                loadDesignDiagrams = true;
-                return;
-            }
-            ListenerDeclarationNode originalListener = entry.getValue();
-            ListenerDeclarationNode modifiedListener = modifiedListenerMap.remove(listenerName);
-            if (!originalListener.toSourceCode().equals(modifiedListener.toSourceCode())) {
-                loadDesignDiagrams = true;
-                return;
-            }
-        }
-
-        if (!modifiedListenerMap.isEmpty()) {
-            loadDesignDiagrams = true;
+        for (Map.Entry<String, T> entry : modifiedMap.entrySet()) {
+            loadDesignDiagrams |= affectsDesign;
+            addAdditionDiff(kind, entry.getValue().lineRange(),
+                    buildSourceMetadata(entry.getKey(), null, entry.getValue().toSourceCode()));
         }
     }
 
     /**
-     * Computes module-level variable differences between original and modified projects to
-     * determine if design diagrams need to be reloaded.
-     *
-     * <p>Module-level variables include client/connection declarations. Changes to these
-     * variables (additions, removals, or modifications) affect the design diagram and
-     * should trigger a reload.
-     *
-     * @param originalVarMap original map of variable names to their declaration nodes
-     * @param modifiedVarMap modified map of variable names to their declaration nodes
+     * Computes class-definition differences. Method changes are reported individually as
+     * OBJECT_FUNCTION diffs (they have flow representations); changes to the remaining class
+     * members (fields, init expressions) are reported as a single CLASS_DEFINITION diff.
      */
-    private void computeModuleVarDiffs(Map<String, ModuleVariableDeclarationNode> originalVarMap,
-                                       Map<String, ModuleVariableDeclarationNode> modifiedVarMap) {
+    private void computeClassDiffs(Map<String, ClassDefinitionNode> originalClassMap,
+                                   Map<String, ClassDefinitionNode> modifiedClassMap) {
 
-        if (loadDesignDiagrams) {
-            return;
-        }
-
-        for (Map.Entry<String, ModuleVariableDeclarationNode> entry : originalVarMap.entrySet()) {
-            String varName = entry.getKey();
-            if (!modifiedVarMap.containsKey(varName)) {
-                loadDesignDiagrams = true;
-                return;
+        for (Map.Entry<String, ClassDefinitionNode> entry : originalClassMap.entrySet()) {
+            String className = entry.getKey();
+            ClassDefinitionNode originalClass = entry.getValue();
+            if (!modifiedClassMap.containsKey(className)) {
+                addDeletionDiff(NodeKind.CLASS_DEFINITION, originalClass.lineRange(),
+                        buildSourceMetadata(className, originalClass.toSourceCode(), null));
+                continue;
             }
-            ModuleVariableDeclarationNode originalVar = entry.getValue();
-            ModuleVariableDeclarationNode modifiedVar = modifiedVarMap.remove(varName);
-            if (!originalVar.toSourceCode().equals(modifiedVar.toSourceCode())) {
-                loadDesignDiagrams = true;
-                return;
+            ClassDefinitionNode modifiedClass = modifiedClassMap.remove(className);
+            String originalClassSource = originalClass.toSourceCode();
+            String modifiedClassSource = modifiedClass.toSourceCode();
+            if (originalClassSource.equals(modifiedClassSource)) {
+                continue;
+            }
+
+            Map<String, FunctionDefinitionNode> originalMethods = extractClassMethods(originalClass);
+            Map<String, FunctionDefinitionNode> modifiedMethods = extractClassMethods(modifiedClass);
+            for (Map.Entry<String, FunctionDefinitionNode> methodEntry : originalMethods.entrySet()) {
+                String methodKey = methodEntry.getKey();
+                FunctionDefinitionNode originalMethod = methodEntry.getValue();
+                Map<String, String> metadata = buildFunctionMetadata(className + "." + methodKey);
+                if (!modifiedMethods.containsKey(methodKey)) {
+                    addDeletionDiff(NodeKind.OBJECT_FUNCTION, originalMethod.lineRange(), metadata);
+                    continue;
+                }
+                compareFunctionBodies(originalMethod, modifiedMethods.remove(methodKey),
+                        NodeKind.OBJECT_FUNCTION, metadata);
+            }
+            for (Map.Entry<String, FunctionDefinitionNode> methodEntry : modifiedMethods.entrySet()) {
+                addAdditionDiff(NodeKind.OBJECT_FUNCTION, methodEntry.getValue().lineRange(),
+                        buildFunctionMetadata(className + "." + methodEntry.getKey()));
+            }
+
+            if (!nonMethodMembersSource(originalClass).equals(nonMethodMembersSource(modifiedClass))) {
+                addModificationDiff(NodeKind.CLASS_DEFINITION, modifiedClass.lineRange(),
+                        originalClass.lineRange(),
+                        buildSourceMetadata(className, originalClassSource, modifiedClassSource));
             }
         }
 
-        if (!modifiedVarMap.isEmpty()) {
-            loadDesignDiagrams = true;
+        for (Map.Entry<String, ClassDefinitionNode> entry : modifiedClassMap.entrySet()) {
+            addAdditionDiff(NodeKind.CLASS_DEFINITION, entry.getValue().lineRange(),
+                    buildSourceMetadata(entry.getKey(), null, entry.getValue().toSourceCode()));
         }
+    }
+
+    private static Map<String, FunctionDefinitionNode> extractClassMethods(ClassDefinitionNode classNode) {
+        Map<String, FunctionDefinitionNode> methods = new LinkedHashMap<>();
+        classNode.members().forEach(member -> {
+            if (member instanceof FunctionDefinitionNode method) {
+                String resourcePath = method.relativeResourcePath().stream()
+                        .map(node -> node.toSourceCode().trim())
+                        .collect(Collectors.joining(""));
+                methods.put(method.functionName().text().trim()
+                        + (resourcePath.isEmpty() ? "" : "#" + resourcePath), method);
+            }
+        });
+        return methods;
+    }
+
+    private static String nonMethodMembersSource(ClassDefinitionNode classNode) {
+        return classNode.members().stream()
+                .filter(member -> !(member instanceof FunctionDefinitionNode))
+                .map(Node::toSourceCode)
+                .collect(Collectors.joining());
     }
 
     /**
@@ -252,10 +331,12 @@ public class SemanticDiffComputer {
 
         for (Map.Entry<String, TypeDefinitionNode> entry : originalTypeDefMap.entrySet()) {
             String typeDefName = entry.getKey();
+            TypeDefinitionNode originalTypeDef = entry.getValue();
             if (!modifiedTypeDefMap.containsKey(typeDefName)) {
+                addDeletionDiff(NodeKind.TYPE_DEFINITION, originalTypeDef.lineRange(),
+                        buildTypeMetadata(typeDefName));
                 continue;
             }
-            TypeDefinitionNode originalTypeDef = entry.getValue();
             TypeDefinitionNode modifiedTypeDef = modifiedTypeDefMap.remove(typeDefName);
             if (originalTypeDef.toSourceCode().equals(modifiedTypeDef.toSourceCode())) {
                 continue;
@@ -412,43 +493,49 @@ public class SemanticDiffComputer {
             return;
         }
 
-        if (originalFunctionBody instanceof FunctionBodyBlockNode originalBodyNode
-                && modifiedFunctionBody instanceof FunctionBodyBlockNode modifiedBodyNode) {
-            if (originalBodyNode.statements().size() != modifiedBodyNode.statements().size()) {
+        if (!(originalFunctionBody instanceof FunctionBodyBlockNode originalBodyNode)
+                || !(modifiedFunctionBody instanceof FunctionBodyBlockNode modifiedBodyNode)) {
+            // Same body class but not a statement block (e.g. both `external` bodies): the
+            // sources already differ per the check above, so report the modification instead
+            // of falling through silently.
+            addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
+            return;
+        }
+
+        if (originalBodyNode.statements().size() != modifiedBodyNode.statements().size()) {
+            addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
+            return;
+        }
+
+        for (int i = 0; i < originalBodyNode.statements().size(); i++) {
+            StatementNode originalStmtNode = originalBodyNode.statements().get(i);
+            StatementNode modifiedStmtNode = modifiedBodyNode.statements().get(i);
+
+            if (originalStmtNode.toSourceCode().equals(modifiedStmtNode.toSourceCode())) {
+                continue;
+            }
+
+            List<Node> allOriginalStmtNodes = new ArrayList<>();
+            extractStatementNodes(originalStmtNode, allOriginalStmtNodes);
+            List<Node> allModifiedStmtNodes = new ArrayList<>();
+            extractStatementNodes(modifiedStmtNode, allModifiedStmtNodes);
+
+            if (allOriginalStmtNodes.size() != allModifiedStmtNodes.size()) {
                 addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
                 return;
             }
 
-            for (int i = 0; i < originalBodyNode.statements().size(); i++) {
-                StatementNode originalStmtNode = originalBodyNode.statements().get(i);
-                StatementNode modifiedStmtNode = modifiedBodyNode.statements().get(i);
-
-                if (originalStmtNode.toSourceCode().equals(modifiedStmtNode.toSourceCode())) {
-                    continue;
-                }
-
-                List<Node> allOriginalStmtNodes = new ArrayList<>();
-                extractStatementNodes(originalStmtNode, allOriginalStmtNodes);
-                List<Node> allModifiedStmtNodes = new ArrayList<>();
-                extractStatementNodes(modifiedStmtNode, allModifiedStmtNodes);
-
-                if (allOriginalStmtNodes.size() != allModifiedStmtNodes.size()) {
-                    addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
+            for (int j = 0; j < allOriginalStmtNodes.size(); j++) {
+                Node originalNode = allOriginalStmtNodes.get(j);
+                Node modifiedNode = allModifiedStmtNodes.get(j);
+                // need to change whether both nodes have the same type
+                if (!originalNode.getClass().equals(modifiedNode.getClass())) {
+                    addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(), metadata);
                     return;
                 }
-
-                for (int j = 0; j < allOriginalStmtNodes.size(); j++) {
-                    Node originalNode = allOriginalStmtNodes.get(j);
-                    Node modifiedNode = allModifiedStmtNodes.get(j);
-                    // need to change whether both nodes have the same type
-                    if (!originalNode.getClass().equals(modifiedNode.getClass())) {
-                        addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(), metadata);
-                        return;
-                    }
-                    if (!originalNode.toSourceCode().trim().equals(modifiedNode.toSourceCode().trim())) {
-                        addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(), metadata);
-                        return;
-                    }
+                if (!originalNode.toSourceCode().trim().equals(modifiedNode.toSourceCode().trim())) {
+                    addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(), metadata);
+                    return;
                 }
             }
         }
@@ -464,6 +551,34 @@ public class SemanticDiffComputer {
         SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, kind,
                 resolveUri(modifiedLineRange.fileName()), modifiedLineRange, originalLineRange, metadata);
         this.semanticDiffs.add(diff);
+    }
+
+    private void addAdditionDiff(NodeKind kind, LineRange lineRange, Map<String, String> metadata) {
+        this.semanticDiffs.add(new SemanticDiff(ChangeType.ADDITION, kind,
+                resolveUri(lineRange.fileName()), lineRange, metadata));
+    }
+
+    private void addDeletionDiff(NodeKind kind, LineRange originalLineRange, Map<String, String> metadata) {
+        this.semanticDiffs.add(new SemanticDiff(ChangeType.DELETION, kind,
+                resolveUri(originalLineRange.fileName()), originalLineRange, metadata));
+    }
+
+    /**
+     * Metadata for construct kinds the review UI renders as source text rather than a
+     * diagram (constants, module vars, listeners, imports, enums, classes): carries the
+     * construct's before/after source so the UI needs no extra content lookup. Either
+     * side may be null (pure addition/deletion).
+     */
+    private static Map<String, String> buildSourceMetadata(String name, String oldSource, String newSource) {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put("name", name);
+        if (oldSource != null) {
+            metadata.put("oldSource", oldSource.strip());
+        }
+        if (newSource != null) {
+            metadata.put("newSource", newSource.strip());
+        }
+        return metadata;
     }
 
     private void extractStatementNodes(Node statementNode, List<Node> nodes) {
@@ -735,21 +850,46 @@ public class SemanticDiffComputer {
     }
 
     /**
-     * Collects a map of document names to Document objects from the given project.
+     * Collects a map of document names to Document objects from the given module, covering
+     * both source and test documents so edits confined to tests still produce diffs. Also
+     * records each document's on-disk path for URI resolution.
      *
-     * @param project the Ballerina project to collect documents from
+     * @param module the module to collect documents from; null yields an empty map (module
+     *               absent on this side of the diff)
      * @return a map of document names to Document objects
      */
-    private Map<String, Document> collectDocumentMap(Project project) {
+    private Map<String, Document> collectDocumentMap(Module module) {
 
         Map<String, Document> documentMap = new HashMap<>();
-        project.currentPackage().getDefaultModule().documentIds().stream()
-                .map(project.currentPackage().getDefaultModule()::document)
+        if (module == null) {
+            return documentMap;
+        }
+        module.documentIds().stream()
+                .map(module::document)
                 .filter(Objects::nonNull)
                 .forEach(document -> {
                     documentMap.put(document.name(), document);
+                    registerDocumentPath(module, document);
+                });
+        module.testDocumentIds().stream()
+                .map(module::document)
+                .filter(Objects::nonNull)
+                .forEach(document -> {
+                    documentMap.put(document.name(), document);
+                    registerDocumentPath(module, document);
                 });
         return documentMap;
+    }
+
+    private void registerDocumentPath(Module module, Document document) {
+        Optional<Path> documentPath = module.project().documentPath(document.documentId());
+        // LineRange.fileName() reflects the syntax tree's file path (normally the document
+        // name); register both so either form resolves. Both sides of the diff share the
+        // same disk path, so a single map serves original and modified lookups.
+        documentPath.ifPresent(path -> {
+            this.currentModuleFilePaths.putIfAbsent(document.name(), path);
+            this.currentModuleFilePaths.putIfAbsent(document.syntaxTree().filePath(), path);
+        });
     }
 
     /**
@@ -764,7 +904,10 @@ public class SemanticDiffComputer {
         for (Map.Entry<String, ServiceDeclarationNode> entry : serviceMap.entrySet()) {
             String serviceName = entry.getKey();
             String basePath = serviceName.split("#")[0];
-            serviceBasePaths.put(basePath, serviceName);
+            // Two services may legally share a base path (different listeners). Keep the
+            // first instead of silently overwriting — the unmatched one then surfaces via
+            // the removed/added handling rather than being paired with the wrong service.
+            serviceBasePaths.putIfAbsent(basePath, serviceName);
         }
         return serviceBasePaths;
     }
@@ -933,7 +1076,10 @@ public class SemanticDiffComputer {
 
     private String resolveUri(String fileName) {
 
-        Path filePath = Path.of(rootProjectPath).resolve(fileName);
+        // Module and test documents don't live directly under the project root, so prefer
+        // the recorded document path; fall back to root-relative for robustness.
+        Path filePath = this.currentModuleFilePaths.getOrDefault(
+                fileName, Path.of(rootProjectPath).resolve(fileName));
         return "ai" + filePath.toUri().toString().substring(4);
     }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -28,6 +28,7 @@ import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.FunctionBodyNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.IfElseStatementNode;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.LockStatementNode;
 import io.ballerina.compiler.syntax.tree.MatchClauseNode;
 import io.ballerina.compiler.syntax.tree.MatchStatementNode;
@@ -200,8 +201,40 @@ public class SemanticDiffComputer {
         computeSourceDiffs(originalNodeRefMap.getEnumNodeMap(), modifiedNodeRefMap.getEnumNodeMap(),
                 NodeKind.ENUM_DECLARATION, false);
         computeClassDiffs(originalNodeRefMap.getClassNodeMap(), modifiedNodeRefMap.getClassNodeMap());
-        computeSourceDiffs(originalNodeRefMap.getImportNodeMap(), modifiedNodeRefMap.getImportNodeMap(),
-                NodeKind.IMPORT_DECLARATION, false);
+        computeImportDiffs(originalNodeRefMap.getImportNodeMap(), modifiedNodeRefMap.getImportNodeMap());
+    }
+
+    /**
+     * Computes import differences by key alone. An import's map key (org/module plus alias)
+     * already encodes everything semantic about the declaration, so two imports with the same
+     * key can only differ in surrounding trivia — e.g. a file-header comment that re-attached
+     * to a different import when one was inserted above it. Comparing source text here (as
+     * {@link #computeSourceDiffs} does) flagged such untouched imports as "modified", showing
+     * reviewers a comment shuffle. Only genuine additions and deletions are reported, and
+     * their displayed source is the canonical {@code import <key>;} form rather than
+     * {@code toSourceCode()}, which would drag any attached leading comment into the view.
+     */
+    private void computeImportDiffs(Map<String, ImportDeclarationNode> originalImportMap,
+                                    Map<String, ImportDeclarationNode> modifiedImportMap) {
+
+        for (Map.Entry<String, ImportDeclarationNode> entry : originalImportMap.entrySet()) {
+            String name = entry.getKey();
+            if (modifiedImportMap.containsKey(name)) {
+                modifiedImportMap.remove(name);
+                continue;
+            }
+            addDeletionDiff(NodeKind.IMPORT_DECLARATION, entry.getValue().lineRange(),
+                    buildSourceMetadata(name, canonicalImportSource(name), null));
+        }
+
+        for (Map.Entry<String, ImportDeclarationNode> entry : modifiedImportMap.entrySet()) {
+            addAdditionDiff(NodeKind.IMPORT_DECLARATION, entry.getValue().lineRange(),
+                    buildSourceMetadata(entry.getKey(), null, canonicalImportSource(entry.getKey())));
+        }
+    }
+
+    private static String canonicalImportSource(String importKey) {
+        return "import " + importKey + ";";
     }
 
     /**

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/NodeKind.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/NodeKind.java
@@ -27,5 +27,13 @@ public enum NodeKind {
     MODULE_FUNCTION,
     OBJECT_FUNCTION,
     TYPE_DEFINITION,
-    DATA_MAPPING_FUNCTION
+    DATA_MAPPING_FUNCTION,
+    // The kinds below have no diagram representation; the review UI renders them as
+    // source-level changes. Only append new constants — the wire format is the ordinal.
+    MODULE_VARIABLE,
+    CONSTANT,
+    LISTENER,
+    CLASS_DEFINITION,
+    ENUM_DECLARATION,
+    IMPORT_DECLARATION
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/Result.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/Result.java
@@ -25,8 +25,14 @@ import java.util.List;
  *
  * @param loadDesignDiagrams indicates whether design diagrams should be loaded
  * @param semanticDiffs   list of semantic differences identified
+ * @param compilationError message of a package-compilation failure hit while comparing design
+ *                         models, when the syntax-level diffs themselves are still valid
  *
  * @since 1.5.0
  */
-public record Result(boolean loadDesignDiagrams, List<SemanticDiff> semanticDiffs) {
+public record Result(boolean loadDesignDiagrams, List<SemanticDiff> semanticDiffs, String compilationError) {
+
+    public Result(boolean loadDesignDiagrams, List<SemanticDiff> semanticDiffs) {
+        this(loadDesignDiagrams, semanticDiffs, null);
+    }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/STNodeRefMap.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/STNodeRefMap.java
@@ -18,7 +18,11 @@
 
 package io.ballerina.copilotagent.core.models;
 
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
+import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
@@ -38,6 +42,10 @@ public class STNodeRefMap {
     private final Map<String, ServiceDeclarationNode> serviceNodeMap = new HashMap<>();
     private final Map<String, TypeDefinitionNode> typeDefNodeMap = new HashMap<>();
     private final Map<String, ModuleVariableDeclarationNode> moduleVarNodeMap = new HashMap<>();
+    private final Map<String, ConstantDeclarationNode> constantNodeMap = new HashMap<>();
+    private final Map<String, EnumDeclarationNode> enumNodeMap = new HashMap<>();
+    private final Map<String, ClassDefinitionNode> classNodeMap = new HashMap<>();
+    private final Map<String, ImportDeclarationNode> importNodeMap = new HashMap<>();
 
     public Map<String, ListenerDeclarationNode> getListenerNodeMap() {
         return this.listenerNodeMap;
@@ -59,6 +67,22 @@ public class STNodeRefMap {
         return this.moduleVarNodeMap;
     }
 
+    public Map<String, ConstantDeclarationNode> getConstantNodeMap() {
+        return this.constantNodeMap;
+    }
+
+    public Map<String, EnumDeclarationNode> getEnumNodeMap() {
+        return this.enumNodeMap;
+    }
+
+    public Map<String, ClassDefinitionNode> getClassNodeMap() {
+        return this.classNodeMap;
+    }
+
+    public Map<String, ImportDeclarationNode> getImportNodeMap() {
+        return this.importNodeMap;
+    }
+
     public void putListenerNode(String key, ListenerDeclarationNode node) {
         this.listenerNodeMap.put(key, node);
     }
@@ -77,5 +101,21 @@ public class STNodeRefMap {
 
     public void putModuleVarNode(String key, ModuleVariableDeclarationNode node) {
         this.moduleVarNodeMap.put(key, node);
+    }
+
+    public void putConstantNode(String key, ConstantDeclarationNode node) {
+        this.constantNodeMap.put(key, node);
+    }
+
+    public void putEnumNode(String key, EnumDeclarationNode node) {
+        this.enumNodeMap.put(key, node);
+    }
+
+    public void putClassNode(String key, ClassDefinitionNode node) {
+        this.classNodeMap.put(key, node);
+    }
+
+    public void putImportNode(String key, ImportDeclarationNode node) {
+        this.importNodeMap.put(key, node);
     }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
@@ -21,10 +21,17 @@ package io.ballerina.copilotagent.extension;
 import io.ballerina.copilotagent.core.SemanticDiffComputer;
 import io.ballerina.copilotagent.core.models.Result;
 import io.ballerina.copilotagent.extension.request.EnsureAiBaselineRequest;
+import io.ballerina.copilotagent.extension.request.PrewarmDependenciesRequest;
 import io.ballerina.copilotagent.extension.request.SemanticDiffRequest;
 import io.ballerina.copilotagent.extension.response.EnsureAiBaselineResponse;
+import io.ballerina.copilotagent.extension.response.PrewarmDependenciesResponse;
 import io.ballerina.copilotagent.extension.response.SemanticDiffResponse;
+import io.ballerina.modelgenerator.commons.PackageUtil;
+import io.ballerina.projects.DependencyGraph;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageDescriptor;
 import io.ballerina.projects.Project;
+import io.ballerina.projects.ResolvedPackageDependency;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.PathUtil;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
@@ -122,6 +129,57 @@ public class CopilotAgentService implements ExtendedLanguageServerService {
 
     private static String toAiUri(Path path) {
         return "ai" + path.toUri().toString().substring(4);
+    }
+
+    /**
+     * Warms the standalone module-package caches (see {@code PackageUtil}) for the package's
+     * direct dependencies. The flow-model generator resolves and compiles each dependency's
+     * standalone package the first time a diagram references it — a one-time-per-session cost
+     * of seconds that otherwise lands on the first review-diff click. Callers fire this in the
+     * background at generation start so the caches are hot by the time the review opens.
+     */
+    @JsonRequest
+    public CompletableFuture<PrewarmDependenciesResponse> prewarmDependencies(PrewarmDependenciesRequest request) {
+        return CompletableFuture.supplyAsync(() -> {
+            PrewarmDependenciesResponse response = new PrewarmDependenciesResponse();
+            try {
+                Path path = PathUtil.convertUriStringToPath(request.projectPath());
+                Project project = this.workspaceManager.loadProject(path);
+                Package currentPackage = project.currentPackage();
+                PackageDescriptor rootDescriptor = currentPackage.descriptor();
+                DependencyGraph<ResolvedPackageDependency> graph =
+                        currentPackage.getResolution().dependencyGraph();
+                // Only direct dependencies: the flow-model generator standalone-resolves the
+                // modules referenced from user code, which come from the package's own imports.
+                // Warming the transitive closure multiplies the background compile cost for
+                // packages the diagrams rarely touch.
+                ResolvedPackageDependency root = graph.getNodes().stream()
+                        .filter(node -> node.packageInstance().descriptor().equals(rootDescriptor))
+                        .findFirst().orElse(null);
+                if (root == null) {
+                    response.setWarmedDependencyCount(0);
+                    return response;
+                }
+                int warmed = 0;
+                for (ResolvedPackageDependency dependency : graph.getDirectDependencies(root)) {
+                    PackageDescriptor descriptor = dependency.packageInstance().descriptor();
+                    if (descriptor.equals(rootDescriptor) || descriptor.isLangLibPackage()
+                            || descriptor.isBuiltInPackage()) {
+                        continue;
+                    }
+                    PackageUtil.resolveModulePackage(descriptor.org().value(), descriptor.name().value(),
+                                    descriptor.version().value().toString())
+                            // The flow-model generator needs the dependency's own semantic model,
+                            // so pre-compile it too; memoized on the cached Package instance.
+                            .ifPresent(PackageUtil::getCompilation);
+                    warmed++;
+                }
+                response.setWarmedDependencyCount(warmed);
+            } catch (Exception e) {
+                response.setError(e);
+            }
+            return response;
+        });
     }
 
     @JsonRequest

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
@@ -20,20 +20,30 @@ package io.ballerina.copilotagent.extension;
 
 import io.ballerina.copilotagent.core.SemanticDiffComputer;
 import io.ballerina.copilotagent.core.models.Result;
+import io.ballerina.copilotagent.extension.request.EnsureAiBaselineRequest;
 import io.ballerina.copilotagent.extension.request.SemanticDiffRequest;
+import io.ballerina.copilotagent.extension.response.EnsureAiBaselineResponse;
 import io.ballerina.copilotagent.extension.response.SemanticDiffResponse;
 import io.ballerina.projects.Project;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.PathUtil;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManagerProxy;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @JavaSPIService("org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService")
@@ -54,6 +64,64 @@ public class CopilotAgentService implements ExtendedLanguageServerService {
     @Override
     public Class<?> getRemoteInterface() {
         return null;
+    }
+
+    /**
+     * (Re)establishes the ai:// frozen baseline of a package from explicit file contents,
+     * atomically from the caller's perspective: any cached ai:// project is evicted, the
+     * package is reloaded, and the provided contents are applied before the response
+     * resolves. This replaces the fire-and-forget didClose/didOpen notification protocol,
+     * whose disk-read timing raced against the caller's first workspace edit.
+     */
+    @JsonRequest
+    public CompletableFuture<EnsureAiBaselineResponse> ensureAiBaseline(EnsureAiBaselineRequest request) {
+        return CompletableFuture.supplyAsync(() -> {
+            EnsureAiBaselineResponse response = new EnsureAiBaselineResponse();
+            try {
+                Path projectRoot = PathUtil.convertUriStringToPath(request.projectPath());
+                // Evict via the package's Ballerina.toml — a concrete file the project
+                // lookup always resolves. Drops the whole cached ai:// project (no-op when
+                // absent), so the next document update rebuilds the package from disk
+                // before applying content.
+                Path evictionAnchor = projectRoot.resolve("Ballerina.toml");
+                this.aiWorkspaceManager.didClose(evictionAnchor,
+                        new DidCloseTextDocumentParams(new TextDocumentIdentifier(toAiUri(evictionAnchor))));
+
+                List<String> failedFiles = new ArrayList<>();
+                int seeded = 0;
+                List<EnsureAiBaselineRequest.BaselineFile> files =
+                        request.files() == null ? List.of() : request.files();
+                for (EnsureAiBaselineRequest.BaselineFile file : files) {
+                    Path filePath = projectRoot.resolve(file.filePath());
+                    try {
+                        // The first change rebuilds the package from disk and the rest update
+                        // documents in place — the same batch technique the extension's
+                        // restore path uses, minus the cross-process timing dependency.
+                        DidChangeTextDocumentParams params = new DidChangeTextDocumentParams(
+                                new VersionedTextDocumentIdentifier(toAiUri(filePath), 1),
+                                List.of(new TextDocumentContentChangeEvent(
+                                        file.content() == null ? "" : file.content())));
+                        this.aiWorkspaceManager.didChange(filePath, params);
+                        seeded++;
+                    } catch (WorkspaceDocumentException | RuntimeException e) {
+                        failedFiles.add(file.filePath());
+                    }
+                }
+                if (files.isEmpty()) {
+                    // No explicit contents: snapshot the package from disk as it stands now.
+                    this.aiWorkspaceManager.loadProject(projectRoot);
+                }
+                response.setSeededFileCount(seeded);
+                response.setFailedFiles(failedFiles);
+            } catch (Exception e) {
+                response.setError(e);
+            }
+            return response;
+        });
+    }
+
+    private static String toAiUri(Path path) {
+        return "ai" + path.toUri().toString().substring(4);
     }
 
     @JsonRequest

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
@@ -132,11 +132,13 @@ public class CopilotAgentService implements ExtendedLanguageServerService {
     }
 
     /**
-     * Warms the standalone module-package caches (see {@code PackageUtil}) for the package's
-     * direct dependencies. The flow-model generator resolves and compiles each dependency's
-     * standalone package the first time a diagram references it — a one-time-per-session cost
-     * of seconds that otherwise lands on the first review-diff click. Callers fire this in the
-     * background at generation start so the caches are hot by the time the review opens.
+     * Warms the standalone module-resolution cache (see {@code PackageUtil}) for the package's
+     * direct dependencies. The flow-model generator standalone-resolves each dependency the
+     * first time a diagram references it, and an unwarmed resolution costs Central round trips
+     * that otherwise land on the first review-diff click. Callers fire this in the background
+     * at generation start so the cache is hot by the time the review opens. Only the resolved
+     * bala path is cached — every consumer loads (and compiles) its own {@code Package}
+     * instance from that path, so there is nothing to usefully pre-compile here.
      */
     @JsonRequest
     public CompletableFuture<PrewarmDependenciesResponse> prewarmDependencies(PrewarmDependenciesRequest request) {
@@ -167,11 +169,11 @@ public class CopilotAgentService implements ExtendedLanguageServerService {
                             || descriptor.isBuiltInPackage()) {
                         continue;
                     }
+                    // Resolution is the expensive, cacheable part: the resolved bala path lands
+                    // in PackageUtil's shared resolution cache. The returned Package instance is
+                    // fresh per call and discarded, so pre-compiling it here would be wasted work.
                     PackageUtil.resolveModulePackage(descriptor.org().value(), descriptor.name().value(),
-                                    descriptor.version().value().toString())
-                            // The flow-model generator needs the dependency's own semantic model,
-                            // so pre-compile it too; memoized on the cached Package instance.
-                            .ifPresent(PackageUtil::getCompilation);
+                            descriptor.version().value().toString());
                     warmed++;
                 }
                 response.setWarmedDependencyCount(warmed);

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/CopilotAgentService.java
@@ -72,6 +72,7 @@ public class CopilotAgentService implements ExtendedLanguageServerService {
                 Result result = diffComputer.computeSemanticDiffs();
                 response.setLoadDesignDiagrams(result.loadDesignDiagrams());
                 response.setSemanticDiffs(result.semanticDiffs());
+                response.setCompilationError(result.compilationError());
             } catch (Exception e) {
                 response.setError(e);
             }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/EnsureAiBaselineRequest.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/EnsureAiBaselineRequest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/EnsureAiBaselineRequest.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/EnsureAiBaselineRequest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.copilotagent.extension.request;
+
+import java.util.List;
+
+/**
+ * Request to (re)establish the ai:// frozen baseline of a package from explicit file
+ * contents. Evicts any cached ai:// project for the path, reloads it, and applies the
+ * given contents — all before the response resolves, so callers can rely on the baseline
+ * being in place (unlike the fire-and-forget didOpen/didChange notification protocol).
+ *
+ * @param projectPath the package root (URI or filesystem path)
+ * @param files       baseline contents to apply; paths are relative to projectPath.
+ *                    May be empty to snapshot the package purely from disk.
+ * @since 1.5.0
+ */
+public record EnsureAiBaselineRequest(String projectPath, List<BaselineFile> files) {
+
+    /**
+     * One file's frozen baseline content.
+     *
+     * @param filePath path relative to the package root
+     * @param content  the exact baseline text for the file
+     */
+    public record BaselineFile(String filePath, String content) {
+    }
+}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/PrewarmDependenciesRequest.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/PrewarmDependenciesRequest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/PrewarmDependenciesRequest.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/request/PrewarmDependenciesRequest.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.copilotagent.extension.request;
+
+/**
+ * Request to warm the standalone module-package caches for a package's direct
+ * dependencies, so the first flow-model request of a review session does not pay the
+ * one-time dependency resolution/compilation cost interactively.
+ *
+ * @param projectPath the package root (URI or filesystem path)
+ * @since 1.5.0
+ */
+public record PrewarmDependenciesRequest(String projectPath) {
+}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/EnsureAiBaselineResponse.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/EnsureAiBaselineResponse.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/EnsureAiBaselineResponse.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/EnsureAiBaselineResponse.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.copilotagent.extension.response;
+
+import io.ballerina.designmodelgenerator.extension.response.AbstractResponse;
+
+import java.util.List;
+
+/**
+ * Response for the ensureAiBaseline request.
+ *
+ * @since 1.5.0
+ */
+public class EnsureAiBaselineResponse extends AbstractResponse {
+    private int seededFileCount;
+    // Files whose baseline content could not be applied (e.g. not part of the package).
+    // The rest of the baseline is still in place.
+    private List<String> failedFiles;
+
+    public int getSeededFileCount() {
+        return seededFileCount;
+    }
+
+    public void setSeededFileCount(int seededFileCount) {
+        this.seededFileCount = seededFileCount;
+    }
+
+    public List<String> getFailedFiles() {
+        return failedFiles;
+    }
+
+    public void setFailedFiles(List<String> failedFiles) {
+        this.failedFiles = failedFiles;
+    }
+}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/PrewarmDependenciesResponse.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/PrewarmDependenciesResponse.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/PrewarmDependenciesResponse.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/PrewarmDependenciesResponse.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.copilotagent.extension.response;
+
+import io.ballerina.designmodelgenerator.extension.response.AbstractResponse;
+
+/**
+ * Response for the prewarmDependencies request.
+ *
+ * @since 1.5.0
+ */
+public class PrewarmDependenciesResponse extends AbstractResponse {
+    private int warmedDependencyCount;
+
+    public int getWarmedDependencyCount() {
+        return warmedDependencyCount;
+    }
+
+    public void setWarmedDependencyCount(int warmedDependencyCount) {
+        this.warmedDependencyCount = warmedDependencyCount;
+    }
+}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/SemanticDiffResponse.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/java/io/ballerina/copilotagent/extension/response/SemanticDiffResponse.java
@@ -31,6 +31,17 @@ import java.util.List;
 public class SemanticDiffResponse extends AbstractResponse {
     private boolean loadDesignDiagrams;
     private List<SemanticDiff> semanticDiffs;
+    // Set when the syntax-level diffs succeeded but the package failed to compile
+    // (design-model comparison). Unlike errorMsg, the diffs are still usable.
+    private String compilationError;
+
+    public String getCompilationError() {
+        return compilationError;
+    }
+
+    public void setCompilationError(String compilationError) {
+        this.compilationError = compilationError;
+    }
 
     public boolean isLoadDesignDiagrams() {
         return loadDesignDiagrams;

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/java/io/ballerina/copilotagent/extension/SemanticDiffComputerTest.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/java/io/ballerina/copilotagent/extension/SemanticDiffComputerTest.java
@@ -93,7 +93,7 @@ public class SemanticDiffComputerTest extends AbstractLSTest {
         actualOutput = gson.fromJson(outputJsonStr, JsonElement.class);
         // assert the results
         if (!actualOutput.equals(testConfig.output())) {
-            TestConfig updatedConfig = new TestConfig(testConfig.description(), 
+            TestConfig updatedConfig = new TestConfig(testConfig.description(),
                     testConfig.projectPath(), actualOutput.getAsJsonObject());
 //            updateConfig(configJsonPath, updatedConfig);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config1.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config1.json
@@ -5,6 +5,26 @@
     "loadDesignDiagrams": true,
     "semanticDiffs": [
       {
+        "changeType": "ADDITION",
+        "nodeKind": "LISTENER",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 4,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 4,
+            "offset": 51
+          }
+        },
+        "metadata": {
+          "name": "unusedListener",
+          "newSource": "listener http:Listener unusedListener = new (8080);"
+        }
+      },
+      {
         "changeType": "DELETION",
         "nodeKind": "OBJECT_FUNCTION",
         "uri": "ai:///main.bal",
@@ -186,6 +206,86 @@
         },
         "metadata": {
           "name": "ErrorResponse"
+        }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "MODULE_VARIABLE",
+        "uri": "ai:///connections.bal",
+        "lineRange": {
+          "fileName": "connections.bal",
+          "startLine": {
+            "line": 3,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 3,
+            "offset": 70
+          }
+        },
+        "metadata": {
+          "name": "petStoreApiUrl",
+          "newSource": "// HTTP client configuration for external API calls\nconfigurable string petStoreApiUrl = \"https://petstore.swagger.io/v2\";"
+        }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "MODULE_VARIABLE",
+        "uri": "ai:///connections.bal",
+        "lineRange": {
+          "fileName": "connections.bal",
+          "startLine": {
+            "line": 6,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 6,
+            "offset": 69
+          }
+        },
+        "metadata": {
+          "name": "petStoreClient",
+          "newSource": "// HTTP client for making external API calls\npublic final http:Client petStoreClient = check new (petStoreApiUrl);"
+        }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "IMPORT_DECLARATION",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 1,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 1,
+            "offset": 22
+          }
+        },
+        "metadata": {
+          "name": "ballerina/uuid",
+          "newSource": "import ballerina/uuid;"
+        }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "IMPORT_DECLARATION",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 21
+          }
+        },
+        "metadata": {
+          "name": "ballerina/log",
+          "newSource": "import ballerina/log;"
         }
       }
     ]

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config10.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config10.json
@@ -3,6 +3,39 @@
   "projectPath": "connection_param_change",
   "output": {
     "loadDesignDiagrams": true,
-    "semanticDiffs": []
+    "semanticDiffs": [
+      {
+        "changeType": "MODIFICATION",
+        "nodeKind": "MODULE_VARIABLE",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 71
+          }
+        },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 68
+          }
+        },
+        "metadata": {
+          "name": "apiClient",
+          "oldSource": "final http:Client apiClient = check new (\"https://api.example.com\");",
+          "newSource": "final http:Client apiClient = check new (\"https://api.v2.example.com\");"
+        }
+      }
+    ]
   }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config2.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config2.json
@@ -37,6 +37,25 @@
         }
       },
       {
+        "changeType": "DELETION",
+        "nodeKind": "TYPE_DEFINITION",
+        "uri": "ai:///types.bal",
+        "lineRange": {
+          "fileName": "types.bal",
+          "startLine": {
+            "line": 0,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 11,
+            "offset": 3
+          }
+        },
+        "metadata": {
+          "name": "Patient"
+        }
+      },
+      {
         "changeType": "MODIFICATION",
         "nodeKind": "TYPE_DEFINITION",
         "uri": "ai:///types.bal",

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config3.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config3.json
@@ -188,6 +188,26 @@
         "metadata": {
           "name": "modulo"
         }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "IMPORT_DECLARATION",
+        "uri": "ai:///functions.bal",
+        "lineRange": {
+          "fileName": "functions.bal",
+          "startLine": {
+            "line": 0,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 0,
+            "offset": 21
+          }
+        },
+        "metadata": {
+          "name": "ballerina/log",
+          "newSource": "import ballerina/log;"
+        }
       }
     ]
   }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config5.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config5.json
@@ -3,6 +3,39 @@
   "projectPath": "listener_changes",
   "output": {
     "loadDesignDiagrams": true,
-    "semanticDiffs": []
+    "semanticDiffs": [
+      {
+        "changeType": "MODIFICATION",
+        "nodeKind": "LISTENER",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 49
+          }
+        },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 49
+          }
+        },
+        "metadata": {
+          "name": "httpListener",
+          "oldSource": "listener http:Listener httpListener = new (8080);",
+          "newSource": "listener http:Listener httpListener = new (9090);"
+        }
+      }
+    ]
   }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config8.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config8.json
@@ -35,6 +35,26 @@
           "servicePath": "/api",
           "resourcePath": "data"
         }
+      },
+      {
+        "changeType": "ADDITION",
+        "nodeKind": "MODULE_VARIABLE",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 68
+          }
+        },
+        "metadata": {
+          "name": "apiClient",
+          "newSource": "final http:Client apiClient = check new (\"https://api.example.com\");"
+        }
       }
     ]
   }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config9.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config9.json
@@ -35,6 +35,26 @@
           "servicePath": "/api",
           "resourcePath": "data"
         }
+      },
+      {
+        "changeType": "DELETION",
+        "nodeKind": "MODULE_VARIABLE",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 2,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 68
+          }
+        },
+        "metadata": {
+          "name": "apiClient",
+          "oldSource": "final http:Client apiClient = check new (\"https://api.example.com\");"
+        }
       }
     ]
   }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -84,16 +84,8 @@ import io.ballerina.modelgenerator.commons.PackageUtil;
 import io.ballerina.projects.DependenciesToml;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Package;
-import io.ballerina.projects.PackageDescriptor;
-import io.ballerina.projects.PackageName;
-import io.ballerina.projects.PackageOrg;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.TomlDocument;
-import io.ballerina.projects.environment.PackageMetadataResponse;
-import io.ballerina.projects.environment.PackageResolver;
-import io.ballerina.projects.environment.ResolutionOptions;
-import io.ballerina.projects.environment.ResolutionRequest;
-import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
@@ -105,7 +97,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -633,21 +624,10 @@ public class AiUtils {
     }
 
     public static Optional<String> resolvePackageVersion(String org, String packageName) {
-        try {
-            PackageResolver resolver = PackageUtil.getSampleProject()
-                    .projectEnvironmentContext().getService(PackageResolver.class);
-            ResolutionRequest resolutionRequest = ResolutionRequest.from(
-                    PackageDescriptor.from(PackageOrg.from(org), PackageName.from(packageName)));
-            Collection<PackageMetadataResponse> metadataResponses = resolver.resolvePackageMetadata(
-                    Collections.singletonList(resolutionRequest),
-                    ResolutionOptions.builder().setOffline(true).build());
-            return metadataResponses.stream().findFirst()
-                    .filter(meta -> meta.resolutionStatus() != ResolutionResponse.ResolutionStatus.UNRESOLVED)
-                    .map(PackageMetadataResponse::resolvedDescriptor)
-                    .map(descriptor -> descriptor.version().value().toString());
-        } catch (RuntimeException e) {
-            return Optional.empty();
-        }
+        // Delegate to PackageUtil.cachedVersion, which performs the same offline metadata resolution
+        // on the current thread's sample project. Doing it here directly would be a second consumer
+        // of the sample-project resolver to keep thread-safe; keeping a single owner avoids that.
+        return Optional.ofNullable(PackageUtil.cachedVersion(org, packageName));
     }
 
     private static synchronized void ensureDependentModulesResolved() {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/PackageUtilConcurrencyTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/PackageUtilConcurrencyTest.java
@@ -1,0 +1,230 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import io.ballerina.modelgenerator.commons.PackageUtil;
+import io.ballerina.projects.Package;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Concurrency stability guard for {@link PackageUtil}'s per-thread sample-project resolution
+ * (wso2/product-integrator#2193).
+ *
+ * <p>The bug it relates to: a single shared sample {@code BuildProject} resolved through an
+ * environment whose {@code EnvironmentPackageCache} is a plain, unsynchronized {@code HashMap};
+ * resolving a package writes into it. Concurrent Language Server requests (flow-model, trigger,
+ * connector and library-metadata generation all resolve here) mutated that one map from multiple
+ * threads and could corrupt it. The fix gives each thread its own sample project (environment,
+ * resolver and cache).
+ *
+ * <p>What this test does: it hammers the resolver-backed entry points from many threads with an
+ * aligned start and asserts (a) no thread throws, (b) the run does not hang, and (c) every concurrent
+ * result matches a single-threaded baseline. It is environment-independent: it never asserts a
+ * particular package is present, only that concurrent resolution is exception-free and deterministic;
+ * the bogus coordinates are the one fixed anchor — they must always resolve as absent, which also
+ * proves the resolver is actually being exercised.
+ *
+ * <p><b>Scope and limitation.</b> This is a stability/consistency guard, not a deterministic
+ * reproduction of #2193. That underlying defect is a {@code HashMap}-resize data race, which is
+ * timing- and load-dependent: a small package set never trips it, and a set large enough to make it
+ * likely also makes an ordinary run slow enough to be indistinguishable from a hang. So this test
+ * does not by itself prove the race is present or absent — it guards against gross concurrency
+ * regressions (exceptions, deadlocks, divergent results) and documents the per-thread contract. The
+ * real protection is the design (per-thread isolation) and, ultimately, a compiler-side thread-safe
+ * cache.
+ *
+ * <p>It lives here, rather than in model-generator-commons (where {@code PackageUtil} is defined),
+ * because this module's test task provisions a real Ballerina distribution ({@code ballerina.home}),
+ * which building the sample-project environment requires.
+ *
+ * <p>Offline only: every method exercised here resolves with {@code setOffline(true)}, so the test
+ * never contacts Ballerina Central.
+ */
+public class PackageUtilConcurrencyTest {
+
+    private static final int THREADS = 16;
+    private static final int ITERATIONS = 25;
+    // Generous relative to the expected runtime (tens of seconds): a breach means a genuine hang
+    // (e.g. a deadlock from a reintroduced lock, or a corrupted cache spinning), not mere slowness.
+    private static final int TIMEOUT_SECONDS = 180;
+
+    private static final String BOGUS_ORG = "zzz.no.org";
+
+    private record Coord(String org, String name) { }
+
+    // A mix of standard-library candidates (present-or-not is decided by the baseline, never asserted)
+    // plus clearly bogus coordinates that must always resolve as absent. Kept modest so the run stays
+    // fast; a couple of dependency-heavy packages (http, graphql) still load transitive graphs, and
+    // the staggered per-thread start below spreads distinct loads across the pool.
+    private static final List<Coord> COORDS = List.of(
+            new Coord("ballerina", "http"),
+            new Coord("ballerina", "graphql"),
+            new Coord("ballerina", "io"),
+            new Coord("ballerina", "log"),
+            new Coord("ballerina", "crypto"),
+            new Coord("ballerina", "cache"),
+            new Coord(BOGUS_ORG, "zzz-no-module"),
+            new Coord(BOGUS_ORG, "another-absent-module"));
+
+    /**
+     * The single-threaded truth for one coordinate, captured before the concurrent run.
+     *
+     * @param cachedVersion   the version returned by {@code cachedVersion}
+     * @param unresolved      whether {@code isModuleUnresolved} reports the module as unresolved
+     * @param offlinePresent  whether the module resolves through {@code getModulePackageOffline}
+     */
+    private record Baseline(String cachedVersion, boolean unresolved, boolean offlinePresent) { }
+
+    @Test
+    public void testConcurrentSampleResolutionIsStableAndConsistent() throws Exception {
+        List<Baseline> baselines = new ArrayList<>(COORDS.size());
+        for (Coord coord : COORDS) {
+            baselines.add(baselineFor(coord));
+        }
+
+        // Sanity: the bogus coordinates must be unresolved, otherwise the test is not actually
+        // exercising the resolver and every other assertion would be vacuous.
+        for (int i = 0; i < COORDS.size(); i++) {
+            if (BOGUS_ORG.equals(COORDS.get(i).org())) {
+                Baseline b = baselines.get(i);
+                Assert.assertNull(b.cachedVersion(), "Bogus coordinate unexpectedly resolved a version");
+                Assert.assertTrue(b.unresolved(), "Bogus coordinate unexpectedly resolved");
+                Assert.assertFalse(b.offlinePresent(), "Bogus coordinate unexpectedly present offline");
+            }
+        }
+
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+        List<String> mismatches = new CopyOnWriteArrayList<>();
+        CyclicBarrier startLine = new CyclicBarrier(THREADS);
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        AtomicBoolean stop = new AtomicBoolean(false);
+        try {
+            List<Future<?>> futures = new ArrayList<>(THREADS);
+            for (int t = 0; t < THREADS; t++) {
+                final int offset = t; // stagger the start coordinate so threads load DISTINCT packages
+                futures.add(pool.submit(() -> {
+                    try {
+                        startLine.await(); // release all threads at once to maximise contention
+                        for (int i = 0; i < ITERATIONS && !stop.get(); i++) {
+                            // Exercise the load path (getModulePackage*, each of which builds a fresh
+                            // lang-lib environment) only on the first pass: that is where every thread
+                            // first-misses at once and hits the resolver. Doing it every pass would
+                            // allocate thousands of environments and exhaust the test heap without
+                            // adding coverage (later passes are memoized path-cache hits anyway). The
+                            // cheap metadata methods run every pass to sustain resolver contention.
+                            boolean exerciseLoads = i == 0;
+                            for (int j = 0; j < COORDS.size(); j++) {
+                                int c = (offset + j) % COORDS.size();
+                                checkAgainstBaseline(COORDS.get(c), baselines.get(c), mismatches, exerciseLoads);
+                            }
+                        }
+                    } catch (Throwable e) {
+                        stop.set(true);
+                        failures.add(e);
+                    }
+                }));
+            }
+            pool.shutdown();
+            // A corrupted HashMap can spin forever; the timeout turns that into a test failure
+            // instead of a hung build.
+            boolean finished = pool.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            Assert.assertTrue(finished,
+                    "Concurrent resolution did not finish within " + TIMEOUT_SECONDS + "s (possible deadlock or "
+                            + "corrupted resolver cache)");
+            for (Future<?> f : futures) {
+                f.get(); // surface anything the task machinery swallowed
+            }
+        } finally {
+            stop.set(true);
+            pool.shutdownNow();
+        }
+
+        Assert.assertTrue(failures.isEmpty(),
+                "Concurrent sample-project resolution threw " + failures.size() + " exception(s); first:\n"
+                        + (failures.isEmpty() ? "none" : stackToString(failures.get(0))));
+        Assert.assertTrue(mismatches.isEmpty(),
+                "Concurrent results diverged from the single-threaded baseline: " + mismatches);
+    }
+
+    private static Baseline baselineFor(Coord coord) {
+        String version = PackageUtil.cachedVersion(coord.org(), coord.name());
+        // isModuleUnresolved needs a version: probe the resolved one when known, else a placeholder
+        // (which, for an absent package, resolves as unresolved).
+        String probeVersion = version != null ? version : "1.0.0";
+        boolean unresolved = PackageUtil.isModuleUnresolved(coord.org(), coord.name(), probeVersion);
+        boolean offlinePresent = PackageUtil.getModulePackageOffline(coord.org(), coord.name()).isPresent();
+        return new Baseline(version, unresolved, offlinePresent);
+    }
+
+    private static void checkAgainstBaseline(Coord coord, Baseline baseline, List<String> mismatches,
+                                             boolean exerciseLoads) {
+        String version = PackageUtil.cachedVersion(coord.org(), coord.name());
+        if (!Objects.equals(version, baseline.cachedVersion())) {
+            mismatches.add("cachedVersion " + coord + ": expected " + baseline.cachedVersion() + " got " + version);
+        }
+
+        String probeVersion = baseline.cachedVersion() != null ? baseline.cachedVersion() : "1.0.0";
+        boolean unresolved = PackageUtil.isModuleUnresolved(coord.org(), coord.name(), probeVersion);
+        if (unresolved != baseline.unresolved()) {
+            mismatches.add("isModuleUnresolved " + coord + ": expected " + baseline.unresolved()
+                    + " got " + unresolved);
+        }
+
+        if (!exerciseLoads) {
+            return;
+        }
+
+        Optional<Package> offline = PackageUtil.getModulePackageOffline(coord.org(), coord.name());
+        if (offline.isPresent() != baseline.offlinePresent()) {
+            mismatches.add("getModulePackageOffline " + coord + ": expected present=" + baseline.offlinePresent()
+                    + " got present=" + offline.isPresent());
+        }
+
+        // Only exercise getModulePackage for coordinates already resolvable offline, so this stays
+        // offline (its cache miss would otherwise fall back to Central for an absent package).
+        if (baseline.offlinePresent()) {
+            Optional<Package> pkg = PackageUtil.getModulePackage(PackageUtil.getSampleProject(),
+                    coord.org(), coord.name());
+            if (pkg.isEmpty()) {
+                mismatches.add("getModulePackage " + coord + ": expected present but was empty");
+            }
+        }
+    }
+
+    private static String stackToString(Throwable t) {
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/PackageUtilConcurrencyTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/PackageUtilConcurrencyTest.java
@@ -138,11 +138,15 @@ public class PackageUtilConcurrencyTest {
                         startLine.await(); // release all threads at once to maximise contention
                         for (int i = 0; i < ITERATIONS && !stop.get(); i++) {
                             // Exercise the load path (getModulePackage*, each of which builds a fresh
-                            // lang-lib environment) only on the first pass: that is where every thread
-                            // first-misses at once and hits the resolver. Doing it every pass would
+                            // lang-lib environment) only on the first pass. Doing it every pass would
                             // allocate thousands of environments and exhaust the test heap without
-                            // adding coverage (later passes are memoized path-cache hits anyway). The
-                            // cheap metadata methods run every pass to sustain resolver contention.
+                            // adding coverage (later passes are memoized path-cache hits anyway).
+                            // Concurrent resolver pressure here comes from the coordinates the shared
+                            // SAMPLE_RESOLUTION_CACHE cannot serve: the single-threaded baseline warmed
+                            // it for offline-present coordinates, but absence is never cached, so the
+                            // bogus coordinates re-enter the resolver on every thread at once. The cheap
+                            // metadata methods (cachedVersion / isModuleUnresolved, neither memoized) run
+                            // every pass to sustain that contention across the whole run.
                             boolean exerciseLoads = i == 0;
                             for (int j = 0; j < COORDS.size(); j++) {
                                 int c = (offset + j) % COORDS.size();

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
@@ -9,6 +9,7 @@
             <class name="io.ballerina.flowmodelgenerator.core.ConnectionActionProviderTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.ConnectorCategoryResolverTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.DiagnosticHandlerTest"/>
+            <class name="io.ballerina.flowmodelgenerator.core.PackageUtilConcurrencyTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.copilot.CopilotUiSchemaIsolationTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.copilot.central.CentralLibrarySearchAccessorTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.copilot.service.ServiceIndexLoaderTest"/>

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/publishers/ProjectUpdateEventPublisher.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/publishers/ProjectUpdateEventPublisher.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.langserver.eventsync.publishers;
 
 import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
@@ -46,6 +47,16 @@ public class ProjectUpdateEventPublisher extends AbstractEventPublisher {
     @Override
     public void publish(ExtendedLanguageClient client, LanguageServerContext serverContext,
                         DocumentServiceContext context) {
+        // The ai:// scheme is the AI copilot's frozen pre-edit baseline — a virtual clone the
+        // user never edits directly. No project-update reaction applies to it: its diagnostics
+        // have no consumer, and the pull-modules / compilation-error prompts would target a
+        // project the user cannot act on. Each subscriber forces a package compilation, so
+        // letting the baseline-seeding didOpen/didChange bursts through costs O(events) full
+        // compiles. Skip the whole fan-out here so every subscriber, present and future, is
+        // covered by a single check.
+        if (CommonUtil.AI_SCHEME.equals(context.workspace().uriScheme())) {
+            return;
+        }
         subscribers.parallelStream()
                 .forEach(subscriber -> subscriber.onEvent(client, context, serverContext));
     }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/runner/BallerinaRunnerService.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/runner/BallerinaRunnerService.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
  * Implementation of Ballerina runner extension for Language Server.
@@ -92,9 +93,25 @@ public class BallerinaRunnerService implements ExtendedLanguageServerService {
                 String msg = "Operation 'ballerinaRunner/diagnostics' failed!";
                 this.clientLogger.logError(RunnerContext.RUNNER_DIAGNOSTICS, msg, e, request.getProjectRootIdentifier(),
                         (Position) null);
+                // Tell the client why (e.g. a package-compilation failure) instead of an
+                // indistinguishable empty response.
+                ProjectDiagnosticsResponse errorResponse = new ProjectDiagnosticsResponse();
+                errorResponse.setErrorMsg(rootCauseMessage(e));
+                return errorResponse;
             }
-            return new ProjectDiagnosticsResponse();
         });
+    }
+
+    // Unwraps only async plumbing (CompletionException); the first real exception's
+    // message already carries the full context (e.g. which module failed to load).
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause instanceof CompletionException
+                && cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        String message = cause.getMessage();
+        return message == null || message.isBlank() ? cause.getClass().getName() : message;
     }
 
     /**

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/runner/ProjectDiagnosticsResponse.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/runner/ProjectDiagnosticsResponse.java
@@ -30,6 +30,9 @@ import java.util.Map;
 public class ProjectDiagnosticsResponse {
 
     private Map<String, List<Diagnostic>> errorDiagnosticMap;
+    // Why the diagnostics could not be produced (e.g. the package failed to compile).
+    // errorDiagnosticMap stays null in that case, which older clients already treat as failure.
+    private String errorMsg;
 
     public Map<String, List<Diagnostic>> getErrorDiagnosticMap() {
         return errorDiagnosticMap;
@@ -37,5 +40,13 @@ public class ProjectDiagnosticsResponse {
 
     public void setErrorDiagnosticMap(Map<String, List<Diagnostic>> errorDiagnosticMap) {
         this.errorDiagnosticMap = errorDiagnosticMap;
+    }
+
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+    public void setErrorMsg(String errorMsg) {
+        this.errorMsg = errorMsg;
     }
 }

--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -65,6 +65,8 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Utility class that contains methods to perform package-related operations.
@@ -72,6 +74,8 @@ import java.util.function.Supplier;
  * @since 1.0.0
  */
 public class PackageUtil {
+
+    private static final Logger LOGGER = Logger.getLogger(PackageUtil.class.getName());
 
     private static final String BALLERINA_HOME_PROPERTY = "ballerina.home";
 
@@ -186,6 +190,9 @@ public class PackageUtil {
         try {
             resolved = resolution.get();
         } catch (RuntimeException e) {
+            // Absence is not cached (see javadoc), so a caller retry can still succeed; log the cause
+            // so a Central outage or corrupted bala is distinguishable from a genuinely missing package.
+            LOGGER.log(Level.FINE, "Sample-project resolution failed for " + key, e);
             return Optional.empty();
         }
         resolved.ifPresent(path -> SAMPLE_RESOLUTION_CACHE.putIfAbsent(key, Optional.of(path)));

--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -36,10 +36,12 @@ import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.bala.BalaProject;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.environment.PackageMetadataResponse;
+import io.ballerina.projects.environment.PackageRepository;
 import io.ballerina.projects.environment.PackageResolver;
 import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.environment.ResolutionResponse;
+import io.ballerina.projects.internal.environment.BallerinaUserHome;
 import io.ballerina.projects.repos.TempDirCompilationCache;
 import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.langserver.LSClientLogger;
@@ -88,7 +90,48 @@ public class PackageUtil {
         return BallerinaCompilerApi.getInstance().getBalaBuildOptions(CommonUtil.TEST_OFFLINE);
     }
 
-    private static final BuildProject SAMPLE_PROJECT = createSampleProject();
+    /**
+     * Per-thread "sample project" used purely as a resolver environment for standalone module
+     * lookups (the project itself is an empty in-memory package; only its {@link PackageResolver}
+     * is used).
+     *
+     * <p><b>Why thread-local (context for the language-server team).</b> A {@code BuildProject}'s
+     * {@code PackageResolver} resolves through its environment's {@code EnvironmentPackageCache},
+     * which is a plain, unsynchronized {@code HashMap}; resolving a package writes into it. While
+     * this was a single shared {@code BuildProject}, concurrent LS requests — flow-model, trigger,
+     * connector and library-metadata generation all resolve here — mutated that one {@code HashMap}
+     * from multiple threads and corrupted it (wso2/product-integrator#2193). Giving each thread its
+     * own sample project (hence its own environment, resolver and cache) removes the shared mutable
+     * state entirely, so these hot, shared LS paths need no locking. The expensive part — avoiding
+     * a Central round trip per lookup — is preserved by {@link #SAMPLE_RESOLUTION_CACHE} below,
+     * which stays shared because it holds only immutable data (resolved bala paths).
+     *
+     * <p>This is the app-side fix for the shared-resolver hazard. If the compiler later makes the
+     * resolver / package cache concurrency-safe, this can collapse back to a single shared instance
+     * with no change to callers.
+     *
+     * <p>Cost/lifecycle: the per-thread project is a lightweight in-memory load of the single shared
+     * {@link #SAMPLE_PROJECT_DIR} (no per-thread temp directory), but its resolver environment does
+     * retain that thread's lang-lib packages. A thread's instance is reclaimed by GC when the thread
+     * dies — it is reachable only through the thread's own {@code ThreadLocalMap}, nothing else holds
+     * it — so live memory tracks the number of threads currently resolving, not the number ever
+     * seen. Cache <i>hits</i> never touch the resolver at all. Do not call {@link #getSampleProject()}
+     * from short-lived threads spawned per request (e.g. a per-call cached thread pool): each such
+     * thread would build a full resolver environment only to discard it when it dies.
+     */
+    private static final ThreadLocal<BuildProject> SAMPLE_PROJECT =
+            ThreadLocal.withInitial(PackageUtil::createSampleProject);
+
+    /**
+     * The Ballerina local package repository, per thread, backed by that thread's sample-project
+     * environment. Thread-local for the same reason as {@link #SAMPLE_PROJECT}: reading a package
+     * through this repository ({@code getPackage}) loads it into the backing environment's
+     * (unsynchronized) package cache, so a single shared instance would corrupt that cache under
+     * concurrent access — the exact hazard #2193 describes, reached through a different door.
+     */
+    private static final ThreadLocal<PackageRepository> LOCAL_REPOSITORY =
+            ThreadLocal.withInitial(() -> BallerinaUserHome.from(
+                    getSampleProject().projectEnvironmentContext().environment()).localPackageRepository());
 
     private static final String PULLING_THE_MODULE_MESSAGE = "Pulling the module '%s' from the central";
     private static final String MODULE_PULLING_FAILED_MESSAGE = "Failed to pull the module: %s";
@@ -116,35 +159,37 @@ public class PackageUtil {
     private static final ConcurrentHashMap<String, Optional<Path>> SAMPLE_RESOLUTION_CACHE =
             new ConcurrentHashMap<>();
 
-    /**
-     * Serializes cache-miss resolutions: before caching, every call built its own sample project
-     * (and resolver), so the shared resolver was never used concurrently. Keep that property.
-     */
-    private static final Object SAMPLE_RESOLUTION_LOCK = new Object();
+    // Namespaces offline-resolution cache entries so they never collide with the latest-version
+    // entries from getModulePackage (whose miss can resolve — and pull — a newer online version).
+    private static final String OFFLINE_RESOLUTION_KEY_PREFIX = "offline:";
 
     /**
-     * Caches only resolved paths. An absence is not remembered: the module-pull flow retries
-     * through here, and a cached failure would outlive the network problem that caused it.
+     * Caches only resolved (immutable) bala paths, keyed by coordinates. Absence is never cached:
+     * the module-pull flow retries through here, and a cached failure would outlive the network
+     * problem that caused it.
+     *
+     * <p>No lock is needed. Resolution now runs on the calling thread's own sample project
+     * ({@link #SAMPLE_PROJECT}), so concurrent misses touch per-thread resolver state, never shared
+     * state. The cache is a {@link ConcurrentHashMap} of immutable paths; two threads racing the
+     * same coordinate simply resolve it independently and store the identical path
+     * ({@code putIfAbsent}). For a coordinate not yet pulled locally, both may ask the compiler to
+     * pull it — the same behavior as before the sample project was shared (each call resolved on its
+     * own project), relying on the compiler tolerating concurrent pulls of one package into the
+     * shared local repository, which is independent of this class.
      */
     private static Optional<Path> memoizedSampleBala(String key, Supplier<Optional<Path>> resolution) {
         Optional<Path> cached = SAMPLE_RESOLUTION_CACHE.get(key);
         if (cached != null) {
             return cached;
         }
-        synchronized (SAMPLE_RESOLUTION_LOCK) {
-            Optional<Path> present = SAMPLE_RESOLUTION_CACHE.get(key);
-            if (present != null) {
-                return present;
-            }
-            Optional<Path> resolved;
-            try {
-                resolved = resolution.get();
-            } catch (RuntimeException e) {
-                return Optional.empty();
-            }
-            resolved.ifPresent(path -> SAMPLE_RESOLUTION_CACHE.put(key, Optional.of(path)));
-            return resolved;
+        Optional<Path> resolved;
+        try {
+            resolved = resolution.get();
+        } catch (RuntimeException e) {
+            return Optional.empty();
         }
+        resolved.ifPresent(path -> SAMPLE_RESOLUTION_CACHE.putIfAbsent(key, Optional.of(path)));
+        return resolved;
     }
 
     private static String sampleResolutionKey(String org, String name, String version, String repository) {
@@ -165,7 +210,8 @@ public class PackageUtil {
      */
     public static String cachedVersion(String org, String name) {
         try {
-            PackageResolver resolver = SAMPLE_PROJECT.projectEnvironmentContext().getService(PackageResolver.class);
+            PackageResolver resolver = getSampleProject().projectEnvironmentContext()
+                    .getService(PackageResolver.class);
             Collection<PackageMetadataResponse> responses = resolver.resolvePackageMetadata(
                     Collections.singletonList(ResolutionRequest.from(
                             PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name)))),
@@ -182,17 +228,48 @@ public class PackageUtil {
     }
 
     /**
-     * Returns the shared sample project used for resolving standalone module packages. Memoized:
-     * this used to build a fresh temp directory + BuildProject per call, which both leaked temp
-     * dirs and defeated every downstream cache (resolver, resolution results) on hot paths like
-     * flow-model generation.
+     * Returns the calling thread's sample project, used for resolving standalone module packages.
+     * See {@link #SAMPLE_PROJECT} for why this is per-thread. It is built once per thread; callers
+     * on the same thread reuse it.
+     *
+     * <p><b>Contract:</b> the returned project is confined to the calling thread. Do not stash it
+     * (or anything derived from its environment/resolver) in a static or otherwise cross-thread
+     * field — doing so re-shares the non-thread-safe resolver and reintroduces #2193.
      */
     public static BuildProject getSampleProject() {
-        return SAMPLE_PROJECT;
+        return SAMPLE_PROJECT.get();
     }
 
-    private static BuildProject createSampleProject() {
-        // Obtain the Ballerina distribution path
+    /**
+     * The Ballerina local package repository for the calling thread, backed by that thread's
+     * sample-project environment. Use this instead of building one from {@link #getSampleProject()}
+     * yourself, so the thread-confinement contract stays in one place. See {@link #LOCAL_REPOSITORY}.
+     */
+    public static PackageRepository localPackageRepository() {
+        return LOCAL_REPOSITORY.get();
+    }
+
+    /**
+     * Whether {@code buildProject} is the calling thread's sample project (i.e. its resolution is
+     * memoizable). Every caller passes {@link #getSampleProject()} on the same thread, so an
+     * identity compare against this thread's {@code ThreadLocal} value is exact and needs no registry.
+     */
+    private static boolean isSampleProject(BuildProject buildProject) {
+        return buildProject == SAMPLE_PROJECT.get();
+    }
+
+    /**
+     * On-disk source of the sample project, created once for the whole process. Every thread's
+     * {@link #SAMPLE_PROJECT} is an in-memory load of this one directory, so per-thread projects add
+     * no per-thread temp directories — only their own resolver environment. The directory is only
+     * ever loaded, never built or compiled, and module resolution writes external balas to the
+     * user's central repository rather than here, so concurrent per-thread loads of it are read-only
+     * and safe. Registered for best-effort deletion on JVM exit (see {@link #createSampleProjectDir}).
+     */
+    private static final Path SAMPLE_PROJECT_DIR = createSampleProjectDir();
+
+    private static Path createSampleProjectDir() {
+        // Obtain the Ballerina distribution path (process-global; set once).
         String ballerinaHome = System.getProperty(BALLERINA_HOME_PROPERTY);
         if (ballerinaHome == null || ballerinaHome.isEmpty()) {
             Path currentPath = getPath(Paths.get(
@@ -202,14 +279,10 @@ public class PackageUtil {
         }
 
         try {
-            // Create a temporary directory
+            // Create a temporary directory with an empty main.bal and a minimal Ballerina.toml.
             Path tempDir = Files.createTempDirectory("ballerina-sample");
-
-            // Create an empty main.bal file
             Path mainBalFile = tempDir.resolve("main.bal");
             Files.createFile(mainBalFile);
-
-            // Create Ballerina.toml file with the specified content
             Path ballerinaTomlFile = tempDir.resolve("Ballerina.toml");
             String tomlContent = "[package]\n" +
                     "org = \"wso2\"\n" +
@@ -217,10 +290,20 @@ public class PackageUtil {
                     "version = \"0.1.0\"\n" +
                     "distribution = \"2201.12.0\"";
             Files.writeString(ballerinaTomlFile, tomlContent, StandardOpenOption.CREATE);
-            return BuildProject.load(tempDir);
+            // Best-effort cleanup. deleteOnExit is LIFO, so register the directory before its files:
+            // the files are removed first, leaving the directory empty when it is deleted at shutdown.
+            // If the load ever leaves extra files here, the non-empty directory delete simply no-ops.
+            tempDir.toFile().deleteOnExit();
+            mainBalFile.toFile().deleteOnExit();
+            ballerinaTomlFile.toFile().deleteOnExit();
+            return tempDir;
         } catch (IOException e) {
             throw new RuntimeException("Error occurred while creating the sample project", e);
         }
+    }
+
+    private static BuildProject createSampleProject() {
+        return BuildProject.load(SAMPLE_PROJECT_DIR);
     }
 
     /**
@@ -282,7 +365,7 @@ public class PackageUtil {
         // environment, and the returned bala is loaded with the default environment), so they
         // are safe to memoize across requests. Resolutions against a caller's real project may
         // depend on that project's state — leave them uncached.
-        if (buildProject == SAMPLE_PROJECT) {
+        if (isSampleProject(buildProject)) {
             return memoizedSampleBala(sampleResolutionKey(org, name, version, repository),
                     () -> resolveVersionedModuleBala(buildProject, org, name, version, repository))
                     .flatMap(PackageUtil::loadBalaPackage);
@@ -337,7 +420,7 @@ public class PackageUtil {
     public static Optional<Package> getModulePackage(BuildProject buildProject, String org, String name) {
         // See the versioned overload for why sample-project resolutions are memoized. The
         // "latest version" lookup below can itself hit Central, so caching matters just as much.
-        if (buildProject == SAMPLE_PROJECT) {
+        if (isSampleProject(buildProject)) {
             return memoizedSampleBala(sampleResolutionKey(org, name, null, null),
                     () -> resolveLatestModuleBala(buildProject, org, name)).flatMap(PackageUtil::loadBalaPackage);
         }
@@ -397,38 +480,45 @@ public class PackageUtil {
      * to actually pull it to the LS's existing explicit, user-notified pull flow (see
      * {@link #pullModuleAndNotify}) rather than pulling it silently as a side effect of a read.
      */
-    public static Optional<Package> getModulePackageOffline(BuildProject buildProject, String org, String name) {
+    public static Optional<Package> getModulePackageOffline(String org, String name) {
+        // Memoize the immutable offline bala path under a distinct "offline:" key — kept separate
+        // from getModulePackage's latest-version cache, whose miss may pull a newer online version —
+        // so repeat lookups skip the resolver entirely. Only the resolve touches the thread-local
+        // resolver; the bala load uses a fresh environment per call (see loadBalaPackage).
+        return memoizedSampleBala(OFFLINE_RESOLUTION_KEY_PREFIX + sampleResolutionKey(org, name, null, null),
+                () -> resolveOfflineModuleBala(org, name)).flatMap(PackageUtil::loadBalaPackage);
+    }
+
+    private static Optional<Path> resolveOfflineModuleBala(String org, String name) {
         ResolutionRequest resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name)));
-        PackageResolver packageResolver = buildProject.projectEnvironmentContext().getService(PackageResolver.class);
-        Collection<PackageMetadataResponse> packageMetadataResponses = packageResolver.resolvePackageMetadata(
-                Collections.singletonList(resolutionRequest),
-                ResolutionOptions.builder().setOffline(true).build());
-        Optional<PackageMetadataResponse> pkgMetadata = packageMetadataResponses.stream().findFirst();
-        if (pkgMetadata.isEmpty() ||
-                pkgMetadata.get().resolutionStatus() == ResolutionResponse.ResolutionStatus.UNRESOLVED) {
+        PackageResolver packageResolver = getSampleProject().projectEnvironmentContext()
+                .getService(PackageResolver.class);
+        Optional<PackageMetadataResponse> pkgMetadata = packageResolver.resolvePackageMetadata(
+                        Collections.singletonList(resolutionRequest),
+                        ResolutionOptions.builder().setOffline(true).build()).stream()
+                .findFirst();
+        if (pkgMetadata.isEmpty()
+                || pkgMetadata.get().resolutionStatus() == ResolutionResponse.ResolutionStatus.UNRESOLVED) {
             return Optional.empty();
         }
 
-        Collection<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(
-                Collections.singletonList(ResolutionRequest.from(pkgMetadata.get().resolvedDescriptor())),
-                ResolutionOptions.builder().setOffline(true).build());
-        Optional<ResolutionResponse> resolutionResponse = resolutionResponses.stream().findFirst();
-        if (resolutionResponse.isEmpty()) {
-            return Optional.empty();
-        }
-
-        Path balaPath = resolutionResponse.get().resolvedPackage().project().sourceRoot();
-        ProjectEnvironmentBuilder defaultBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
-        defaultBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
-        BalaProject balaProject = BalaProject.loadProject(defaultBuilder, balaPath);
-        return Optional.ofNullable(balaProject.currentPackage());
+        // Filter for a RESOLVED entry (matching resolveLatestModuleBala): resolvePackages can return
+        // a non-empty collection whose single entry is UNRESOLVED with a null resolvedPackage(),
+        // which would otherwise NPE on resolvedPackage().project().
+        return packageResolver.resolvePackages(
+                        Collections.singletonList(ResolutionRequest.from(pkgMetadata.get().resolvedDescriptor())),
+                        ResolutionOptions.builder().setOffline(true).build()).stream()
+                .filter(response -> response.resolvedPackage() != null)
+                .findFirst()
+                .map(response -> response.resolvedPackage().project().sourceRoot());
     }
 
     public static boolean isModuleUnresolved(String org, String name, String version) {
         ResolutionRequest resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name), PackageVersion.from(version)));
-        PackageResolver packageResolver = SAMPLE_PROJECT.projectEnvironmentContext().getService(PackageResolver.class);
+        PackageResolver packageResolver = getSampleProject().projectEnvironmentContext()
+                .getService(PackageResolver.class);
         return packageResolver.resolvePackageMetadata(Collections.singletonList(resolutionRequest),
                         ResolutionOptions.builder().setOffline(true).build()).stream()
                 .findFirst()
@@ -635,16 +725,16 @@ public class PackageUtil {
         if (PackageUtil.isModuleUnresolved(completeModuleInfo.org(), completeModuleInfo.packageName(),
                 completeModuleInfo.version())) {
             notifyClient(lsClientLogger, completeModuleInfo, MessageType.Info, PULLING_THE_MODULE_MESSAGE);
-            modulePackage = getModulePackage(SAMPLE_PROJECT, completeModuleInfo.org(), completeModuleInfo.packageName(),
-                    completeModuleInfo.version());
+            modulePackage = getModulePackage(getSampleProject(), completeModuleInfo.org(),
+                    completeModuleInfo.packageName(), completeModuleInfo.version());
             if (modulePackage.isEmpty()) {
                 notifyClient(lsClientLogger, completeModuleInfo, MessageType.Error, MODULE_PULLING_FAILED_MESSAGE);
             } else {
                 notifyClient(lsClientLogger, completeModuleInfo, MessageType.Info, MODULE_PULLING_SUCCESS_MESSAGE);
             }
         } else {
-            modulePackage = getModulePackage(SAMPLE_PROJECT, completeModuleInfo.org(), completeModuleInfo.packageName(),
-                    completeModuleInfo.version());
+            modulePackage = getModulePackage(getSampleProject(), completeModuleInfo.org(),
+                    completeModuleInfo.packageName(), completeModuleInfo.version());
         }
         return modulePackage;
     }

--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -62,6 +62,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 /**
  * Utility class that contains methods to perform package-related operations.
@@ -87,7 +88,7 @@ public class PackageUtil {
         return BallerinaCompilerApi.getInstance().getBalaBuildOptions(CommonUtil.TEST_OFFLINE);
     }
 
-    private static final BuildProject SAMPLE_PROJECT = getSampleProject();
+    private static final BuildProject SAMPLE_PROJECT = createSampleProject();
 
     private static final String PULLING_THE_MODULE_MESSAGE = "Pulling the module '%s' from the central";
     private static final String MODULE_PULLING_FAILED_MESSAGE = "Failed to pull the module: %s";
@@ -95,6 +96,68 @@ public class PackageUtil {
 
     // Concurrent map to store locks for each project
     private static final ConcurrentHashMap<Path, ReentrantLock> PROJECT_LOCKS = new ConcurrentHashMap<>();
+
+    /**
+     * Session cache for sample-project module resolutions, keyed by
+     * {@code org:name:version:repository}. Resolving a module against the sample project is
+     * extremely expensive — non-sticky resolution contacts Ballerina Central over HTTP even for
+     * locally cached packages, and a missing package throws after a network round trip — and the
+     * flow-model generator triggers one such resolution per remote-call node on EVERY
+     * getFlowModel request. Before this cache, a single warm flow-model fetch took seconds of
+     * pure network time.
+     *
+     * A bala package is immutable per version, so positive entries never go stale. The accepted
+     * trade-off is that a "latest version" lookup or a transient network failure sticks for the
+     * LS session.
+     *
+     * Caches the resolved bala path rather than the loaded package, which would retain that
+     * package's syntax trees and symbols for the session.
+     */
+    private static final ConcurrentHashMap<String, Optional<Path>> SAMPLE_RESOLUTION_CACHE =
+            new ConcurrentHashMap<>();
+
+    /**
+     * Serializes cache-miss resolutions: before caching, every call built its own sample project
+     * (and resolver), so the shared resolver was never used concurrently. Keep that property.
+     */
+    private static final Object SAMPLE_RESOLUTION_LOCK = new Object();
+
+    /**
+     * Caches only resolved paths. An absence is not remembered: the module-pull flow retries
+     * through here, and a cached failure would outlive the network problem that caused it.
+     */
+    private static Optional<Path> memoizedSampleBala(String key, Supplier<Optional<Path>> resolution) {
+        Optional<Path> cached = SAMPLE_RESOLUTION_CACHE.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        synchronized (SAMPLE_RESOLUTION_LOCK) {
+            Optional<Path> present = SAMPLE_RESOLUTION_CACHE.get(key);
+            if (present != null) {
+                return present;
+            }
+            Optional<Path> resolved;
+            try {
+                resolved = resolution.get();
+            } catch (RuntimeException e) {
+                return Optional.empty();
+            }
+            resolved.ifPresent(path -> SAMPLE_RESOLUTION_CACHE.put(key, Optional.of(path)));
+            return resolved;
+        }
+    }
+
+    private static String sampleResolutionKey(String org, String name, String version, String repository) {
+        return org + ":" + name + ":" + (version == null ? "<latest>" : version)
+                + ":" + (repository == null ? "" : repository);
+    }
+
+    private static Optional<Package> loadBalaPackage(Path balaPath) {
+        ProjectEnvironmentBuilder defaultBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
+        defaultBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
+        BalaProject balaProject = BalaProject.loadProject(defaultBuilder, balaPath, balaBuildOptions());
+        return Optional.ofNullable(balaProject.currentPackage());
+    }
 
     /**
      * Resolves the version of a package available in the local repositories (offline),
@@ -118,7 +181,17 @@ public class PackageUtil {
         return null;
     }
 
+    /**
+     * Returns the shared sample project used for resolving standalone module packages. Memoized:
+     * this used to build a fresh temp directory + BuildProject per call, which both leaked temp
+     * dirs and defeated every downstream cache (resolver, resolution results) on hot paths like
+     * flow-model generation.
+     */
     public static BuildProject getSampleProject() {
+        return SAMPLE_PROJECT;
+    }
+
+    private static BuildProject createSampleProject() {
         // Obtain the Ballerina distribution path
         String ballerinaHome = System.getProperty(BALLERINA_HOME_PROPERTY);
         if (ballerinaHome == null || ballerinaHome.isEmpty()) {
@@ -205,6 +278,21 @@ public class PackageUtil {
      */
     public static Optional<Package> getModulePackage(BuildProject buildProject, String org, String name,
                                                      String version, String repository) {
+        // Sample-project resolutions are descriptor-only (the project just supplies a resolver
+        // environment, and the returned bala is loaded with the default environment), so they
+        // are safe to memoize across requests. Resolutions against a caller's real project may
+        // depend on that project's state — leave them uncached.
+        if (buildProject == SAMPLE_PROJECT) {
+            return memoizedSampleBala(sampleResolutionKey(org, name, version, repository),
+                    () -> resolveVersionedModuleBala(buildProject, org, name, version, repository))
+                    .flatMap(PackageUtil::loadBalaPackage);
+        }
+        return resolveVersionedModuleBala(buildProject, org, name, version, repository)
+                .flatMap(PackageUtil::loadBalaPackage);
+    }
+
+    private static Optional<Path> resolveVersionedModuleBala(BuildProject buildProject, String org, String name,
+                                                             String version, String repository) {
         PackageOrg packageOrg = PackageOrg.from(org);
         PackageName packageName = PackageName.from(name);
         PackageVersion packageVersion = PackageVersion.from(version);
@@ -213,17 +301,19 @@ public class PackageUtil {
                 : PackageDescriptor.from(packageOrg, packageName, packageVersion, repository);
         PackageResolver packageResolver = buildProject.projectEnvironmentContext().getService(PackageResolver.class);
 
+        // Offline-first: an exact-version bala is immutable, so a local-cache hit is guaranteed
+        // to equal the remote answer — no reason to contact Central for it. Only a local miss
+        // falls back to online resolution (which can pull the package).
+        ResolutionRequest resolutionRequest = ResolutionRequest.from(packageDescriptor);
         Optional<ResolutionResponse> resolutionResponse =
-                resolveResponse(packageResolver, ResolutionRequest.from(packageDescriptor), CommonUtil.TEST_OFFLINE);
+                resolveResponse(packageResolver, resolutionRequest, true);
+        if (resolutionResponse.isEmpty() && !CommonUtil.TEST_OFFLINE) {
+            resolutionResponse = resolveResponse(packageResolver, resolutionRequest, false);
+        }
         if (resolutionResponse.isEmpty()) {
             return Optional.empty();
         }
-
-        Path balaPath = resolutionResponse.get().resolvedPackage().project().sourceRoot();
-        ProjectEnvironmentBuilder defaultBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
-        defaultBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
-        BalaProject balaProject = BalaProject.loadProject(defaultBuilder, balaPath, balaBuildOptions());
-        return Optional.ofNullable(balaProject.currentPackage());
+        return Optional.of(resolutionResponse.get().resolvedPackage().project().sourceRoot());
     }
 
     /**
@@ -245,6 +335,16 @@ public class PackageUtil {
     }
 
     public static Optional<Package> getModulePackage(BuildProject buildProject, String org, String name) {
+        // See the versioned overload for why sample-project resolutions are memoized. The
+        // "latest version" lookup below can itself hit Central, so caching matters just as much.
+        if (buildProject == SAMPLE_PROJECT) {
+            return memoizedSampleBala(sampleResolutionKey(org, name, null, null),
+                    () -> resolveLatestModuleBala(buildProject, org, name)).flatMap(PackageUtil::loadBalaPackage);
+        }
+        return resolveLatestModuleBala(buildProject, org, name).flatMap(PackageUtil::loadBalaPackage);
+    }
+
+    private static Optional<Path> resolveLatestModuleBala(BuildProject buildProject, String org, String name) {
         ResolutionRequest resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name)));
         PackageResolver packageResolver = buildProject.projectEnvironmentContext().getService(PackageResolver.class);
@@ -268,20 +368,26 @@ public class PackageUtil {
             packageDescriptor = pkgMetadata.get().resolvedDescriptor();
         }
 
+        // Offline-first: the descriptor now carries an exact version (from the local metadata
+        // or the remote latest-version lookup above), and an exact-version bala is immutable —
+        // resolve from the local cache when present, contact Central only on a local miss.
         Collection<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(
                 Collections.singletonList(ResolutionRequest.from(packageDescriptor)),
-                ResolutionOptions.builder().setOffline(CommonUtil.TEST_OFFLINE).build());
-        Optional<ResolutionResponse> resolutionResponse = resolutionResponses.stream().findFirst();
-        if (resolutionResponse.isEmpty() || resolutionResponse.get().resolvedPackage() == null) {
-            // Offline and the package could not be resolved from the local repositories.
+                ResolutionOptions.builder().setOffline(true).build());
+        Optional<ResolutionResponse> resolutionResponse = resolutionResponses.stream()
+                .filter(response -> response.resolvedPackage() != null).findFirst();
+        if (resolutionResponse.isEmpty() && !CommonUtil.TEST_OFFLINE) {
+            resolutionResponses = packageResolver.resolvePackages(
+                    Collections.singletonList(ResolutionRequest.from(packageDescriptor)),
+                    ResolutionOptions.builder().setOffline(false).build());
+            resolutionResponse = resolutionResponses.stream()
+                    .filter(response -> response.resolvedPackage() != null).findFirst();
+        }
+        if (resolutionResponse.isEmpty()) {
+            // The package could not be resolved from the local repositories or Central.
             return Optional.empty();
         }
-
-        Path balaPath = resolutionResponse.get().resolvedPackage().project().sourceRoot();
-        ProjectEnvironmentBuilder defaultBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
-        defaultBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
-        BalaProject balaProject = BalaProject.loadProject(defaultBuilder, balaPath, balaBuildOptions());
-        return Optional.ofNullable(balaProject.currentPackage());
+        return Optional.of(resolutionResponse.get().resolvedPackage().project().sourceRoot());
     }
 
     /**
@@ -509,8 +615,8 @@ public class PackageUtil {
             String version = CommonUtil.TEST_OFFLINE
                     ? cachedVersion(moduleInfo.org(), moduleInfo.packageName())
                     : RemoteCentral.getInstance().latestPackageVersion(moduleInfo.org(), moduleInfo.packageName());
-            // Under TEST_OFFLINE a null version means the package was never provisioned into the build-owned
-            // cache. Fail loudly (matching the TEST_OFFLINE contract above) so a missing lock entry is
+            // Under CommonUtil.TEST_OFFLINE a null version means the package was never provisioned into the build-owned
+            // cache. Fail loudly (matching the CommonUtil.TEST_OFFLINE contract above) so a missing lock entry is
             // self-diagnosing, rather than silently degrading into an empty model downstream.
             if (CommonUtil.TEST_OFFLINE && version == null) {
                 throw new IllegalStateException(String.format(

--- a/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/trigger/LibraryMetadataReader.java
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/trigger/LibraryMetadataReader.java
@@ -35,7 +35,6 @@ import io.ballerina.projects.PackageVersion;
 import io.ballerina.projects.environment.PackageRepository;
 import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
-import io.ballerina.projects.internal.environment.BallerinaUserHome;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -177,14 +176,15 @@ public final class LibraryMetadataReader {
         return getCompiledPackageFromLocalRepository(moduleInfo).map(pkg -> pkg.project().sourceRoot());
     }
 
-    /** The Ballerina local repository handle, resolved once and cached. */
+    /**
+     * The Ballerina local repository handle for the calling thread. Delegates to
+     * {@link PackageUtil#localPackageRepository()} rather than caching a single instance here: the
+     * repository is backed by a sample-project environment whose package cache is not thread-safe,
+     * so reading through a shared instance concurrently would corrupt that cache. Keeping it
+     * per-thread is the same fix applied to the sample project itself (wso2/product-integrator#2193).
+     */
     private PackageRepository localRepository() {
-        return LocalRepositoryHolder.INSTANCE;
-    }
-
-    private static final class LocalRepositoryHolder {
-        private static final PackageRepository INSTANCE = BallerinaUserHome.from(
-                PackageUtil.getSampleProject().projectEnvironmentContext().environment()).localPackageRepository();
+        return PackageUtil.localPackageRepository();
     }
 
     private Optional<TriggerMetadataModel> readPackagedMetadata(String moduleName) {
@@ -257,7 +257,7 @@ public final class LibraryMetadataReader {
 
     private Optional<Path> resolvePackageRoot(ModuleInfo moduleInfo) {
         try {
-            Optional<Package> pkg = PackageUtil.getModulePackageOffline(PackageUtil.getSampleProject(),
+            Optional<Package> pkg = PackageUtil.getModulePackageOffline(
                     moduleInfo.org(), moduleInfo.moduleName());
             return pkg.map(aPackage -> aPackage.project().sourceRoot());
         } catch (Throwable e) {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerModelReader.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/connector/TriggerModelReader.java
@@ -400,8 +400,7 @@ public class TriggerModelReader {
         if (metadata.isEmpty()) {
             return metadataReader.isLocallyResolvable(moduleInfo) ? Resolution.ABSENT : Resolution.UNRESOLVED;
         }
-        Optional<Package> pkg = PackageUtil.getModulePackageOffline(PackageUtil.getSampleProject(), orgName,
-                moduleName);
+        Optional<Package> pkg = PackageUtil.getModulePackageOffline(orgName, moduleName);
         if (pkg.isEmpty()) {
             return Resolution.UNRESOLVED;
         }
@@ -462,8 +461,7 @@ public class TriggerModelReader {
         try {
             String targetModule = packageInfo.moduleName() != null && !packageInfo.moduleName().isBlank()
                     ? packageInfo.moduleName() : packageInfo.packageName();
-            Optional<Package> pkg = PackageUtil.getModulePackageOffline(PackageUtil.getSampleProject(),
-                    packageInfo.org(), targetModule);
+            Optional<Package> pkg = PackageUtil.getModulePackageOffline(packageInfo.org(), targetModule);
             if (pkg.isEmpty()) {
                 return Optional.empty();
             }

--- a/packages/ballerina-language-server/spotbugs-exclude.xml
+++ b/packages/ballerina-language-server/spotbugs-exclude.xml
@@ -265,4 +265,11 @@
         <Class name="io.ballerina.projectservice.core.baltool.BalToolsUtil" />
         <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
     </Match>
+    <Match>
+        <!-- Returning the shared sample project is the point: it is a process-wide memoized
+             instance whose per-call re-creation defeated resolution caching (see PackageUtil). -->
+        <Class name="io.ballerina.modelgenerator.commons.PackageUtil" />
+        <Method name="getSampleProject" />
+        <Bug pattern="MS_EXPOSE_REP"/>
+    </Match>
 </FindBugsFilter>

--- a/packages/ballerina-language-server/spotbugs-exclude.xml
+++ b/packages/ballerina-language-server/spotbugs-exclude.xml
@@ -266,8 +266,10 @@
         <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
     </Match>
     <Match>
-        <!-- Returning the shared sample project is the point: it is a process-wide memoized
-             instance whose per-call re-creation defeated resolution caching (see PackageUtil). -->
+        <!-- Returning the sample project is the point: it is a per-thread memoized instance
+             (SAMPLE_PROJECT is a ThreadLocal), confined to the calling thread. Resolution caching
+             lives in SAMPLE_RESOLUTION_CACHE. Do not store the returned project across threads
+             (see PackageUtil). -->
         <Class name="io.ballerina.modelgenerator.commons.PackageUtil" />
         <Method name="getSampleProject" />
         <Bug pattern="MS_EXPOSE_REP"/>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
@@ -18,7 +18,8 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import styled from "@emotion/styled";
-import { SemanticDiff, ChangeTypeEnum, MACHINE_VIEW, VisualizerLocation } from "@wso2/ballerina-core";
+import { SemanticDiff, ChangeTypeEnum, NodeKindEnum, MACHINE_VIEW, VisualizerLocation } from "@wso2/ballerina-core";
+import { getNodeKindLabel } from "../../../ReviewMode/nodeKindLabels";
 import { getColorByMethod } from "../../../BI/ServiceDesigner/components/ResourceAccordion";
 
 const Container = styled.div<{ subtle?: boolean; expanded?: boolean }>`
@@ -259,10 +260,9 @@ const MethodBadge = styled.span<{ $color: string }>`
     flex-shrink: 0;
 `;
 
-// nodeKind === 2 is TYPE in semantic diffs
-const NODE_KIND_TYPE = 2;
-const NODE_KIND_RESOURCE = 1;
-const NODE_KIND_FUNCTION = 0;
+const NODE_KIND_FUNCTION = NodeKindEnum.MODULE_FUNCTION;
+const NODE_KIND_RESOURCE = NodeKindEnum.OBJECT_FUNCTION;
+const NODE_KIND_TYPE = NodeKindEnum.TYPE_DEFINITION;
 
 interface DiffEntry {
     symbol: string;
@@ -341,8 +341,10 @@ function getFileName(filePath: string): string {
 function getDiffLabel(diff: SemanticDiff): string {
     if (diff.metadata) {
         if (diff.nodeKind === NODE_KIND_RESOURCE) {
-            const m = diff.metadata as { accessor: string; servicePath: string; resourcePath: string };
-            return m.resourcePath;
+            // Class methods are OBJECT_FUNCTION diffs too but carry only `name` —
+            // fall through to it when there's no resource path.
+            const m = diff.metadata as { accessor?: string; servicePath?: string; resourcePath?: string };
+            if (m.resourcePath) return m.resourcePath;
         }
         const m = diff.metadata as { name?: string };
         if (m.name) return m.name;
@@ -364,9 +366,7 @@ function getDiffKindLabel(diff: SemanticDiff): string {
         const m = diff.metadata as { name?: string } | undefined;
         return m?.name === "main" ? "automation" : "function";
     }
-    if (diff.nodeKind === NODE_KIND_RESOURCE) return "resource";
-    if (diff.nodeKind === NODE_KIND_TYPE) return "type";
-    return "function";
+    return getNodeKindLabel(diff.nodeKind, diff.metadata);
 }
 
 function getChangeTypeLabel(changeType: number): string {
@@ -449,6 +449,8 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
     const serviceGroups: Record<string, DiffEntry[]> = {};
     const functionEntries: DiffEntry[] = [];
     const typeEntries: DiffEntry[] = [];
+    // Non-diagram construct kinds (constants, module vars, listeners, classes, enums, imports)
+    const declarationEntries: DiffEntry[] = [];
     let hasTypeView = false;
 
     for (const diff of semanticDiffs) {
@@ -456,12 +458,18 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
         if (isType && hasTypeView) continue;
         if (isType) hasTypeView = true;
 
+        // OBJECT_FUNCTION covers both service members and plain class methods; only the
+        // former carry a servicePath, and only they belong under a service group.
+        const servicePath = diff.nodeKind === NODE_KIND_RESOURCE
+            ? (diff.metadata as { servicePath?: string } | undefined)?.servicePath
+            : undefined;
+
         const entry: DiffEntry = {
             symbol: getSymbol(diff.changeType),
             changeType: diff.changeType,
             label: isType ? "Types" : getDiffLabel(diff),
-            accessor: diff.nodeKind === NODE_KIND_RESOURCE
-                ? (diff.metadata as { accessor: string } | undefined)?.accessor?.toUpperCase()
+            accessor: servicePath !== undefined
+                ? (diff.metadata as { accessor?: string } | undefined)?.accessor?.toUpperCase()
                 : undefined,
             kindLabel: getDiffKindLabel(diff),
             nodeKind: diff.nodeKind,
@@ -469,15 +477,17 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
         };
         viewIndex++;
 
-        if (diff.nodeKind === NODE_KIND_RESOURCE) {
-            const m = diff.metadata as { servicePath?: string } | undefined;
-            const svcPath = m?.servicePath || "/";
+        if (servicePath !== undefined) {
+            const svcPath = servicePath || "/";
             if (!serviceGroups[svcPath]) serviceGroups[svcPath] = [];
             serviceGroups[svcPath].push(entry);
-        } else if (diff.nodeKind === NODE_KIND_FUNCTION) {
+        } else if (diff.nodeKind === NODE_KIND_FUNCTION || diff.nodeKind === NODE_KIND_RESOURCE) {
+            // Plain functions, and class methods (OBJECT_FUNCTION without a service path)
             functionEntries.push(entry);
-        } else {
+        } else if (isType) {
             typeEntries.push(entry);
+        } else {
+            declarationEntries.push(entry);
         }
     }
 
@@ -491,6 +501,9 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
     }
     if (typeEntries.length > 0) {
         groups.push({ groupLabel: "types", entries: typeEntries });
+    }
+    if (declarationEntries.length > 0) {
+        groups.push({ groupLabel: "declarations", entries: declarationEntries });
     }
 
     return { groups, viewCount: viewIndex - startIndex };
@@ -761,8 +774,10 @@ export const ReviewBar: React.FC<ReviewBarProps> = ({
             await rpcClient.getAiPanelRpcClient().revertGeneration({ generationId });
             rpcClient.getVisualizerRpcClient().goBack();
         } catch (error) {
+            // Nothing was reverted (e.g. no checkpoint exists) — the backend already told
+            // the user via an error notification. Keep the bar so the review stays
+            // actionable; closing it here would make the failure look like a success.
             console.error("[ReviewBar] Error discarding changes:", error);
-            rpcClient.getVisualizerRpcClient().goBack();
         } finally {
             setIsProcessing(false);
         }

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
@@ -646,11 +646,14 @@ const CollapsibleGroupList: React.FC<{
                 const isFunctions = group.groupLabel === "functions";
                 const isTypes = group.groupLabel === "types";
                 const isDesign = group.groupLabel === "design";
-                const isCollapsible = isService || isFunctions;
+                const isDeclarations = group.groupLabel === "declarations";
+                const isCollapsible = isService || isFunctions || isDeclarations;
                 const isCollapsed = !!collapsed[gi];
 
                 const displayLabel = isService
                     ? group.groupLabel.slice("service ".length)
+                    : isDeclarations
+                    ? "declarations"
                     : "functions";
 
                 return (
@@ -666,6 +669,9 @@ const CollapsibleGroupList: React.FC<{
                                 )}
                                 {isFunctions && (
                                     <span className="codicon codicon-symbol-method" style={{ fontSize: "11px", color: "var(--vscode-descriptionForeground)" }} />
+                                )}
+                                {isDeclarations && (
+                                    <span className="codicon codicon-symbol-variable" style={{ fontSize: "11px", color: "var(--vscode-descriptionForeground)" }} />
                                 )}
                                 {isService && <span style={{ color: "var(--vscode-descriptionForeground)", fontWeight: 400 }}>service</span>}
                                 <span>{displayLabel}</span>

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyComponentDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyComponentDiagram.tsx
@@ -22,6 +22,7 @@ import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Diagram } from "@wso2/component-diagram";
 import { ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
+import { fetchDesignModel, ReviewModelCache } from "./reviewModelCache";
 
 const SpinnerContainer = styled.div`
     display: flex;
@@ -40,6 +41,8 @@ interface ReadonlyComponentDiagramProps {
     filePath: string;
     position: NodePosition;
     useFileSchema?: boolean;
+    /** Session-scoped model cache owned by ReviewMode — survives toggle/navigation remounts. */
+    modelCache: ReviewModelCache;
 }
 
 const EmptyMessage = styled.div`
@@ -59,7 +62,7 @@ function isDesignModelEmpty(model: CDModel): boolean {
 }
 
 export function ReadonlyComponentDiagram(props: ReadonlyComponentDiagramProps): JSX.Element {
-    const { projectPath, useFileSchema } = props;
+    const { projectPath, useFileSchema, modelCache } = props;
     const { rpcClient } = useRpcContext();
     const [project, setProject] = useState<CDModel | null>(null);
     const [isLoaded, setIsLoaded] = useState(false);
@@ -72,15 +75,13 @@ export function ReadonlyComponentDiagram(props: ReadonlyComponentDiagramProps): 
         // Stale-response guard: a slower earlier request (e.g. after toggling Old/New)
         // must not overwrite this render with the other version's model.
         let cancelled = false;
-        rpcClient
-            .getBIDiagramRpcClient()
-            .getDesignModel({ projectPath, useFileSchema })
-            .then((response) => {
+        fetchDesignModel(rpcClient, modelCache, projectPath, useFileSchema)
+            .then((designModel) => {
                 if (cancelled) {
                     return;
                 }
-                if (response?.designModel) {
-                    setProject(response.designModel);
+                if (designModel) {
+                    setProject(designModel);
                 } else {
                     setLoadFailed(true);
                 }
@@ -96,7 +97,7 @@ export function ReadonlyComponentDiagram(props: ReadonlyComponentDiagramProps): 
         return () => {
             cancelled = true;
         };
-    }, [projectPath, useFileSchema, rpcClient]);
+    }, [projectPath, useFileSchema, rpcClient, modelCache]);
 
     // No-op handlers for readonly mode
     const noOpHandler = () => {

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyComponentDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyComponentDiagram.tsx
@@ -63,28 +63,40 @@ export function ReadonlyComponentDiagram(props: ReadonlyComponentDiagramProps): 
     const { rpcClient } = useRpcContext();
     const [project, setProject] = useState<CDModel | null>(null);
     const [isLoaded, setIsLoaded] = useState(false);
+    const [loadFailed, setLoadFailed] = useState(false);
 
     useEffect(() => {
         setProject(null);
         setIsLoaded(false);
-        fetchProject();
-    }, [projectPath, useFileSchema]);
-
-    const fetchProject = () => {
+        setLoadFailed(false);
+        // Stale-response guard: a slower earlier request (e.g. after toggling Old/New)
+        // must not overwrite this render with the other version's model.
+        let cancelled = false;
         rpcClient
             .getBIDiagramRpcClient()
             .getDesignModel({ projectPath, useFileSchema })
             .then((response) => {
+                if (cancelled) {
+                    return;
+                }
                 if (response?.designModel) {
                     setProject(response.designModel);
+                } else {
+                    setLoadFailed(true);
                 }
                 setIsLoaded(true);
             })
             .catch((error) => {
                 console.error("Error getting design model", error);
-                setIsLoaded(true);
+                if (!cancelled) {
+                    setLoadFailed(true);
+                    setIsLoaded(true);
+                }
             });
-    };
+        return () => {
+            cancelled = true;
+        };
+    }, [projectPath, useFileSchema, rpcClient]);
 
     // No-op handlers for readonly mode
     const noOpHandler = () => {
@@ -99,10 +111,17 @@ export function ReadonlyComponentDiagram(props: ReadonlyComponentDiagramProps): 
         );
     }
 
+    // A load failure is not the same as a genuinely empty design — say which one it is,
+    // and name the version actually being shown.
+    const versionLabel = useFileSchema ? "previous" : "current";
+    if (loadFailed) {
+        return <EmptyMessage>The design diagram for the {versionLabel} version could not be loaded.</EmptyMessage>;
+    }
+
     if (!project || isDesignModelEmpty(project)) {
         return (
             <EmptyMessage>
-                No top-level constructs found in the previous version
+                No top-level constructs found in the {versionLabel} version
             </EmptyMessage>
         );
     }

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -44,6 +44,15 @@ const MessageContainer = styled.div`
     color: var(--vscode-descriptionForeground);
 `;
 
+const DiffNoticeBanner = styled.div`
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--vscode-inputValidation-warningForeground, var(--vscode-foreground));
+    background: var(--vscode-inputValidation-warningBackground, transparent);
+    border-bottom: 1px solid var(--vscode-inputValidation-warningBorder, var(--vscode-panel-border));
+    word-break: break-word;
+`;
+
 interface ItemMetadata {
     type: string;
     name: string;
@@ -156,6 +165,10 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
     const [flowModel, setFlowModel] = useState<Flow | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [unavailableMessage, setUnavailableMessage] = useState<string | null>(null);
+    // Why the unified diff degraded to the New-only view, when it did. Rendering the
+    // fallback silently made an old-side fetch failure indistinguishable from "nothing
+    // to highlight" — the single most confusing form of a broken diff.
+    const [diffNotice, setDiffNotice] = useState<string | null>(null);
     // Latest callbacks held in refs so the load effect can call them without listing them
     // as dependencies — the parent re-creates onModelLoaded on every render, which would
     // otherwise retrigger a full refetch each render.
@@ -171,6 +184,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         setIsLoading(true);
         setFlowModel(null);
         setUnavailableMessage(null);
+        setDiffNotice(null);
         let cancelled = false;
         loadFlowModel()
             .then((model) => {
@@ -290,10 +304,12 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         // them sequentially doubled the time-to-first-render for diff mode. Results are
         // cached per version, so the extra fetch on a metadata-mismatch fallback is free
         // if the user then toggles to New/Old.
+        let oldFetchError: unknown = null;
         const [newFlow, oldFlow] = await Promise.all([
             fetchFlowModelVersion(false),
             fetchFlowModelVersion(true).catch((error): Flow | null => {
                 console.error("[Reviewing Changes] Error fetching old flow model:", error);
+                oldFetchError = error;
                 return null;
             }),
         ]);
@@ -310,6 +326,11 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         }
         if (!oldFlow || !isSameExpectedFunction(oldFlow, newFlow, expectedMetadata)) {
             onDiffUnavailableRef.current?.();
+            setDiffNotice(
+                oldFetchError
+                    ? "The previous version of this diagram could not be loaded, so change highlighting is unavailable. Showing the new version."
+                    : "The previous version could not be matched to this change, so change highlighting is unavailable. Showing the new version."
+            );
             return newFlow;
         }
 
@@ -318,6 +339,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         } catch (error) {
             console.error("[Reviewing Changes] Error merging flow models for diff:", error);
             onDiffUnavailableRef.current?.();
+            setDiffNotice("The unified diff could not be built for this change. Showing the new version.");
             return newFlow;
         }
     };
@@ -336,6 +358,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
 
     return (
         <Container>
+            {viewMode === "diff" && diffNotice && <DiffNoticeBanner>⚠ {diffNotice}</DiffNoticeBanner>}
             <Diagram model={flowModel} readOnly={true} />
         </Container>
     );

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -17,12 +17,12 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { ChangeTypeEnum, Flow, NodePosition, ParentMetadata, SemanticDiff } from "@wso2/ballerina-core";
+import { Flow, NodePosition, ParentMetadata, SemanticDiff } from "@wso2/ballerina-core";
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
 import { Diagram, mergeFlowModelsForDiff, stampDiffState } from "@wso2/bi-diagram";
-import { getFlowLookupPosition } from "./position-utils";
+import { fetchFlowModelVersion, getVersionsForChangeType, ReviewModelCache } from "./reviewModelCache";
 
 const SpinnerContainer = styled.div`
     display: flex;
@@ -65,22 +65,6 @@ export type ExpectedFlowMetadata = Pick<SemanticDiff, "nodeKind" | "metadata">;
 const NODE_KIND_FUNCTION = 0;
 const NODE_KIND_RESOURCE = 1;
 
-/**
- * Which versions of a file structurally exist for a semantic-diff change type.
- * Single source of truth for the toggle availability (ReviewMode) and the
- * diff-mode fetch branching below.
- */
-export function getVersionsForChangeType(changeType: number): { old: boolean; new: boolean } {
-    switch (changeType) {
-        case ChangeTypeEnum.ADDITION:
-            return { old: false, new: true };
-        case ChangeTypeEnum.DELETION:
-            return { old: true, new: false };
-        default:
-            return { old: true, new: true };
-    }
-}
-
 interface ReadonlyFlowDiagramProps {
     projectPath: string;
     filePath: string;
@@ -91,6 +75,8 @@ interface ReadonlyFlowDiagramProps {
     changeType: number;
     expectedMetadata?: ExpectedFlowMetadata;
     onDiffUnavailable?: () => void;
+    /** Session-scoped model cache owned by ReviewMode — survives navigation remounts. */
+    modelCache: ReviewModelCache;
 }
 
 function getEventStartData(flow: Flow): ParentMetadata | undefined {
@@ -160,6 +146,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         changeType,
         expectedMetadata,
         onDiffUnavailable,
+        modelCache,
     } = props;
     const { rpcClient } = useRpcContext();
     const [flowModel, setFlowModel] = useState<Flow | null>(null);
@@ -176,9 +163,6 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
     const onDiffUnavailableRef = useRef(onDiffUnavailable);
     onModelLoadedRef.current = onModelLoaded;
     onDiffUnavailableRef.current = onDiffUnavailable;
-    // Review content is frozen while the review is open, so fetched versions are cached
-    // per view — toggling Diff/New/Old re-derives locally instead of re-querying the LS.
-    const flowCache = useRef<{ key: string; versions: Map<boolean, Flow | null> }>({ key: "", versions: new Map() });
 
     useEffect(() => {
         setIsLoading(true);
@@ -223,54 +207,16 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         };
     }, [filePath, position, oldPosition, viewMode, expectedMetadata, changeType, rpcClient]);
 
-    // Fetch one version of the enclosing function's flow model.
+    // Fetch one version of the enclosing function's flow model, through the session
+    // cache owned by ReviewMode — toggling Diff/New/Old or navigating back to this
+    // item re-derives locally instead of re-querying the LS.
     // useFileSchema=true reads the frozen original (ai://); false reads the live edits (file://).
-    const fetchFlowModelVersion = async (useFileSchema: boolean): Promise<Flow | null> => {
-        const lookupPosition = getFlowLookupPosition(position, oldPosition, useFileSchema);
-        const cacheKey = `${filePath}:${position.startLine}:${position.startColumn}:${position.endLine}:` +
-            `${position.endColumn}:${oldPosition?.startLine ?? ""}:${oldPosition?.startColumn ?? ""}:` +
-            `${oldPosition?.endLine ?? ""}:${oldPosition?.endColumn ?? ""}`;
-        if (flowCache.current.key !== cacheKey) {
-            flowCache.current = { key: cacheKey, versions: new Map() };
-        }
-        // capture the entry so a late response can't poison a newer view's cache
-        const cacheEntry = flowCache.current;
-        if (cacheEntry.versions.has(useFileSchema)) {
-            return cacheEntry.versions.get(useFileSchema);
-        }
-
-        // First resolve the full function range using getEnclosedFunction,
-        // since the position from semantic diff may only cover the changed statement
-        const enclosedFn = await rpcClient.getBIDiagramRpcClient().getEnclosedFunction({
-            filePath: filePath,
-            position: { line: lookupPosition.startLine, offset: lookupPosition.startColumn },
-            useFileSchema,
-        });
-        const startLine = enclosedFn?.startLine ?? {
-            line: lookupPosition.startLine,
-            offset: lookupPosition.startColumn,
-        };
-        const endLine = enclosedFn?.endLine ?? {
-            line: lookupPosition.endLine,
-            offset: lookupPosition.endColumn,
-        };
-
-        const response = await rpcClient.getBIDiagramRpcClient().getFlowModel({
-            filePath: filePath,
-            startLine,
-            endLine,
-            useFileSchema,
-        });
-        const flow = response?.flowModel ?? null;
-        if (flowCache.current === cacheEntry) {
-            cacheEntry.versions.set(useFileSchema, flow);
-        }
-        return flow;
-    };
+    const fetchVersion = (useFileSchema: boolean): Promise<Flow | null> =>
+        fetchFlowModelVersion(rpcClient, modelCache, { filePath, position, oldPosition, useFileSchema });
 
     const loadFlowModel = async (): Promise<Flow | null> => {
         if (viewMode === "old") {
-            const oldFlow = await fetchFlowModelVersion(true);
+            const oldFlow = await fetchVersion(true);
             if (oldFlow && !metadataMatchesExpected(oldFlow, expectedMetadata)) {
                 onDiffUnavailableRef.current?.();
                 return null;
@@ -278,7 +224,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
             return oldFlow;
         }
         if (viewMode === "new") {
-            const newFlow = await fetchFlowModelVersion(false);
+            const newFlow = await fetchVersion(false);
             if (newFlow && !metadataMatchesExpected(newFlow, expectedMetadata)) {
                 // Match the "old" branch: disable the diff toggle up front instead of
                 // waiting for the user to click Diff and discover it later.
@@ -291,11 +237,11 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         // unified diff mode
         const versions = getVersionsForChangeType(changeType);
         if (!versions.old) {
-            const newFlow = await fetchFlowModelVersion(false);
+            const newFlow = await fetchVersion(false);
             return newFlow ? stampDiffState(newFlow, "added") : null;
         }
         if (!versions.new) {
-            const oldFlow = await fetchFlowModelVersion(true);
+            const oldFlow = await fetchVersion(true);
             return oldFlow ? stampDiffState(oldFlow, "removed") : null;
         }
 
@@ -306,8 +252,8 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         // if the user then toggles to New/Old.
         let oldFetchError: unknown = null;
         const [newFlow, oldFlow] = await Promise.all([
-            fetchFlowModelVersion(false),
-            fetchFlowModelVersion(true).catch((error): Flow | null => {
+            fetchVersion(false),
+            fetchVersion(true).catch((error): Flow | null => {
                 console.error("[Reviewing Changes] Error fetching old flow model:", error);
                 oldFetchError = error;
                 return null;

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlySourceDiff.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlySourceDiff.tsx
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import styled from "@emotion/styled";
+import { ChangeTypeEnum } from "@wso2/ballerina-core";
+import { ReviewViewMode } from "./ReadonlyFlowDiagram";
+
+const Container = styled.div`
+    height: 100%;
+    overflow: auto;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    box-sizing: border-box;
+`;
+
+const PanelTitle = styled.div`
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--vscode-descriptionForeground);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+`;
+
+const SourceBlock = styled.pre<{ variant: "old" | "new" | "plain" }>`
+    margin: 0;
+    padding: 12px 16px;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: var(--vscode-editor-font-size, 13px);
+    white-space: pre-wrap;
+    word-break: break-word;
+    border-radius: 4px;
+    border: 1px solid
+        ${(props: { variant: "old" | "new" | "plain" }) =>
+            props.variant === "old"
+                ? "var(--vscode-inputValidation-errorBorder, #f85149)"
+                : props.variant === "new"
+                ? "var(--vscode-gitDecoration-addedResourceForeground, #2ea043)"
+                : "var(--vscode-panel-border)"};
+    background: var(--vscode-editor-background);
+    color: var(--vscode-editor-foreground);
+`;
+
+const EmptyNote = styled.div`
+    color: var(--vscode-descriptionForeground);
+    font-size: 13px;
+    font-style: italic;
+`;
+
+export interface ReadonlySourceDiffProps {
+    oldSource?: string;
+    newSource?: string;
+    changeType: number;
+    viewMode: ReviewViewMode;
+}
+
+/**
+ * Renders a construct change that has no diagram representation (constants, module
+ * variables, listeners, classes, enums, imports) as before/after source blocks. The
+ * before/after text travels inside the SemanticDiff metadata, so no extra fetch is
+ * needed — this view cannot fail asynchronously.
+ */
+export function ReadonlySourceDiff(props: ReadonlySourceDiffProps): JSX.Element {
+    const { oldSource, newSource, changeType, viewMode } = props;
+
+    const showOld = viewMode !== "new" && oldSource !== undefined;
+    const showNew = viewMode !== "old" && newSource !== undefined;
+
+    if (!showOld && !showNew) {
+        const missing =
+            viewMode === "old"
+                ? changeType === ChangeTypeEnum.ADDITION
+                    ? "This element was added — there is no previous version."
+                    : "The previous version of this element is unavailable."
+                : changeType === ChangeTypeEnum.DELETION
+                ? "This element was deleted — there is no new version."
+                : "The new version of this element is unavailable.";
+        return (
+            <Container>
+                <EmptyNote>{missing}</EmptyNote>
+            </Container>
+        );
+    }
+
+    return (
+        <Container>
+            {showOld && (
+                <div>
+                    <PanelTitle>{changeType === ChangeTypeEnum.DELETION ? "Removed" : "Before"}</PanelTitle>
+                    <SourceBlock variant={showNew ? "old" : "plain"}>{oldSource}</SourceBlock>
+                </div>
+            )}
+            {showNew && (
+                <div>
+                    <PanelTitle>{changeType === ChangeTypeEnum.ADDITION ? "Added" : "After"}</PanelTitle>
+                    <SourceBlock variant={showOld ? "new" : "plain"}>{newSource}</SourceBlock>
+                </div>
+            )}
+        </Container>
+    );
+}

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlySourceDiff.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlySourceDiff.tsx
@@ -50,9 +50,9 @@ const SourceBlock = styled.pre<{ variant: "old" | "new" | "plain" }>`
     border: 1px solid
         ${(props: { variant: "old" | "new" | "plain" }) =>
             props.variant === "old"
-                ? "var(--vscode-inputValidation-errorBorder, #f85149)"
+                ? "var(--vscode-inputValidation-errorBorder, var(--vscode-charts-red))"
                 : props.variant === "new"
-                ? "var(--vscode-gitDecoration-addedResourceForeground, #2ea043)"
+                ? "var(--vscode-gitDecoration-addedResourceForeground, var(--vscode-charts-green))"
                 : "var(--vscode-panel-border)"};
     background: var(--vscode-editor-background);
     color: var(--vscode-editor-foreground);

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyTypeDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyTypeDiagram.tsx
@@ -35,6 +35,16 @@ const Container = styled.div`
     pointer-events: auto;
 `;
 
+const MessageContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    color: var(--vscode-descriptionForeground);
+    padding: 0 24px;
+    text-align: center;
+`;
+
 interface ItemMetadata {
     type: string;
     name: string;
@@ -52,17 +62,21 @@ export function ReadonlyTypeDiagram(props: ReadonlyTypeDiagramProps): JSX.Elemen
     const { filePath, onModelLoaded, useFileSchema } = props;
     const { rpcClient } = useRpcContext();
     const [typesModel, setTypesModel] = useState<Type[] | null>(null);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     useEffect(() => {
         setTypesModel(null);
-        fetchTypesModel();
-    }, [filePath, useFileSchema]);
-
-    const fetchTypesModel = () => {
+        setErrorMessage(null);
+        // Stale-response guard: a slower earlier request (e.g. after toggling Old/New)
+        // must not overwrite this render with the other version's model.
+        let cancelled = false;
         rpcClient
             .getBIDiagramRpcClient()
             .getTypes({ filePath: filePath, useFileSchema })
             .then((response) => {
+                if (cancelled) {
+                    return;
+                }
                 if (response?.types) {
                     setTypesModel(response.types);
 
@@ -84,17 +98,31 @@ export function ReadonlyTypeDiagram(props: ReadonlyTypeDiagramProps): JSX.Elemen
                             name: "No Types",
                         });
                     }
+                } else {
+                    // A resolved-but-empty response (e.g. the source is mid-edit and not
+                    // parseable) previously left the spinner up forever.
+                    setErrorMessage("The type diagram is unavailable for the selected version.");
                 }
             })
             .catch((error) => {
                 console.error("Error fetching types model:", error);
+                if (!cancelled) {
+                    setErrorMessage("The type diagram could not be loaded.");
+                }
             });
-    };
+        return () => {
+            cancelled = true;
+        };
+    }, [filePath, useFileSchema, rpcClient]);
 
     // No-op handlers for readonly mode
     const noOpHandler = () => {
         console.log("Diagram is in readonly mode");
     };
+
+    if (errorMessage) {
+        return <MessageContainer>{errorMessage}</MessageContainer>;
+    }
 
     if (!typesModel) {
         return (

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyTypeDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyTypeDiagram.tsx
@@ -22,6 +22,7 @@ import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
 import { TypeDiagram as TypeDesignDiagram } from "@wso2/type-diagram";
+import { fetchTypesModel, ReviewModelCache } from "./reviewModelCache";
 
 const SpinnerContainer = styled.div`
     display: flex;
@@ -56,10 +57,12 @@ interface ReadonlyTypeDiagramProps {
     filePath: string;
     onModelLoaded?: (metadata: ItemMetadata) => void;
     useFileSchema?: boolean;
+    /** Session-scoped model cache owned by ReviewMode — survives toggle/navigation remounts. */
+    modelCache: ReviewModelCache;
 }
 
 export function ReadonlyTypeDiagram(props: ReadonlyTypeDiagramProps): JSX.Element {
-    const { filePath, onModelLoaded, useFileSchema } = props;
+    const { filePath, onModelLoaded, useFileSchema, modelCache } = props;
     const { rpcClient } = useRpcContext();
     const [typesModel, setTypesModel] = useState<Type[] | null>(null);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -70,26 +73,24 @@ export function ReadonlyTypeDiagram(props: ReadonlyTypeDiagramProps): JSX.Elemen
         // Stale-response guard: a slower earlier request (e.g. after toggling Old/New)
         // must not overwrite this render with the other version's model.
         let cancelled = false;
-        rpcClient
-            .getBIDiagramRpcClient()
-            .getTypes({ filePath: filePath, useFileSchema })
-            .then((response) => {
+        fetchTypesModel(rpcClient, modelCache, filePath, useFileSchema)
+            .then((types) => {
                 if (cancelled) {
                     return;
                 }
-                if (response?.types) {
-                    setTypesModel(response.types);
+                if (types) {
+                    setTypesModel(types);
 
                     // Extract metadata from the types
-                    if (onModelLoaded && response.types.length > 0) {
+                    if (onModelLoaded && types.length > 0) {
                         // If there's a single type, use it; otherwise show "Types" as plural
-                        const firstType = response.types[0];
+                        const firstType = types[0];
                         onModelLoaded({
                             type: "Type",
                             name:
-                                response.types.length === 1
+                                types.length === 1
                                     ? firstType.name || "Unknown"
-                                    : `${response.types.length} Types`,
+                                    : `${types.length} Types`,
                         });
                     } else if (onModelLoaded) {
                         // No types found
@@ -113,7 +114,7 @@ export function ReadonlyTypeDiagram(props: ReadonlyTypeDiagramProps): JSX.Elemen
         return () => {
             cancelled = true;
         };
-    }, [filePath, useFileSchema, rpcClient]);
+    }, [filePath, useFileSchema, rpcClient, modelCache]);
 
     // No-op handlers for readonly mode
     const noOpHandler = () => {

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -117,6 +117,35 @@ const CloseButton = styled.button`
     }
 `;
 
+const CompileErrorMessage = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-width: 560px;
+    padding: 16px 20px;
+    color: var(--vscode-foreground);
+    border: 1px solid var(--vscode-inputValidation-warningBorder, ${ThemeColors.PRIMARY});
+    background: var(--vscode-inputValidation-warningBackground, transparent);
+    border-radius: 4px;
+    font-size: 13px;
+`;
+
+const ErrorDetail = styled.div`
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 12px;
+    color: var(--vscode-errorForeground);
+    word-break: break-word;
+`;
+
+const CompileWarningBanner = styled.div`
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--vscode-inputValidation-warningForeground, var(--vscode-foreground));
+    background: var(--vscode-inputValidation-warningBackground, transparent);
+    border-bottom: 1px solid var(--vscode-inputValidation-warningBorder, ${ThemeColors.PRIMARY});
+    word-break: break-word;
+`;
+
 enum DiagramType {
     COMPONENT = "component",
     FLOW = "flow",
@@ -244,6 +273,7 @@ export function ReviewMode(): JSX.Element {
     const [isLoading, setIsLoading] = useState(true);
     const [currentItemMetadata, setCurrentItemMetadata] = useState<ItemMetadata | null>(null);
     const [isWorkspace, setIsWorkspace] = useState(false);
+    const [semanticDiffError, setSemanticDiffError] = useState<string | null>(null);
     const [viewMode, setViewMode] = useState<ReviewViewMode>("diff");
     // View indices where the unified diff could not be built (old version missing/mismatched)
     const [diffUnavailableViews, setDiffUnavailableViews] = useState<Set<number>>(new Set());
@@ -274,6 +304,7 @@ export function ReviewMode(): JSX.Element {
 
             setProjectPath(tempDirPath);
             setIsWorkspace(isWorkspaceProject);
+            setSemanticDiffError(data.semanticDiffError ?? null);
             setSemanticDiffData({ semanticDiffs, loadDesignDiagrams });
 
             const packagesToReview = isWorkspaceProject ? affectedPackages : [tempDirPath];
@@ -499,7 +530,7 @@ export function ReviewMode(): JSX.Element {
         return (
             <ReviewContainer>
                 <TitleBar
-                    title="No Changes"
+                    title={semanticDiffError ? "Review Unavailable" : "No Changes"}
                     actions={
                         <>
                             <ReviewModeBadge>Reviewing Changes</ReviewModeBadge>
@@ -512,7 +543,19 @@ export function ReviewMode(): JSX.Element {
                     hideUndoRedo={true}
                 />
                 <DiagramContainer style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
-                    <div style={{ color: "var(--vscode-foreground)" }}>No changes to review</div>
+                    {semanticDiffError ? (
+                        <CompileErrorMessage>
+                            <strong>The changes could not be analyzed because the project fails to compile.</strong>
+                            <ErrorDetail>{semanticDiffError}</ErrorDetail>
+                            <div>
+                                The changes are already applied to your files. If the error mentions a
+                                dependency, running <code>bal build</code> in the project usually resolves it
+                                by refreshing <code>Dependencies.toml</code>.
+                            </div>
+                        </CompileErrorMessage>
+                    ) : (
+                        <div style={{ color: "var(--vscode-foreground)" }}>No changes to review</div>
+                    )}
                 </DiagramContainer>
             </ReviewContainer>
         );
@@ -584,6 +627,11 @@ export function ReviewMode(): JSX.Element {
                 hideBack={true}
                 hideUndoRedo={true}
             />
+            {semanticDiffError && (
+                <CompileWarningBanner title={semanticDiffError}>
+                    ⚠ The project fails to compile, so diagrams may be unavailable: {semanticDiffError}
+                </CompileWarningBanner>
+            )}
             <DiagramContainer>{renderDiagram()}</DiagramContainer>
             <ReviewNavigation
                 key={`nav-${currentIndex}-${views.length}`}

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -17,13 +17,15 @@
  */
 
 import React, { useEffect, useState, useCallback, useRef } from "react";
-import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum, NodePosition } from "@wso2/ballerina-core";
+import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum, NodeKindEnum, NodePosition } from "@wso2/ballerina-core";
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
 import { ExpectedFlowMetadata, ReadonlyFlowDiagram, ReviewViewMode, getVersionsForChangeType } from "./ReadonlyFlowDiagram";
 import { diffBelongsToPackage } from "./path-utils";
 import { ReadonlyTypeDiagram } from "./ReadonlyTypeDiagram";
+import { ReadonlySourceDiff } from "./ReadonlySourceDiff";
+import { getNodeKindLabel, SOURCE_VIEW_KINDS } from "./nodeKindLabels";
 import { ReviewNavigation } from "./ReviewNavigation";
 import { Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
 import { TitleBar } from "../../components/TitleBar";
@@ -150,6 +152,7 @@ enum DiagramType {
     COMPONENT = "component",
     FLOW = "flow",
     TYPE = "type",
+    SOURCE = "source",
 }
 
 interface ReviewView {
@@ -161,12 +164,8 @@ interface ReviewView {
     label?: string;
     changeType: number;
     expectedMetadata?: ExpectedFlowMetadata;
-}
-
-enum NodeKindEnum {
-    FUNCTION = 0,
-    RESOURCE_FUNCTION = 1,
-    TYPE = 2,
+    /** Construct name + before/after source, for SOURCE views (carried in diff metadata). */
+    sourceMeta?: { name?: string; oldSource?: string; newSource?: string };
 }
 
 // Map numeric changeType to string
@@ -183,23 +182,12 @@ function getChangeTypeString(changeType: number): string {
     }
 }
 
-// Map numeric nodeKind to string
-function getNodeKindString(nodeKind: number): string {
-    switch (nodeKind) {
-        case NodeKindEnum.FUNCTION:
-            return "function";
-        case NodeKindEnum.RESOURCE_FUNCTION:
-            return "resource";
-        case NodeKindEnum.TYPE:
-            return "type";
-        default:
-            return "component";
-    }
-}
-
 function getDiagramType(nodeKind: number): DiagramType {
-    if (nodeKind === NodeKindEnum.TYPE) {
+    if (nodeKind === NodeKindEnum.TYPE_DEFINITION) {
         return DiagramType.TYPE;
+    }
+    if (SOURCE_VIEW_KINDS.has(nodeKind)) {
+        return DiagramType.SOURCE;
     }
     return DiagramType.FLOW;
 }
@@ -208,15 +196,20 @@ function getDiagramType(nodeKind: number): DiagramType {
 function convertToReviewView(diff: SemanticDiff, projectPath: string, packageName?: string): ReviewView {
     const fileName = diff.uri.split("/").pop() || diff.uri;
     const changeTypeStr = getChangeTypeString(diff.changeType);
-    const nodeKindStr = getNodeKindString(diff.nodeKind);
+    const nodeKindStr = getNodeKindLabel(diff.nodeKind, diff.metadata);
+    const diagramType = getDiagramType(diff.nodeKind);
 
     // Include package name in label if provided (for multi-package scenarios)
     const changeLabel = packageName
         ? `${changeTypeStr}: ${nodeKindStr} in ${packageName}/${fileName}`
         : `${changeTypeStr}: ${nodeKindStr} in ${fileName}`;
 
+    const metadata = diff.metadata as
+        | { name?: string; oldSource?: string; newSource?: string }
+        | undefined;
+
     return {
-        type: getDiagramType(diff.nodeKind),
+        type: diagramType,
         filePath: diff.uri,
         position: {
             startLine: diff.lineRange.startLine.line,
@@ -239,6 +232,10 @@ function convertToReviewView(diff: SemanticDiff, projectPath: string, packageNam
             nodeKind: diff.nodeKind,
             metadata: diff.metadata,
         },
+        sourceMeta:
+            diagramType === DiagramType.SOURCE
+                ? { name: metadata?.name, oldSource: metadata?.oldSource, newSource: metadata?.newSource }
+                : undefined,
     };
 }
 
@@ -273,6 +270,7 @@ export function ReviewMode(): JSX.Element {
     const [isLoading, setIsLoading] = useState(true);
     const [currentItemMetadata, setCurrentItemMetadata] = useState<ItemMetadata | null>(null);
     const [isWorkspace, setIsWorkspace] = useState(false);
+    const [modifiedFiles, setModifiedFiles] = useState<string[]>([]);
     const [semanticDiffError, setSemanticDiffError] = useState<string | null>(null);
     const [viewMode, setViewMode] = useState<ReviewViewMode>("diff");
     // View indices where the unified diff could not be built (old version missing/mismatched)
@@ -304,6 +302,7 @@ export function ReviewMode(): JSX.Element {
 
             setProjectPath(tempDirPath);
             setIsWorkspace(isWorkspaceProject);
+            setModifiedFiles(data.modifiedFiles ?? []);
             setSemanticDiffError(data.semanticDiffError ?? null);
             setSemanticDiffData({ semanticDiffs, loadDesignDiagrams });
 
@@ -388,12 +387,19 @@ export function ReviewMode(): JSX.Element {
         });
     }, [rpcClient]);
 
-    // Set metadata for component diagram when view changes
+    // Set metadata for component/source views when view changes (they don't load a model
+    // that would report metadata back)
     useEffect(() => {
         if (currentView?.type === "component" && !currentItemMetadata) {
             setCurrentItemMetadata({
                 type: "Design",
                 name: "",
+            });
+        }
+        if (currentView?.type === "source" && !currentItemMetadata) {
+            setCurrentItemMetadata({
+                type: "Change",
+                name: currentView.sourceMeta?.name ?? "",
             });
         }
     }, [currentView, currentItemMetadata]);
@@ -445,6 +451,12 @@ export function ReviewMode(): JSX.Element {
         if (!currentView) {
             return { diff: false, new: true, old: false };
         }
+        if (currentView.type === DiagramType.SOURCE) {
+            // Source views carry their own before/after text; "diff" shows both blocks.
+            const hasOld = currentView.sourceMeta?.oldSource !== undefined;
+            const hasNew = currentView.sourceMeta?.newSource !== undefined;
+            return { diff: hasOld && hasNew, new: hasNew, old: hasOld };
+        }
         const versions = getVersionsForChangeType(currentView.changeType);
         const diff = currentView.type === DiagramType.FLOW && !diffUnavailableViews.has(currentIndex);
         return { diff, new: versions.new, old: versions.old };
@@ -465,8 +477,15 @@ export function ReviewMode(): JSX.Element {
             return <div>No view to display</div>;
         }
 
-        // Create a unique key for each diagram to force re-mount when switching views
-        const diagramKey = `${currentView.type}-${currentIndex}-${currentView.filePath}`;
+        // Create a unique key for each diagram to force re-mount when switching views.
+        // For type/design diagrams the Old/New toggle is part of the key: their fetch
+        // effects have no stale-response guard, so remounting on toggle prevents an
+        // out-of-order response from rendering the wrong version. Flow diagrams cache
+        // versions internally and derive the toggle locally, so their key excludes it.
+        const diagramKey =
+            currentView.type === "flow"
+                ? `${currentView.type}-${currentIndex}-${currentView.filePath}`
+                : `${currentView.type}-${currentIndex}-${currentView.filePath}-${effectiveViewMode}`;
 
         switch (currentView.type) {
             case "component":
@@ -503,6 +522,17 @@ export function ReviewMode(): JSX.Element {
                         filePath={currentView.filePath}
                         onModelLoaded={handleModelLoaded}
                         useFileSchema={effectiveViewMode === "old"}
+                    />
+                );
+            case "source":
+                // The construct's name is shown by the TitleBar (via currentItemMetadata).
+                return (
+                    <ReadonlySourceDiff
+                        key={diagramKey}
+                        oldSource={currentView.sourceMeta?.oldSource}
+                        newSource={currentView.sourceMeta?.newSource}
+                        changeType={currentView.changeType}
+                        viewMode={effectiveViewMode}
                     />
                 );
             default:
@@ -552,6 +582,22 @@ export function ReviewMode(): JSX.Element {
                                 dependency, running <code>bal build</code> in the project usually resolves it
                                 by refreshing <code>Dependencies.toml</code>.
                             </div>
+                        </CompileErrorMessage>
+                    ) : modifiedFiles.length > 0 ? (
+                        // Files changed but nothing produced a reviewable code diff (e.g. only
+                        // Config.toml / markdown / JSON edits). Say what changed instead of the
+                        // misleading "No changes to review".
+                        <CompileErrorMessage style={{ borderColor: "var(--vscode-panel-border)", background: "transparent" }}>
+                            <strong>No code changes to review as diagrams.</strong>
+                            <div>
+                                {modifiedFiles.length} file{modifiedFiles.length === 1 ? " was" : "s were"} changed
+                                and already applied to your project:
+                            </div>
+                            <ErrorDetail style={{ color: "var(--vscode-foreground)" }}>
+                                {modifiedFiles.map((f) => (
+                                    <div key={f}>{f}</div>
+                                ))}
+                            </ErrorDetail>
                         </CompileErrorMessage>
                     ) : (
                         <div style={{ color: "var(--vscode-foreground)" }}>No changes to review</div>

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -21,11 +21,12 @@ import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum, NodeKindEnum, NodeP
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
-import { ExpectedFlowMetadata, ReadonlyFlowDiagram, ReviewViewMode, getVersionsForChangeType } from "./ReadonlyFlowDiagram";
+import { ExpectedFlowMetadata, ReadonlyFlowDiagram, ReviewViewMode } from "./ReadonlyFlowDiagram";
 import { diffBelongsToPackage } from "./path-utils";
 import { ReadonlyTypeDiagram } from "./ReadonlyTypeDiagram";
 import { ReadonlySourceDiff } from "./ReadonlySourceDiff";
 import { getNodeKindLabel, SOURCE_VIEW_KINDS } from "./nodeKindLabels";
+import { getVersionsForChangeType, prefetchReviewView, ReviewModelCache } from "./reviewModelCache";
 import { ReviewNavigation } from "./ReviewNavigation";
 import { Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
 import { TitleBar } from "../../components/TitleBar";
@@ -277,6 +278,11 @@ export function ReviewMode(): JSX.Element {
     const [diffUnavailableViews, setDiffUnavailableViews] = useState<Set<number>>(new Set());
     const pendingIndexRef = useRef<number | null>(null);
     const viewsLengthRef = useRef<number>(0);
+    // Session-scoped LS model cache shared by all diagram components. The per-item
+    // components are remounted on navigation/toggle (their keys include currentIndex),
+    // so any cache they hold themselves dies with them — this one survives, making
+    // revisits and Old/New toggles cache hits instead of fresh LS round trips.
+    const modelCacheRef = useRef<ReviewModelCache>(new Map());
 
     useEffect(() => {
         viewsLengthRef.current = views.length;
@@ -293,6 +299,9 @@ export function ReviewMode(): JSX.Element {
             const location = await rpcClient.getVisualizerLocation();
             const data = location?.reviewData;
             if (!data?.semanticDiffs || !data?.tempProjectPath) return;
+
+            // New review payload — models cached for a previous generation are stale.
+            modelCacheRef.current = new Map();
 
             const tempDirPath = data.tempProjectPath;
             const isWorkspaceProject = data.isWorkspace ?? false;
@@ -386,6 +395,37 @@ export function ReviewMode(): JSX.Element {
             }
         });
     }, [rpcClient]);
+
+    // Warm the session cache for EVERY item once per review payload, ordered outward
+    // from the item the review opened on, so any chip click or prev/next lands on an
+    // already-fetched model. Two workers keep the sweep from starving the mounted
+    // component's own fetch (which the promise cache dedups against anyway); a failed
+    // prefetch evicts itself, so the visit-time fetch still gets a fresh attempt.
+    const prefetchedViewsRef = useRef<ReviewView[] | null>(null);
+    useEffect(() => {
+        if (views.length === 0 || prefetchedViewsRef.current === views) {
+            return;
+        }
+        prefetchedViewsRef.current = views;
+        const cache = modelCacheRef.current;
+        const order: ReviewView[] = [];
+        for (let distance = 0; order.length < views.length; distance++) {
+            const ahead = currentIndex + distance;
+            const behind = currentIndex - distance;
+            if (ahead < views.length) order.push(views[ahead]);
+            if (distance > 0 && behind >= 0) order.push(views[behind]);
+        }
+        let nextIndex = 0;
+        const worker = (): void => {
+            if (nextIndex >= order.length || modelCacheRef.current !== cache) {
+                // A new review payload replaced the cache — stop sweeping stale views.
+                return;
+            }
+            prefetchReviewView(rpcClient, cache, order[nextIndex++]).then(worker);
+        };
+        worker();
+        worker();
+    }, [views, currentIndex, rpcClient]);
 
     // Set metadata for component/source views when view changes (they don't load a model
     // that would report metadata back)
@@ -497,6 +537,7 @@ export function ReviewMode(): JSX.Element {
                         filePath={currentView.filePath}
                         position={currentView.position}
                         useFileSchema={effectiveViewMode === "old"}
+                        modelCache={modelCacheRef.current}
                     />
                 );
             case "flow":
@@ -512,6 +553,7 @@ export function ReviewMode(): JSX.Element {
                         changeType={currentView.changeType}
                         expectedMetadata={currentView.expectedMetadata}
                         onDiffUnavailable={handleDiffUnavailable}
+                        modelCache={modelCacheRef.current}
                     />
                 );
             case "type":
@@ -522,6 +564,7 @@ export function ReviewMode(): JSX.Element {
                         filePath={currentView.filePath}
                         onModelLoaded={handleModelLoaded}
                         useFileSchema={effectiveViewMode === "old"}
+                        modelCache={modelCacheRef.current}
                     />
                 );
             case "source":

--- a/packages/ballerina-visualizer/src/views/ReviewMode/nodeKindLabels.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/nodeKindLabels.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { NodeKindEnum, SemanticDiff } from "@wso2/ballerina-core";
+
+/**
+ * Shared nodeKind wording for the review surfaces (ReviewMode + ReviewBar) — a deliberate
+ * leaf module (no React/RPC) so both import one table instead of mirroring the LS enum twice.
+ */
+const NODE_KIND_LABELS: Record<number, string> = {
+    [NodeKindEnum.MODULE_FUNCTION]: "function",
+    [NodeKindEnum.OBJECT_FUNCTION]: "resource",
+    [NodeKindEnum.TYPE_DEFINITION]: "type",
+    [NodeKindEnum.DATA_MAPPING_FUNCTION]: "data mapping",
+    [NodeKindEnum.MODULE_VARIABLE]: "variable",
+    [NodeKindEnum.CONSTANT]: "constant",
+    [NodeKindEnum.LISTENER]: "listener",
+    [NodeKindEnum.CLASS_DEFINITION]: "class",
+    [NodeKindEnum.ENUM_DECLARATION]: "enum",
+    [NodeKindEnum.IMPORT_DECLARATION]: "import",
+};
+
+export function getNodeKindLabel(nodeKind: number, metadata?: SemanticDiff["metadata"]): string {
+    // OBJECT_FUNCTION covers both service resource/remote members and plain class
+    // methods; only the former carry resource metadata (accessor/servicePath).
+    if (nodeKind === NodeKindEnum.OBJECT_FUNCTION
+        && !(metadata as { accessor?: string } | undefined)?.accessor) {
+        return "method";
+    }
+    return NODE_KIND_LABELS[nodeKind] ?? "component";
+}
+
+/**
+ * Construct kinds with no diagram representation, rendered as before/after source blocks.
+ * Explicit membership on purpose: an ordinal-range check would silently misrender a future
+ * kind appended after these that DOES have a diagram.
+ */
+export const SOURCE_VIEW_KINDS: ReadonlySet<number> = new Set([
+    NodeKindEnum.MODULE_VARIABLE,
+    NodeKindEnum.CONSTANT,
+    NodeKindEnum.LISTENER,
+    NodeKindEnum.CLASS_DEFINITION,
+    NodeKindEnum.ENUM_DECLARATION,
+    NodeKindEnum.IMPORT_DECLARATION,
+]);

--- a/packages/ballerina-visualizer/src/views/ReviewMode/reviewModelCache.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/reviewModelCache.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/packages/ballerina-visualizer/src/views/ReviewMode/reviewModelCache.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/reviewModelCache.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CDModel, ChangeTypeEnum, Flow, NodePosition, Type } from "@wso2/ballerina-core";
+import { BallerinaRpcClient } from "@wso2/ballerina-rpc-client";
+import { getFlowLookupPosition } from "./position-utils";
+
+/**
+ * Review-session-scoped cache of LS model fetches, keyed by view identity + version.
+ *
+ * Review content is frozen while a review is open, so any model fetched once stays
+ * valid for the whole session. The cache lives in ReviewMode (not in the per-item
+ * diagram components, which are remounted on every prev/next navigation and on the
+ * Old/New toggle for type/design views) so that navigating back to an already-seen
+ * item, or flipping the toggle, never re-hits the LS.
+ *
+ * Promises (not resolved values) are cached so concurrent requests for the same
+ * model — e.g. a prefetch racing the mounted component's own fetch — collapse into
+ * one LS round trip. A rejected fetch evicts itself so an error never becomes sticky.
+ */
+export type ReviewModelCache = Map<string, Promise<unknown>>;
+
+export function getOrFetch<T>(cache: ReviewModelCache, key: string, fetch: () => Promise<T>): Promise<T> {
+    const existing = cache.get(key);
+    if (existing) {
+        return existing as Promise<T>;
+    }
+    const promise = fetch();
+    cache.set(key, promise);
+    promise.catch(() => {
+        if (cache.get(key) === promise) {
+            cache.delete(key);
+        }
+    });
+    return promise;
+}
+
+/**
+ * Which versions of a file structurally exist for a semantic-diff change type.
+ * Single source of truth for the toggle availability (ReviewMode), the diff-mode
+ * fetch branching (ReadonlyFlowDiagram), and prefetching below.
+ */
+export function getVersionsForChangeType(changeType: number): { old: boolean; new: boolean } {
+    switch (changeType) {
+        case ChangeTypeEnum.ADDITION:
+            return { old: false, new: true };
+        case ChangeTypeEnum.DELETION:
+            return { old: true, new: false };
+        default:
+            return { old: true, new: true };
+    }
+}
+
+export interface FlowVersionParams {
+    filePath: string;
+    position: NodePosition;
+    oldPosition?: NodePosition;
+    /** true reads the frozen original (ai://); false reads the live edits (file://). */
+    useFileSchema: boolean;
+}
+
+function positionKey(position?: NodePosition): string {
+    if (!position) {
+        return "";
+    }
+    return `${position.startLine}:${position.startColumn}:${position.endLine}:${position.endColumn}`;
+}
+
+/**
+ * Fetch one version of the enclosing function's flow model (enclosed-function lookup
+ * followed by the flow-model request), deduped through the session cache.
+ */
+export function fetchFlowModelVersion(
+    rpcClient: BallerinaRpcClient,
+    cache: ReviewModelCache,
+    params: FlowVersionParams
+): Promise<Flow | null> {
+    const { filePath, position, oldPosition, useFileSchema } = params;
+    const key = `flow:${filePath}:${positionKey(position)}:${positionKey(oldPosition)}:${useFileSchema}`;
+    return getOrFetch(cache, key, async () => {
+        const lookupPosition = getFlowLookupPosition(position, oldPosition, useFileSchema);
+
+        // First resolve the full function range using getEnclosedFunction,
+        // since the position from semantic diff may only cover the changed statement
+        const enclosedFn = await rpcClient.getBIDiagramRpcClient().getEnclosedFunction({
+            filePath,
+            position: { line: lookupPosition.startLine, offset: lookupPosition.startColumn },
+            useFileSchema,
+        });
+        const startLine = enclosedFn?.startLine ?? {
+            line: lookupPosition.startLine,
+            offset: lookupPosition.startColumn,
+        };
+        const endLine = enclosedFn?.endLine ?? {
+            line: lookupPosition.endLine,
+            offset: lookupPosition.endColumn,
+        };
+
+        const response = await rpcClient.getBIDiagramRpcClient().getFlowModel({
+            filePath,
+            startLine,
+            endLine,
+            useFileSchema,
+        });
+        return response?.flowModel ?? null;
+    });
+}
+
+/** Fetch the type-diagram model for one version, deduped through the session cache. */
+export function fetchTypesModel(
+    rpcClient: BallerinaRpcClient,
+    cache: ReviewModelCache,
+    filePath: string,
+    useFileSchema: boolean | undefined
+): Promise<Type[] | null> {
+    const key = `types:${filePath}:${useFileSchema === true}`;
+    return getOrFetch(cache, key, async () => {
+        const response = await rpcClient.getBIDiagramRpcClient().getTypes({ filePath, useFileSchema });
+        return response?.types ?? null;
+    });
+}
+
+/** Fetch the design/component model for one version, deduped through the session cache. */
+export function fetchDesignModel(
+    rpcClient: BallerinaRpcClient,
+    cache: ReviewModelCache,
+    projectPath: string,
+    useFileSchema: boolean | undefined
+): Promise<CDModel | null> {
+    const key = `design:${projectPath}:${useFileSchema === true}`;
+    return getOrFetch(cache, key, async () => {
+        const response = await rpcClient.getBIDiagramRpcClient().getDesignModel({ projectPath, useFileSchema });
+        return response?.designModel ?? null;
+    });
+}
+
+/** The structural subset of ReviewMode's ReviewView that prefetching needs. */
+export interface PrefetchableReviewView {
+    /** DiagramType value: "flow" | "type" | "component" | "source". */
+    type: string;
+    filePath: string;
+    position: NodePosition;
+    oldPosition?: NodePosition;
+    projectPath: string;
+    changeType: number;
+}
+
+/**
+ * Warms the session cache with what a view fetches when it first mounts, so navigating
+ * to it lands on an already-resolved model. Lives next to the fetchers on purpose: the
+ * per-view-kind fetch shape is this module's knowledge, not ReviewMode's.
+ *
+ * Only the versions shown by each view's initial mode are warmed — flow opens in diff
+ * mode (both versions per its change type); type/component open in "new" and fetch
+ * "old" on demand when toggled; source views carry their content in the diff metadata.
+ * A failed prefetch evicts itself from the cache (see getOrFetch). The returned promise
+ * settles when the view's fetches settle (never rejects) so callers can pace a sweep.
+ */
+export function prefetchReviewView(
+    rpcClient: BallerinaRpcClient,
+    cache: ReviewModelCache,
+    view: PrefetchableReviewView | undefined
+): Promise<void> {
+    if (!view) {
+        return Promise.resolve();
+    }
+    const fetches: Promise<unknown>[] = [];
+    switch (view.type) {
+        case "flow": {
+            const versions = getVersionsForChangeType(view.changeType);
+            const params = { filePath: view.filePath, position: view.position, oldPosition: view.oldPosition };
+            if (versions.new) {
+                fetches.push(fetchFlowModelVersion(rpcClient, cache, { ...params, useFileSchema: false }));
+            }
+            if (versions.old) {
+                fetches.push(fetchFlowModelVersion(rpcClient, cache, { ...params, useFileSchema: true }));
+            }
+            break;
+        }
+        case "type":
+            fetches.push(fetchTypesModel(rpcClient, cache, view.filePath, false));
+            break;
+        case "component":
+            fetches.push(fetchDesignModel(rpcClient, cache, view.projectPath, false));
+            break;
+        default:
+            break;
+    }
+    return Promise.allSettled(fetches).then((): void => undefined);
+}

--- a/packages/bi-diagram/src/components/Diagram.tsx
+++ b/packages/bi-diagram/src/components/Diagram.tsx
@@ -138,7 +138,9 @@ export function Diagram(props: DiagramProps) {
 
     const [showErrorFlow, setShowErrorFlow] = useState(false);
     const [nodeComments, setNodeComments] = useState<Map<string, FlowNode[]>>(new Map());
-    const [diagramEngine] = useState<DiagramEngine>(generateEngine());
+    // Lazy initializer: generateEngine() registers ~20 factories, and the non-lazy form
+    // would rebuild (and discard) an engine on every render of this component.
+    const [diagramEngine] = useState<DiagramEngine>(() => generateEngine());
     const [diagramModel, setDiagramModel] = useState<DiagramModel | null>(null);
     const [canvasVisible, setCanvasVisible] = useState(!(isAgentFocusView && embedded));
     const [showComponentPanel, setShowComponentPanel] = useState(false);


### PR DESCRIPTION
## What this does

This PR re-lands the review-mode empty-diff fixes and performance optimizations (originally #855, reverted in #928) and resolves the concurrency hazard in `PackageUtil`'s sample-project package resolution (fixes [wso2/product-integrator#2193](https://github.com/wso2/product-integrator/issues/2193)).

---

### 1. Concurrency Fix: `PackageUtil` Sample-Project Resolution

#### Root Cause (Upstream Compiler Internals)
* In `ballerina-lang` (`io.ballerina.projects.internal.environment.EnvironmentPackageCache`), the package cache maintains two plain, unsynchronized `java.util.HashMap` fields (`projectsById` and `projectsByOrgNameVersion`).
* Calling `PackageResolver.resolvePackages()` or `resolvePackageMetadata()` invokes `EnvironmentPackageCache.cache(Package pkg)`, which directly mutates these maps via `computeIfAbsent`.
* When `SAMPLE_PROJECT` was previously held as a global singleton, concurrent LS requests (flow-model generation, trigger models, connector resolution, library metadata) concurrently mutated these maps, causing `HashMap` corruption (lost updates, tree-bin corruption, infinite loops on resize).

> **Note for Future Upstream Fix in `ballerina-platform/ballerina-lang`:**  
> The permanent compiler-level fix belongs in:  
> `compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java`  
> Synchronizing `EnvironmentPackageCache` (e.g., using `ConcurrentHashMap` or synchronizing `cache()` / `getPackage()`) will make `BuildProject` environments safe for concurrent shared resolution upstream.

#### Solution in this PR (Application-Level Isolation)
Instead of coarse locking (`SAMPLE_RESOLUTION_LOCK`, which serialized unrelated LS requests), this PR decouples the immutable cache from the mutable compiler resolver:

1. **Per-Thread Resolver (`ThreadLocal<BuildProject>`)**:
   - `SAMPLE_PROJECT` is now a `ThreadLocal<BuildProject>`. Each LS worker thread resolves through its own isolated `Environment`, `DefaultPackageResolver`, and `EnvironmentPackageCache`.
   - Eliminates cross-thread mutable state with zero locking on hot LS paths.
2. **Lock-Free Immutable Cache (`SAMPLE_RESOLUTION_CACHE`)**:
   - Retains the performance optimization by caching resolved `.bala` file paths (`ConcurrentHashMap<String, Optional<Path>>`).
   - Cache hits never touch the resolver; cache misses resolve on the calling thread's isolated environment and populate via `putIfAbsent`.
3. **Closed Secondary Access Paths (`localPackageRepository()`)**:
   - `LibraryMetadataReader` and `AiUtils` now use `PackageUtil.localPackageRepository()` (also `ThreadLocal`), preventing secondary un-synchronized environment access via `BallerinaUserHome`.
4. **Memory & Disk Hygiene**:
   - Per-thread projects load in-memory from a single shared, static directory (`SAMPLE_PROJECT_DIR`) with `deleteOnExit`. No per-thread temporary directories are created on disk.
   - Thread-local instances are held in the worker thread's `ThreadLocalMap` and garbage-collected when the thread terminates.
5. **Forward Compatibility**:
   - If/when `ballerina-lang` synchronizes `EnvironmentPackageCache`, `PackageUtil` can collapse `ThreadLocal` back to a shared instance with zero API breakage to callers.

---

### 2. Review Diff Improvements & Performance Optimizations

#### A. Language Server (`SemanticDiffComputer` & Services)
* **Comprehensive Module & Construct Coverage**:
  * **All Modules & Tests**: `SemanticDiffComputer` now iterates over all packages and submodules (`pkg.modules()`) including test documents, with URIs resolved via exact document paths.
  * **New Construct Diff Support**: Emits semantic diffs for module variables/configurables (`MODULE_VAR`), constants (`CONSTANT`), listeners (`LISTENER`), class definitions (`CLASS_DEFINITION`), enum definitions (`ENUM_DEFINITION`), and imports (`IMPORT`).
  * **Class Diffing**: Diffed method-by-method as `FUNCTION` diffs; class headers (metadata, visibility, `isolated` / class-type qualifiers, class keyword, and name) and non-method members are diffed as `CLASS_DEFINITION`.
  * **Trivia-Insensitive Import Diffing**: Imports are compared strictly by semantic identity (`org/module:alias`) rather than raw source code trivia. Prevents untouched imports from showing as "modified" when leading comments re-attach due to reordering/insertions. Added/deleted imports render in canonical `import <key>;` form.
  * **Type Deletion & External Function Support**: Explicitly tracks type definition deletions and external function body modifications (previously omitted).
* **`copilotAgentService/ensureAiBaseline` RPC**:
  * Replaced fire-and-forget `didOpen` LSP notifications with an awaitable request that explicitly evicts, reloads, and applies baseline snapshot contents before tool execution starts. Kills the race where the LS indexed mid-edit files from disk.
* **`copilotAgentService/prewarmDependencies` RPC**:
  * Resolves and pre-compiles a package's direct dependencies asynchronously in the background at turn start, removing ~3.5s of dependency resolution off the critical review click path.
* **Virtual Document Event Optimization**:
  * `ProjectUpdateEventPublisher` skips `PROJECT_UPDATE` subscriber fan-out for `ai://` virtual documents, preventing unnecessary package recompilations for frozen baseline files.

#### B. VS Code Extension Host (`AgentExecutor`, `ApprovalViewManager`, Checkpoints)
* **Robust Baseline Seeding & Mid-Run Package Seeding**:
  * `AgentExecutor` awaits `ensureAiBaseline` prior to running the agent loop.
  * When a new package is created mid-run (`Ballerina.toml` write), its baseline is initialized with empty files so subsequent writes review cleanly as additions rather than diffing against itself.
* **Package Mapping & Error Isolation**:
  * Normalizes file path casing, trailing slashes, and Windows drive letters when matching modified files to packages.
  * Unions `Ballerina.toml` and `ProjectSource` package lists so empty package arrays don't orphan modified files.
  * If `getSemanticDiff` fails for one package, sibling packages still render their diffs, and an explicit `semanticDiffError` is recorded rather than masquerading as a no-op turn.
* **Review Reseed Invalidation**:
  * Finalizes pending reviews on all threads when a new generation starts (since the single `ai://` LS baseline slot is reseeded for the new run).
* **Safe Revert & Checkpoint Verification**:
  * `restoreWorkspaceSnapshot` returns an explicit boolean status; `revertGeneration` verifies that the workspace restore succeeded before marking the generation reverted in state.
* **Concurrent Execution Bounds**:
  * Parallelizes `getSemanticDiff` calls (concurrency cap: 3).
  * Parallelizes baseline seeding (concurrency cap: 4).
  * Chunks workspace checkpoint file reads in 32-way concurrent batches.

#### C. Visualizer Webview UI (`ReviewMode`, `ReviewBar`, Diagram Engine)
* **`ReadonlySourceDiff` Component**:
  * Renders non-diagram constructs (module variables, constants, listeners, classes, enums, imports) as syntax-highlighted old/new source diff blocks with VS Code theme border variables.
* **Unified Labels & Declarations Grouping**:
  * Centralized `NodeKindEnum` in `ballerina-core` with `nodeKindLabels.ts` shared between `ReviewMode` and `ReviewBar`.
  * Groups non-service constructs under a collapsible `declarations` group in the `ReviewBar`. Class methods label as "method" rather than "resource".
* **Review Session Model Cache (`reviewModelCache.ts`)**:
  * Implemented a review-session promise cache shared across diagram components. Prevents redundant LS round-trips during prev/next navigation or `Old`/`New`/`Diff` toggle switches and collapses concurrent requests.
  * **Outward Prefetching**: Automatically warms models for all items in the review payload starting outward from the active item using 2 background workers.
* **Diagram Engine Render Optimization**:
  * Initialized `DiagramEngine` lazily with `useState(() => new DiagramEngine())` in `bi-diagram`, eliminating the repeated creation/destruction of ~20 node/link factories on every re-render.
* **Non-`.bal` Changes & Failure States**:
  * Displays modified non-`.bal` files (e.g., `Config.toml`, `Ballerina.toml`) rather than reporting "No changes to review".
  * Replaced permanent spinners with warning banners and explicit failure states when old-side flow-model compilations fail.

---

### 3. Why Parallel Execution is Critical for Review Mode

Review Mode transforms raw code diffs into interactive visual flow, type, and component diff diagrams. Sequential execution previously caused substantial latency and UI stalls during review generation and navigation. We introduced bounded parallel execution across four key paths:

1. **Simultaneous Old vs. New Model Generation**:
   - Rendering a unified diff diagram requires fetching both the **original model** (`file://`) and the **modified model** (`ai://`) from the Language Server.
   - Sequential fetches doubled user wait time (`T_old + T_new` ~4s). Fetching both concurrently halves the latency (`max(T_old, T_new)` ~2s) per diagram.

2. **Multi-Package Diff Collection**:
   - In multi-package workspaces or migration workflows, Copilot frequently modifies multiple packages in a single turn.
   - The extension collects `getSemanticDiff` across affected packages concurrently (bounded at 3 concurrent workers) so multi-core LS workers process compilations in parallel rather than compounding sequential compilation times.

3. **Background Prefetching for Zero-Lag Navigation**:
   - An AI generation often touches 5–10 functions/types. Without prefetching, navigating between items (clicking "Next" or clicking review chips in chat) incurred a 1–2s loading spinner on every single item.
   - Two background workers prefetch and warm models in the review-session cache outward from the active item. By the time the user reviews the first change, subsequent diagrams are already cached in memory and render instantly.

4. **Turn-Start Baseline Seeding & Checkpoint Reads**:
   - Pre-seeding baseline packages into the LS (`ensureAiBaseline`) runs with bounded concurrency (cap: 4), and workspace file snapshots are read in 32-way concurrent chunks rather than one file at a time.

> **Direct Connection to the Concurrency Fix**:  
> Because Review Mode intentionally dispatches these concurrent requests to maximize UI responsiveness, the Language Server's resolution paths (e.g., `PackageUtil`, `LibraryMetadataReader`, `TriggerModelReader`) frequently receive overlapping requests on separate worker threads. This makes the thread-isolation fix in `PackageUtil` essential to prevent concurrent compiler cache corruption.

---

### 4. Testing & Verification

* **Concurrency Stability Test**:
  * Added `PackageUtilConcurrencyTest` in `flow-model-generator-core`.
  * Runs 16 threads synchronized via `CyclicBarrier` across 25 iterations exercising `cachedVersion`, `isModuleUnresolved`, `getModulePackageOffline`, and `getModulePackage`.
  * Asserts execution completes without exceptions, hangs, or divergences from a single-threaded baseline.
* **Unit & Integration Suites**:
  * Language Server test suites pass (`./gradlew test`).
  * Extension unit tests (`pnpm run test:unit`) pass.
  * Visualizer unit tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Re-lands review-mode empty-diff fixes and performance improvements.
- Adds broader semantic diff support for declarations, source-only changes, and trivia-only changes.
- Adds reliable baseline seeding, dependency prewarming, bounded concurrency, caching, prefetching, and improved failure handling.
- Improves review UI rendering for source diffs, diagram fallbacks, compilation errors, and partial results.
- Isolates `PackageUtil` sample-project resolution per thread and adds concurrency coverage.
- Improves workspace restore validation and diagnostic error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->