### PR TITLE
Fix overlapping entries in the type helper pane

### DIFF
--- a/packages/type-editor/src/TypeHelper/TypeHelper.tsx
+++ b/packages/type-editor/src/TypeHelper/TypeHelper.tsx
@@ -147,6 +147,11 @@ namespace S {
 
 const FunctionItemLabel = styled.span`
     font-size: 13px;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 `;
 
 export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
@@ -336,7 +341,7 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
                                                                                             key={`${subCategory.category}-${item.name}`}
                                                                                         >
                                                                                             <Icon name="bi-type" sx={{ fontSize: '16px' }} />
-                                                                                            <FunctionItemLabel>{item.name}</FunctionItemLabel>
+                                                                                            <FunctionItemLabel title={item.name}>{item.name}</FunctionItemLabel>
                                                                                         </ExpandableList.Item>
                                                                                     </SlidingPaneNavContainer>
                                                                                 ))}
@@ -354,7 +359,7 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
                                                                                 key={`${category.category}-${item.name}`}
                                                                             >
                                                                                 <Icon name="bi-type" sx={{ fontSize: '16px' }} />
-                                                                                <FunctionItemLabel>{item.name}</FunctionItemLabel>
+                                                                                <FunctionItemLabel title={item.name}>{item.name}</FunctionItemLabel>
                                                                             </ExpandableList.Item>
                                                                         </SlidingPaneNavContainer>
                                                                     ))}
@@ -382,7 +387,7 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
                                                             >
                                                                 <ExpandableList.Item>
                                                                     <Icon name="bi-type" sx={{ fontSize: '16px' }} />
-                                                                    <FunctionItemLabel>{item.name}</FunctionItemLabel>
+                                                                    <FunctionItemLabel title={item.name}>{item.name}</FunctionItemLabel>
                                                                 </ExpandableList.Item>
                                                             </SlidingPaneNavContainer>
                                                         ))}
@@ -426,7 +431,7 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
                                                                                             key={`${subCategory.category}-${item.name}`}
                                                                                         >
                                                                                             <Icon name="bi-type" sx={{ fontSize: '16px' }} />
-                                                                                            <FunctionItemLabel>{item.name}</FunctionItemLabel>
+                                                                                            <FunctionItemLabel title={item.name}>{item.name}</FunctionItemLabel>
                                                                                         </ExpandableList.Item>
                                                                                     </SlidingPaneNavContainer>
                                                                                 ))}
@@ -444,7 +449,7 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
                                                                                 key={`${category.category}-${item.name}`}
                                                                             >
                                                                                 <Icon name="bi-type" sx={{ fontSize: '16px' }} />
-                                                                                <FunctionItemLabel>{item.name}</FunctionItemLabel>
+                                                                                <FunctionItemLabel title={item.name}>{item.name}</FunctionItemLabel>
                                                                             </ExpandableList.Item>
                                                                         </SlidingPaneNavContainer>
                                                                     ))}

--- a/packages/type-editor/src/TypeHelper/styles/HorizontalList.tsx
+++ b/packages/type-editor/src/TypeHelper/styles/HorizontalList.tsx
@@ -22,11 +22,20 @@ export const HorizontalListContainer = styled.div`
     display: flex;
     flex-direction: column;
     gap: 3px;
+    min-width: 0;
+
+    /* SlidingPaneNavContainer wraps its children in unstyled divs that default to
+       min-width:auto, which lets a long label stretch the fixed-height row. */
+    div:has(> .expandable-list-item),
+    div:has(> div > .expandable-list-item) {
+        min-width: 0;
+    }
 `;
 
 export const HorizontalListItem = styled.div`
     display: flex;
     width: 100%;
+    min-width: 0;
     justify-content: space-between;
     align-items: center;
     gap: 12px;
@@ -38,4 +47,6 @@ export const HorizontalListItemLeftContent = styled.div`
     display: flex;
     align-items: center;
     gap: 10px;
+    flex: 1;
+    min-width: 0;
 `;


### PR DESCRIPTION
Fixes : https://github.com/wso2/product-integrator/issues/2239

### Problem
`SlidingPaneNavContainer` rows are a fixed `height: 32px`, but the helper pane label had no truncation. The GitHub trigger contributes whole anonymous type descriptors (`isolated service object {isolated remote function onOpened(...) ...}`) under **Used Variable Types**, so that text wrapped over ~10 lines and painted across the adjacent rows and the section headers.

### Fix
Truncate the label to a single line with an ellipsis, and add the full type as a `title` tooltip. Ellipsis needs a bounded ancestor, so `min-width: 0` is set down the chain — including the two unstyled divs `SlidingPaneNavContainer` wraps its children in, reached via `:has()`.

### Tests
`tsc --noEmit` on `packages/type-editor` passes. Layout verified in a headless Chromium repro of the same DOM/CSS chain: before, the long entry overflows its row and overlaps the next one; after, rows stay 32px with the name ellipsised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed overlapping entries in the type helper pane.
- Truncated long type names to one line with an ellipsis.
- Added `title` tooltips to show full type names.
- Added `min-width: 0` and flex sizing across relevant containers to support truncation in fixed-width rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->