### PR TITLE
Draw every diagram node's border with the same token

### DIFF
--- a/packages/bi-diagram/src/components/nodes/AgentNode/AgentNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/AgentNode/AgentNodeWidget.tsx
@@ -27,6 +27,9 @@ import {
     DRAFT_NODE_BORDER_WIDTH,
     LABEL_HEIGHT,
     LABEL_WIDTH,
+    NODE_BORDER_COLOR,
+    NODE_BORDER_ERROR_COLOR,
+    NODE_BORDER_SELECTED_COLOR,
     NODE_BORDER_WIDTH,
     NODE_GAP_X,
     NODE_HEIGHT,
@@ -81,12 +84,12 @@ export namespace NodeStyles {
         border-style: ${(props: NodeStyleProp) => (props.disabled ? "dashed" : "solid")};
         border-color: ${(props: NodeStyleProp) =>
             props.hasError
-                ? ThemeColors.ERROR
+                ? NODE_BORDER_ERROR_COLOR
                 : props.isSelected && !props.disabled
-                    ? ThemeColors.SECONDARY
+                    ? NODE_BORDER_SELECTED_COLOR
                     : props.hovered && !props.disabled && !props.readOnly
-                        ? ThemeColors.SECONDARY
-                        : ThemeColors.OUTLINE_VARIANT};
+                        ? NODE_BORDER_SELECTED_COLOR
+                        : NODE_BORDER_COLOR};
         border-radius: 10px;
         background-color: ${(props: NodeStyleProp) =>
             props?.isActiveBreakpoint ? ThemeColors.DEBUGGER_BREAKPOINT_BACKGROUND : ThemeColors.SURFACE_DIM};

--- a/packages/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
@@ -28,6 +28,8 @@ import {
     NODE_BG_COLOR,
     NODE_BG_HOVER_COLOR,
     NODE_HOVER_GLOW,
+    HIGHLIGHT_NODE_BORDER_COLOR,
+    HIGHLIGHT_NODE_BORDER_WIDTH,
     NODE_BORDER_COLOR,
     NODE_BORDER_ERROR_COLOR,
     NODE_BORDER_SELECTED_COLOR,
@@ -39,7 +41,7 @@ import {
     NODE_TEXT_COLOR,
     NODE_WIDTH,
 } from "../../../resources/constants";
-import { Button, Icon, Item, Menu, MenuItem, ThemeColors } from "@wso2/ui-toolkit";
+import { Button, Icon, Item, Menu, MenuItem } from "@wso2/ui-toolkit";
 import { MoreVertIcon } from "../../../resources";
 import { FlowNode } from "../../../utils/types";
 import NodeIcon from "../../NodeIcon";
@@ -51,6 +53,7 @@ import {
     getDiffTitleStyles,
     getNodeTitle,
     getWorkflowFunctionName,
+    isWorkflowNode,
     nodeHasError,
 } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
@@ -71,6 +74,7 @@ export namespace NodeStyles {
         readOnly: boolean;
         isActiveBreakpoint: boolean;
         isSelected?: boolean;
+        isWorkflowNode?: boolean;
     };
     export const Box = styled.div<NodeStyleProp>`
         display: flex;
@@ -81,16 +85,23 @@ export namespace NodeStyles {
         min-height: ${NODE_HEIGHT}px;
         padding: 0 ${NODE_PADDING}px;
         opacity: ${(props: NodeStyleProp) => (props.disabled ? 0.7 : 1)};
-        border: ${(props: NodeStyleProp) => (props.disabled ? DRAFT_NODE_BORDER_WIDTH : NODE_BORDER_WIDTH)}px;
+        border: ${(props: NodeStyleProp) =>
+            props.disabled
+                ? DRAFT_NODE_BORDER_WIDTH
+                : props.isWorkflowNode
+                    ? HIGHLIGHT_NODE_BORDER_WIDTH
+                    : NODE_BORDER_WIDTH}px;
         border-style: ${(props: NodeStyleProp) => (props.disabled ? "dashed" : "solid")};
         border-color: ${(props: NodeStyleProp) =>
             props.hasError
                 ? NODE_BORDER_ERROR_COLOR
                 : props.isSelected && !props.disabled
-                    ? ThemeColors.SECONDARY
+                    ? NODE_BORDER_SELECTED_COLOR
                     : props.hovered && !props.disabled && !props.readOnly
-                        ? ThemeColors.SECONDARY
-                        : ThemeColors.OUTLINE_VARIANT};
+                        ? NODE_BORDER_SELECTED_COLOR
+                        : props.isWorkflowNode
+                            ? HIGHLIGHT_NODE_BORDER_COLOR
+                            : NODE_BORDER_COLOR};
         border-radius: 10px;
         background-color: ${(props: NodeStyleProp) =>
             props?.isActiveBreakpoint ? NODE_BG_BREAKPOINT_COLOR : props.hovered && !props.disabled && !props.readOnly ? NODE_BG_HOVER_COLOR : NODE_BG_COLOR};
@@ -432,6 +443,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                 readOnly={readOnly}
                 isActiveBreakpoint={isActiveBreakpoint}
                 isSelected={isSelected}
+                isWorkflowNode={isWorkflowNode(model.node)}
                 style={getDiffContainerStyles(model.node)}
                 onMouseEnter={() => setIsBoxHovered(true)}
                 onMouseLeave={() => setIsBoxHovered(false)}

--- a/packages/bi-diagram/src/components/nodes/ErrorNode/ErrorNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/ErrorNode/ErrorNodeWidget.tsx
@@ -38,7 +38,7 @@ import {
     DRAFT_NODE_BORDER_WIDTH,
     NODE_GAP_Y,
 } from "../../../resources/constants";
-import { Button, Item, Menu, MenuItem, ThemeColors } from "@wso2/ui-toolkit";
+import { Button, Item, Menu, MenuItem } from "@wso2/ui-toolkit";
 import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
@@ -136,10 +136,10 @@ export namespace NodeStyles {
             props.hasError
                 ? NODE_BORDER_ERROR_COLOR
                 : (props.isSelected || props.selected) && !props.disabled
-                    ? ThemeColors.SECONDARY
+                    ? NODE_BORDER_SELECTED_COLOR
                     : props.hovered && !props.disabled
-                        ? ThemeColors.SECONDARY
-                        : ThemeColors.OUTLINE_VARIANT};
+                        ? NODE_BORDER_SELECTED_COLOR
+                        : NODE_BORDER_COLOR};
         border-radius: 8px;
         background-color: ${(props: NodeStyleProp) =>
             props?.isActiveBreakpoint ? NODE_BG_BREAKPOINT_COLOR : props.hovered && !props.disabled ? NODE_BG_HOVER_COLOR : NODE_BG_COLOR};

--- a/packages/bi-diagram/src/components/nodes/EvalNode/EvalNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/EvalNode/EvalNodeWidget.tsx
@@ -23,6 +23,7 @@ import {
 } from "@wso2/ui-toolkit";
 import { EvalNodeModel } from "./EvalNodeModel";
 import {
+    NODE_BORDER_COLOR, NODE_BORDER_ERROR_COLOR, NODE_BORDER_SELECTED_COLOR,
     NODE_BORDER_WIDTH, NODE_HEIGHT, NODE_PADDING, NODE_WIDTH,
 } from "../../../resources/constants";
 import { MoreVertIcon } from "../../../resources/icons";
@@ -61,10 +62,10 @@ const Box = styled.div<BoxProps>`
     border: ${NODE_BORDER_WIDTH}px solid
         ${(props: BoxProps) =>
         props.hasError
-            ? ThemeColors.ERROR
+            ? NODE_BORDER_ERROR_COLOR
             : props.isSelected || props.hovered
-                ? ThemeColors.SECONDARY
-                : ThemeColors.OUTLINE_VARIANT};
+                ? NODE_BORDER_SELECTED_COLOR
+                : NODE_BORDER_COLOR};
     border-radius: 10px;
     background-color: ${(props: BoxProps) =>
         props.isActiveBreakpoint ? ThemeColors.DEBUGGER_BREAKPOINT_BACKGROUND : ThemeColors.SURFACE_DIM};

--- a/packages/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
@@ -34,7 +34,7 @@ import {
     NODE_TEXT_COLOR,
     NODE_WIDTH,
 } from "../../../resources/constants";
-import { Button, Item, Menu, MenuItem, ThemeColors } from "@wso2/ui-toolkit";
+import { Button, Item, Menu, MenuItem } from "@wso2/ui-toolkit";
 import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
@@ -328,10 +328,10 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                                     : hasError
                                     ? NODE_BORDER_ERROR_COLOR
                                     : isSelected && !disabled
-                                        ? ThemeColors.SECONDARY
+                                        ? NODE_BORDER_SELECTED_COLOR
                                         : (isHovered || isNoteActive) && !disabled && !readOnly
-                                            ? ThemeColors.SECONDARY
-                                            : ThemeColors.OUTLINE_VARIANT
+                                            ? NODE_BORDER_SELECTED_COLOR
+                                            : NODE_BORDER_COLOR
                             }
                             strokeWidth={NODE_BORDER_WIDTH}
                             strokeDasharray={disabled ? "5 5" : getDiffStrokeDasharray(model.node)}

--- a/packages/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
@@ -31,7 +31,7 @@ import {
     NODE_BORDER_WIDTH,
     NODE_HEIGHT,
 } from "../../../resources/constants";
-import { Item, Menu, MenuItem, ThemeColors } from "@wso2/ui-toolkit";
+import { Item, Menu, MenuItem } from "@wso2/ui-toolkit";
 import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
@@ -223,10 +223,10 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                                     : hasError
                                     ? NODE_BORDER_ERROR_COLOR
                                     : isSelected && !disabled
-                                        ? ThemeColors.SECONDARY
+                                        ? NODE_BORDER_SELECTED_COLOR
                                         : isHovered && !disabled && !readOnly
-                                            ? ThemeColors.SECONDARY
-                                            : ThemeColors.OUTLINE_VARIANT
+                                            ? NODE_BORDER_SELECTED_COLOR
+                                            : NODE_BORDER_COLOR
                             }
                             strokeWidth={NODE_BORDER_WIDTH}
                             strokeDasharray={disabled ? "5 5" : getDiffStrokeDasharray(model.node)}

--- a/packages/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
@@ -38,7 +38,7 @@ import {
     CONTAINER_PADDING,
     DRAFT_NODE_BORDER_WIDTH,
 } from "../../../resources/constants";
-import { Button, Item, Menu, MenuItem, ThemeColors } from "@wso2/ui-toolkit";
+import { Button, Item, Menu, MenuItem } from "@wso2/ui-toolkit";
 import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
@@ -149,10 +149,10 @@ export namespace NodeStyles {
             props.hasError
                 ? NODE_BORDER_ERROR_COLOR
                 : (props.isSelected || props.selected) && !props.disabled
-                    ? ThemeColors.SECONDARY
+                    ? NODE_BORDER_SELECTED_COLOR
                     : props.hovered && !props.disabled && !props.readOnly
-                        ? ThemeColors.SECONDARY
-                        : ThemeColors.OUTLINE_VARIANT};
+                        ? NODE_BORDER_SELECTED_COLOR
+                        : NODE_BORDER_COLOR};
         border-radius: 8px;
         background-color: ${(props: NodeStyleProp) =>
             props?.isActiveBreakpoint ? NODE_BG_BREAKPOINT_COLOR : props.hovered && !props.disabled && !props.readOnly ? NODE_BG_HOVER_COLOR : NODE_BG_COLOR};

--- a/packages/bi-diagram/src/test/__snapshots__/Diagram.flowModel.render.test.tsx.snap
+++ b/packages/bi-diagram/src/test/__snapshots__/Diagram.flowModel.render.test.tsx.snap
@@ -988,7 +988,7 @@ exports[`bi-diagram — render + snapshot from a real captured flow model matche
                     opacity="1"
                     rx="5"
                     ry="5"
-                    stroke="var(--vscode-dropdown-border)"
+                    stroke="var(--vscode-foreground)"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"

--- a/packages/bi-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
+++ b/packages/bi-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
+.css-16 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-27 {font-size: 14px; max-width: 81.33333333333333px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium";}
 .css-39 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; gap: 2px; width: 100%; padding: 8px; margin-top: 2px;}
 .css-3 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 0;}
@@ -48,7 +49,6 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
 .css-44:hover [data-agent-name] {opacity: 0.7;}
 .css-44:hover {background-color: transparent;}
 .css-49 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-foreground); cursor: pointer;}
-.css-16 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-15 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
 .css-17 {margin-top: -3px;}
 .css-30 {position: absolute; top: -1px; left: -1px; right: -1px; bottom: -1px; border-radius: 10px; border: 2px solid var(--vscode-terminal-ansiCyan); opacity: 0; -webkit-transition: opacity 0.4s ease-out; transition: opacity 0.4s ease-out; -webkit-animation: animation-1knexeq 1.5s ease-in-out infinite alternate; animation: animation-1knexeq 1.5s ease-in-out infinite alternate; pointer-events: none; z-index: 1;}
@@ -1310,7 +1310,7 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
                     opacity="1"
                     rx="5"
                     ry="5"
-                    stroke="var(--vscode-dropdown-border)"
+                    stroke="var(--vscode-foreground)"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -1650,6 +1650,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
+.css-16 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-36 {font-size: 14px; max-width: 81.33333333333333px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium";}
 .css-69 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; gap: 2px; width: 100%; padding: 8px; margin-top: 2px;}
 .css-3 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 0;}
@@ -1667,6 +1668,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
 .css-75 {margin-bottom: -2px; z-index: 2;}
 .css-90 {display: none; -webkit-animation: animation-1l5m1tj 0.2s ease-out forwards; animation: animation-1l5m1tj 0.2s ease-out forwards; cursor: pointer;}
 .css-78 {height: 24px; width: 24px; cursor: pointer; font-size: 24px; color: var(--vscode-terminal-ansiMagenta);}
+.css-40 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 280px; min-height: 50px; padding: 0 8px; opacity: 1; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 10px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-74 {-webkit-flex: 1; -ms-flex: 1; flex: 1; min-width: 0; color: var(--vscode-foreground); opacity: 0.7; font-family: monospace; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;}
 .css-21 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; position: absolute; padding: 8px; left: 52px; width: max-content;}
 .css-48 {border-radius: 5px; position: absolute; top: -6px; left: 46px;}
@@ -1696,18 +1698,15 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
 .css-73:hover [data-agent-name] {opacity: 0.7;}
 .css-73:hover {background-color: transparent;}
 .css-44 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-foreground); cursor: pointer;}
-.css-16 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-15 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
 .css-17 {margin-top: -3px;}
 .css-60 {position: absolute; top: -1px; left: -1px; right: -1px; bottom: -1px; border-radius: 10px; border: 2px solid var(--vscode-terminal-ansiCyan); opacity: 0; -webkit-transition: opacity 0.4s ease-out; transition: opacity 0.4s ease-out; -webkit-animation: animation-1knexeq 1.5s ease-in-out infinite alternate; animation: animation-1knexeq 1.5s ease-in-out infinite alternate; pointer-events: none; z-index: 1;}
 .css-25 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 280px; min-height: 50px; padding: 0 8px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); opacity: 1; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 10px; cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-82 {position: fixed; width: 230px; height: 208px; top: 2169.6px; left: -245px; border: 2px dashed var(--vscode-foreground); border-radius: 10px; background-color: transparent; z-index: -1; display: flex; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; pointer-events: none;}
 .css-67 {position: absolute; bottom: -5px; right: -5px; display: flex; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; border-radius: 50%;}
-.css-40 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 280px; min-height: 50px; padding: 0 8px; opacity: 1; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 10px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-92 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 20px; height: 20px;}
 .css-5 {position: relative; cursor: move; overflow: unset; height: unset !important;}
 .css-79 {position: fixed; width: 490px; height: 648.6px; top: 1931px; left: -275px; border: 2px dashed var(--vscode-foreground); border-radius: 10px; background-color: transparent; z-index: -1; display: flex; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; pointer-events: none;}
-.css-50 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-46 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; width: 100%; padding: 8px;}
 .css-2 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
 .css-33 {height: 16px; width: 16px; cursor: pointer;}
@@ -1716,6 +1715,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
 .css-22 {font-size: 14px; max-width: 230px; font-family: "GilmerMedium";}
 .css-20 {margin-bottom: -2px;}
 .css-87 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 8px; height: 8px; border: 2px solid var(--vscode-foreground); background-color: var(--vscode-sideBar-background); border-radius: 50%; cursor: not-allowed;}
+.css-50 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-28 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; gap: 2px; -webkit-flex: 1; -ms-flex: 1; flex: 1; min-width: 0; padding: 8px;}
 .css-72 {font-size: 12px; max-width: 200px; overflow: hidden; text-overflow: ellipsis; font-family: monospace; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; color: var(--vscode-foreground); opacity: 0.7; margin-top: -2px;}
 .css-42 {font-size: 12px; width: 100%; min-width: 0; overflow: hidden; text-overflow: ellipsis; font-family: monospace; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; word-break: break-all; color: var(--vscode-foreground); opacity: 0.7;}
@@ -6603,7 +6603,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                     opacity="1"
                     rx="5"
                     ry="5"
-                    stroke="var(--vscode-dropdown-border)"
+                    stroke="var(--vscode-foreground)"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -6903,7 +6903,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                     opacity="1"
                     rx="5"
                     ry="5"
-                    stroke="var(--vscode-dropdown-border)"
+                    stroke="var(--vscode-foreground)"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -8120,7 +8120,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                     opacity="1"
                     rx="5"
                     ry="5"
-                    stroke="var(--vscode-dropdown-border)"
+                    stroke="var(--vscode-foreground)"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -8391,7 +8391,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                     opacity="1"
                     rx="5"
                     ry="5"
-                    stroke="var(--vscode-dropdown-border)"
+                    stroke="var(--vscode-foreground)"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -9132,6 +9132,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
+.css-16 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-27 {font-size: 14px; max-width: 81.33333333333333px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium";}
 .css-3 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 0;}
 .css-3>*:first-child {border-bottom-left-radius: 0; border-bottom-right-radius: 0;}
@@ -9144,6 +9145,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
 .css-54 {font-size: 12px; max-width: 230px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: monospace;}
 .css-50 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; width: 100%; position: absolute; padding: 8px; left: 52px;}
 .css-62 {display: none; -webkit-animation: animation-1l5m1tj 0.2s ease-out forwards; animation: animation-1l5m1tj 0.2s ease-out forwards; cursor: pointer;}
+.css-36 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 280px; min-height: 50px; padding: 0 8px; opacity: 1; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 10px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-21 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; position: absolute; padding: 8px; left: 52px; width: max-content;}
 .css-45 {border-radius: 5px; position: absolute; top: -6px; left: 46px;}
 .css-60 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 8px; height: 8px; border: 2px solid var(--vscode-foreground); background-color: var(--vscode-sideBar-background); border-radius: 50%; cursor: pointer;}
@@ -9164,14 +9166,11 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
 .css-51 {font-size: 14px; max-width: 230px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium";}
 .css-55 {position: fixed; width: 500px; height: 261.6px; top: 1254.2px; left: -185px; border: 2px dashed var(--vscode-foreground); border-radius: 10px; background-color: transparent; z-index: -1; display: flex; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; pointer-events: none;}
 .css-41 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-foreground); cursor: pointer;}
-.css-16 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-15 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
 .css-17 {margin-top: -3px;}
 .css-28 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 280px; min-height: 50px; padding: 0 8px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); opacity: 1; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 10px; cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
-.css-36 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 280px; min-height: 50px; padding: 0 8px; opacity: 1; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 10px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-64 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 20px; height: 20px;}
 .css-5 {position: relative; cursor: move; overflow: unset; height: unset !important;}
-.css-49 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-43 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; width: 100%; padding: 8px;}
 .css-2 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
 .css-52 {border-radius: 5px; -webkit-flex-shrink: 0; -ms-flex-negative: 0; flex-shrink: 0;}
@@ -9179,6 +9178,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
 .css-22 {font-size: 14px; max-width: 230px; font-family: "GilmerMedium";}
 .css-20 {margin-bottom: -2px;}
 .css-59 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 8px; height: 8px; border: 2px solid var(--vscode-foreground); background-color: var(--vscode-sideBar-background); border-radius: 50%; cursor: not-allowed;}
+.css-49 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-31 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; gap: 2px; -webkit-flex: 1; -ms-flex: 1; flex: 1; min-width: 0; padding: 8px;}
 .css-39 {font-size: 12px; width: 100%; min-width: 0; overflow: hidden; text-overflow: ellipsis; font-family: monospace; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; word-break: break-all; color: var(--vscode-foreground); opacity: 0.7;}
 .css-48 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; color: var(--vscode-foreground); cursor: default;}
@@ -11378,7 +11378,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                     opacity="1"
                     rx="5"
                     ry="5"
-                    stroke="var(--vscode-dropdown-border)"
+                    stroke="var(--vscode-foreground)"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -11565,7 +11565,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                     opacity="1"
                     rx="5"
                     ry="5"
-                    stroke="var(--vscode-dropdown-border)"
+                    stroke="var(--vscode-foreground)"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -12439,6 +12439,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with diagnostics correctly: fl
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
+.css-15 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-33 {font-size: 14px; max-width: 81.33333333333333px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium";}
 .css-3 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 0;}
 .css-3>*:first-child {border-bottom-left-radius: 0; border-bottom-right-radius: 0;}
@@ -12458,7 +12459,6 @@ exports[`BI Diagram - Snapshot Tests renders flow with diagnostics correctly: fl
 .css-32 {position: relative; display: inline-block; cursor: default; pointer-events: auto;}
 .css-22 {border-radius: 5px;}
 .css-26 svg {fill: var(--vscode-terminal-ansiMagenta);}
-.css-15 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-14 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
 .css-16 {margin-top: -3px;}
 .css-40 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 20px; height: 20px;}
@@ -13140,6 +13140,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with error handler correctly: 
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
+.css-15 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-26 {font-size: 14px; max-width: 81.33333333333333px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium";}
 .css-3 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 0;}
 .css-3>*:first-child {border-bottom-left-radius: 0; border-bottom-right-radius: 0;}
@@ -13160,7 +13161,6 @@ exports[`BI Diagram - Snapshot Tests renders flow with error handler correctly: 
 .css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default; position: relative;}
 .css-25 {position: relative; display: inline-block; cursor: default; pointer-events: auto;}
 .css-22 {border-radius: 5px;}
-.css-15 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-14 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
 .css-16 {margin-top: -3px;}
 .css-34 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 20px; height: 20px;}
@@ -13650,6 +13650,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with suggestions correctly: fl
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
+.css-15 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-foreground); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-26 {font-size: 14px; max-width: 81.33333333333333px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium";}
 .css-3 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 0;}
 .css-3>*:first-child {border-bottom-left-radius: 0; border-bottom-right-radius: 0;}
@@ -13669,7 +13670,6 @@ exports[`BI Diagram - Snapshot Tests renders flow with suggestions correctly: fl
 .css-25 {position: relative; display: inline-block; cursor: default; pointer-events: auto;}
 .css-22 {border-radius: 5px;}
 .css-29 svg {fill: var(--vscode-terminal-ansiMagenta);}
-.css-15 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-14 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
 .css-16 {margin-top: -3px;}
 .css-40 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 20px; height: 20px;}

--- a/packages/bi-diagram/src/utils/node.ts
+++ b/packages/bi-diagram/src/utils/node.ts
@@ -28,7 +28,23 @@ import {
 } from "../resources/constants";
 import { Branch, FlowNode, FlowNodeDiffState } from "./types";
 
-const WORKFLOW_NODE_KINDS = new Set(["WORKFLOW_RUN", "ACTIVITY_CALL", "SEND_DATA", "WAIT_DATA", "HUMAN_TASK"]);
+// Workflow statements carry the heavier border so they read as a distinct layer from the plain
+// statements around them. The dedicated widgets (activity call, send, wait) draw that border
+// unconditionally; the kinds listed here are the ones that reach a general-purpose widget
+// (the base node, the call box) and have to ask for it.
+const WORKFLOW_NODE_KINDS = new Set([
+    "WORKFLOW_RUN",
+    "CHILD_WORKFLOW_RUN",
+    "CHILD_WORKFLOW_CALL",
+    "CHILD_WORKFLOW_SEND_DATA",
+    "CHILD_WORKFLOW_WAIT",
+    "ACTIVITY_CALL",
+    "CONNECTION_ACTIVITY_CALL",
+    "SEND_DATA",
+    "WAIT_DATA",
+    "UPDATE_DATA",
+    "HUMAN_TASK",
+]);
 
 // Durable-agentic-workflow register/add statements: rendered without the module prefix and
 // with the registered name (metadata.description) as the node's second line.


### PR DESCRIPTION
## Purpose

<img width="844" height="671" alt="image" src="https://github.com/user-attachments/assets/38c759bc-5ebc-424a-8fcb-c8ce9691a76f" />

Fixes: https://github.com/wso2/product-integrator/issues/2224
Some nodes in the flow diagram render with no visible border while the nodes around them have one.

Two families of border styling had drifted apart:

- Most widgets rest on `NODE_BORDER_COLOR` = `ThemeColors.ON_SURFACE` → `var(--vscode-foreground)`, a strong, high-contrast line.
- Seven widgets rest on `ThemeColors.OUTLINE_VARIANT` → `var(--vscode-dropdown-border)`, a faint hairline that is very low contrast in most themes and undefined in some — so those nodes read as border-less.

The split ran through the selected/hovered colour too: the faint family highlighted in `ThemeColors.SECONDARY`, the rest in `NODE_BORDER_SELECTED_COLOR` (`ThemeColors.PRIMARY`), so an if node and the node beside it highlighted in different colours.

Separately, `isWorkflowNode` — which grants workflow statements the heavier `HIGHLIGHT_NODE_BORDER_WIDTH` — was effectively dead. Every kind in `WORKFLOW_NODE_KINDS` is routed by `NodeFactoryVisitor` to a *dedicated* widget, never to `BaseNodeWidget` where the check lived. A `WORKFLOW_RUN` drawn as a call box took the plain 1.8px border while the activity call and send node next to it took 2.4px.

## Goals
Every node body draws its border from one set of tokens, and the workflow border actually applies to the workflow statements it was written for.

## Approach
**Colour** — pointed the seven outliers at the shared `NODE_BORDER_COLOR` / `NODE_BORDER_SELECTED_COLOR` / `NODE_BORDER_ERROR_COLOR` tokens:

| Widget | |
|---|---|
| `ApiCallNodeWidget` | calls, resource actions, `WORKFLOW_RUN`, `CHILD_WORKFLOW_RUN`/`CALL` |
| `WhileNodeWidget` | while / foreach / lock |
| `ErrorNodeWidget` | error handler |
| `IfNodeWidget`, `MatchNodeWidget` | the diamond's SVG `stroke` |
| `AgentNodeWidget` | agent |
| `EvalNodeWidget` | eval |

**Width** — gave `ApiCallNodeWidget` the same `isWorkflowNode` gate `BaseNodeWidget` has, so `WORKFLOW_RUN` / `CHILD_WORKFLOW_RUN` / `CHILD_WORKFLOW_CALL` take the workflow border while plain remote and resource calls keep the normal one. Extended `WORKFLOW_NODE_KINDS` with the child-workflow and `UPDATE_DATA` kinds that land on a general-purpose widget, and documented what the set is for.

Also dropped five now-unused `ThemeColors` imports.

**Left alone deliberately**
- `CommentNode` (border matches its own background until hover), `EndNode` (filled circle), `EmptyNode` (transparent add-point), `ButtonNode` (Accept/Discard popup) — border-less by design, not part of the node-body language.
- The agent's model/tool circles keep `OUTLINE_VARIANT`; they are sub-elements meant to read as subordinate to the agent box.
- The `DURABLE_AGENT_*` kinds. `DURABLE_AGENT_RUN` and the non-waiting result reads still draw the normal border while their waiting siblings draw the heavier one via `WaitDataNode`. Whether durable-agent statements belong in the workflow layer is a design call, not a bug, so this PR does not make it.

## UI Component Development
- [x] Added reusable UI components to the ui-toolkit — N/A, no new components; this consolidates existing style tokens inside `bi-diagram`.
- [x] Use ui-toolkit components wherever possible — unchanged.
- [x] Matches with the native VSCode look and feel — the unified border uses `--vscode-foreground`, the same theme variable the majority of nodes already used.

## User stories
As a developer reading a flow diagram, every node has the same visible outline, so no node looks unfinished or disabled next to its neighbours.

## Release note
Fixed flow diagram nodes — calls, loops, error handlers, if/match, agents and evals — rendering without a visible border in most VS Code themes.

## Documentation
N/A — visual consistency fix with no behavioural or API change.

## Training
N/A

## Certification
N/A — no functional change to certify.

## Marketing
N/A

## Automation tests
- Unit tests

  `packages/bi-diagram` suite: **85/85 passing, 9/9 suites**. `tsc --noEmit -p tsconfig.spec.json` clean.

  7 render snapshots updated. Every changed line in the snapshot diff was exactly `var(--vscode-dropdown-border)` → `var(--vscode-foreground)` — no layout, sizing, or structural change, which also confirms the diagnosis.

  Coverage gap worth noting: the test fixtures contain no workflow nodes, so the `isWorkflowNode` width change is not exercised by the snapshots. It is worth an eyeball on a real workflow diagram before merge.
- Integration tests

  N/A — no integration surface touched.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React only, no Java changes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
macOS (darwin 25.5.0), Node via the repo's rush/pnpm toolchain, Jest + jsdom.

## Learning
The faint colour is `var(--vscode-dropdown-border)`. In themes that do not define it, the `var()` has no fallback, so a CSS `border-color` declaration is dropped and the SVG `stroke` presentation attribute paints nothing — the node loses its border entirely rather than merely dimming. Routing every node body through one token removes that failure mode from all of them at once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Standardized node border colors across API call, loop, error, conditional, agent, and eval nodes with shared `NODE_BORDER_*` tokens.
- Applied workflow-specific border width and color to `ApiCallNodeWidget`.
- Expanded `WORKFLOW_NODE_KINDS` for additional workflow node types.
- Removed unused `ThemeColors` imports.
- Updated seven render snapshots. Tests and TypeScript checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->