### PR TITLE
Allow configuring the init method of a service class

### DIFF
--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/scenario.md
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/scenario.md
@@ -1,0 +1,65 @@
+Configuring the `init` method of a Service Class from the service class designer.
+
+Create an integration project, add a Type artifact and create a Service Class.
+Open the created service class for editing — the designer must render the
+generated `init` method as a FunctionCard under its own **Constructor** section
+(kind badge `INIT`), not as the old read-only "Constructor: init" link. Click the
+card's edit action; it opens the Service Function form, whose model carries the
+init guards (name not editable, return type disabled) and the parameter schema.
+Add a parameter through the Parameters param-manager, save, and confirm the new
+parameter reached `types.bal` and survives reopening the form.
+
+## Steps
+
+| # | Action | Verification |
+|---|--------|-------------|
+| 1 | Create project/integration and open the Type Editor | "Add Type" button visible |
+| 2 | Add Type → Kind "Service Class", name `Greeter`, Save | `data-testid="type-node-Greeter"` present |
+| 3 | Open the `Greeter` node menu → Edit | Service class designer open ("Method"/"Variable" buttons visible) |
+| 4 | Inspect the Constructor section | "Constructor" heading, `INIT` badge, `edit-method-button-init` present |
+| 5 | Click `edit-method-button-init` | Service Function form opens; name field reads `init` and is not editable |
+| 6 | Add Parameter: type `string`, name `greeting` → Add | `greeting-item` param row rendered |
+| 7 | Save the form | Back on the service class designer, Constructor card still present |
+| 8 | Verify persistence | `types.bal` declares `function init(string greeting)` |
+
+## Gaps
+
+- The New Type panel can come up on the **Import** tab, where the Kind dropdown
+  `createType()` fills does not exist (`waitForTypeEditor()`'s
+  `type-editor-container` is present on both tabs, so it does not discriminate).
+  The tab buttons carry no `data-testid` — `create-from-scratch-tab` is the id of
+  the content they reveal. Click the tab by its accessible name and wait for that
+  container. Switching tabs resets the form, so click before filling.
+- `init` renders as a FunctionCard with `edit-method-button-init` /
+  `delete-method-button-init` and an uppercased `INIT` kind badge, inside a
+  "Constructor" section above Class Variables. It is not duplicated under Methods.
+- The card's edit action opens the **Service Function** form, and the init guards
+  hold there: the Function Name field is `init` and `readonly`, and no Return Type
+  field is rendered at all (`getByRole('textbox', {name: /Return Type/})` → 0).
+- ParamManager's add affordance is a `LinkButton` (a div with `i.codicon-add`),
+  not a `<button>` — `getByRole('button', {name: 'Add Parameter'})` never matches.
+- The Parameter Type field is a `FormExpressionEditor` with **no** `data-testid`.
+  It exposes its label through `arialabel` on the `vscode-text-area` host, and the
+  editable node is that host's shadow-DOM `textarea`:
+  `vscode-text-area[arialabel="Parameter Type"] textarea` (the same convention
+  `TypeEditorUtils.waitForTextbox()` already uses). Typing opens the
+  `add-type-completion` popup — dismiss it with Escape.
+- The param editor's **Add** button stays disabled until the typed values
+  validate. A `click({force: true})` before then silently no-ops and leaves the
+  editor open, so the row never appears — wait for it to be enabled first.
+- `ParamItem`'s testid is `<key>-item`, and a new param's key is `""` while it is
+  being edited; it becomes the parameter name only after Add. So `greeting-item`
+  is a valid post-condition for the save, not for the edit.
+
+## Local harness notes (macOS)
+
+- `playwright-vscode-tester` hard-codes the VS Code executable at
+  `Contents/MacOS/Electron`. VS Code renamed it to `Code` in recent versions, so a
+  `latest` download (the authoring daemon's default) cannot be launched at all.
+  The committed suite pins `1.125.1`; run the daemon the same way:
+  `BI_E2E_VSCODE_VERSION=1.125.1 node .../scripts/daemon.mjs <name>`.
+- The launcher writes no `update.mode`, so the test VS Code auto-updates itself
+  and replaces the bundle mid-session — after which every later launch fails with
+  `Contents/MacOS/Electron: No such file or directory`. Recovery: delete
+  `e2e-test/test-resources/Visual Studio Code.app` (and `stable.zip`) and let the
+  pinned version download again.

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/01_project.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/01_project.step.js
@@ -1,0 +1,9 @@
+{
+  const state = await createProjectAndIntegration('ServiceClassInit');
+  fs.writeFileSync(path.join(sessionDir, 'state.json'), JSON.stringify(state, null, 2));
+
+  await navigateToIntegrationOverview(state.integrationName);
+  await addArtifact('Type', 'type');
+  await waitForText('Add Type', 30000);
+  console.log(`project ready: ${state.projectName} — Type Editor open`);
+}

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/02_create_service_class.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/02_create_service_class.step.js
@@ -1,0 +1,34 @@
+{
+  const frame = await getBIWebview();
+
+  const addTypeBtn = frame.getByRole('button', { name: 'Add Type' });
+  await addTypeBtn.waitFor({ timeout: 60000 });
+  await addTypeBtn.click({ force: true });
+  console.log('clicked Add Type');
+
+  // The New Type panel can come up on the Import tab; select "Create from
+  // scratch" explicitly (it resets the form, so click before filling).
+  // (the tab button carries no testid; `create-from-scratch-tab` is its content container)
+  const scratchTab = frame.getByRole('button', { name: /Create from scratch/ }).first();
+  await scratchTab.waitFor({ state: 'visible', timeout: 30000 });
+  await scratchTab.click({ force: true });
+  await frame.locator('[data-testid="create-from-scratch-tab"]').waitFor({ state: 'visible', timeout: 30000 });
+  await window.waitForTimeout(1000);
+
+  const form = new Form(window, BI_INTEGRATOR_LABEL, frame);
+  await form.switchToFormView(false, frame);
+  await form.fill({
+    values: {
+      'Name': { type: 'input', value: 'Greeter' },
+      'Kind': { type: 'dropdown', value: 'Service Class' },
+    },
+  });
+  console.log('filled Name=Greeter Kind=Service Class');
+
+  await form.submit('Save', true);
+  await window.waitForTimeout(2000);
+
+  const node = frame.locator('[data-testid="type-node-Greeter"]');
+  await node.waitFor({ timeout: 60000 });
+  console.log('type-node-Greeter visible in diagram');
+}

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/03_open_designer.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/03_open_designer.step.js
@@ -1,0 +1,22 @@
+{
+  const frame = await getBIWebview();
+
+  // Open the node's three-dot menu and click Edit. The popover can close on its
+  // own while the diagram re-renders, so drive open+click as one retryable unit.
+  const menuButton = frame.locator('[data-testid="type-node-Greeter-menu"]');
+  const menuItem = frame.locator('#menu-item-edit');
+  const methodButton = frame.getByRole('button', { name: ' Method' });
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    await menuButton.waitFor({ state: 'visible', timeout: 30000 });
+    const icon = menuButton.getByRole('img');
+    const target = (await icon.count()) > 0 ? icon.first() : menuButton;
+    await target.click({ force: true });
+    const clicked = await menuItem.waitFor({ state: 'visible', timeout: 5000 })
+      .then(() => menuItem.click({ force: true, timeout: 5000 })).then(() => true).catch(() => false);
+    if (clicked && await methodButton.waitFor({ state: 'visible', timeout: 30000 }).then(() => true).catch(() => false)) break;
+    await window.waitForTimeout(1000);
+  }
+  await methodButton.waitFor({ state: 'visible', timeout: 30000 });
+  console.log('service class designer open');
+}

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/04_open_init_form.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/04_open_init_form.step.js
@@ -1,0 +1,21 @@
+{
+  const frame = await getBIWebview();
+
+  // PR #953: init is rendered as a FunctionCard under its own "Constructor"
+  // section instead of the old read-only "Constructor: init" link.
+  const constructorHeading = frame.getByText('Constructor', { exact: true });
+  await constructorHeading.waitFor({ state: 'visible', timeout: 30000 });
+  console.log('Constructor section heading present');
+
+  const editInit = frame.locator('[data-testid="edit-method-button-init"]');
+  await editInit.waitFor({ state: 'visible', timeout: 30000 });
+  console.log('edit-method-button-init present');
+
+  await editInit.locator('i').click({ force: true });
+  console.log('clicked init edit action');
+
+  // The card's edit action opens the Service Function form.
+  const functionName = frame.getByRole('textbox', { name: /Function Name/ }).first();
+  await functionName.waitFor({ state: 'visible', timeout: 30000 });
+  console.log('Service Function form open');
+}

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/05_add_init_parameter.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/05_add_init_parameter.step.js
@@ -1,0 +1,50 @@
+{
+  const frame = await getBIWebview();
+
+  // The init guards come from getFunctionFromSource: the name is fixed and the
+  // return type field is not rendered at all.
+  const nameField = frame.getByRole('textbox', { name: /Function Name/ }).first();
+  if ((await nameField.inputValue()) !== 'init') throw new Error('function name is not init');
+  if ((await nameField.getAttribute('readonly')) === null) throw new Error('init name field is editable');
+  if ((await frame.getByRole('textbox', { name: /Return Type/ }).count()) !== 0) {
+    throw new Error('return type field is rendered for init');
+  }
+  console.log('init guards hold: name=init readonly, no return type field');
+
+  // ParamManager's add affordance is a LinkButton, not a <button>.
+  const addParam = frame.locator('div:has(i.codicon-add) >> text=Add Parameter').first();
+  await addParam.waitFor({ state: 'visible', timeout: 30000 });
+  await addParam.click({ force: true });
+  console.log('clicked Add Parameter');
+
+  // FormExpressionEditor exposes its label through `arialabel` on the
+  // vscode-text-area host; the editable node is the shadow-DOM textarea.
+  const typeField = frame.locator('vscode-text-area[arialabel="Parameter Type"] textarea').first();
+  await typeField.waitFor({ state: 'visible', timeout: 30000 });
+  await typeField.click({ force: true });
+  await typeField.fill('string');
+  await window.waitForTimeout(2000);
+  const completion = frame.getByTestId('add-type-completion');
+  if (await completion.isVisible().catch(() => false)) {
+    await typeField.press('Escape');
+  }
+  console.log('filled Parameter Type = string');
+
+  const paramName = frame.getByRole('textbox', { name: /Parameter Name/ }).first();
+  await paramName.fill('greeting');
+  console.log('filled Parameter Name = greeting');
+
+  // Add stays disabled until the form validates the typed values; a force
+  // click before then silently no-ops and leaves the editor open.
+  const addButton = frame.getByRole('button', { name: 'Add', exact: true });
+  await addButton.waitFor({ state: 'visible', timeout: 15000 });
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline && await addButton.isDisabled().catch(() => true)) {
+    await window.waitForTimeout(500);
+  }
+  await addButton.click({ force: true });
+
+  const paramRow = frame.getByTestId('greeting-item');
+  await paramRow.waitFor({ state: 'visible', timeout: 30000 });
+  console.log('greeting-item param row rendered');
+}

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/06_save_and_verify.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/service-class-init-config/steps/06_save_and_verify.step.js
@@ -1,0 +1,20 @@
+{
+  const frame = await getBIWebview();
+
+  const saveButton = frame.getByRole('button', { name: 'Save', exact: true });
+  await saveButton.waitFor({ state: 'visible', timeout: 15000 });
+  await saveButton.click({ force: true });
+  console.log('clicked Save on the Service Function form');
+
+  // Saving returns to the service class designer; the Constructor card stays.
+  const editInit = frame.locator('[data-testid="edit-method-button-init"]');
+  await editInit.waitFor({ state: 'visible', timeout: 60000 });
+  console.log('back on the service class designer, Constructor card present');
+
+  const source = await waitForTypesBalContent((s) => /function init\s*\(\s*string greeting/.test(s), 60000);
+  console.log('types.bal:\n' + source);
+  if (!/function init\s*\(\s*string greeting/.test(source)) {
+    throw new Error('init parameter was not written to types.bal');
+  }
+  console.log('types.bal declares function init(string greeting)');
+}

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/test.list.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/test.list.ts
@@ -72,6 +72,7 @@ import configuration from './configuration/configuration.spec';
 import typeTest from './type-editor/type.spec';
 import typeExplorerNavigationTest from './type-editor/type-explorer-navigation.spec';
 import serviceClassEditingTest from './type-editor/service-class-editing.spec';
+import serviceClassInitTest from './type-editor/service-class-init-config.spec';
 
 import importIntegration from './import-integration/import-integration.spec';
 
@@ -198,6 +199,7 @@ test.describe('Ballerina E2E Group 4', { tag: '@group4' }, async () => {
     test.describe(typeTest);
     test.describe(typeExplorerNavigationTest);
     test.describe(serviceClassEditingTest);
+    test.describe(serviceClassInitTest);
 
     // <----Data Mapper Test---->
     test.describe.skip(inlineDataMapper); // Failing due to a issue

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/TypeEditorUtils.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/TypeEditorUtils.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Frame, Locator, Page } from '@playwright/test';
+import { expect, Frame, Locator, Page } from '@playwright/test';
 import { Form, switchToIFrame } from '@wso2/playwright-vscode-tester';
 import { BI_INTEGRATOR_LABEL } from '../utils/helpers';
 
@@ -405,6 +405,65 @@ export class TypeEditorUtils {
         await this.openTypeNodeMenuItem(name, 'edit', () =>
             methodButton.waitFor({ state: 'visible', timeout: 30000 })
                 .then(() => true).catch(() => false));
+    }
+
+    /**
+     * Select the "Create from scratch" tab in the New Type panel. The panel has
+     * been observed to come up on the Import tab, where the Kind dropdown
+     * createType() fills does not exist. Clicking the tab resets the form, so
+     * call this before filling anything.
+     */
+    async openCreateFromScratchTab(): Promise<void> {
+        // The tab button carries no testid; `create-from-scratch-tab` is the id
+        // of the content it reveals, which is what confirms the switch landed.
+        const tabButton = this.webView.getByRole('button', { name: /Create from scratch/ }).first();
+        await this.waitForElement(tabButton, 30000);
+        await tabButton.click({ force: true });
+        await this.waitForElement(this.webView.locator('[data-testid="create-from-scratch-tab"]'), 30000);
+    }
+
+    /**
+     * Open the Service Function form for a service class's `init` method from
+     * the designer's Constructor section. `init` is configured there rather
+     * than through the inline OperationForm, so this waits on the form's own
+     * (non-editable) name field as the post-condition.
+     */
+    async openInitFunctionForm(): Promise<void> {
+        const editInit = this.webView.getByTestId('edit-method-button-init');
+        await this.waitForElement(editInit, 30000);
+        await editInit.locator('i').click({ force: true });
+        await this.waitForElement(this.webView.getByRole('textbox', { name: /Function Name/ }).first(), 30000);
+    }
+
+    /**
+     * Add a parameter through the Service Function form's param manager.
+     */
+    async addFunctionParameter(name: string, type: string): Promise<void> {
+        // ParamManager's add affordance is a LinkButton, not a <button>.
+        const addParam = this.webView.locator('div:has(i.codicon-add) >> text=Add Parameter').first();
+        await this.waitForElement(addParam, 30000);
+        await addParam.click({ force: true });
+
+        // FormExpressionEditor exposes its label through `arialabel` on the
+        // vscode-text-area host; the editable node is its shadow-DOM textarea.
+        const typeField = this.webView.locator('vscode-text-area[arialabel="Parameter Type"] textarea').first();
+        await this.waitForElement(typeField, 30000);
+        await typeField.click({ force: true });
+        await typeField.fill(type);
+        await this.handleTypeCompletion(typeField);
+
+        const nameField = this.webView.getByRole('textbox', { name: /Parameter Name/ }).first();
+        await nameField.fill(name);
+
+        // Add stays disabled until the typed values validate; a force click
+        // before then silently no-ops and leaves the param editor open.
+        const addButton = this.webView.getByRole('button', { name: 'Add', exact: true });
+        await this.waitForElement(addButton, 15000);
+        await expect(addButton).toBeEnabled({ timeout: 30000 });
+        await addButton.click({ force: true });
+
+        // ParamItem takes the saved parameter's name as its testid prefix.
+        await this.waitForElement(this.webView.getByTestId(`${name}-item`), 30000);
     }
 
     /**

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/service-class-init-config.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/service-class-init-config.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { expect, test } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { addArtifact, BI_INTEGRATOR_LABEL, getWebview, initTest, logStep, newProjectPath, page } from '../utils/helpers';
+import { TypeEditorUtils } from './TypeEditorUtils';
+
+export default function createTests() {
+    test.describe.serial('Type Editor Service Class Init Tests', {
+    }, async () => {
+        initTest();
+
+        test('Configure the init method of a Service Class', async ({ }, testInfo) => {
+            const testAttempt = testInfo.retry + 1;
+            console.log('Configuring a Service Class init method in test attempt: ', testAttempt);
+
+            const serviceClassName = `InitService${testAttempt}`;
+
+            logStep('Open the Type Editor');
+            await addArtifact('Type', 'type');
+            await page.page.waitForLoadState('networkidle');
+
+            const artifactWebView = await getWebview(BI_INTEGRATOR_LABEL, page);
+            const typeUtils = new TypeEditorUtils(page.page, artifactWebView);
+            await typeUtils.waitForTypeEditor();
+
+            logStep(`Create the ${serviceClassName} service class`);
+            await typeUtils.openCreateFromScratchTab();
+            const form = await typeUtils.createType(serviceClassName, 'Service Class');
+            await typeUtils.saveAndWait(form);
+            await typeUtils.verifyTypeNodeExists(serviceClassName);
+
+            logStep('Open the service class designer');
+            await typeUtils.openServiceClassForEditing(serviceClassName);
+
+            // The generated `init` is rendered as a FunctionCard in its own
+            // Constructor section (kind badge uppercased), not as the old
+            // read-only "Constructor: init" link.
+            logStep('Verify the Constructor section renders the init function card');
+            await expect(artifactWebView.getByText('Constructor', { exact: true })).toBeVisible({ timeout: 30000 });
+            await expect(artifactWebView.getByText('INIT', { exact: true })).toBeVisible();
+            await expect(artifactWebView.getByTestId('edit-method-button-init')).toBeVisible();
+
+            logStep('Open the init function form');
+            await typeUtils.openInitFunctionForm();
+
+            // The card's edit action opens ServiceFunctionForm, whose
+            // getFunctionFromSource model carries the init guards: the name is
+            // fixed and the return type field is not rendered at all.
+            const functionName = artifactWebView.getByRole('textbox', { name: /Function Name/ }).first();
+            await expect(functionName).toHaveValue('init');
+            await expect(functionName).toHaveAttribute('readonly', '');
+            await expect(artifactWebView.getByRole('textbox', { name: /Return Type/ })).toHaveCount(0);
+
+            logStep('Add a parameter to init');
+            await typeUtils.addFunctionParameter('greeting', 'string');
+
+            logStep('Save the init configuration');
+            const saveButton = artifactWebView.getByRole('button', { name: 'Save', exact: true });
+            await saveButton.waitFor({ state: 'visible', timeout: 15000 });
+            await saveButton.click({ force: true });
+
+            // Saving returns to the service class designer, Constructor card intact.
+            await expect(artifactWebView.getByTestId('edit-method-button-init')).toBeVisible({ timeout: 60000 });
+
+            logStep('Verify the parameter reached types.bal');
+            const typesBal = path.join(newProjectPath, 'types.bal');
+            await expect.poll(
+                () => (fs.existsSync(typesBal) ? fs.readFileSync(typesBal, 'utf-8') : ''),
+                { timeout: 60000, message: 'init parameter was not written to types.bal' }
+            ).toMatch(/function init\s*\(\s*string greeting/);
+        });
+    });
+}

--- a/packages/ballerina-visualizer/src/views/BI/ServiceClassEditor/FunctionCard.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceClassEditor/FunctionCard.tsx
@@ -153,7 +153,7 @@ export function FunctionCard(params: FunctionCardProps) {
             <AccordionHeader onClick={handleResourceImplement}>
                 <MethodSection>
                     <MethodBox color={getColorByMethod(functionModel.accessor?.value || functionModel.kind)}>
-                        {functionModel.accessor?.value?.toUpperCase() || functionModel.kind.toLowerCase()}
+                        {functionModel.accessor?.value?.toUpperCase() || functionModel.kind.toUpperCase()}
                     </MethodBox>
                     <MethodPath>{functionModel.name.value}</MethodPath>
                 </MethodSection>

--- a/packages/ballerina-visualizer/src/views/BI/ServiceClassEditor/ServiceClassDesigner.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceClassEditor/ServiceClassDesigner.tsx
@@ -17,7 +17,7 @@
  */
 
 import { Type, ServiceClassModel, ModelFromCodeRequest, FieldType, FunctionModel, NodePosition, STModification, removeStatement, LineRange, EVENT_TYPE, MACHINE_VIEW, DIRECTORY_MAP } from "@wso2/ballerina-core";
-import { Codicon, Typography, ProgressRing, Menu, MenuItem, Popover, Item, ThemeColors, LinkButton, View } from "@wso2/ui-toolkit";
+import { Codicon, Typography, ProgressRing, Menu, MenuItem, Popover, Item, ThemeColors, View } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
 import React, { useEffect, useState } from "react";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
@@ -45,12 +45,6 @@ const ScrollableSection = styled.div`
     gap: 16px;
     overflow-y: auto;
     height: 80vh;
-    padding: 15px;
-`;
-
-const InfoContainer = styled.div`
-    display: flex;
-    gap: 20px;
     padding: 15px;
 `;
 
@@ -84,11 +78,6 @@ const EmptyStateText = styled(Typography)`
     color: ${ThemeColors.ON_SURFACE_VARIANT};
     padding: 12px;
     text-align: center;
-`;
-
-const InfoSection = styled.div`
-    display: flex;
-    align-items: center;
 `;
 
 interface ServiceClassDesignerProps {
@@ -392,6 +381,28 @@ export function ServiceClassDesigner(props: ServiceClassDesignerProps) {
     }
 
     const hasInitFunction = serviceClassModel?.functions?.some(func => func.kind === 'INIT');
+    const initFunction = serviceClassModel?.functions?.find(func => func.kind === 'INIT' && func.enabled);
+
+    // `init` is configured through ServiceFunctionForm rather than the inline OperationForm: only its
+    // `getFunctionFromSource` model carries the init guards (non-editable name, disabled return type).
+    const handleConfigureInitFunction = async (func: FunctionModel) => {
+        const lineRange: LineRange = func.codedata.lineRange;
+        const currentFilePath = (await rpcClient.getVisualizerRpcClient().joinProjectPath({ segments: [fileName] })).filePath;
+        await rpcClient.getVisualizerRpcClient().openView({
+            type: EVENT_TYPE.OPEN_VIEW,
+            location: {
+                view: MACHINE_VIEW.ServiceFunctionForm,
+                position: {
+                    startLine: lineRange.startLine.line,
+                    startColumn: lineRange.startLine.offset,
+                    endLine: lineRange.endLine.line,
+                    endColumn: lineRange.endLine.offset,
+                },
+                documentUri: currentFilePath,
+                artifactType: DIRECTORY_MAP.TYPE
+            }
+        });
+    };
 
     const menuItems: Item[] = [
         {
@@ -482,31 +493,24 @@ export function ServiceClassDesigner(props: ServiceClassDesignerProps) {
                 )}
                 {serviceClassModel && (
                     <>
-                        <InfoContainer>
-                            {serviceClassModel.functions?.
-                                filter((func) => func.kind === "INIT" && func.enabled)
-                                .map((functionModel, index) => (
-                                    <InfoSection>
-                                        <Icon
-                                            name={'info'}
-                                            isCodicon
-                                            sx={{ marginRight: "8px" }}
-                                        />
-                                        <Typography key={`${index}-label`} variant="body3">
-                                            Constructor:
-                                        </Typography>
-                                        <Typography key={`${index}-value`} variant="body3">
-                                            <LinkButton
-                                                sx={{ fontSize: 12, padding: 8, gap: 4 }}
-                                                onClick={() => handleOpenDiagram(functionModel)}
-                                            >
-                                                {functionModel.name.value}
-                                            </LinkButton>
-                                        </Typography>
-                                    </InfoSection>
-                                ))}
-                        </InfoContainer>
                         <ScrollableSection>
+                            {initFunction && (
+                                <Section>
+                                    <SectionHeader>
+                                        <SectionTitle>Constructor</SectionTitle>
+                                    </SectionHeader>
+
+                                    <ScrollableContent>
+                                        <FunctionCard
+                                            functionModel={initFunction}
+                                            goToSource={() => { }}
+                                            onEditFunction={() => handleConfigureInitFunction(initFunction)}
+                                            onDeleteFunction={() => handleDeleteFunction(initFunction)}
+                                            onFunctionImplement={() => handleOpenDiagram(initFunction)}
+                                        />
+                                    </ScrollableContent>
+                                </Section>
+                            )}
                             <Section style={{ maxHeight: '40%' }}>
                                 <SectionHeader>
                                     <SectionTitle>Class Variables</SectionTitle>


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-integrator/issues/1819

In the GraphQL service designer, an object type's `init` could not be given parameters. LS support for this exists (ballerina-platform/ballerina-language-server#274) but had no reachable UI: the service class designer rendered `init` as a plain "Constructor: init" link that only opened the flow diagram, and `bce28cdb64` had removed the diagram's Configure button for `init`.

## Approach
- Render `init` as a `FunctionCard` in its own Constructor section, matching how the HTTP service designer presents it.
- The card's edit action opens `ServiceFunctionForm`, so the model comes from `getFunctionFromSource` — the `CLASS` context one, which keeps the parameter schema and marks the name/return type read-only. The inline `OperationForm` is deliberately not used: the class model stamps `kind = "INIT"`, which `buildUpdateModel` does not special-case, so saving through it would rewrite the function name.
- Uppercase the `FunctionCard` kind badge so `INIT`/`DEFAULT`/`REMOTE` match the `GET` badges beside them.

## Tests
Added an E2E case (`e2e-playwright-tests/type-editor/service-class-init-config.spec.ts`, registered in `test.list.ts`) that creates a Service Class type, opens its designer, and edits `init` through the new Constructor card. It asserts the card renders with its `INIT` badge, that the Service Function form carries the init guards (name fixed to `init`, no return type field), and that a parameter added there reaches `types.bal` as `function init(string greeting)`.

Supporting helpers were added to `TypeEditorUtils`, and the authoring scenario used to derive the flow is kept under `e2e-test/e2e-authoring/scenarios/service-class-init-config/` along with the selector gaps it turned up.

## Notes
Pre-existing, not addressed here: a class `init` declaring `returns error?` loses that clause on save, because `getObjectFunctionFromSource` disables the return type and `generateFunctionSignatureSource` only emits `returns` when enabled. Needs an LS fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Enable users to configure parameters for the `init` method in the GraphQL service designer.
- Display `init` as a `FunctionCard` in the Constructor section.
- Open `ServiceFunctionForm` for constructor editing with appropriate `init` field restrictions.
- Display function kind badges in uppercase, including `INIT`, `DEFAULT`, and `REMOTE`.
- Add end-to-end coverage for adding and saving `init` parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->