### PR TITLE
[Agent Builder] Fix event trigger deletion for agents

### DIFF
--- a/packages/ballerina-core/src/interfaces/bi.ts
+++ b/packages/ballerina-core/src/interfaces/bi.ts
@@ -21,7 +21,7 @@ import { LinePosition } from "./common";
 import { Diagnostic as VSCodeDiagnostic } from "vscode-languageserver-types";
 import { ValueTypeConstraint } from "../rpc-types/ai-agent/interfaces";
 import { Type } from "./extended-lang-client";
-import { ValidationResult, ValidationRule } from "./service";
+import { AgentTriggerDeletionScope, ValidationResult, ValidationRule } from "./service";
 
 export type { NodePosition };
 
@@ -190,6 +190,8 @@ export type AgentUsageTrigger = {
     listeners: AgentUsageTriggerListener[];
     entryPoint?: AgentUsageTriggerEntryPoint;
     orphansService?: boolean;
+    scope?: AgentTriggerDeletionScope;
+    helpers?: AgentUsageTriggerListener[];
 };
 
 export type AgentUsageTriggerEntryPoint = {

--- a/packages/ballerina-core/src/interfaces/service.ts
+++ b/packages/ballerina-core/src/interfaces/service.ts
@@ -40,6 +40,10 @@ export type AgentTriggerKind = "CHAT" | "EVENT" | "HTTP";
 
 export type AgentTriggerDeletionScope = "ENTRY_POINT" | "ENTRY_POINT_BODY" | "SERVICE";
 
+export function triggerScopeNoun(scope?: AgentTriggerDeletionScope): "Endpoint" | "Trigger" {
+    return scope === "ENTRY_POINT" ? "Endpoint" : "Trigger";
+}
+
 /**
  * For schema-driven triggers (unified TriggerModel), `functions` and `schemaFunctions` split the
  * handlers in two: `functions` holds what exists in the user's source, `schemaFunctions` the

--- a/packages/ballerina-core/src/interfaces/service.ts
+++ b/packages/ballerina-core/src/interfaces/service.ts
@@ -38,7 +38,7 @@ export type ListenerModel = {
 
 export type AgentTriggerKind = "CHAT" | "EVENT" | "HTTP";
 
-export type AgentTriggerDeletionScope = "ENTRY_POINT" | "SERVICE";
+export type AgentTriggerDeletionScope = "ENTRY_POINT" | "ENTRY_POINT_BODY" | "SERVICE";
 
 /**
  * For schema-driven triggers (unified TriggerModel), `functions` and `schemaFunctions` split the

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/agent/AgentTriggerDeletionScope.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/agent/AgentTriggerDeletionScope.java
@@ -20,5 +20,6 @@ package io.ballerina.servicemodelgenerator.extension.builder.service.agent;
 
 public enum AgentTriggerDeletionScope {
     ENTRY_POINT,
+    ENTRY_POINT_BODY,
     SERVICE
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/agent/EventAgentTriggerChannel.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/agent/EventAgentTriggerChannel.java
@@ -81,6 +81,11 @@ public class EventAgentTriggerChannel implements AgentTriggerChannel {
     }
 
     @Override
+    public AgentTriggerDeletionScope deletionScope() {
+        return AgentTriggerDeletionScope.ENTRY_POINT_BODY;
+    }
+
+    @Override
     public Map<String, Value> additionalProperties() {
         return Map.of(INSTRUCTIONS, AgentTriggerChannel.instructionsField(
                 "What the agent should do with each event. The event itself is passed along "

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/builder/service/AgentTriggerGenerationTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/builder/service/AgentTriggerGenerationTest.java
@@ -1211,8 +1211,10 @@ public class AgentTriggerGenerationTest {
                 "an http resource returns the answer inline, so it owns no reply method to orphan");
         Assert.assertEquals(stamped("ballerinax", "telegram", "event").deletionScope(), "SERVICE",
                 "a chat channel's handler offloads to a reply method and a client field in the same service");
-        Assert.assertEquals(stamped("ballerinax", "kafka", "event").deletionScope(), "SERVICE",
-                "an event handler offloads the same way, and it is not registered anywhere");
+        Assert.assertEquals(stamped("ballerinax", "kafka", "event").deletionScope(), "ENTRY_POINT_BODY",
+                "an event handler is required by its service type, so removing the agent empties it instead");
+        Assert.assertEquals(stamped("ballerinax", "trigger.github", "event").deletionScope(), "ENTRY_POINT_BODY",
+                "one wired handler among required siblings must not take the whole service with it");
         Assert.assertNull(stamped("ballerina", "ftp", "file").deletionScope(),
                 "a trigger that cannot call an agent carries no scope to act on");
     }

--- a/packages/ballerina-visualizer/src/MainPanel.tsx
+++ b/packages/ballerina-visualizer/src/MainPanel.tsx
@@ -212,6 +212,8 @@ const MainPanel = () => {
     const navKeyRef = useRef<number>(0);
     const remountKeyRef = useRef<number>(0);
     const previousNavTargetRef = useRef<string | undefined>(undefined);
+    const agentFocusTargetRef = useRef<string | undefined>(undefined);
+    const agentFocusIdRef = useRef<number>(0);
 
     useSuppressAgentStatusOrb(viewHidesAgentStatusOrb(activeView) || !!viewError);
     useTraceAnimationBridge();
@@ -349,8 +351,15 @@ const MainPanel = () => {
                             if ((await fetchProductMode(rpcClient)) === ProductMode.AGENT_BUILDER) {
                                 const { AgentBuilderOverview } = await import("./views/BI/AgentBuilderOverview");
                                 if (isStaleNavigation()) return;
-                                const agentFocus = value.documentUri && value.position
-                                    ? { path: value.documentUri, startLine: value.position.startLine, requestId: navKey }
+                                const agentFocusTarget = value.documentUri && value.position
+                                    ? `${value.documentUri}::${value.position.startLine}`
+                                    : undefined;
+                                if (agentFocusTarget !== agentFocusTargetRef.current) {
+                                    agentFocusTargetRef.current = agentFocusTarget;
+                                    agentFocusIdRef.current += 1;
+                                }
+                                const agentFocus = agentFocusTarget
+                                    ? { path: value.documentUri, startLine: value.position.startLine, requestId: agentFocusIdRef.current }
                                     : undefined;
                                 setViewComponent(
                                     <AgentBuilderOverview projectPath={value.projectPath} agentFocus={agentFocus} />

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/useAgentEditorController.ts
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/useAgentEditorController.ts
@@ -63,6 +63,7 @@ export interface AgentEditorController {
     openView(view: AgentEditorView): void;
     selectAgent(name: string): void;
     close(position?: NodePosition): void;
+    cancel(): void;
     back(): void;
     setBackHandler(handler: (() => void) | null): void;
 }
@@ -85,7 +86,7 @@ export function useAgentEditorController(host: AgentEditorHost): AgentEditorCont
 
     const setLoading = (loading: boolean) => host.onLoadingChange?.(loading);
 
-    const close = useCallback((position?: NodePosition) => {
+    const resetView = useCallback(() => {
         setBackOverride(null);
         setView("NONE");
         setMemoryNode(undefined);
@@ -93,8 +94,16 @@ export function useAgentEditorController(host: AgentEditorHost): AgentEditorCont
         setSelectedAgentName("");
         setAgentNode(undefined);
         host.onSelectionChange?.(undefined);
-        void host.onRefresh(position);
     }, [host]);
+
+    const close = useCallback((position?: NodePosition) => {
+        resetView();
+        void host.onRefresh(position);
+    }, [resetView, host]);
+
+    const cancel = useCallback(() => {
+        resetView();
+    }, [resetView]);
 
     const resolveToolComponent = useCallback(async (toolName: string) => {
         const project = await rpcClient.getBIDiagramRpcClient().getProjectComponents();
@@ -351,6 +360,6 @@ export function useAgentEditorController(host: AgentEditorHost): AgentEditorCont
     return {
         view, agentNode, memoryNode, memoryPropertyKey: memoryKeyOf(agentNode), selectedTool, selectedAgentName,
         diagramCallbacks, onAgentCreated: host.onAgentCreated,
-        openView, selectAgent, close, back, setBackHandler,
+        openView, selectAgent, close, cancel, back, setBackHandler,
     };
 }

--- a/packages/ballerina-visualizer/src/views/BI/AgentBuilderOverview/AgentTabs.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AgentBuilderOverview/AgentTabs.tsx
@@ -213,7 +213,7 @@ const GLYPH_ICON_SX = { fontSize: ICON_SIZE, color: "inherit" };
 const ACTION_ICON_SX = { fontSize: 16, color: "inherit" };
 
 export function agentKey(agent: ProjectStructureArtifactResponse): string {
-    return `${agent.path}::${agent.position?.startLine ?? 0}`;
+    return `${agent.path}::${agent.name}`;
 }
 
 function AgentGlyph() {

--- a/packages/ballerina-visualizer/src/views/BI/AgentBuilderOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AgentBuilderOverview/index.tsx
@@ -26,6 +26,7 @@ import {
     FOCUS_FLOW_DIAGRAM_VIEW,
     MACHINE_VIEW,
     ProjectStructure,
+    ProjectStructureArtifactResponse,
     isSamePath,
 } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
@@ -169,6 +170,8 @@ export interface AgentFocusRequest {
     requestId: number;
 }
 
+const rememberedKeys = new Map<string, string>();
+
 interface AgentBuilderOverviewProps {
     projectPath: string;
     agentFocus?: AgentFocusRequest;
@@ -179,7 +182,8 @@ export function AgentBuilderOverview({ projectPath, agentFocus }: AgentBuilderOv
     const { platformExtState } = usePlatformExtContext();
     const [projectStructure, setProjectStructure] = useState<ProjectStructure>();
     const [isInProject, setIsInProject] = useState(false);
-    const [selectedKey, setSelectedKey] = useState<string>();
+    const [selectedKey, setSelectedKeyState] = useState<string | undefined>(() => rememberedKeys.get(projectPath));
+    const pendingRenameRef = useRef<{ artifact: ProjectStructureArtifactResponse; agentsAtStash: ProjectStructureArtifactResponse[] }>();
     const [showAddAgent, setShowAddAgent] = useState(false);
     const [showAddLibraryArtifact, setShowAddLibraryArtifact] = useState(false);
     const [deployAnchor, setDeployAnchor] = useState<HTMLElement | null>(null);
@@ -216,12 +220,41 @@ export function AgentBuilderOverview({ projectPath, agentFocus }: AgentBuilderOv
         [projectStructure]
     );
 
+    const setSelectedKey = useCallback((key: string) => {
+        rememberedKeys.set(projectPath, key);
+        setSelectedKeyState(key);
+    }, [projectPath]);
+
     const isLibrary = projectStructure?.isLibrary ?? false;
 
     const selectedAgent = useMemo(
         () => agents.find((agent) => agentKey(agent) === selectedKey) ?? agents[0],
         [agents, selectedKey]
     );
+
+    useEffect(() => {
+        if (!selectedKey && agents.length > 0) {
+            setSelectedKey(agentKey(agents[0]));
+        }
+    }, [agents, selectedKey, setSelectedKey]);
+
+    useEffect(() => rpcClient.onIdentifierUpdated((artifacts) => {
+        const renamed = artifacts?.find((artifact) => artifact.type === DIRECTORY_MAP.AGENT);
+        if (renamed) {
+            pendingRenameRef.current = { artifact: renamed, agentsAtStash: agents };
+        }
+    }), [rpcClient, agents]);
+
+    useEffect(() => {
+        const pending = pendingRenameRef.current;
+        if (!pending || pending.agentsAtStash === agents) {
+            return;
+        }
+        pendingRenameRef.current = undefined;
+        if (selectedKey && !agents.some((agent) => agentKey(agent) === selectedKey)) {
+            setSelectedKey(agentKey(pending.artifact));
+        }
+    }, [agents, selectedKey, setSelectedKey]);
 
     const appliedFocusRef = useRef<number>();
 
@@ -238,7 +271,7 @@ export function AgentBuilderOverview({ projectPath, agentFocus }: AgentBuilderOv
         appliedFocusRef.current = agentFocus.requestId;
         setSelectedKey(agentKey(match));
         setShowAddAgent(false);
-    }, [agents, agentFocus]);
+    }, [agents, agentFocus, setSelectedKey]);
 
     if (projectStructure && !selectedAgent) {
         sawEmptyRef.current = true;

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -1258,7 +1258,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         pendingCapabilityCloseRef.current = false;
         pendingDurableMcpAgentRef.current = null;
         if (agentEditor.view !== "NONE") {
-            agentEditor.close();
+            agentEditor.cancel();
         }
         // Dismissing the panel ends the agent flow, so the flags that say "this activity list belongs
         // to an agent" end with it. They are not cleared in resetNodeSelectionStates, which also runs

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.test.ts
@@ -568,11 +568,20 @@ const scatteredChannels = {
 } as unknown as CDModel;
 
 describe("rail ordering", () => {
-    it("keeps rows of the same channel together", () => {
-        const labels = findAgentUsages(scatteredChannels, { filePath: AGENTS_BAL, startLine: 4 })
-            .map((usage) => usage.label);
+    const labelsOf = (model: CDModel) =>
+        findAgentUsages(model, { filePath: AGENTS_BAL, startLine: 4 }).map((usage) => usage.label);
 
-        expect(labels).toEqual(["onAssigned", "onReopened", "Agent Chat", "main"]);
+    it("groups rows by channel, and orders the channels by name", () => {
+        expect(labelsOf(scatteredChannels)).toEqual(["Agent Chat", "onAssigned", "onReopened", "main"]);
+    });
+
+    it("does not depend on the order the design model happens to list services in", () => {
+        const reversed = {
+            ...scatteredChannels,
+            services: [...(scatteredChannels.services ?? [])].reverse(),
+        } as unknown as CDModel;
+
+        expect(labelsOf(reversed)).toEqual(labelsOf(scatteredChannels));
     });
 });
 

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.test.ts
@@ -16,10 +16,11 @@
  * under the License.
  */
 
-import { CDFunction, CDModel, CDResourceFunction } from "@wso2/ballerina-core";
+import { AgentUsageTrigger, CDFunction, CDModel, CDResourceFunction } from "@wso2/ballerina-core";
 import {
     AgentTriggerScopes,
     agentCallerProtocols,
+    clearAgentCallFromHandler,
     deleteEachResolved,
     findAgentUsages,
     findListenerPosition,
@@ -611,6 +612,12 @@ describe("try it on a rail row", () => {
         });
     });
 
+    it("drops an attached listener the model carries no declaration for", () => {
+        const row = httpRows({ ...supportApi, attachedListeners: ["http-listener", "gone"] })[0];
+
+        expect(row.tryIt?.listener).toBe("httpListener");
+    });
+
     it("aims each endpoint of one service at its own resource", () => {
         const rows = httpRows({
             ...supportApi,
@@ -702,7 +709,7 @@ describe("triggers that only Ballerina Central knows about", () => {
         return { client: { getServiceDesignerRpcClient: () => ({ searchTriggers }) } as never, searchTriggers };
     };
 
-    it("asks only about the protocols that actually call this agent", () => {
+    it("asks only about the protocols that actually call this agent, and says nothing when the agent is not in the model", () => {
         expect(agentCallerProtocols(slackModel, agent)).toEqual(["slack"]);
         expect(agentCallerProtocols(slackModel, { filePath: AGENTS_BAL, startLine: 99 })).toEqual([]);
     });
@@ -827,6 +834,23 @@ describe("event handler rows", () => {
         expect(rows[0].trigger?.orphansService).toBe(true);
     });
 
+    it("does not orphan the service when a sibling handler reaches a different agent", () => {
+        const service = issuesService(["onOpened"], ["runAgentOnOpened"]);
+        const crossAgentService = {
+            ...service,
+            remoteFunctions: [
+                service.remoteFunctions[0],
+                { ...service.remoteFunctions[1], connections: [SUPPORT_AGENT_UUID] },
+                service.remoteFunctions[2],
+            ],
+        };
+
+        const rows = eventRows(crossAgentService);
+
+        expect(rows.map((row) => row.label)).toEqual(["onOpened"]);
+        expect(rows[0].trigger?.orphansService).toBe(false);
+    });
+
     it("names the helpers that reach the agent so the offload target can be resolved", () => {
         const rows = eventRows(issuesService(["onOpened"], ["runAgentOnOpened", "init"]));
 
@@ -854,6 +878,12 @@ describe("finding the agent call inside a handler", () => {
         expect(namesHelper(node("start self.rerunAgentOnOpened(payload)"), "runAgentOnOpened")).toBe(false);
         expect(namesHelper(node("log:printInfo(\"hi\")"), "runAgentOnOpened")).toBe(false);
         expect(namesHelper({ properties: {} } as never, "runAgentOnOpened")).toBe(false);
+    });
+
+    it("treats regex metacharacters in the helper name literally", () => {
+        expect(() => namesHelper(node("start self.foo(payload)"), "foo(")).not.toThrow();
+        expect(namesHelper(node("start self.processAddd(payload)"), "processAdd+")).toBe(false);
+        expect(namesHelper(node("start self.processAdd(payload)"), "processAdd+")).toBe(false);
     });
 
     it("reads the line an edit has to be ordered by", () => {
@@ -930,5 +960,98 @@ describe("deleting components whose positions have moved", () => {
         await deleteEachResolved(client, listeners, locate);
 
         expect(deleteByComponentInfo.mock.calls.map((call) => call[0].component.name)).toEqual(["sharedListener"]);
+    });
+});
+
+describe("clearing an agent call from a handler", () => {
+    const flowNode = (expression: string, line: number) => ({
+        properties: { expression: { value: expression } },
+        codedata: { lineRange: { startLine: { line } } },
+    });
+
+    const trigger = (orphansService: boolean): AgentUsageTrigger => ({
+        serviceName: "/github",
+        documentUri: GITHUB_BAL,
+        position: { startLine: 5, startColumn: 0, endLine: 6, endColumn: 1 },
+        listeners: [],
+        entryPoint: {
+            label: "onOpened",
+            documentUri: GITHUB_BAL,
+            position: { startLine: 10, startColumn: 0, endLine: 11, endColumn: 1 },
+        },
+        scope: "ENTRY_POINT_BODY",
+        orphansService,
+        helpers: [{ symbol: "runAgent", documentUri: GITHUB_BAL, position: { startLine: 40, startColumn: 0, endLine: 41, endColumn: 1 } }],
+    });
+
+    const clientSeeing = (siblingCallsHelper: boolean) => {
+        const designModel = {
+            services: [{
+                absolutePath: "/github",
+                resourceFunctions: [],
+                remoteFunctions: [
+                    { name: "onOpened", location: { filePath: GITHUB_BAL, ...range(10) } },
+                    { name: "onClosed", location: { filePath: GITHUB_BAL, ...range(15) } },
+                ],
+                functions: [{ name: "runAgent", location: { filePath: GITHUB_BAL, ...range(40) } }],
+            }],
+        } as unknown as CDModel;
+
+        const getFlowModel = jest.fn().mockImplementation(({ startLine }) => {
+            if (startLine.line === 10) {
+                return Promise.resolve({ flowModel: { nodes: [flowNode("start self.runAgent(payload)", 11)] } });
+            }
+            if (startLine.line === 15) {
+                return Promise.resolve({
+                    flowModel: { nodes: siblingCallsHelper ? [flowNode("start self.runAgent(payload)", 16)] : [] },
+                });
+            }
+            return Promise.resolve({ flowModel: { nodes: [] } });
+        });
+        const deleteFlowNode = jest.fn().mockResolvedValue({});
+        const getDesignModel = jest.fn().mockResolvedValue({ designModel });
+        const deleteByComponentInfo = jest.fn().mockResolvedValue({});
+
+        return {
+            client: {
+                getVisualizerLocation: jest.fn().mockResolvedValue({ projectPath: "/proj" }),
+                getBIDiagramRpcClient: () => ({ getFlowModel, deleteFlowNode, getDesignModel, deleteByComponentInfo }),
+            } as never,
+            deleteFlowNode,
+            deleteByComponentInfo,
+            getDesignModel,
+        };
+    };
+
+    it("deletes the call and the helper when no sibling reaches the agent at all", async () => {
+        const { client, deleteFlowNode, deleteByComponentInfo, getDesignModel } = clientSeeing(false);
+
+        await clearAgentCallFromHandler(client, trigger(true));
+
+        expect(deleteFlowNode).toHaveBeenCalledTimes(1);
+        expect(getDesignModel).toHaveBeenCalledTimes(1);
+        expect(deleteByComponentInfo).toHaveBeenCalledWith(
+            expect.objectContaining({ component: expect.objectContaining({ name: "runAgent" }) })
+        );
+    });
+
+    it("deletes the helper even when a sibling reaches a different agent, as long as it does not call this helper", async () => {
+        const { client, deleteFlowNode, deleteByComponentInfo } = clientSeeing(false);
+
+        await clearAgentCallFromHandler(client, trigger(false));
+
+        expect(deleteFlowNode).toHaveBeenCalledTimes(1);
+        expect(deleteByComponentInfo).toHaveBeenCalledWith(
+            expect.objectContaining({ component: expect.objectContaining({ name: "runAgent" }) })
+        );
+    });
+
+    it("keeps the helper a sibling still calls by name", async () => {
+        const { client, deleteFlowNode, deleteByComponentInfo } = clientSeeing(true);
+
+        await clearAgentCallFromHandler(client, trigger(false));
+
+        expect(deleteFlowNode).toHaveBeenCalledTimes(1);
+        expect(deleteByComponentInfo).not.toHaveBeenCalled();
     });
 });

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.test.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { CDFunction, CDModel } from "@wso2/ballerina-core";
+import { CDFunction, CDModel, CDResourceFunction } from "@wso2/ballerina-core";
 import {
     AgentTriggerScopes,
     agentCallerProtocols,
@@ -771,7 +771,7 @@ const issuesService = (wired: string[], helpers: string[]) => ({
     location: { filePath: GITHUB_BAL, ...range(5) },
     attachedListeners: ["github-listener"],
     connections: [AGENT_UUID],
-    resourceFunctions: [],
+    resourceFunctions: [] as CDResourceFunction[],
     remoteFunctions: ["onOpened", "onClosed", "onReopened"].map((name, i) =>
         handler(name, 10 + i * 5, wired.includes(name))),
     functions: helpers.map((name, i) => handler(name, 40 + i * 5, true)),

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.test.ts
@@ -20,9 +20,13 @@ import { CDFunction, CDModel } from "@wso2/ballerina-core";
 import {
     AgentTriggerScopes,
     agentCallerProtocols,
+    deleteEachResolved,
     findAgentUsages,
     findListenerPosition,
+    findServiceHelperPosition,
+    namesHelper,
     resolveTriggerScopes,
+    startLineOf,
 } from "./agentUsages";
 
 const AGENT_UUID = "c371fce0-2d2e-4e47-2f32-13911cf544a8";
@@ -583,6 +587,19 @@ describe("rail ordering", () => {
 
         expect(labelsOf(reversed)).toEqual(labelsOf(scatteredChannels));
     });
+
+    it("orders same-channel services by where they are declared", () => {
+        const [first, , third] = scatteredChannels.services ?? [];
+        const swapped = {
+            ...scatteredChannels,
+            services: [
+                { ...third, location: { ...third.location, startLine: { line: 5, offset: 0 } } },
+                { ...first, location: { ...first.location, startLine: { line: 70, offset: 0 } } },
+            ],
+        } as unknown as CDModel;
+
+        expect(labelsOf(swapped)).toEqual(["onReopened", "onAssigned", "main"]);
+    });
 });
 
 describe("try it on a rail row", () => {
@@ -592,12 +609,6 @@ describe("try it on a rail row", () => {
             listener: "httpListener",
             resource: { method: "post", path: "products/[string productId]/questions" },
         });
-    });
-
-    it("drops an attached listener the model carries no declaration for", () => {
-        const row = httpRows({ ...supportApi, attachedListeners: ["http-listener", "gone"] })[0];
-
-        expect(row.tryIt?.listener).toBe("httpListener");
     });
 
     it("aims each endpoint of one service at its own resource", () => {
@@ -693,9 +704,6 @@ describe("triggers that only Ballerina Central knows about", () => {
 
     it("asks only about the protocols that actually call this agent", () => {
         expect(agentCallerProtocols(slackModel, agent)).toEqual(["slack"]);
-    });
-
-    it("says nothing when the agent is not in the model", () => {
         expect(agentCallerProtocols(slackModel, { filePath: AGENTS_BAL, startLine: 99 })).toEqual([]);
     });
 
@@ -746,5 +754,181 @@ describe("triggers that only Ballerina Central knows about", () => {
 
         expect(searchTriggers).not.toHaveBeenCalled();
         expect(scopes.get("http")).toBe("ENTRY_POINT");
+    });
+});
+
+const GITHUB_BAL = "/proj/github_trigger.bal";
+const ISSUES_UUID = "issues-service";
+const EVENT_CHANNELS: AgentTriggerScopes = new Map([["github", "ENTRY_POINT_BODY"]]);
+
+const handler = (name: string, line: number, wired: boolean) => ({
+    name,
+    location: { filePath: GITHUB_BAL, ...range(line) },
+    connections: wired ? [AGENT_UUID] : [],
+});
+
+const issuesService = (wired: string[], helpers: string[]) => ({
+    location: { filePath: GITHUB_BAL, ...range(5) },
+    attachedListeners: ["github-listener"],
+    connections: [AGENT_UUID],
+    resourceFunctions: [],
+    remoteFunctions: ["onOpened", "onClosed", "onReopened"].map((name, i) =>
+        handler(name, 10 + i * 5, wired.includes(name))),
+    functions: helpers.map((name, i) => handler(name, 40 + i * 5, true)),
+    absolutePath: "/github",
+    type: "github:IssuesService",
+    icon: "github.png",
+    uuid: ISSUES_UUID,
+    enableFlowModel: true,
+    sortText: "github_trigger.bal5",
+});
+
+const eventRows = (service: unknown) =>
+    findAgentUsages(
+        {
+            ...model,
+            listeners: [{
+                symbol: "githubListener",
+                location: { filePath: GITHUB_BAL, ...range(3) },
+                attachedServices: [ISSUES_UUID],
+                uuid: "github-listener",
+            }],
+            services: [service],
+        } as unknown as CDModel,
+        { filePath: AGENTS_BAL, startLine: 4 },
+        EVENT_CHANNELS
+    ).filter((usage) => usage.type === "github:IssuesService");
+
+describe("event handler rows", () => {
+    it("scopes the row to its own handler rather than the whole service", () => {
+        const rows = eventRows(issuesService(["onOpened"], ["runAgentOnOpened"]));
+
+        expect(rows.map((row) => row.label)).toEqual(["onOpened"]);
+        expect(rows[0].trigger?.scope).toBe("ENTRY_POINT_BODY");
+        expect(rows[0].trigger?.entryPoint).toMatchObject({ label: "onOpened", documentUri: GITHUB_BAL });
+    });
+
+    it("offers the service when no other handler reaches the agent", () => {
+        const rows = eventRows(issuesService(["onOpened"], ["runAgentOnOpened"]));
+
+        expect(rows[0].trigger?.orphansService).toBe(true);
+    });
+
+    it("keeps the service while a sibling handler still reaches the agent", () => {
+        const rows = eventRows(issuesService(["onOpened", "onClosed"], ["runAgentOnOpened", "runAgentOnClosed"]));
+
+        expect(rows.map((row) => row.label)).toEqual(["onOpened", "onClosed"]);
+        expect(rows.every((row) => row.trigger?.orphansService === false)).toBe(true);
+    });
+
+    it("does not count the required empty siblings against the service", () => {
+        const rows = eventRows(issuesService(["onClosed"], ["runAgentOnClosed"]));
+
+        expect(rows[0].trigger?.orphansService).toBe(true);
+    });
+
+    it("names the helpers that reach the agent so the offload target can be resolved", () => {
+        const rows = eventRows(issuesService(["onOpened"], ["runAgentOnOpened", "init"]));
+
+        expect(rows[0].trigger?.helpers?.map((helper) => helper.symbol)).toEqual(["runAgentOnOpened", "init"]);
+    });
+
+    it("carries no helpers for a scope that deletes the member outright", () => {
+        expect(httpRows(supportApi)[0].trigger?.helpers).toBeUndefined();
+    });
+});
+
+describe("finding the agent call inside a handler", () => {
+    const node = (expression: string, line = 11) => ({
+        properties: { expression: { value: expression } },
+        codedata: { lineRange: { startLine: { line } } },
+    }) as never;
+
+    it("matches the offload however the generator wrote it", () => {
+        expect(namesHelper(node("start self.runAgentOnOpened(payload)"), "runAgentOnOpened")).toBe(true);
+        expect(namesHelper(node("runAgentOnOpened(payload)"), "runAgentOnOpened")).toBe(true);
+    });
+
+    it("does not match a member that merely shares a prefix or suffix", () => {
+        expect(namesHelper(node("start self.runAgentOnOpenedTwice(payload)"), "runAgentOnOpened")).toBe(false);
+        expect(namesHelper(node("start self.rerunAgentOnOpened(payload)"), "runAgentOnOpened")).toBe(false);
+        expect(namesHelper(node("log:printInfo(\"hi\")"), "runAgentOnOpened")).toBe(false);
+        expect(namesHelper({ properties: {} } as never, "runAgentOnOpened")).toBe(false);
+    });
+
+    it("reads the line an edit has to be ordered by", () => {
+        expect(startLineOf(node("a", 20))).toBe(20);
+        expect(startLineOf({} as never)).toBe(0);
+    });
+});
+
+describe("re-resolving a reply method after the handler edit", () => {
+    const helperModel = {
+        services: [{
+            absolutePath: "/github",
+            type: "github:IssuesService",
+            functions: [
+                { name: "runAgentOnOpened", location: { filePath: GITHUB_BAL, ...range(37) } },
+                { name: "runAgentOnClosed", location: { filePath: GITHUB_BAL, ...range(45) } },
+            ],
+        }],
+    } as unknown as CDModel;
+
+    it("finds the helper at the position it now occupies", () => {
+        expect(findServiceHelperPosition(helperModel, "/github", "runAgentOnClosed", GITHUB_BAL))
+            .toEqual({ startLine: 45, startColumn: 0, endLine: 46, endColumn: 1 });
+    });
+
+    it("returns nothing for a helper that is gone, in another service, or in another file", () => {
+        expect(findServiceHelperPosition(helperModel, "/github", "runAgentOnDeleted", GITHUB_BAL)).toBeUndefined();
+        expect(findServiceHelperPosition(helperModel, "/elsewhere", "runAgentOnOpened", GITHUB_BAL)).toBeUndefined();
+        expect(findServiceHelperPosition(helperModel, "/github", "runAgentOnOpened", "/other.bal")).toBeUndefined();
+    });
+});
+
+describe("deleting components whose positions have moved", () => {
+    const listeners = [
+        { symbol: "githubListener", documentUri: GITHUB_BAL, position: { startLine: 3 } },
+        { symbol: "sharedListener", documentUri: GITHUB_BAL, position: { startLine: 1 } },
+    ] as never;
+
+    const clientSeeing = (models: unknown[]) => {
+        const getDesignModel = jest.fn();
+        models.forEach((model) => getDesignModel.mockResolvedValueOnce({ designModel: model }));
+        const deleteByComponentInfo = jest.fn().mockResolvedValue({});
+        return {
+            client: {
+                getVisualizerLocation: jest.fn().mockResolvedValue({ projectPath: "/proj" }),
+                getBIDiagramRpcClient: () => ({ getDesignModel, deleteByComponentInfo }),
+            } as never,
+            getDesignModel,
+            deleteByComponentInfo,
+        };
+    };
+
+    const seeing = (symbol: string, line: number) =>
+        ({ listeners: [{ symbol, location: { filePath: GITHUB_BAL, ...range(line) } }] });
+
+    const locate = (model: CDModel, target: { symbol: string; documentUri: string }) =>
+        findListenerPosition(model, target.symbol, target.documentUri);
+
+    it("re-reads the model before each deletion, so an earlier edit cannot stale a later one", async () => {
+        const { client, getDesignModel, deleteByComponentInfo } = clientSeeing([
+            seeing("githubListener", 14),
+            seeing("sharedListener", 1),
+        ]);
+
+        await deleteEachResolved(client, listeners, locate);
+
+        expect(getDesignModel).toHaveBeenCalledTimes(2);
+        expect(deleteByComponentInfo.mock.calls.map((call) => call[0].component.startLine)).toEqual([14, 1]);
+    });
+
+    it("skips a component that is already gone", async () => {
+        const { client, deleteByComponentInfo } = clientSeeing([{ listeners: [] }, seeing("sharedListener", 1)]);
+
+        await deleteEachResolved(client, listeners, locate);
+
+        expect(deleteByComponentInfo.mock.calls.map((call) => call[0].component.name)).toEqual(["sharedListener"]);
     });
 });

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.ts
@@ -22,8 +22,10 @@ import {
     AgentUsageTrigger,
     AgentUsageTriggerListener,
     AgentUsageTryIt,
+    CDFunction,
     CDLocation,
     CDModel,
+    CDResourceFunction,
     CDService,
     FlowNode,
     NodePosition,
@@ -129,11 +131,12 @@ function entryPointTrigger(
     location: CDLocation
 ): AgentUsageTrigger {
     const entryPoints = [...(service.resourceFunctions ?? []), ...(service.remoteFunctions ?? [])];
+    const wired = entryPoints.filter((fn) => (fn.connections?.length ?? 0) > 0 || (fn.workflows?.length ?? 0) > 0);
     return {
         ...trigger,
         entryPoint: { label, documentUri: location.filePath, position: toPosition(location) },
         orphansService: scope === "ENTRY_POINT_BODY"
-            ? entryPoints.filter((fn) => fn.connections?.includes(uuid)).length === 1
+            ? wired.length === 1 && Boolean(wired[0].connections?.includes(uuid))
             : entryPoints.length === 1 && (service.functions?.length ?? 0) === 0,
         scope,
         helpers: scope === "ENTRY_POINT_BODY" ? agentHelpers(service, uuid) : undefined,
@@ -376,12 +379,16 @@ export function startLineOf(node: FlowNode): number {
     return node.codedata?.lineRange?.startLine?.line ?? 0;
 }
 
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function namesHelper(node: FlowNode, helper: string): boolean {
     const expression = node.properties?.expression?.value;
     if (typeof expression !== "string") {
         return false;
     }
-    return new RegExp(`(^|[^\\w.])(self\\.)?${helper}\\s*\\(`).test(expression);
+    return new RegExp(`(^|[^\\w.])(self\\.)?${escapeRegExp(helper)}\\s*\\(`).test(expression);
 }
 
 export function findServiceHelperPosition(
@@ -428,6 +435,39 @@ export async function deleteEachResolved(
     }
 }
 
+async function otherEntryPoints(
+    rpcClient: BallerinaRpcClient,
+    trigger: AgentUsageTrigger
+): Promise<(CDResourceFunction | CDFunction)[]> {
+    const location = await rpcClient.getVisualizerLocation();
+    const model = (await rpcClient.getBIDiagramRpcClient()
+        .getDesignModel({ projectPath: location?.projectPath }))?.designModel;
+    const service = (model?.services ?? []).find((candidate) => serviceName(candidate) === trigger.serviceName);
+    return [...(service?.resourceFunctions ?? []), ...(service?.remoteFunctions ?? [])].filter(
+        (fn) =>
+            !samePath(fn.location.filePath, trigger.entryPoint.documentUri) ||
+            fn.location.startLine.line !== trigger.entryPoint.position.startLine
+    );
+}
+
+async function isHelperCalledElsewhere(
+    rpcClient: BallerinaRpcClient,
+    siblings: (CDResourceFunction | CDFunction)[],
+    helperSymbol: string
+): Promise<boolean> {
+    for (const sibling of siblings) {
+        const response = await rpcClient.getBIDiagramRpcClient().getFlowModel({
+            filePath: sibling.location.filePath,
+            startLine: sibling.location.startLine,
+            endLine: sibling.location.endLine,
+        });
+        if ((response?.flowModel?.nodes ?? []).some((node) => namesHelper(node, helperSymbol))) {
+            return true;
+        }
+    }
+    return false;
+}
+
 export async function clearAgentCallFromHandler(
     rpcClient: BallerinaRpcClient,
     trigger: AgentUsageTrigger
@@ -446,12 +486,21 @@ export async function clearAgentCallFromHandler(
         throw new Error(`no agent call found in ${entryPoint.label}`);
     }
 
+    const referencedHelpers = helpers.filter((helper) => calls.some((node) => namesHelper(node, helper.symbol)));
+    const siblings = trigger.orphansService ? [] : await otherEntryPoints(rpcClient, trigger);
+    const deletableHelpers: AgentUsageTriggerListener[] = [];
+    for (const helper of referencedHelpers) {
+        if (!(await isHelperCalledElsewhere(rpcClient, siblings, helper.symbol))) {
+            deletableHelpers.push(helper);
+        }
+    }
+
     for (const node of calls) {
         await rpcClient.getBIDiagramRpcClient().deleteFlowNode({ filePath: entryPoint.documentUri, flowNode: node });
     }
 
     await deleteEachResolved(
         rpcClient,
-        helpers.filter((helper) => calls.some((node) => namesHelper(node, helper.symbol))),
+        deletableHelpers,
         (model, helper) => findServiceHelperPosition(model, trigger.serviceName, helper.symbol, helper.documentUri));
 }

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.ts
@@ -20,10 +20,12 @@ import {
     AgentTriggerDeletionScope,
     AgentUsage,
     AgentUsageTrigger,
+    AgentUsageTriggerListener,
     AgentUsageTryIt,
     CDLocation,
     CDModel,
     CDService,
+    FlowNode,
     NodePosition,
 } from "@wso2/ballerina-core";
 import { BallerinaRpcClient } from "@wso2/ballerina-rpc-client";
@@ -112,18 +114,29 @@ function triggerFor(model: CDModel, service: CDService): AgentUsageTrigger {
     };
 }
 
+function agentHelpers(service: CDService, uuid: string): AgentUsageTriggerListener[] {
+    return (service.functions ?? [])
+        .filter((fn) => fn.connections?.includes(uuid))
+        .map((fn) => ({ symbol: fn.name, documentUri: fn.location.filePath, position: toPosition(fn.location) }));
+}
+
 function entryPointTrigger(
     service: CDService,
     trigger: AgentUsageTrigger,
+    uuid: string,
+    scope: AgentTriggerDeletionScope,
     label: string,
     location: CDLocation
 ): AgentUsageTrigger {
+    const entryPoints = [...(service.resourceFunctions ?? []), ...(service.remoteFunctions ?? [])];
     return {
         ...trigger,
         entryPoint: { label, documentUri: location.filePath, position: toPosition(location) },
-        orphansService:
-            (service.resourceFunctions?.length ?? 0) + (service.remoteFunctions?.length ?? 0) === 1 &&
-            (service.functions?.length ?? 0) === 0,
+        orphansService: scope === "ENTRY_POINT_BODY"
+            ? entryPoints.filter((fn) => fn.connections?.includes(uuid)).length === 1
+            : entryPoints.length === 1 && (service.functions?.length ?? 0) === 0,
+        scope,
+        helpers: scope === "ENTRY_POINT_BODY" ? agentHelpers(service, uuid) : undefined,
     };
 }
 
@@ -158,9 +171,10 @@ function usagesForService(
     const name = serviceName(service);
     const isAgentChat = modulePrefix(service.type) === "ai";
     const trigger = scope ? triggerFor(model, service) : undefined;
-    const serviceTrigger = scope === "ENTRY_POINT" ? undefined : trigger;
+    const memberScoped = scope === "ENTRY_POINT" || scope === "ENTRY_POINT_BODY";
+    const serviceTrigger = memberScoped ? undefined : trigger;
     const scopedTrigger = (rowLabel: string, location: CDLocation) =>
-        scope === "ENTRY_POINT" ? entryPointTrigger(service, trigger, rowLabel, location) : trigger;
+        memberScoped ? entryPointTrigger(service, trigger, uuid, scope, rowLabel, location) : trigger;
     const tryIt = tryItFor(model, service);
     const isHttp = modulePrefix(service.type) === "http";
     const usages: AgentUsage[] = [];
@@ -356,4 +370,88 @@ export async function resolveTriggerScopes(
         }
     }
     return resolved;
+}
+
+export function startLineOf(node: FlowNode): number {
+    return node.codedata?.lineRange?.startLine?.line ?? 0;
+}
+
+export function namesHelper(node: FlowNode, helper: string): boolean {
+    const expression = node.properties?.expression?.value;
+    if (typeof expression !== "string") {
+        return false;
+    }
+    return new RegExp(`(^|[^\\w.])(self\\.)?${helper}\\s*\\(`).test(expression);
+}
+
+export function findServiceHelperPosition(
+    model: CDModel,
+    service: string,
+    helper: string,
+    filePath: string
+): NodePosition | undefined {
+    const owner = (model?.services ?? []).find((candidate) => serviceName(candidate) === service);
+    const fn = (owner?.functions ?? []).find(
+        (candidate) => candidate.name === helper && samePath(candidate.location?.filePath ?? "", filePath));
+    return fn ? toPosition(fn.location) : undefined;
+}
+
+export function deleteComponentAt(
+    rpcClient: BallerinaRpcClient,
+    name: string,
+    documentUri: string,
+    position: NodePosition
+): Promise<unknown> {
+    return rpcClient.getBIDiagramRpcClient().deleteByComponentInfo({
+        filePath: documentUri,
+        component: {
+            name, filePath: documentUri,
+            startLine: position.startLine, startColumn: position.startColumn,
+            endLine: position.endLine, endColumn: position.endColumn,
+        },
+    });
+}
+
+export async function deleteEachResolved(
+    rpcClient: BallerinaRpcClient,
+    targets: AgentUsageTriggerListener[],
+    locate: (model: CDModel, target: AgentUsageTriggerListener) => NodePosition | undefined
+): Promise<void> {
+    for (const target of targets) {
+        const location = await rpcClient.getVisualizerLocation();
+        const model = await rpcClient.getBIDiagramRpcClient()
+            .getDesignModel({ projectPath: location?.projectPath });
+        const position = locate(model?.designModel, target);
+        if (position) {
+            await deleteComponentAt(rpcClient, target.symbol, target.documentUri, position);
+        }
+    }
+}
+
+export async function clearAgentCallFromHandler(
+    rpcClient: BallerinaRpcClient,
+    trigger: AgentUsageTrigger
+): Promise<void> {
+    const entryPoint = trigger.entryPoint;
+    const helpers = trigger.helpers ?? [];
+    const response = await rpcClient.getBIDiagramRpcClient().getFlowModel({
+        filePath: entryPoint.documentUri,
+        startLine: { line: entryPoint.position.startLine, offset: entryPoint.position.startColumn },
+        endLine: { line: entryPoint.position.endLine, offset: entryPoint.position.endColumn },
+    });
+    const calls = (response?.flowModel?.nodes ?? [])
+        .filter((node) => helpers.some((helper) => namesHelper(node, helper.symbol)))
+        .sort((a, b) => startLineOf(b) - startLineOf(a));
+    if (calls.length === 0) {
+        throw new Error(`no agent call found in ${entryPoint.label}`);
+    }
+
+    for (const node of calls) {
+        await rpcClient.getBIDiagramRpcClient().deleteFlowNode({ filePath: entryPoint.documentUri, flowNode: node });
+    }
+
+    await deleteEachResolved(
+        rpcClient,
+        helpers.filter((helper) => calls.some((node) => namesHelper(node, helper.symbol))),
+        (model, helper) => findServiceHelperPosition(model, trigger.serviceName, helper.symbol, helper.documentUri));
 }

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.ts
@@ -247,14 +247,10 @@ function isGeneratedChatService(filePath?: string): boolean {
 }
 
 function groupByChannel(services: CDService[]): CDService[] {
-    const order = new Map<string, number>();
-    services.forEach((service) => {
-        const channel = modulePrefix(service.type);
-        if (!order.has(channel)) {
-            order.set(channel, order.size);
-        }
-    });
-    return [...services].sort((a, b) => order.get(modulePrefix(a.type)) - order.get(modulePrefix(b.type)));
+    return [...services].sort((a, b) =>
+        modulePrefix(a.type).localeCompare(modulePrefix(b.type)) ||
+        (a.location?.filePath ?? "").localeCompare(b.location?.filePath ?? "") ||
+        (a.location?.startLine?.line ?? 0) - (b.location?.startLine?.line ?? 0));
 }
 
 export function findAgentUsages(

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/agentUsages.ts
@@ -300,8 +300,8 @@ export function findAgentUsages(
 
 const usageCache = new Map<string, AgentUsage[]>();
 
-export function usageCacheKey(projectPath: string, filePath: string, startLine: number): string {
-    return `${projectPath}::${filePath}::${startLine}`;
+export function usageCacheKey(projectPath: string, filePath: string, agentName: string): string {
+    return `${projectPath}::${filePath}::${agentName}`;
 }
 
 export function getCachedUsages(key: string): AgentUsage[] | undefined {

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/index.tsx
@@ -46,7 +46,8 @@ import {
     AgentUsage,
     AgentUsageTrigger,
     FOCUS_FLOW_DIAGRAM_VIEW,
-    FocusFlowDiagramView
+    FocusFlowDiagramView,
+    triggerScopeNoun
 } from "@wso2/ballerina-core";
 import { PanelContainer } from "@wso2/ballerina-side-panel";
 import { ConnectionConfig, ConnectionCreator, ConnectionSelectionList } from "../../../components/ConnectionSelector";
@@ -135,6 +136,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
     const usageRequestIdRef = useRef(0);
     const usagesDirtyRef = useRef(true);
     const usagesContentRef = useRef(0);
+    const deletingTriggerRef = useRef(false);
     const [agentFormKey, setAgentFormKey] = useState(0);
     const [agentTypeFormMode, setAgentTypeFormMode] = useState<"ALL" | "MODEL">("ALL");
 
@@ -184,6 +186,9 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
     useEffect(() => {
         const unsubscribeContentUpdated = rpcClient.onProjectContentUpdated((state: boolean) => {
             console.log(">>> on project content updated", state);
+            if (deletingTriggerRef.current) {
+                return;
+            }
             usagesDirtyRef.current = true;
             usagesContentRef.current++;
             if (isAgent) {
@@ -378,7 +383,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
         }
 
         const isEndpoint = trigger.scope === "ENTRY_POINT";
-        const label = isEndpoint ? "Endpoint" : "Trigger";
+        const label = triggerScopeNoun(trigger.scope);
         const only = `Delete ${label}`;
         const withService = `Delete ${label} and Service`;
         const consequence = isEndpoint
@@ -428,6 +433,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
             return;
         }
         setShowProgressIndicator(true);
+        deletingTriggerRef.current = true;
         try {
             if (scope === "endpoint" && trigger.scope === "ENTRY_POINT_BODY") {
                 await clearAgentCallFromHandler(rpcClient, trigger);
@@ -444,6 +450,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
             await rpcClient.getAIAgentRpcClient().fixMissingImports();
             usagesDirtyRef.current = true;
             usagesContentRef.current++;
+            debouncedGetAgentModel();
         } catch (error) {
             console.error(">>> agent focus: failed to delete trigger", error);
             rpcClient.getCommonRpcClient().showErrorMessage({
@@ -451,6 +458,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
                     + "Some changes may have been applied. Review the source before retrying.",
             });
         } finally {
+            deletingTriggerRef.current = false;
             setShowProgressIndicator(false);
         }
     };

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/index.tsx
@@ -44,6 +44,7 @@ import {
     NodePosition,
     NodeMetadata,
     AgentUsage,
+    AgentUsageTrigger,
     FOCUS_FLOW_DIAGRAM_VIEW,
     FocusFlowDiagramView
 } from "@wso2/ballerina-core";
@@ -56,6 +57,9 @@ import { goToAgent, goToAgentDefinitionFromInstance, resolveAgentDefinitionLocat
 import { buildAgentRenderNode, withAgentUsages } from "./agent";
 import {
     agentCallerProtocols,
+    clearAgentCallFromHandler,
+    deleteComponentAt,
+    deleteEachResolved,
     findAgentUsages,
     findListenerPosition,
     getAgentTriggerScopes,
@@ -353,34 +357,38 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
 
     const confirmTriggerDeletion = async (usage: AgentUsage): Promise<"endpoint" | "service" | undefined> => {
         const trigger = usage.trigger;
-        const listenerNames = trigger.listeners.map((listener) => listener.symbol);
+        const listeners = trigger.listeners.map((listener) => listener.symbol).join(", ");
+        const listenerNote = listeners
+            ? ` Its listener ${listeners} will also be deleted because no other service uses it.`
+            : "";
 
         if (!trigger.entryPoint) {
             const confirmed = await rpcClient.getCommonRpcClient().showInformationModal({
-                message: `Delete the ${usage.typeLabel ?? "trigger"} ${trigger.serviceName}?`,
-                detail: listenerNames.length > 0
-                    ? `Its listener ${listenerNames.join(", ")} will be removed too — nothing else uses it.`
-                    : "The service owns everything it needs to call the agent, so that goes with it.",
-                items: ["Delete"],
+                message: `Are you sure you want to delete the ${trigger.serviceName} trigger?`,
+                detail: `The agent will no longer run when this trigger fires.${listenerNote}`,
+                items: ["Delete Trigger"],
             });
-            return confirmed === "Delete" ? "service" : undefined;
+            return confirmed === "Delete Trigger" ? "service" : undefined;
         }
 
-        const endpointOnly = "Delete Endpoint";
-        const withService = "Delete Endpoint and Service";
-        const service = `${usage.typeLabel ?? "the service"} ${trigger.serviceName}`;
-        const listenerNote = listenerNames.length > 0
-            ? ` and its listener ${listenerNames.join(", ")} goes with it — nothing else uses it`
-            : "";
+        const isEndpoint = trigger.scope === "ENTRY_POINT";
+        const label = isEndpoint ? "Endpoint" : "Trigger";
+        const only = `Delete ${label}`;
+        const withService = `Delete ${label} and Service`;
+        const consequence = isEndpoint
+            ? "The agent will no longer be reachable at this endpoint."
+            : "The agent will no longer run when this event occurs.";
+        const remainder = trigger.orphansService
+            ? `No other ${label.toLowerCase()} on ${trigger.serviceName} uses the agent, `
+                + `so the service can be deleted as well.${listenerNote}`
+            : `Other ${label.toLowerCase()}s on ${trigger.serviceName} are unaffected.`;
 
         const choice = await rpcClient.getCommonRpcClient().showInformationModal({
-            message: `Delete ${trigger.entryPoint.label}?`,
-            detail: trigger.orphansService
-                ? `It is the only endpoint on ${service}. Delete the service too${listenerNote}.`
-                : `Only this endpoint is removed. ${service} stays.`,
-            items: trigger.orphansService ? [endpointOnly, withService] : [endpointOnly],
+            message: `Are you sure you want to delete the ${trigger.entryPoint.label} ${label.toLowerCase()}?`,
+            detail: `${consequence} ${remainder}`,
+            items: trigger.orphansService ? [only, withService] : [only],
         });
-        if (choice === endpointOnly) {
+        if (choice === only) {
             return "endpoint";
         }
         return choice === withService ? "service" : undefined;
@@ -415,36 +423,17 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
         }
         setShowProgressIndicator(true);
         try {
-            const deleteComponent = (name: string, documentUri: string, position: NodePosition) =>
-                rpcClient.getBIDiagramRpcClient().deleteByComponentInfo({
-                    filePath: documentUri,
-                    component: {
-                        name,
-                        filePath: documentUri,
-                        startLine: position.startLine,
-                        startColumn: position.startColumn,
-                        endLine: position.endLine,
-                        endColumn: position.endColumn,
-                    },
-                });
-
-            if (scope === "endpoint") {
+            if (scope === "endpoint" && trigger.scope === "ENTRY_POINT_BODY") {
+                await clearAgentCallFromHandler(rpcClient, trigger);
+            } else if (scope === "endpoint") {
                 const entryPoint = trigger.entryPoint;
-                await deleteComponent(entryPoint.label, entryPoint.documentUri, entryPoint.position);
+                await deleteComponentAt(
+                    rpcClient, entryPoint.label, entryPoint.documentUri, entryPoint.position);
             } else {
-                await deleteComponent(trigger.serviceName, trigger.documentUri, trigger.position);
-                for (const listener of trigger.listeners) {
-                    const location = await rpcClient.getVisualizerLocation();
-                    const response = await rpcClient
-                        .getBIDiagramRpcClient()
-                        .getDesignModel({ projectPath: location?.projectPath });
-                    const position = findListenerPosition(
-                        response?.designModel, listener.symbol, listener.documentUri);
-                    if (!position) {
-                        continue;
-                    }
-                    await deleteComponent(listener.symbol, listener.documentUri, position);
-                }
+                await deleteComponentAt(
+                    rpcClient, trigger.serviceName, trigger.documentUri, trigger.position);
+                await deleteEachResolved(rpcClient, trigger.listeners,
+                    (model, listener) => findListenerPosition(model, listener.symbol, listener.documentUri));
             }
             await rpcClient.getAIAgentRpcClient().fixMissingImports();
             usagesDirtyRef.current = true;
@@ -452,8 +441,8 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
         } catch (error) {
             console.error(">>> agent focus: failed to delete trigger", error);
             rpcClient.getCommonRpcClient().showErrorMessage({
-                message: `Failed to delete the ${scope === "endpoint" ? "endpoint" : "trigger"}. `
-                    + "The deletion may be partially applied.",
+                message: `Unable to delete the ${scope === "endpoint" ? "endpoint" : "trigger"}. `
+                    + "Some changes may have been applied. Review the source before retrying.",
             });
         } finally {
             setShowProgressIndicator(false);

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/index.tsx
@@ -166,6 +166,12 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
     const expressionOffsetRef = useRef<number>(0); // To track the expression offset on adding import statements
 
     useEffect(() => {
+        if (embedded && props.position) {
+            embeddedPositionRef.current = props.position;
+        }
+    }, [embedded, props.position?.startLine, props.position?.endLine]);
+
+    useEffect(() => {
         if (isAgent) {
             getAgentModel();
         } else if (isAgentType) {
@@ -293,7 +299,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
 
 
     const loadAgentUsages = (renderNode: FlowNode, flow: Flow, pos: NodePosition, projectKey: string) => {
-        const key = usageCacheKey(projectKey, filePath, pos.startLine);
+        const key = usageCacheKey(projectKey, filePath, String(renderNode.properties?.variable?.value ?? ""));
         const cached = getCachedUsages(key);
         if (!usagesDirtyRef.current && cached) {
             return;
@@ -380,7 +386,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
             : "The agent will no longer run when this event occurs.";
         const remainder = trigger.orphansService
             ? `No other ${label.toLowerCase()} on ${trigger.serviceName} uses the agent, `
-                + `so the service can be deleted as well.${listenerNote}`
+            + `so the service can be deleted as well.${listenerNote}`
             : `Other ${label.toLowerCase()}s on ${trigger.serviceName} are unaffected.`;
 
         const choice = await rpcClient.getCommonRpcClient().showInformationModal({
@@ -486,7 +492,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
             const connections = fetchedFlow?.connections || [];
             const projectKey = location?.projectPath ?? projectPath ?? "";
             const cachedUsages = kind === "AGENT"
-                ? getCachedUsages(usageCacheKey(projectKey, filePath, pos.startLine))
+                ? getCachedUsages(usageCacheKey(projectKey, filePath, String(agentDecl.properties?.variable?.value ?? "")))
                 : undefined;
             const renderNode: FlowNode = kind === "AGENT"
                 ? withAgentUsages(buildAgentRenderNode(agentDecl, connections), cachedUsages ?? [], false)
@@ -1080,7 +1086,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
         } else if (agentPanel !== "NONE") {
             handleCloseAgentPanel();
         } else {
-            agentEditor.close();
+            agentEditor.cancel();
         }
     };
 
@@ -1286,7 +1292,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
                     title={agentPanelTitle}
                     show={true}
                     onClose={showConnectionPanel ? handleCloseConnectionPanel
-                        : agentPanel !== "NONE" ? handleCloseAgentPanel : () => agentEditor.close()}
+                        : agentPanel !== "NONE" ? handleCloseAgentPanel : () => agentEditor.cancel()}
                     onBack={agentPanelOnBack}
                 >
                     {renderAgentPanelContent()}

--- a/packages/bi-diagram/src/components/nodes/AgentNode/AgentNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/AgentNode/AgentNodeWidget.tsx
@@ -879,10 +879,10 @@ export function AgentNodeWidget(props: AgentNodeWidgetProps) {
     };
 
     const canDeleteTrigger = (usage: AgentUsage) =>
-        !readOnly && Boolean(usage.trigger) && Boolean(agentNode?.onDeleteTrigger);
+        Boolean(usage.trigger) && Boolean(agentNode?.onDeleteTrigger);
 
     const canTryTrigger = (usage: AgentUsage) =>
-        !readOnly && Boolean(usage.tryIt) && Boolean(agentNode?.onTryTrigger);
+        Boolean(usage.tryIt) && Boolean(agentNode?.onTryTrigger);
 
     const hasUsageMenu = (usage: AgentUsage) => canTryTrigger(usage) || canDeleteTrigger(usage);
 
@@ -906,7 +906,7 @@ export function AgentNodeWidget(props: AgentNodeWidgetProps) {
         hasUsageMenu(usage) ? usageMenuX(usage) : Math.max(0, USAGE_TEXT_RIGHT_X - usageTextWidth(usage));
 
     const agentUsageOptions = { canAddTrigger: Boolean(agentNode?.onAddTrigger) };
-    const showsAddTile = !readOnly && showsAddTriggerTile(agentWidgetType, agentUsageOptions);
+    const showsAddTile = showsAddTriggerTile(agentWidgetType, agentUsageOptions);
     const addTileRow = usages.length + (hiddenUsageCount > 0 ? 1 : 0);
     const addTileY = addTileRow * AGENT_USAGE_ROW_PITCH
         - (addTileRow > 0 ? AGENT_NODE_USAGE_GAP - AGENT_NODE_TOOL_GAP : 0);
@@ -1165,7 +1165,7 @@ export function AgentNodeWidget(props: AgentNodeWidgetProps) {
                                 key="delete-trigger"
                                 item={{
                                     id: "deleteTrigger",
-                                    label: selectedUsage.trigger?.entryPoint ? "Delete Endpoint" : "Delete Trigger",
+                                    label: "Delete Trigger",
                                     onClick: () => onDeleteTrigger(selectedUsage),
                                 }}
                             />

--- a/packages/bi-diagram/src/components/nodes/AgentNode/AgentNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/AgentNode/AgentNodeWidget.tsx
@@ -52,6 +52,7 @@ import {
     resolveBrandIcon,
     resolveEntryTypeGlyph,
     resolveKindDefaultIcon,
+    triggerScopeNoun,
 } from "@wso2/ballerina-core";
 import ReactMarkdown from "react-markdown";
 
@@ -492,28 +493,32 @@ function UsageIcon(props: { usage: AgentUsage; codedata?: FlowNode["codedata"] }
 
 function EdgeAddButton(props: {
     anchorX: number; y: number; side: "left" | "right"; label: string; title: string; testId: string;
-    animationDelay?: number; onClick: () => void;
+    animationDelay?: number; onClick: () => void; readOnly?: boolean;
 }) {
-    const { anchorX, y, side, label, title, testId, animationDelay, onClick } = props;
+    const { anchorX, y, side, label, title, testId, animationDelay, onClick, readOnly } = props;
     const dir = side === "right" ? 1 : -1;
     const plusCx = dir * EDGE_ADD_PLUS_CX;
     const labelX = dir * (EDGE_ADD_PLUS_CX + EDGE_ADD_PLUS_R + EDGE_ADD_LABEL_GAP);
+    const strokeColor = readOnly ? ThemeColors.OUTLINE_VARIANT : ThemeColors.ON_SURFACE;
+    const labelColor = readOnly ? ThemeColors.ON_SURFACE_VARIANT : ADD_TILE_LABEL_COLOR;
     return (
         <g
             data-testid={testId}
             transform={`translate(${anchorX}, ${y})`}
             onClick={onClick}
             css={css`
-                cursor: pointer;
+                cursor: ${readOnly ? "not-allowed" : "pointer"};
                 > g {
                     ${animationDelay === undefined ? "" : usageFadeIn(animationDelay)}
                 }
-                &:hover .edge-add-stroke {
-                    stroke: ${ThemeColors.SECONDARY};
-                }
-                &:hover text {
-                    fill: ${ThemeColors.SECONDARY};
-                }
+                ${readOnly ? "" : css`
+                    &:hover .edge-add-stroke {
+                        stroke: ${ThemeColors.SECONDARY};
+                    }
+                    &:hover text {
+                        fill: ${ThemeColors.SECONDARY};
+                    }
+                `}
             `}
         >
             <g>
@@ -531,7 +536,7 @@ function EdgeAddButton(props: {
                     cy="0"
                     r={EDGE_ADD_DOT_R}
                     fill={ThemeColors.SURFACE_DIM}
-                    stroke={ThemeColors.ON_SURFACE}
+                    stroke={strokeColor}
                     strokeWidth={1.5}
                 />
                 <line
@@ -540,7 +545,7 @@ function EdgeAddButton(props: {
                     y1="0"
                     x2={dir * EDGE_ADD_LINE_END}
                     y2="0"
-                    stroke={ThemeColors.ON_SURFACE}
+                    stroke={strokeColor}
                     strokeWidth={1.5}
                 />
                 <circle
@@ -549,18 +554,18 @@ function EdgeAddButton(props: {
                     cy="0"
                     r={EDGE_ADD_PLUS_R}
                     fill={ThemeColors.SURFACE_DIM}
-                    stroke={ThemeColors.ON_SURFACE}
+                    stroke={strokeColor}
                     strokeWidth={1.5}
                 />
                 <line className="edge-add-stroke" x1={plusCx - 4} y1="0" x2={plusCx + 4} y2="0"
-                    stroke={ThemeColors.ON_SURFACE} strokeWidth={1.5} strokeLinecap="round" />
+                    stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" />
                 <line className="edge-add-stroke" x1={plusCx} y1="-4" x2={plusCx} y2="4"
-                    stroke={ThemeColors.ON_SURFACE} strokeWidth={1.5} strokeLinecap="round" />
+                    stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" />
                 <text
                     x={labelX}
                     y="0"
                     textAnchor={side === "right" ? "start" : "end"}
-                    fill={ADD_TILE_LABEL_COLOR}
+                    fill={labelColor}
                     fontSize="13px"
                     fontFamily="GilmerMedium"
                     dominantBaseline="middle"
@@ -887,7 +892,7 @@ export function AgentNodeWidget(props: AgentNodeWidgetProps) {
     const hasUsageMenu = (usage: AgentUsage) => canTryTrigger(usage) || canDeleteTrigger(usage);
 
     const deleteTriggerLabel = (usage: AgentUsage) =>
-        usage.trigger?.scope === "ENTRY_POINT" ? "Delete Endpoint" : "Delete Trigger";
+        `Delete ${triggerScopeNoun(usage.trigger?.scope)}`;
 
     const tryTriggerLabel = (usage: AgentUsage) =>
         (usage.type?.split(":")[0] ?? usage.type) === "ai" ? "Chat" : "Try It";
@@ -1113,6 +1118,7 @@ export function AgentNodeWidget(props: AgentNodeWidgetProps) {
                                     <NodeStyles.MenuButton
                                         appearance="icon"
                                         onClick={(e) => handleUsageMenuClick(e, usage)}
+                                        buttonSx={readOnly ? { cursor: "not-allowed" } : {}}
                                         css={css`
                                         padding: 2px;
                                         height: ${USAGE_MENU_SIZE}px;
@@ -1187,6 +1193,7 @@ export function AgentNodeWidget(props: AgentNodeWidgetProps) {
                         title="Connect this agent to a chat channel or event source that will call it"
                         animationDelay={animateUsages ? addTileRow * 70 : undefined}
                         onClick={onAddTriggerClick}
+                        readOnly={readOnly}
                     />
                 )}
 

--- a/packages/bi-diagram/src/components/nodes/AgentNode/AgentNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/AgentNode/AgentNodeWidget.tsx
@@ -886,6 +886,9 @@ export function AgentNodeWidget(props: AgentNodeWidgetProps) {
 
     const hasUsageMenu = (usage: AgentUsage) => canTryTrigger(usage) || canDeleteTrigger(usage);
 
+    const deleteTriggerLabel = (usage: AgentUsage) =>
+        usage.trigger?.scope === "ENTRY_POINT" ? "Delete Endpoint" : "Delete Trigger";
+
     const tryTriggerLabel = (usage: AgentUsage) =>
         (usage.type?.split(":")[0] ?? usage.type) === "ai" ? "Chat" : "Try It";
 
@@ -1165,7 +1168,7 @@ export function AgentNodeWidget(props: AgentNodeWidgetProps) {
                                 key="delete-trigger"
                                 item={{
                                     id: "deleteTrigger",
-                                    label: "Delete Trigger",
+                                    label: deleteTriggerLabel(selectedUsage),
                                     onClick: () => onDeleteTrigger(selectedUsage),
                                 }}
                             />

--- a/packages/bi-diagram/src/components/nodes/AgentWidget/useAgentFocusFit.ts
+++ b/packages/bi-diagram/src/components/nodes/AgentWidget/useAgentFocusFit.ts
@@ -103,13 +103,12 @@ export function useAgentFocusFit(diagramEngine: DiagramEngine, isAgentFocusView:
             }
             const agentNode = findAgentFocusNode(nodes);
             positionAgentFocusNode(agentNode);
-            // Measured after paint: before it, the node still reports its previous size.
-            requestAnimationFrame(() => {
+            requestAnimationFrame(() => requestAnimationFrame(() => {
                 fitToContainer(false);
                 diagramEngine.repaintCanvas();
                 setCanvasVisible(true);
                 watchNodeSize(agentNode);
-            });
+            }));
         },
         [isAgentFocusView, fitToContainer, diagramEngine, watchNodeSize]
     );

--- a/packages/bi-diagram/src/test/AgentNodeStability.test.tsx
+++ b/packages/bi-diagram/src/test/AgentNodeStability.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Diagram } from "../components/Diagram";
+import { Flow } from "../utils/types";
+
+const agentFlow = (): Flow => ({
+    fileName: "agents.bal",
+    nodes: [{
+        id: "agent-1",
+        codedata: { node: "AGENT", lineRange: { fileName: "agents.bal", startLine: { line: 4, offset: 0 }, endLine: { line: 8, offset: 1 } } },
+        returning: true,
+        properties: { variable: { value: "mathTutorAgent" } },
+        metadata: {
+            label: "AI Agent",
+            data: {
+                agentInfo: {
+                    animateUsages: false,
+                    usages: [{
+                        label: "POST /chat",
+                        type: "http:Service",
+                        documentUri: "main.bal",
+                        position: { startLine: 6, startColumn: 4, endLine: 9, endColumn: 5 },
+                        trigger: { serviceName: "/math-tutor", documentUri: "main.bal", listeners: [],
+                            position: { startLine: 5, startColumn: 0, endLine: 12, endColumn: 1 } },
+                    }],
+                },
+            },
+        },
+    }],
+    connections: [],
+} as unknown as Flow);
+
+const agentNode = { onAddTrigger: jest.fn(), onDeleteTrigger: jest.fn(), onTryTrigger: jest.fn() };
+
+const props = {
+    onAddNode: jest.fn(), onDeleteNode: jest.fn(), onNodeSelect: jest.fn(),
+    onAddComment: jest.fn(), goToSource: jest.fn(), openView: jest.fn(),
+};
+
+const GEOMETRY_TESTIDS = ["agent-node", "agent-usage-column", "agent-usage-row", "agent-usage-menu", "agent-add-trigger"];
+
+async function geometryOf(readOnly: boolean): Promise<Record<string, number>> {
+    const dom = render(<Diagram model={agentFlow()} {...props} agentNode={agentNode} readOnly={readOnly} />);
+    await waitFor(() => expect(dom.container.querySelector("[data-testid='agent-node']")).toBeTruthy(),
+        { timeout: 10000 });
+    const counts = Object.fromEntries(GEOMETRY_TESTIDS.map((id) =>
+        [id, dom.container.querySelectorAll(`[data-testid='${id}']`).length]));
+    dom.unmount();
+    return counts;
+}
+
+describe("the agent node's footprint does not depend on transient state", () => {
+    it("renders the same geometry-bearing elements whether or not readOnly is set", async () => {
+        const editable = await geometryOf(false);
+        const loading = await geometryOf(true);
+
+        expect(loading).toEqual(editable);
+    });
+
+    it("still draws the usage column and its add tile while a refresh is in flight", async () => {
+        const loading = await geometryOf(true);
+
+        expect(loading["agent-usage-column"]).toBe(1);
+        expect(loading["agent-add-trigger"]).toBe(1);
+        expect(loading["agent-usage-row"]).toBe(1);
+        expect(loading["agent-usage-menu"]).toBe(1);
+    });
+});


### PR DESCRIPTION
Changes include:

- You can now remove an agent from one event trigger without deleting the whole service
- Triggers now show in a consistent order every time
- Fixed the agent node shifting position while a refresh was in progress
- Fixed tab selection jumping to the wrong agent after a rename or edit
- Fixed the agent diagram loading off-center on first open
- Closing the Add Tool or Add Memory panel without saving no longer reloads the diagram