### PR TITLE
Add package visibility option to the publish flow in library packages

### DIFF
--- a/packages/ballerina-core/src/rpc-types/common/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/common/interfaces.ts
@@ -131,7 +131,10 @@ export interface TomlPackage {
     version: string;
     title: string;
     library?: boolean;
+    visibility?: PackageVisibility;
 }
+
+export type PackageVisibility = 'public' | 'private';
 
 export interface WorkspaceTomlValues {
     workspace: TomlWorkspace;

--- a/packages/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
@@ -37,6 +37,7 @@ import {
     ProjectFileResponse,
     OpenExternalUrlRequest,
     PackageTomlValues,
+    PackageVisibility,
     PublishToCentralResponse,
     RunExternalCommandRequest,
     RunExternalCommandResponse,
@@ -646,7 +647,8 @@ export class CommonRpcManager implements CommonRPCAPI {
         return {
             orgName: tomlValues?.package?.org ?? getUsername(),
             packageName: tomlValues?.package?.name ?? fallbackName,
-            version: tomlValues?.package?.version ?? '0.1.0'
+            version: tomlValues?.package?.version ?? '0.1.0',
+            visibility: tomlValues?.package?.visibility === 'private' ? 'private' : 'public'
         };
     }
 
@@ -684,11 +686,38 @@ export class CommonRpcManager implements CommonRPCAPI {
             return undefined;
         }
 
+        const visibility = await this.promptForPublishVisibility(current.visibility);
+        if (visibility === undefined) {
+            return undefined;
+        }
+
         return {
             orgName: orgName.trim(),
             packageName: packageName.trim(),
-            version: version.trim()
+            version: version.trim(),
+            visibility
         };
+    }
+
+    private async promptForPublishVisibility(current: PackageVisibility): Promise<PackageVisibility | undefined> {
+        const items: (QuickPickItem & { value: PackageVisibility; })[] = [
+            {
+                label: 'Public',
+                description: 'Visible to everyone on Ballerina Central',
+                value: 'public'
+            },
+            {
+                label: 'Private',
+                description: 'Visible only to members of the organization',
+                value: 'private'
+            }
+        ];
+        const selected = await window.showQuickPick(items, {
+            title: 'Edit Package Visibility',
+            placeHolder: `Visibility (current: ${current === 'private' ? 'Private' : 'Public'})`,
+            ignoreFocusOut: true
+        });
+        return selected?.value;
     }
 
     private async updatePackageToml(projectPath: string, update: (content: string) => string): Promise<void> {
@@ -724,7 +753,10 @@ export class CommonRpcManager implements CommonRPCAPI {
         return this.updatePackageSection(content, (section) => {
             let updated = this.upsertTomlField(section, 'org', details.orgName);
             updated = this.upsertTomlField(updated, 'name', details.packageName);
-            return this.upsertTomlField(updated, 'version', details.version);
+            updated = this.upsertTomlField(updated, 'version', details.version);
+            return details.visibility === 'private'
+                ? this.upsertTomlField(updated, 'visibility', 'private')
+                : this.removeTomlField(updated, 'visibility');
         });
     }
 
@@ -748,6 +780,10 @@ export class CommonRpcManager implements CommonRPCAPI {
         return fieldPattern.test(section)
             ? section.replace(fieldPattern, fieldLine)
             : this.insertTomlField(section, fieldLine);
+    }
+
+    private removeTomlField(section: string, field: string): string {
+        return section.replace(new RegExp(`^\\s*${field}\\s*=.*\\n?`, 'm'), '');
     }
 
     private insertTomlField(section: string, fieldLine: string): string {

--- a/packages/ballerina-extension/src/rpc-managers/common/utils.ts
+++ b/packages/ballerina-extension/src/rpc-managers/common/utils.ts
@@ -20,7 +20,7 @@ import * as os from 'os';
 import { NodePosition } from "@wso2/syntax-tree";
 import { StateMachine } from "../../stateMachine";
 import { Position, Progress, Range, Uri, ViewColumn, window, workspace, WorkspaceEdit } from "vscode";
-import { isPathInside, isSamePath, PROJECT_KIND, ProjectInfo, TextEdit, WorkspaceTypeResponse } from "@wso2/ballerina-core";
+import { isPathInside, isSamePath, PackageVisibility, PROJECT_KIND, ProjectInfo, TextEdit, WorkspaceTypeResponse } from "@wso2/ballerina-core";
 import axios from 'axios';
 import fs from 'fs';
 import * as path from 'path';
@@ -391,6 +391,7 @@ export interface PublishPackageInfo {
     orgName: string;
     packageName: string;
     version: string;
+    visibility: PackageVisibility;
 }
 
 export async function getPublishDescriptionInfo(projectPath: string): Promise<PublishDescriptionInfo> {
@@ -441,6 +442,7 @@ export function getPublishConfirmation(
         `Organization: ${packageInfo.orgName || '<required>'}`,
         `Package: ${packageInfo.packageName || '<required>'}`,
         `Version: ${packageInfo.version || '<required>'}`,
+        `Visibility: ${packageInfo.visibility === 'private' ? 'Private' : 'Public'}`,
         `Description file: ${descriptionInfo.activeDocName}`
     ].join('\n');
 
@@ -456,8 +458,11 @@ export function getPublishConfirmation(
             primaryButton: 'Edit Description File'
         };
     }
+    const audience = packageInfo.visibility === 'private'
+        ? `Your ${artifactType} will be accessible only to members of the "${packageInfo.orgName}" organization.`
+        : `Your ${artifactType} will be made available to the Ballerina community.`;
     return {
-        message: `Publish "${projectName}" to Ballerina Central\n\n${packageDetails}\n\nYour ${artifactType} will be made available to the Ballerina community.`,
+        message: `Publish "${projectName}" to Ballerina Central\n\n${packageDetails}\n\n${audience}`,
         primaryButton: 'Publish to Central'
     };
 }


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2/product-integrator/issues/2257

Adds support for setting the package visibility when editing package details in the publish flow for library packages.
