### PR TITLE
Classify Try It services by module prefix

### DIFF
--- a/packages/ballerina-extension/src/features/tryit/activator.ts
+++ b/packages/ballerina-extension/src/features/tryit/activator.ts
@@ -35,6 +35,7 @@ import { getCurrentProjectRoot } from "../../utils/project-utils";
 import { requiresPackageSelection, selectIntegrationOrPrompt } from "../../utils/command-utils";
 import { VisualizerWebview } from "../../views/visualizer/webview";
 import { TracerMachine } from "../tracing";
+import { resolveServiceType, ServiceType } from "./service-type";
 
 // File constants
 const FILE_NAMES = {
@@ -416,29 +417,6 @@ async function findServiceForResource(services: ServiceInfo[], resourceMetadata:
     }
 }
 
-// The design model reports service types as module-qualified names (e.g. 'mcp:StreamableHttpService'),
-// so the module prefix is what identifies the kind. A substring match on the type name would classify
-// MCP services as HTTP, since 'StreamableHttpService' contains 'Http'.
-function resolveServiceType(type: string): ServiceType | undefined {
-    // The design model omits the type for services whose listener could not be resolved.
-    if (!type) {
-        return undefined;
-    }
-
-    switch (type.split(':')[0].trim().toLowerCase()) {
-        case 'http':
-            return ServiceType.HTTP;
-        case 'graphql':
-            return ServiceType.GRAPHQL;
-        case 'mcp':
-            return ServiceType.MCP;
-        case 'ai':
-            return ServiceType.AGENT;
-        default:
-            return undefined;
-    }
-}
-
 async function getAvailableServices(projectDir: string): Promise<ServiceInfo[] | null> {
     try {
         const langClient = StateMachine.langClient();
@@ -455,7 +433,7 @@ async function getAvailableServices(projectDir: string): Promise<ServiceInfo[] |
                 const trimmedPath = absolutePath.trim();
                 const name = displayName || (trimmedPath.startsWith('/') ? trimmedPath.substring(1) : trimmedPath);
 
-                const serviceType = resolveServiceType(type);
+                const serviceType = resolveServiceType(type)!;
 
                 const listener = {
                     name: attachedListeners
@@ -1086,13 +1064,6 @@ function disposeErrorWatcher() {
 }
 
 // Service information interface
-enum ServiceType {
-    HTTP = 'HTTP',
-    AGENT = 'AI Agent',
-    GRAPHQL = 'GraphQL',
-    MCP = 'MCP'
-}
-
 interface ServiceInfo {
     name?: string;
     basePath: string;

--- a/packages/ballerina-extension/src/features/tryit/activator.ts
+++ b/packages/ballerina-extension/src/features/tryit/activator.ts
@@ -416,6 +416,29 @@ async function findServiceForResource(services: ServiceInfo[], resourceMetadata:
     }
 }
 
+// The design model reports service types as module-qualified names (e.g. 'mcp:StreamableHttpService'),
+// so the module prefix is what identifies the kind. A substring match on the type name would classify
+// MCP services as HTTP, since 'StreamableHttpService' contains 'Http'.
+function resolveServiceType(type: string): ServiceType | undefined {
+    // The design model omits the type for services whose listener could not be resolved.
+    if (!type) {
+        return undefined;
+    }
+
+    switch (type.split(':')[0].trim().toLowerCase()) {
+        case 'http':
+            return ServiceType.HTTP;
+        case 'graphql':
+            return ServiceType.GRAPHQL;
+        case 'mcp':
+            return ServiceType.MCP;
+        case 'ai':
+            return ServiceType.AGENT;
+        default:
+            return undefined;
+    }
+}
+
 async function getAvailableServices(projectDir: string): Promise<ServiceInfo[] | null> {
     try {
         const langClient = StateMachine.langClient();
@@ -427,25 +450,12 @@ async function getAvailableServices(projectDir: string): Promise<ServiceInfo[] |
         });
 
         const services = response.designModel.services
-            .filter(({ type }) => {
-                const lowerType = type.toLowerCase();
-                return lowerType.includes('http') || lowerType.includes('ai') || lowerType.includes('graphql') || lowerType.includes('mcp');
-            })
+            .filter(({ type }) => resolveServiceType(type) !== undefined)
             .map(({ displayName, absolutePath, location, attachedListeners, type }) => {
                 const trimmedPath = absolutePath.trim();
                 const name = displayName || (trimmedPath.startsWith('/') ? trimmedPath.substring(1) : trimmedPath);
 
-                let serviceType: ServiceType;
-                const lowerType = type.toLowerCase();
-                if (lowerType.includes('http')) {
-                    serviceType = ServiceType.HTTP;
-                } else if (lowerType.includes('graphql')) {
-                    serviceType = ServiceType.GRAPHQL;
-                } else if (lowerType.includes('mcp')) {
-                    serviceType = ServiceType.MCP;
-                } else {
-                    serviceType = ServiceType.AGENT;
-                }
+                const serviceType = resolveServiceType(type);
 
                 const listener = {
                     name: attachedListeners

--- a/packages/ballerina-extension/src/features/tryit/service-type.ts
+++ b/packages/ballerina-extension/src/features/tryit/service-type.ts
@@ -24,14 +24,14 @@ export enum ServiceType {
 }
 
 // Match the module prefix, not a substring of the whole name: 'mcp:StreamableHttpService'
-// contains 'Http'. trim() because the anonymous-listener path builds the type from source
-// code and can carry the listener's indentation.
+// contains 'Http'. The anonymous-listener path builds the type from source code, so the
+// prefix arrives with the listener's leading trivia attached, comments included.
 export function resolveServiceType(type: string): ServiceType | undefined {
     if (!type) {
         return undefined;
     }
 
-    switch (type.split(':')[0].trim().toLowerCase()) {
+    switch (type.replace(/\/\/[^\n]*/g, '').split(':')[0].trim().toLowerCase()) {
         case 'http':
             return ServiceType.HTTP;
         case 'graphql':

--- a/packages/ballerina-extension/src/features/tryit/service-type.ts
+++ b/packages/ballerina-extension/src/features/tryit/service-type.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export enum ServiceType {
+    HTTP = 'HTTP',
+    AGENT = 'AI Agent',
+    GRAPHQL = 'GraphQL',
+    MCP = 'MCP'
+}
+
+// Match the module prefix, not a substring of the whole name: 'mcp:StreamableHttpService'
+// contains 'Http'. trim() because the anonymous-listener path builds the type from source
+// code and can carry the listener's indentation.
+export function resolveServiceType(type: string): ServiceType | undefined {
+    if (!type) {
+        return undefined;
+    }
+
+    switch (type.split(':')[0].trim().toLowerCase()) {
+        case 'http':
+            return ServiceType.HTTP;
+        case 'graphql':
+            return ServiceType.GRAPHQL;
+        case 'mcp':
+            return ServiceType.MCP;
+        case 'ai':
+            return ServiceType.AGENT;
+        default:
+            return undefined;
+    }
+}

--- a/packages/ballerina-extension/src/test-support/tryitServiceType.test.ts
+++ b/packages/ballerina-extension/src/test-support/tryitServiceType.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Every type string below was observed on the design model response from the language
+ * server jar this extension bundles.
+ */
+
+import { resolveServiceType, ServiceType } from '../features/tryit/service-type';
+
+describe('resolveServiceType', () => {
+    it.each([
+        ['http:Service', ServiceType.HTTP],
+        ['graphql:Service', ServiceType.GRAPHQL],
+        ['ai:Service', ServiceType.AGENT],
+        ['mcp:Service', ServiceType.MCP],
+        ['mcp:StreamableHttpService', ServiceType.MCP],
+    ])('%s resolves to %s', (type, expected) => {
+        expect(resolveServiceType(type)).toBe(expected);
+    });
+
+    it.each([
+        ['an unsupported module', 'tcp:Service'],
+        ['a same-package type, which carries no module prefix', 'MyService'],
+        ['a missing type, omitted for an unresolved listener', undefined],
+        ['an empty type', ''],
+    ])('excludes %s', (_case, type) => {
+        expect(resolveServiceType(type as string)).toBeUndefined();
+    });
+
+    it('tolerates the indentation the anonymous-listener path carries', () => {
+        expect(resolveServiceType('        http:Service')).toBe(ServiceType.HTTP);
+    });
+});

--- a/packages/ballerina-extension/src/test-support/tryitServiceType.test.ts
+++ b/packages/ballerina-extension/src/test-support/tryitServiceType.test.ts
@@ -45,7 +45,15 @@ describe('resolveServiceType', () => {
         expect(resolveServiceType(type as string)).toBeUndefined();
     });
 
-    it('tolerates the indentation the anonymous-listener path carries', () => {
-        expect(resolveServiceType('        http:Service')).toBe(ServiceType.HTTP);
+    // The anonymous-listener path builds the type from the listener's source code, so
+    // whatever trivia precedes the type descriptor rides along:
+    //   service /x on new
+    //           // a standalone comment
+    //           http:Listener(9201)
+    it.each([
+        ['indentation', '        http:Service'],
+        ['a standalone comment line', '        // a standalone comment\n        http:Service'],
+    ])('sees past %s', (_case, type) => {
+        expect(resolveServiceType(type)).toBe(ServiceType.HTTP);
     });
 });


### PR DESCRIPTION
## Purpose
Try It classified services by substring-matching the design model's type name, checking `http` before `mcp`. A streamable-HTTP MCP service is reported as `mcp:StreamableHttpService`, which contains `Http`, so it was classified as HTTP and routed through `getOpenAPIDefinition`. The OpenAPI tool correctly returns no content for an MCP service, so the empty-match guard threw "No service matches the base path" and the MCP Inspector was never opened.

The design model always reports module-qualified type names, in both generator paths: the explicit service type descriptor, and the fallback that builds `<listener module>:Service`. This PR updates the logic to match on that module prefix instead. Verified against the bundled language server jar that `http:Service`, `graphql:Service`, `ai:Service`, `mcp:Service` and `mcp:StreamableHttpService` all resolve as expected, with only the last changing behaviour.

Manually tested "Try It" for the 4 service types as well.

Fixes https://github.com/wso2/product-integrator/issues/2177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Try It service classification to use the module prefix from the service type.
- Added shared `ServiceType` and `resolveServiceType` logic.
- Added unit tests for supported, unsupported, and comment-prefixed service types.
- Correctly routes `mcp:StreamableHttpService` to the MCP Inspector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->