### PR TITLE
Fix type editor diagnostics file path resolution

### DIFF
--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/scenario.md
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/scenario.md
@@ -1,0 +1,63 @@
+Verify that the Type Editor surfaces language-server diagnostics inline for
+invalid input in a record field's Type box and in its name box.
+
+The scenario creates a record type `Organization` through the Type Editor, then
+opens "Add Type" again and adds a record field whose Type is a type that does
+not exist in the project. That field must show the language server's
+undefined-type diagnostic inline, and the diagnostic must clear once a real type
+is entered. The field's name is then set to a Ballerina reserved keyword, which
+must show the reserved-keyword diagnostic and clear once corrected. The panel is
+closed without saving, leaving the project unchanged.
+
+This covers ballerina-vscode PR #961 / product-integrator#2181: the type editor
+sent a bare `types.bal` as `filePath` to `expressionEditor/diagnostics`, so the
+language server could not resolve the project and the request failed with
+`ProjectException: provided file path does not exist`. The diagnostic was
+therefore never rendered — the fields stayed silent on invalid input. The fix
+resolves the file name against `projectPath` in `TypeField.tsx` and
+`IdentifierField.tsx` (and in the context-based editors).
+
+## Steps
+
+| # | Action | Verification |
+|---|--------|-------------|
+| 1 | Create project and open the Type Editor | Type diagram with "Add Type" button visible |
+| 2 | Add record type `Organization` with one field, save | `data-testid="type-node-Organization"` present |
+| 3 | Add Type -> add a field, set its Type to `NoSuchTypeHere` | `undefined type 'NoSuchTypeHere'` shown |
+| 4 | Set the Type back to `string`; set the field name to `function` | Diagnostic clears, then ``function` is a reserved keyword`` shown; clears once the name is corrected |
+| 5 | Close the panel without saving | No `DiagnosticsProbe` node; `types.bal` unchanged |
+
+## Gaps
+
+- **The type's own Name box is not coverage for this fix.** It is served by
+  `TypeCreatorTab` in `TypeEditor.tsx`, which already resolved the path against
+  `projectPath` before PR #961 — a duplicate type name reports
+  `redeclared symbol '<name>'` on both sides of the fix. Only the field-level
+  boxes (`TypeField.tsx`, `IdentifierField.tsx`) flip from silent to
+  diagnosing. `ContextTypeCreator.tsx` / `EditTypeView.tsx`, also in the PR,
+  are reached only through `EntryPointTypeCreator`, not the type diagram, so
+  this scenario does not exercise them.
+- A duplicate record *field* name produces no diagnostic even after the fix, and
+  neither does an invalid identifier in the edit view's "Type name" box — so
+  neither is usable as an assertion.
+- The diagnostic text renders through `TextField`'s `errorMsg` -> `ErrorBanner`
+  in the ui-toolkit (a `submodules/` package, out of scope to edit), which has
+  no `data-testid`. The warning codicon is its only stable marker.
+- Validation is debounced 250ms and then round-trips to the language server, and
+  the banner can briefly show the message for an intermediate keystroke — wait
+  for the settled text, not the first message to appear.
+- `add-field-button` is a div wrapping a `vscode-button`; the handler is on the
+  inner button, so `domClick` on the div is a no-op. It also reports as outside
+  the viewport while the panel is laying out, so force-click it in a retry loop.
+- The "Create from scratch" / "Import" tab buttons render outside the viewport at
+  the test window size; Playwright refuses even a force-click, so they need a
+  real DOM click (`domClick`).
+
+## Environment note
+
+The authoring daemon (and the committed Playwright suite) launch VS Code through
+`@wso2/playwright-vscode-tester`, which hardcodes `Contents/MacOS/Electron` as
+the macOS executable. VS Code renamed that binary to `Code` in a release after
+1.100.0, so an unpinned `latest` download leaves the harness unable to launch.
+Run with `BI_E2E_VSCODE_VERSION=1.100.0` (the version
+`package.json`'s `e2e-test-setup` script already pins).

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/steps/01_project.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/steps/01_project.step.js
@@ -1,0 +1,19 @@
+{
+  const state = await createProjectAndIntegration('TypeEditorDiagnostics');
+  fs.writeFileSync(path.join(sessionDir, 'state.json'), JSON.stringify(state, null, 2));
+
+  await navigateToIntegrationOverview(state.integrationName);
+
+  // The authoring addArtifact() helper force-clicks the card; that silently
+  // no-ops on the artifact cards (same reason the committed helper uses
+  // domClick). Open the picker and dispatch a real DOM click on the card.
+  const frame = await getBIWebview();
+  await frame.getByRole('button', { name: /Add Artifact/i }).click({ force: true });
+  const typeCard = frame.locator('#type');
+  await typeCard.waitFor({ state: 'visible', timeout: 30000 });
+  await domClick(typeCard);
+
+  // The type diagram's first load waits on the language server warming up.
+  await waitForText('Add Type', 120000);
+  console.log(`project ready: ${state.projectName} — Type Editor open`);
+}

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/steps/02_create_base_type.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/steps/02_create_base_type.step.js
@@ -1,0 +1,40 @@
+{
+  const frame = await getBIWebview();
+
+  // A type must already exist in the project for the redeclared-symbol
+  // diagnostic in step 03 to have something to collide with.
+  const addTypeBtn = frame.getByRole('button', { name: 'Add Type' });
+  await addTypeBtn.waitFor({ state: 'visible', timeout: 120000 });
+  await addTypeBtn.click({ force: true });
+
+  // The panel can open on either tab. The tab buttons sit outside the
+  // viewport at this window size, so a pointer click (even force:true) is
+  // refused — dispatch a real DOM click.
+  const openScratchTab = async () => {
+    const content = frame.locator('[data-testid="create-from-scratch-tab"]');
+    if (await content.isVisible().catch(() => false)) return content;
+    await domClick(frame.getByRole('button', { name: 'Create from scratch' }));
+    await content.waitFor({ state: 'visible', timeout: 30000 });
+    return content;
+  };
+  await openScratchTab();
+
+  const nameInput = frame.getByRole('textbox', { name: 'Name' }).first();
+  await nameInput.waitFor({ state: 'visible', timeout: 30000 });
+  await nameInput.fill('Organization');
+  console.log('filled type name: Organization');
+
+  // The new-record form starts with no field rows — add one so the record is
+  // not empty.
+  await frame.locator('[data-testid="add-field-button"]').click();
+  const idField = frame.locator('[data-testid="identifier-field"]').last();
+  await idField.dblclick();
+  await idField.type('id');
+  await window.keyboard.press('Escape');
+
+  await frame.locator('[data-testid="type-create-save"]').click({ force: true });
+  console.log('clicked Save');
+
+  await frame.locator('[data-testid="type-node-Organization"]').waitFor({ timeout: 60000 });
+  console.log('type-node-Organization visible in diagram');
+}

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/steps/03_field_type_diagnostic.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/steps/03_field_type_diagnostic.step.js
@@ -1,0 +1,63 @@
+{
+  const frame = await getBIWebview();
+
+  await frame.getByRole('button', { name: 'Add Type' }).click({ force: true });
+
+  // The tab buttons sit outside the viewport at this window size, so a pointer
+  // click (even force:true) is refused — dispatch a real DOM click.
+  const content = frame.locator('[data-testid="create-from-scratch-tab"]');
+  if (!(await content.isVisible().catch(() => false))) {
+    await domClick(frame.getByRole('button', { name: 'Create from scratch' }));
+  }
+  await content.waitFor({ state: 'visible', timeout: 30000 });
+  await frame.getByRole('textbox', { name: 'Name' }).first().fill('DiagnosticsProbe');
+  console.log('New Type panel open, name DiagnosticsProbe');
+
+  // add-field-button is a div wrapping a vscode-button — the handler is on the
+  // inner button, so a DOM click on the div does nothing; force-click it, and
+  // retry because it can be reported outside the viewport while the panel is
+  // still laying out.
+  const addField = frame.locator('[data-testid="add-field-button"]');
+  const addDeadline = Date.now() + 30000;
+  while (Date.now() < addDeadline) {
+    if (await frame.locator('[data-testid="type-field"]').count()) break;
+    await addField.scrollIntoViewIfNeeded().catch(() => {});
+    await addField.click({ force: true, timeout: 5000 }).catch(() => {});
+    await window.waitForTimeout(1000);
+  }
+  const idField = frame.locator('[data-testid="identifier-field"]').last();
+  await idField.dblclick();
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  await window.keyboard.type('probe');
+
+  // Point the field's Type at a type that does not exist in the project.
+  const typeField = frame.locator('[data-testid="type-field"]').last();
+  await typeField.dblclick();
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  await window.keyboard.type('NoSuchTypeHere');
+  // The type helper panel opens on focus and covers the form — dismiss it.
+  await window.keyboard.press('Escape');
+  console.log('filled field type: NoSuchTypeHere');
+
+  // The diagnostic renders through TextField's errorMsg -> ErrorBanner, which
+  // carries no data-testid; its only stable marker is the warning codicon.
+  // Validation is debounced 250ms and then round-trips to the language server,
+  // and the banner can briefly show the message for an intermediate keystroke,
+  // so wait for the settled text rather than the first one that appears.
+  const banner = content.locator('div:has(> i.codicon-warning)');
+  const expected = "undefined type 'NoSuchTypeHere'";
+  const deadline = Date.now() + 60000;
+  let texts = [];
+  while (Date.now() < deadline) {
+    texts = (await banner.allInnerTexts().catch(() => [])).map((t) => t.trim()).filter(Boolean);
+    if (texts.includes(expected)) break;
+    await window.waitForTimeout(500);
+  }
+  if (!texts.includes(expected)) {
+    throw new Error(
+      `expected the field-type diagnostic ${JSON.stringify(expected)}, got ${JSON.stringify(texts)} — ` +
+      'pre-fix this stayed empty because expressionEditor/diagnostics was sent a bare "types.bal" (PR #961)'
+    );
+  }
+  console.log('FIELD TYPE DIAGNOSTIC: ' + JSON.stringify(texts));
+}

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/steps/04_field_name_diagnostic.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/steps/04_field_name_diagnostic.step.js
@@ -1,0 +1,46 @@
+{
+  const frame = await getBIWebview();
+  const content = frame.locator('[data-testid="create-from-scratch-tab"]');
+  const banner = content.locator('div:has(> i.codicon-warning)');
+  const bannerTexts = async () =>
+    (await banner.allInnerTexts().catch(() => [])).map((t) => t.trim()).filter(Boolean);
+  const waitForBanner = async (predicate, label) => {
+    const deadline = Date.now() + 60000;
+    let texts = [];
+    while (Date.now() < deadline) {
+      texts = await bannerTexts();
+      if (predicate(texts)) return texts;
+      await window.waitForTimeout(500);
+    }
+    throw new Error(`${label}; last banners: ${JSON.stringify(texts)}`);
+  };
+
+  // Restore a valid type so the only diagnostic left in play is the name's.
+  const typeField = frame.locator('[data-testid="type-field"]').last();
+  await typeField.dblclick();
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  await window.keyboard.type('string');
+  await window.keyboard.press('Escape');
+  await waitForBanner((texts) => texts.length === 0, 'field-type diagnostic never cleared after setting type back to string');
+  console.log('field type diagnostic cleared with type=string');
+
+  // A reserved keyword is not a legal field name.
+  const idField = frame.locator('[data-testid="identifier-field"]').last();
+  await idField.dblclick();
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  await window.keyboard.type('function');
+  const expected = '`function` is a reserved keyword';
+  const texts = await waitForBanner(
+    (t) => t.includes(expected),
+    `expected the field-name diagnostic ${JSON.stringify(expected)} — pre-fix this stayed empty (PR #961)`
+  );
+  console.log('FIELD NAME DIAGNOSTIC: ' + JSON.stringify(texts));
+
+  // Correcting the name clears it — proves the round-trip re-runs and comes
+  // back clean, which the pre-fix failing request could never do either.
+  await idField.dblclick();
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  await window.keyboard.type('probe');
+  await waitForBanner((t) => t.length === 0, 'field-name diagnostic never cleared after correcting the name');
+  console.log('field name diagnostic cleared after correcting the name');
+}

--- a/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/steps/05_close_without_saving.step.js
+++ b/packages/ballerina-extension/e2e-test/e2e-authoring/scenarios/type-editor-diagnostics/steps/05_close_without_saving.step.js
@@ -1,0 +1,25 @@
+{
+  const state = JSON.parse(fs.readFileSync(path.join(sessionDir, 'state.json'), 'utf8'));
+  const frame = await getBIWebview();
+
+  // Leave the project as step 02 left it — the probe type is discarded.
+  await frame.locator('[data-testid="close-panel-btn"]').click({ force: true });
+  await frame.getByRole('button', { name: 'Add Type' }).waitFor({ state: 'visible', timeout: 60000 });
+  console.log('panel closed, back on the type diagram');
+
+  if (await frame.locator('[data-testid="type-node-DiagnosticsProbe"]').count()) {
+    throw new Error('DiagnosticsProbe was saved even though the panel was closed without saving');
+  }
+
+  const candidates = [
+    path.join(state.integrationDir, 'types.bal'),
+    path.join(state.projectDir, 'types.bal'),
+  ];
+  const found = candidates.find((p) => fs.existsSync(p));
+  if (!found) throw new Error('types.bal not found in project or integration directory');
+  const source = fs.readFileSync(found, 'utf8');
+  if (source.includes('DiagnosticsProbe') || source.includes('NoSuchTypeHere')) {
+    throw new Error(`types.bal picked up the discarded type:\n---\n${source}`);
+  }
+  console.log('source verified: only Organization present, invalid form discarded');
+}

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/TypeEditorUtils.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/TypeEditorUtils.ts
@@ -20,6 +20,11 @@ import { Frame, Locator, Page } from '@playwright/test';
 import { Form, switchToIFrame } from '@wso2/playwright-vscode-tester';
 import { BI_INTEGRATOR_LABEL, domClick } from '../utils/helpers';
 
+/** Per-keystroke delay used when replacing a field's value — see replaceLastFieldValue(). */
+const TYPE_KEYSTROKE_DELAY_MS = 100;
+/** How many times replaceLastFieldValue() retypes a value that did not settle. */
+const REPLACE_VALUE_ATTEMPTS = 4;
+
 /**
  * Utility class for type editor test operations
  */
@@ -629,17 +634,69 @@ export class TypeEditorUtils {
      * fillIdentifierField()/fillTypeField() this clears the existing value
      * instead of appending, and never accepts a type-helper suggestion — the
      * point is to leave a value the user typed, valid or not.
+     *
+     * The box is a `vscode-text-field` whose value is React-controlled: every
+     * keystroke round-trips through the owning editor's state (and, for the
+     * type box, kicks off a language-server validation) before it comes back
+     * as the input's value. Typing at full speed therefore loses the leading
+     * characters on a loaded runner — `NoSuchTypeHere` arrived as
+     * `uchTypeHere` on the Linux CI agent — because a re-render carrying the
+     * pre-keystroke value lands on top of what was typed in the meantime. So
+     * type with a delay and, since no fixed delay is guaranteed to be enough,
+     * check the value that actually settled and retype when it is wrong.
      */
     private async replaceLastFieldValue(testId: 'identifier-field' | 'type-field', value: string): Promise<void> {
         const field = this.webView.locator(`[data-testid="${testId}"]`).last();
         await this.waitForElement(field);
-        await field.dblclick();
-        await this.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
-        await this.page.keyboard.type(value);
-        if (testId === 'type-field') {
-            // The type helper panel opens on focus and covers the form.
-            await this.page.keyboard.press('Escape');
+        // `vscode-text-field` keeps the real <input> in its shadow root, which
+        // Playwright's CSS engine pierces. It is only used to read the value
+        // back — inputValue() rejects the custom element wrapper.
+        const input = field.locator('input');
+        await this.waitForElement(input);
+
+        let settled = '';
+        for (let attempt = 1; attempt <= REPLACE_VALUE_ATTEMPTS; attempt++) {
+            await field.dblclick();
+            await this.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+            await this.page.keyboard.type(value, { delay: TYPE_KEYSTROKE_DELAY_MS });
+            if (testId === 'type-field') {
+                // The type helper panel opens on focus and covers the form.
+                await this.page.keyboard.press('Escape');
+            }
+            settled = await this.waitForFieldValue(input, value);
+            if (settled === value) {
+                return;
+            }
+            console.log(`  ⚠️  ${testId} settled as ${JSON.stringify(settled)}, retyping ` +
+                `${JSON.stringify(value)} (attempt ${attempt} of ${REPLACE_VALUE_ATTEMPTS})`);
         }
+        throw new Error(
+            `expected the ${testId} to hold ${JSON.stringify(value)}, got ${JSON.stringify(settled)}`
+        );
+    }
+
+    /**
+     * Poll the input until it holds `expected`, and return whatever it holds
+     * when the wait ends. A re-render can still overwrite the box after the
+     * last keystroke, so the value is only treated as final once it has
+     * survived a further beat.
+     */
+    private async waitForFieldValue(input: Locator, expected: string, timeout: number = 10000): Promise<string> {
+        const deadline = Date.now() + timeout;
+        let current = await input.inputValue().catch(() => '');
+        while (Date.now() < deadline) {
+            if (current === expected) {
+                await this.page.waitForTimeout(500);
+                current = await input.inputValue().catch(() => '');
+                if (current === expected) {
+                    return current;
+                }
+                continue;
+            }
+            await this.page.waitForTimeout(250);
+            current = await input.inputValue().catch(() => '');
+        }
+        return current;
     }
 
     async setLastFieldName(name: string): Promise<void> {

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/TypeEditorUtils.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/TypeEditorUtils.ts
@@ -18,7 +18,7 @@
 
 import { Frame, Locator, Page } from '@playwright/test';
 import { Form, switchToIFrame } from '@wso2/playwright-vscode-tester';
-import { BI_INTEGRATOR_LABEL } from '../utils/helpers';
+import { BI_INTEGRATOR_LABEL, domClick } from '../utils/helpers';
 
 /**
  * Utility class for type editor test operations
@@ -208,7 +208,9 @@ export class TypeEditorUtils {
                 `original error: ${(error as Error).message}`
             );
         }
-        await addTypeButton.click();
+        // `force` — the floating Copilot orb/invite box has been observed to
+        // overlap and intercept pointer events on this button.
+        await addTypeButton.click({ force: true });
     }
 
     /**
@@ -571,6 +573,142 @@ export class TypeEditorUtils {
         if (isCurrentlyChecked !== checked) {
             await checkbox.click();
         }
+    }
+
+    /**
+     * Open the Add Type panel's "Create from scratch" tab. The panel keeps
+     * whichever tab was last used, so a test that runs after an import test
+     * cannot assume it. The tab buttons render outside the viewport at the
+     * test window size, which makes Playwright refuse even a force-click, so
+     * dispatch a real DOM click.
+     */
+    async openCreateFromScratchTab(): Promise<Locator> {
+        const content = this.webView.locator('[data-testid="create-from-scratch-tab"]');
+        if (!(await content.isVisible().catch(() => false))) {
+            await domClick(this.webView.getByRole('button', { name: 'Create from scratch' }));
+        }
+        await this.waitForElement(content, 30000);
+        return content;
+    }
+
+    /**
+     * Set the type name on the Create-from-scratch tab.
+     */
+    async setTypeName(name: string): Promise<void> {
+        const input = this.webView.getByRole('textbox', { name: 'Name' }).first();
+        await this.waitForElement(input, 30000);
+        await input.fill(name);
+    }
+
+    /**
+     * Add an empty record field row, leaving its default name and type.
+     *
+     * `add-field-button` is a div wrapping a `vscode-button`; the click handler
+     * sits on the inner button, so a DOM click on the div is a no-op. A
+     * force-click works, but the button can be reported outside the viewport
+     * while the panel is still laying out — retry until a row appears.
+     */
+    async addEmptyRecordField(): Promise<void> {
+        const addButton = this.webView.locator('[data-testid="add-field-button"]');
+        const rows = this.webView.locator('[data-testid="type-field"]');
+        const before = await rows.count();
+        const deadline = Date.now() + 30000;
+        while (Date.now() < deadline) {
+            if (await rows.count() > before) {
+                return;
+            }
+            await addButton.scrollIntoViewIfNeeded().catch(() => { });
+            await addButton.click({ force: true, timeout: 5000 }).catch(() => { });
+            await this.page.waitForTimeout(1000);
+        }
+        throw new Error('add-field-button never added a field row');
+    }
+
+    /**
+     * Replace the contents of the last field row's name or type box. Unlike
+     * fillIdentifierField()/fillTypeField() this clears the existing value
+     * instead of appending, and never accepts a type-helper suggestion — the
+     * point is to leave a value the user typed, valid or not.
+     */
+    private async replaceLastFieldValue(testId: 'identifier-field' | 'type-field', value: string): Promise<void> {
+        const field = this.webView.locator(`[data-testid="${testId}"]`).last();
+        await this.waitForElement(field);
+        await field.dblclick();
+        await this.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+        await this.page.keyboard.type(value);
+        if (testId === 'type-field') {
+            // The type helper panel opens on focus and covers the form.
+            await this.page.keyboard.press('Escape');
+        }
+    }
+
+    async setLastFieldName(name: string): Promise<void> {
+        await this.replaceLastFieldValue('identifier-field', name);
+    }
+
+    async setLastFieldType(type: string): Promise<void> {
+        await this.replaceLastFieldValue('type-field', type);
+    }
+
+    /**
+     * Diagnostics render through TextField's `errorMsg` -> `ErrorBanner` in the
+     * ui-toolkit, which carries no data-testid (and lives in `submodules/`, out
+     * of scope to change). The warning codicon is its only stable marker.
+     */
+    private fieldDiagnostics(panel: Locator): Locator {
+        return panel.locator('div:has(> i.codicon-warning)');
+    }
+
+    private async diagnosticTexts(panel: Locator): Promise<string[]> {
+        const texts = await this.fieldDiagnostics(panel).allInnerTexts().catch(() => []);
+        return texts.map((text) => text.trim()).filter(Boolean);
+    }
+
+    /**
+     * Wait for the given diagnostic message to be shown in the panel.
+     *
+     * Validation is debounced 250ms and then round-trips to the language
+     * server, and the banner can briefly show the message for an intermediate
+     * keystroke, so wait for the settled text rather than the first message
+     * that appears.
+     */
+    async verifyFieldDiagnostic(panel: Locator, message: string, timeout: number = 60000): Promise<void> {
+        const deadline = Date.now() + timeout;
+        let texts: string[] = [];
+        while (Date.now() < deadline) {
+            texts = await this.diagnosticTexts(panel);
+            if (texts.includes(message)) {
+                return;
+            }
+            await this.page.waitForTimeout(500);
+        }
+        throw new Error(
+            `expected diagnostic ${JSON.stringify(message)} in the type editor, got ${JSON.stringify(texts)}`
+        );
+    }
+
+    /**
+     * Wait until no diagnostic is shown in the panel.
+     */
+    async verifyNoFieldDiagnostic(panel: Locator, timeout: number = 60000): Promise<void> {
+        const deadline = Date.now() + timeout;
+        let texts: string[] = [];
+        while (Date.now() < deadline) {
+            texts = await this.diagnosticTexts(panel);
+            if (texts.length === 0) {
+                return;
+            }
+            await this.page.waitForTimeout(500);
+        }
+        throw new Error(`expected no diagnostic in the type editor, got ${JSON.stringify(texts)}`);
+    }
+
+    /**
+     * Close the type editor side panel, discarding whatever is in the form.
+     */
+    async closePanel(): Promise<void> {
+        await this.webView.locator('[data-testid="close-panel-btn"]').click({ force: true });
+        await this.waitForDiagramReady();
     }
 
     /**

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/TypeEditorUtils.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/TypeEditorUtils.ts
@@ -20,9 +20,7 @@ import { Frame, Locator, Page } from '@playwright/test';
 import { Form, switchToIFrame } from '@wso2/playwright-vscode-tester';
 import { BI_INTEGRATOR_LABEL, domClick } from '../utils/helpers';
 
-/** Per-keystroke delay used when replacing a field's value — see replaceLastFieldValue(). */
-const TYPE_KEYSTROKE_DELAY_MS = 100;
-/** How many times replaceLastFieldValue() retypes a value that did not settle. */
+/** How many times replaceLastFieldValue() re-enters a value that did not settle. */
 const REPLACE_VALUE_ATTEMPTS = 4;
 
 /**
@@ -635,39 +633,40 @@ export class TypeEditorUtils {
      * instead of appending, and never accepts a type-helper suggestion — the
      * point is to leave a value the user typed, valid or not.
      *
-     * The box is a `vscode-text-field` whose value is React-controlled: every
-     * keystroke round-trips through the owning editor's state (and, for the
-     * type box, kicks off a language-server validation) before it comes back
-     * as the input's value. Typing at full speed therefore loses the leading
-     * characters on a loaded runner — `NoSuchTypeHere` arrived as
-     * `uchTypeHere` on the Linux CI agent — because a re-render carrying the
-     * pre-keystroke value lands on top of what was typed in the meantime. So
-     * type with a delay and, since no fixed delay is guaranteed to be enough,
-     * check the value that actually settled and retype when it is wrong.
+     * Deliberately a single fill() rather than keystrokes. The box is a
+     * `vscode-text-field` whose value is React-controlled, and on a loaded
+     * runner a re-render lands between the first two keystrokes and drops what
+     * was typed so far, leaving the value short of its leading characters —
+     * `NoSuchTypeHere` arrived as `oSuchTypeHere` on the Linux CI agent, and
+     * the same happens locally under 8x CPU throttling. Retyping does not help
+     * because the re-render is triggered by focusing the field, so every
+     * attempt loses the same characters. fill() sets the value in one input
+     * event, which that re-render cannot cut in half.
      */
     private async replaceLastFieldValue(testId: 'identifier-field' | 'type-field', value: string): Promise<void> {
         const field = this.webView.locator(`[data-testid="${testId}"]`).last();
         await this.waitForElement(field);
         // `vscode-text-field` keeps the real <input> in its shadow root, which
-        // Playwright's CSS engine pierces. It is only used to read the value
-        // back — inputValue() rejects the custom element wrapper.
+        // Playwright's CSS engine pierces. fill() and inputValue() both need
+        // that inner input — neither accepts the custom element wrapper.
         const input = field.locator('input');
         await this.waitForElement(input);
 
         let settled = '';
         for (let attempt = 1; attempt <= REPLACE_VALUE_ATTEMPTS; attempt++) {
             await field.dblclick();
-            await this.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
-            await this.page.keyboard.type(value, { delay: TYPE_KEYSTROKE_DELAY_MS });
+            await input.fill(value);
             if (testId === 'type-field') {
                 // The type helper panel opens on focus and covers the form.
                 await this.page.keyboard.press('Escape');
             }
+            // A re-render can still clobber the whole value; that one is
+            // recoverable, because by the next attempt the field has settled.
             settled = await this.waitForFieldValue(input, value);
             if (settled === value) {
                 return;
             }
-            console.log(`  ⚠️  ${testId} settled as ${JSON.stringify(settled)}, retyping ` +
+            console.log(`  ⚠️  ${testId} settled as ${JSON.stringify(settled)}, re-entering ` +
                 `${JSON.stringify(value)} (attempt ${attempt} of ${REPLACE_VALUE_ATTEMPTS})`);
         }
         throw new Error(
@@ -677,9 +676,9 @@ export class TypeEditorUtils {
 
     /**
      * Poll the input until it holds `expected`, and return whatever it holds
-     * when the wait ends. A re-render can still overwrite the box after the
-     * last keystroke, so the value is only treated as final once it has
-     * survived a further beat.
+     * when the wait ends. A re-render can still overwrite the box after it was
+     * filled, so the value is only treated as final once it has survived a
+     * further beat.
      */
     private async waitForFieldValue(input: Locator, expected: string, timeout: number = 10000): Promise<string> {
         const deadline = Date.now() + timeout;

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/type.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/type.spec.ts
@@ -146,6 +146,67 @@ export default function createTests() {
 
         });
 
+        /**
+         * Regression coverage for the type editor's inline diagnostics
+         * (product-integrator#2181 / ballerina-vscode#961). The editor used to
+         * send a bare `types.bal` as `filePath` to
+         * `expressionEditor/diagnostics`, which the language server cannot
+         * resolve a project from, so the request failed and the field stayed
+         * silent on invalid input. Both assertions below show nothing at all
+         * before that fix.
+         */
+        test('Type Editor Field Diagnostics', async ({ }, testInfo) => {
+            const testAttempt = testInfo.retry + 1;
+            logStep(`Type editor field diagnostics — attempt ${testAttempt}`);
+
+            // The serial block's earlier tests leave the type diagram open, but this
+            // test is also useful on its own (`--grep`), and then the run starts on
+            // the integration overview instead — navigate there when that is the case.
+            let artifactWebView = await getWebview(BI_INTEGRATOR_LABEL, page);
+            const onTypeDiagram = await artifactWebView
+                .getByRole('button', { name: 'Add Type' })
+                .isVisible()
+                .catch(() => false);
+            if (!onTypeDiagram) {
+                logStep('Type diagram not open — navigating to the Type Editor');
+                await addArtifact('Type', 'type');
+                await page.page.waitForLoadState('networkidle');
+                artifactWebView = await getWebview(BI_INTEGRATOR_LABEL, page);
+            }
+            const typeUtils = new TypeEditorUtils(page.page, artifactWebView);
+            await typeUtils.waitForTypeEditor();
+
+            logStep('Opening the Add Type panel on the Create from scratch tab');
+            await typeUtils.clickAddType();
+            const panel = await typeUtils.openCreateFromScratchTab();
+            await typeUtils.setTypeName(`DiagnosticsProbe${testAttempt}`);
+
+            logStep('Adding a record field whose type does not exist in the project');
+            await typeUtils.addEmptyRecordField();
+            await typeUtils.setLastFieldName('probe');
+            await typeUtils.setLastFieldType('NoSuchTypeHere');
+
+            logStep('Verifying the undefined-type diagnostic is shown');
+            await typeUtils.verifyFieldDiagnostic(panel, "undefined type 'NoSuchTypeHere'");
+
+            logStep('Restoring a valid type and verifying the diagnostic clears');
+            await typeUtils.setLastFieldType('string');
+            await typeUtils.verifyNoFieldDiagnostic(panel);
+
+            logStep('Setting the field name to a reserved keyword');
+            await typeUtils.setLastFieldName('function');
+
+            logStep('Verifying the reserved-keyword diagnostic is shown');
+            await typeUtils.verifyFieldDiagnostic(panel, '`function` is a reserved keyword');
+
+            logStep('Correcting the field name and verifying the diagnostic clears');
+            await typeUtils.setLastFieldName('probe');
+            await typeUtils.verifyNoFieldDiagnostic(panel);
+
+            logStep('Closing the panel without saving');
+            await typeUtils.closePanel();
+        });
+
         test('Import Type from JSON', async ({ }, testInfo) => {
             const testAttempt = testInfo.retry + 1;
             logStep(`Import type from JSON — attempt ${testAttempt}`);

--- a/packages/type-editor/src/TypeEditor/ContextBasedTypeEditor/ContextTypeCreator.tsx
+++ b/packages/type-editor/src/TypeEditor/ContextBasedTypeEditor/ContextTypeCreator.tsx
@@ -359,7 +359,7 @@ export function ContextTypeCreatorTab(props: ContextTypeCreatorProps) {
         });
 
         const response = await rpcClient.getBIDiagramRpcClient().getExpressionDiagnostics({
-            filePath: type?.codedata?.lineRange?.fileName || "types.bal",
+            filePath: Utils.joinPath(URI.file(projectPath), type?.codedata?.lineRange?.fileName || "types.bal").fsPath,
             context: {
                 expression: value,
                 startLine: {

--- a/packages/type-editor/src/TypeEditor/ContextBasedTypeEditor/EditTypeView.tsx
+++ b/packages/type-editor/src/TypeEditor/ContextBasedTypeEditor/EditTypeView.tsx
@@ -351,7 +351,7 @@ export function EditTypeView(props: EditTypeViewProps) {
         });
 
         const response = await rpcClient.getBIDiagramRpcClient().getExpressionDiagnostics({
-            filePath: type?.codedata?.lineRange?.fileName || "types.bal",
+            filePath: Utils.joinPath(URI.file(projectPath), type?.codedata?.lineRange?.fileName || "types.bal").fsPath,
             context: {
                 expression: value,
                 startLine: {

--- a/packages/type-editor/src/TypeEditor/IdentifierField.tsx
+++ b/packages/type-editor/src/TypeEditor/IdentifierField.tsx
@@ -60,7 +60,7 @@ export const IdentifierField = forwardRef<HTMLInputElement, IdentifierFieldProps
         });
 
         const response = await rpcClient.getBIDiagramRpcClient().getExpressionDiagnostics({
-            filePath: rootType?.codedata?.lineRange?.fileName || "types.bal",
+            filePath: Utils.joinPath(URI.file(projectPath), rootType?.codedata?.lineRange?.fileName || "types.bal").fsPath,
             context: {
                 expression: value,
                 startLine: {

--- a/packages/type-editor/src/TypeEditor/TypeField.tsx
+++ b/packages/type-editor/src/TypeEditor/TypeField.tsx
@@ -136,7 +136,7 @@ export const TypeField = forwardRef<HTMLInputElement, TypeFieldProps>((props, re
         });
 
         const response = await rpcClient.getBIDiagramRpcClient().getExpressionDiagnostics({
-            filePath: rootType?.codedata?.lineRange?.fileName || "types.bal",
+            filePath: Utils.joinPath(URI.file(projectPath), rootType?.codedata?.lineRange?.fileName || "types.bal").fsPath,
             context: {
                 expression: value,
                 startLine: {


### PR DESCRIPTION
Fixes : https://github.com/wso2/product-integrator/issues/2181

### Problem
The type editor sent a bare `types.bal` as `filePath` to `expressionEditor/diagnostics`. The LS can't resolve a project from a relative path, so the request failed with an internal error instead of returning the diagnostic. For a new type there is no `codedata.lineRange` at all, so the fallback name was always used.

### Fix
Resolve the file name against `projectPath` in `TypeField`, `IdentifierField`, `EditTypeView` and `ContextTypeCreator`, matching what `TypeCreatorTab` already did.

### Tests
`tsc --noEmit` on `packages/type-editor` passes. Not yet verified end to end in the extension.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Resolve type editor diagnostic file paths against `projectPath`.
- Add end-to-end coverage for invalid field types and reserved keyword field names.
- Verify diagnostics clear after corrections and unsaved changes are discarded.
- Add reusable Playwright helpers for type creation, field editing, diagnostic checks, and panel closure.
- Improve field input reliability with delayed typing and settled-value retries.
- Update `clickAddType()` to use force-click behavior.

TypeScript compilation passes for `packages/type-editor`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->