### PR TITLE
Run the scheduled E2E suite on Windows alongside Linux

### DIFF
--- a/.github/actions/run-e2e-group/action.yml
+++ b/.github/actions/run-e2e-group/action.yml
@@ -60,6 +60,12 @@ runs:
       env:
         # Not under test-results/ (Playwright's outputDir, wiped every invocation).
         PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-first.json
+        # Passed through env, not interpolated into the run: block below — a `${{ }}`
+        # expression is substituted into the script text before the shell parses it, so a
+        # caller-supplied group would be executed rather than matched. Both callers pass a
+        # literal matrix value today; this keeps that from being load-bearing. Same reason
+        # setup-ballerina/action.yml passes gradlePropertiesRef this way.
+        TEST_GROUP: ${{ inputs.group }}
       run: |
         # Windows runs VS Code headed on the runner's own desktop, so there is no xvfb
         # display to create and no ffmpeg X11 screen grab to wrap the run in. The suite
@@ -68,13 +74,13 @@ runs:
         # only the whole-session record.mp4 is Linux-only.
         if [ "$RUNNER_OS" = "Windows" ]; then
           cd packages/ballerina-extension
-          pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ inputs.group }}
+          pnpm exec playwright test -c e2e-test/playwright.config.js --grep "$TEST_GROUP"
           exit
         fi
         export $(dbus-launch)
         export DISPLAY=:98.0
         cd packages/ballerina-extension
-        xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ inputs.group }}"
+        xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c 'ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep "$TEST_GROUP"'
 
     # Not run automatically on Windows: with maxFailures 10 and a 20-minute per-test
     # timeout, a second --last-failed pass over platform failures can spend what is left
@@ -88,17 +94,19 @@ runs:
       env:
         # run_attempt-suffixed so a second re-run doesn't overwrite the first's report.
         PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-rerun-${{ github.run_attempt }}.json
+        # See the first-attempt step for why this is an env var and not an interpolation.
+        TEST_GROUP: ${{ inputs.group }}
       run: |
         rm -rf packages/ballerina-extension/e2e-test/data/new-project
         if [ "$RUNNER_OS" = "Windows" ]; then
           cd packages/ballerina-extension
-          pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ inputs.group }} --last-failed
+          pnpm exec playwright test -c e2e-test/playwright.config.js --grep "$TEST_GROUP" --last-failed
           exit
         fi
         export $(dbus-launch)
         export DISPLAY=:98.0
         cd packages/ballerina-extension
-        xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ inputs.group }} --last-failed"
+        xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c 'ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep "$TEST_GROUP" --last-failed'
 
     - name: Upload Ballerina e2e Test results
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/actions/run-e2e-group/action.yml
+++ b/.github/actions/run-e2e-group/action.yml
@@ -62,8 +62,9 @@ runs:
         PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-first.json
       run: |
         # Windows runs VS Code headed on the runner's own desktop, so there is no xvfb
-        # display to create and no ffmpeg X11 screen grab to wrap the run in. Playwright's
-        # own per-test videos, screenshots and traces are still produced and uploaded;
+        # display to create and no ffmpeg X11 screen grab to wrap the run in. The suite
+        # captures its own failure screenshots (setup.ts) and session video (test.list.ts)
+        # on both platforms, and BI_E2E_TRACE keeps traces working where retries are 0;
         # only the whole-session record.mp4 is Linux-only.
         if [ "$RUNNER_OS" = "Windows" ]; then
           cd packages/ballerina-extension
@@ -75,9 +76,15 @@ runs:
         cd packages/ballerina-extension
         xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c "ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ inputs.group }}"
 
+    # Not run automatically on Windows: with maxFailures 10 and a 20-minute per-test
+    # timeout, a second --last-failed pass over platform failures can spend what is left
+    # of the 60-minute budget and get the leg killed before it uploads anything, which is
+    # the same cost BI_E2E_RETRIES: 0 removes from the first attempt. The re-run still
+    # happens on a manual "Re-run failed jobs" (check-results success), which is the
+    # resume path it exists for.
     - name: Run Failed Ballerina e2e Test (Re-run)
       shell: bash
-      if: steps.run-tests-first.outcome == 'failure' || steps.check-results.outcome == 'success'
+      if: (steps.run-tests-first.outcome == 'failure' && runner.os != 'Windows') || steps.check-results.outcome == 'success'
       env:
         # run_attempt-suffixed so a second re-run doesn't overwrite the first's report.
         PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-rerun-${{ github.run_attempt }}.json

--- a/.github/actions/run-e2e-group/action.yml
+++ b/.github/actions/run-e2e-group/action.yml
@@ -2,10 +2,11 @@ name: 'Run E2E test group'
 description: >-
   Runs one matrix group of the Ballerina e2e Playwright suite (first attempt, then a
   --last-failed re-run if needed) and uploads its results/recordings/project-data
-  artifacts. Shared by reusable-build.yml's BalE2ETest job and e2e-scheduled.yml's E2E
-  job — see "Scheduled E2E testing" in .github/workflows/README.md for the design
-  rationale. Assumes the workspace is already prepared (deps installed, Ballerina
-  distribution installed) by the calling job.
+  artifacts. Runs on both Linux and Windows runners; every artifact name carries the
+  platform so the two legs never collide. Shared by reusable-build.yml's BalE2ETest job
+  and e2e-scheduled.yml's E2E job — see "Scheduled E2E testing" in
+  .github/workflows/README.md for the design rationale. Assumes the workspace is already
+  prepared (deps installed, Ballerina distribution installed) by the calling job.
 inputs:
   group:
     description: 'Matrix group name, e.g. group1'
@@ -13,6 +14,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Artifact names are lowercase ('linux', 'windows'). GitHub expressions have no
+    # lowercase function, so runner.os ('Linux'/'Windows') is folded here once rather
+    # than passed in as a second input the caller could contradict.
+    - name: Resolve platform label
+      shell: bash
+      id: platform
+      run: echo "label=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
     - name: Check for previous test results
       shell: bash
       if: github.run_attempt > 1
@@ -26,16 +35,22 @@ runs:
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       continue-on-error: true
       with:
-        name: Ballerina-e2e-test-results-linux-${{ inputs.group }}-${{ env.PREVIOUS_ATTEMPT }}
+        name: Ballerina-e2e-test-results-${{ steps.platform.outputs.label }}-${{ inputs.group }}-${{ env.PREVIOUS_ATTEMPT }}
         # Restored e2e-reports/ is deliberately kept, not discarded — see README.
         path: packages/ballerina-extension
 
-    - name: Install packages
+    # Linux only: the Windows runner already has an interactive desktop session, a
+    # working keyring, and no need for a virtual display or dbus.
+    - name: Install display and keyring packages
       shell: bash
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y xvfb ffmpeg gnome-keyring libsecret-1.0 dbus-x11
-        cd packages/ballerina-extension && npx playwright install
+
+    - name: Install Playwright browsers
+      shell: bash
+      run: cd packages/ballerina-extension && npx playwright install
 
     - name: Run Ballerina e2e Test (First Attempt)
       shell: bash
@@ -46,6 +61,15 @@ runs:
         # Not under test-results/ (Playwright's outputDir, wiped every invocation).
         PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-first.json
       run: |
+        # Windows runs VS Code headed on the runner's own desktop, so there is no xvfb
+        # display to create and no ffmpeg X11 screen grab to wrap the run in. Playwright's
+        # own per-test videos, screenshots and traces are still produced and uploaded;
+        # only the whole-session record.mp4 is Linux-only.
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          cd packages/ballerina-extension
+          pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ inputs.group }}
+          exit
+        fi
         export $(dbus-launch)
         export DISPLAY=:98.0
         cd packages/ballerina-extension
@@ -59,6 +83,11 @@ runs:
         PLAYWRIGHT_JSON_OUTPUT_FILE: e2e-reports/e2e-results-rerun-${{ github.run_attempt }}.json
       run: |
         rm -rf packages/ballerina-extension/e2e-test/data/new-project
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          cd packages/ballerina-extension
+          pnpm exec playwright test -c e2e-test/playwright.config.js --grep ${{ inputs.group }} --last-failed
+          exit
+        fi
         export $(dbus-launch)
         export DISPLAY=:98.0
         cd packages/ballerina-extension
@@ -68,7 +97,7 @@ runs:
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: always()
       with:
-        name: Ballerina-e2e-test-results-linux-${{ inputs.group }}-${{ github.run_attempt }}
+        name: Ballerina-e2e-test-results-${{ steps.platform.outputs.label }}-${{ inputs.group }}-${{ github.run_attempt }}
         path: |
           packages/ballerina-extension/test-results/**
           packages/ballerina-extension/e2e-reports/**
@@ -79,7 +108,7 @@ runs:
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: always()
       with:
-        name: Ballerina-e2e-test-recording-linux-${{ inputs.group }}-${{ github.run_attempt }}
+        name: Ballerina-e2e-test-recording-${{ steps.platform.outputs.label }}-${{ inputs.group }}-${{ github.run_attempt }}
         path: |
           packages/ballerina-extension/e2e-test/test-resources/videos/**
           packages/ballerina-extension/e2e-test/test-resources/screenshots/**
@@ -91,7 +120,7 @@ runs:
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: always()
       with:
-        name: Ballerina-e2e-test-project-linux-${{ inputs.group }}-${{ github.run_attempt }}
+        name: Ballerina-e2e-test-project-${{ steps.platform.outputs.label }}-${{ inputs.group }}-${{ github.run_attempt }}
         path: |
           packages/ballerina-extension/e2e-test/data/new-project/**
         retention-days: 5

--- a/.github/actions/run-e2e-group/action.yml
+++ b/.github/actions/run-e2e-group/action.yml
@@ -82,6 +82,17 @@ runs:
         cd packages/ballerina-extension
         xvfb-run --server-num 98.0 -s "-ac -screen 0 1920x1080x24" bash -c 'ffmpeg -y -nostdin -f x11grab -r 30 -s 1920x1080 -i :98.0 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -hide_banner -loglevel error record.mp4 & pnpm exec playwright test -c e2e-test/playwright.config.js --grep "$TEST_GROUP"'
 
+    # The first-attempt step is continue-on-error, and the re-run below — the only step
+    # that turns a test failure into a job failure — is skipped on Windows. Without this,
+    # no Windows step ever fails, the job-level continue-on-error never fires, and
+    # removing that expression to start gating would change nothing. Re-asserting the
+    # outcome here keeps the four reversions in the README order-independent. Remove this
+    # together with the re-run guard below.
+    - name: Surface Windows first-attempt failure
+      shell: bash
+      if: runner.os == 'Windows' && steps.run-tests-first.outcome == 'failure'
+      run: exit 1
+
     # Not run automatically on Windows: with maxFailures 10 and a 20-minute per-test
     # timeout, a second --last-failed pass over platform failures can spend what is left
     # of the 60-minute budget and get the leg killed before it uploads anything, which is

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -20,6 +20,12 @@
 const fs = require('fs');
 const path = require('path');
 
+// Which runner produced the results being aggregated. The caller invokes this script once
+// per platform over that platform's own artifact folder, so the step-summary heading and
+// every history row say where the numbers came from. Empty when unset, which is how the
+// rows written before Windows was added read.
+const PLATFORM = process.env.E2E_OS || '';
+
 function findResultFiles(rootDir) {
   const found = [];
   const walk = (dir) => {
@@ -249,6 +255,7 @@ function toNdjson(allTests) {
         runAttempt,
         sourceTag,
         sourceSha,
+        os: PLATFORM,
         ...t,
       })
     )
@@ -277,7 +284,7 @@ function toMarkdown({
   groupCount,
 }) {
   const lines = [];
-  lines.push('## E2E flakiness report');
+  lines.push(PLATFORM ? `## E2E flakiness report (${PLATFORM})` : '## E2E flakiness report');
   lines.push('');
   lines.push(
     `Groups reported: ${groupCount} · Total: ${total} · Passed: ${passed} · Failed: ${failed} · Skipped: ${skipped} · Flaky (passed after retry): ${flaky}`

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,7 @@ workflow because the extension manifest owns the shared extension/LS version.
 | `reusable-build.yml` | `workflow_call` only | Reusable build pipeline (ballerina-only) |
 | `devBuild.yml` | manual + `workflow_call` | Builds a custom branch as a timestamped pre-release VSIX. It creates workflow artifacts only: no GitHub release and no marketplace publication. `schedule.yml` reuses this workflow after stamping the nightly branch. |
 | `schedule.yml` | nightly cron + manual | Syncs the `builds/nightly` branch, runs the LS multi-branch pack/test/Windows-build matrix, calls `devBuild.yml`, and moves the `nightly` tag after every job passes. Manual runs can select a source branch and otherwise behave exactly like scheduled nightlies, including notifications. The VSIX remains a workflow artifact; no GitHub Release is created. See [Versioning](#versioning) and [The nightly branch](#the-nightly-branch). |
-| `e2e-scheduled.yml` | every 6h cron + manual | Runs the Playwright E2E suite against the nightly VSIX without rebuilding, and tracks flakiness over time. See [Scheduled E2E testing](#scheduled-e2e-testing). |
+| `e2e-scheduled.yml` | every 6h cron + manual | Runs the Playwright E2E suite on Linux and Windows against the nightly VSIX without rebuilding, and tracks flakiness over time. See [Scheduled E2E testing](#scheduled-e2e-testing). |
 | `pull-request.yml` | PRs + manual | Detects changes with `dorny/paths-filter`; if anything build-relevant changed, runs `reusable-build.yml` which builds the entire chain (LS via Gradle, then all TS packages and the extension VSIX via rush) in a single job. Windows LS coverage runs in `schedule.yml` only. |
 | `release-pre-release.yml` | manual dispatch | Builds either a timestamped pre-release or the release version authored in the extension manifest. Its `githubRelease` input creates a GitHub Release with the VSIX and LS jar and publishes the matching `io.ballerina:ballerina-language-server` package. Real releases also perform the release branch/PR handling. |
 | `publish-vsix.yml` | manual dispatch | Publishes a built VSIX (passed by `workflowRunId`) to VSCode Marketplace + OpenVSX |
@@ -237,6 +237,24 @@ Ballerina distribution version to what the nightly LS actually shipped with, not
 `gradle.properties` on the current checkout — otherwise a version bump on the default branch
 between nightly builds would fail the whole suite in a way indistinguishable from flakiness.
 
+**Runs on Linux and Windows.** The `E2E` matrix is platform × group, so a run executes 8 legs.
+`run-e2e-group` lowercases `runner.os` into a platform label and puts it in every artifact name
+(`Ballerina-e2e-test-results-windows-group1-1`), and skips the Linux-only setup on Windows: no
+`apt-get`, no `xvfb`, no `dbus`, and no `ffmpeg` X11 screen grab, because the Windows runner already
+has a desktop session. Playwright's own per-test videos, screenshots and traces are recorded on both
+platforms; only the whole-session `record.mp4` is Linux-only. `Prepare` publishes the platform list
+as an output so the matrix and `Report`'s download/aggregation loops read the same list.
+
+**Windows runs but does not gate.** The Windows legs set `continue-on-error`, and `Report` turns a
+Windows-only aggregation failure into a warning, so `needs.E2E.result` stays `success` and the chat
+notification does not fire on a Windows failure. Windows results still reach the step summary and the
+`e2e-metrics` history — `aggregate-e2e-results.js` runs once per platform, and every history row now
+carries an `os` field (absent on rows written before this). To make Windows a gate, drop the
+`continue-on-error` expression on the `E2E` job and the `windows` branch in `Report`'s aggregation
+loop. It is not a gate yet because parts of the suite are still Linux-only — a `zip` shell-out for
+failure snapshots, a `bal` invocation that does not resolve `bal.bat`, a hard-coded `/tmp` path in
+one spec, and `SIGKILL` teardown that leaves Windows file locks behind. Those are tracked separately.
+
 **Handles GitHub's "Re-run failed jobs" across the whole pipeline.** A matrix group can be
 re-run independently, advancing only its own `github.run_attempt`; `run-e2e-group` restores the
 previous attempt's `.last-run.json` to resume `--last-failed` targeting, and deliberately keeps
@@ -404,7 +422,7 @@ configured.
 | `ls-test` | `reusable-build.yml`, `schedule.yml` — runs the LS gradle suite, then aggregates and uploads coverage (see [Language server test coverage](#language-server-test-coverage)) |
 | `updateVersion` | `build`, `schedule.yml` — resolves and writes the version in the extension manifest |
 | `resolve-source-branch` | `schedule.yml` — the latest-`staging/*`-else-`main` resolution described under [The nightly branch](#the-nightly-branch) |
-| `run-e2e-group` | `reusable-build.yml`, `e2e-scheduled.yml` — runs one matrix group of the E2E suite (first attempt + `--last-failed` re-run) and uploads its artifacts; see [Scheduled E2E testing](#scheduled-e2e-testing) |
+| `run-e2e-group` | `reusable-build.yml`, `e2e-scheduled.yml` — runs one matrix group of the E2E suite (first attempt + `--last-failed` re-run) on a Linux or Windows runner and uploads its artifacts under a platform-tagged name; see [Scheduled E2E testing](#scheduled-e2e-testing) |
 | `release` | `release-pre-release.yml` — owns everything that materialises a release: the version commit, `release/<version>`, the tag, the GitHub release and its assets |
 | `pr` | `release-pre-release.yml` — opens the follow-up pull requests (release PR into `X.Y.x`, next-snapshot PR into `main`) + Google Chat notification |
 | `dailyBuildNotification` | `schedule.yml` — success chat notification |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -255,11 +255,10 @@ the suite are still Linux-only — a `zip` shell-out for failure snapshots, a `b
 does not resolve `bal.bat`, a hard-coded `/tmp` path in one spec, and `SIGKILL` teardown that leaves
 Windows file locks behind. Those are tracked separately.
 
-There are three places that let Windows through, and making it a gate means reverting all three: the
+There are four places that let Windows through, and making it a gate means reverting all four: the
 `continue-on-error` expression on the `E2E` job, the `windows` branch in `Report`'s download loop,
-and the `windows` branch in `Report`'s aggregation loop. The `runner.os != 'Windows'` guard on
-`run-e2e-group`'s re-run step should come off at the same time, since a gating platform wants the
-`--last-failed` pass back.
+the `windows` branch in `Report`'s aggregation loop, and the `runner.os != 'Windows'` guard on
+`run-e2e-group`'s re-run step — a gating platform wants the `--last-failed` pass back.
 
 **The Windows legs run with `BI_E2E_RETRIES: 0`.** `playwright.config.js` otherwise retries a failed
 test twice, and the suite is serial (`workers: 1`) with a 20-minute per-test timeout — so while the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -241,8 +241,9 @@ between nightly builds would fail the whole suite in a way indistinguishable fro
 `run-e2e-group` lowercases `runner.os` into a platform label and puts it in every artifact name
 (`Ballerina-e2e-test-results-windows-group1-1`), and skips the Linux-only setup on Windows: no
 `apt-get`, no `xvfb`, no `dbus`, and no `ffmpeg` X11 screen grab, because the Windows runner already
-has a desktop session. Playwright's own per-test videos, screenshots and traces are recorded on both
-platforms; only the whole-session `record.mp4` is Linux-only. `Prepare` publishes the platform list
+has a desktop session. The suite captures its own failure screenshots (`setup.ts`) and session video
+(`test.list.ts`) on both platforms — these do not come from Playwright's `use.video`/`use.screenshot`,
+which are both `off`; only the whole-session `record.mp4` is Linux-only. `Prepare` publishes the platform list
 as an output so the matrix and `Report`'s download/aggregation loops read the same list.
 
 **Windows runs but does not gate.** The Windows legs set `continue-on-error`, and `Report` turns a
@@ -256,7 +257,9 @@ Windows file locks behind. Those are tracked separately.
 
 There are three places that let Windows through, and making it a gate means reverting all three: the
 `continue-on-error` expression on the `E2E` job, the `windows` branch in `Report`'s download loop,
-and the `windows` branch in `Report`'s aggregation loop.
+and the `windows` branch in `Report`'s aggregation loop. The `runner.os != 'Windows'` guard on
+`run-e2e-group`'s re-run step should come off at the same time, since a gating platform wants the
+`--last-failed` pass back.
 
 **The Windows legs run with `BI_E2E_RETRIES: 0`.** `playwright.config.js` otherwise retries a failed
 test twice, and the suite is serial (`workers: 1`) with a 20-minute per-test timeout — so while the
@@ -267,6 +270,15 @@ phase exists to measure; the cost is that Windows flakiness is not distinguishab
 failure until retries are turned back on. `maxFailures: 10` is deliberately left alone: it truncates
 a badly-failing group early, which is what keeps a leg inside the job timeout and producing an
 artifact at all.
+
+Two things follow from zero retries. `run-e2e-group`'s `--last-failed` re-run is a second whole
+invocation whose condition is independent of the retry count, so on Windows it is skipped on a first
+attempt — it would re-execute up to ten platform failures against what is left of the 60-minute
+budget, which is the cost zero retries removes from the first pass. It still runs on a manual
+"Re-run failed jobs", the resume path it exists for. And `trace: 'on-first-retry'` captures nothing
+when nothing is retried, so the Windows legs set `BI_E2E_TRACE: retain-on-first-failure`; the trace
+is the only one of the three diagnostics that depends on a retry, since the screenshots and video are
+the suite's own.
 
 **Handles GitHub's "Re-run failed jobs" across the whole pipeline.** A matrix group can be
 re-run independently, advancing only its own `github.run_attempt`; `run-e2e-group` restores the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -258,7 +258,9 @@ Windows file locks behind. Those are tracked separately.
 There are four places that let Windows through, and making it a gate means reverting all four: the
 `continue-on-error` expression on the `E2E` job, the `windows` branch in `Report`'s download loop,
 the `windows` branch in `Report`'s aggregation loop, and the `runner.os != 'Windows'` guard on
-`run-e2e-group`'s re-run step — a gating platform wants the `--last-failed` pass back.
+`run-e2e-group`'s re-run step — a gating platform wants the `--last-failed` pass back. That guard
+pairs with the `Surface Windows first-attempt failure` step just above it, which exists only because
+the guard removes the one step that would otherwise fail the job; drop both together.
 
 **The Windows legs run with `BI_E2E_RETRIES: 0`.** `playwright.config.js` otherwise retries a failed
 test twice, and the suite is serial (`workers: 1`) with a 20-minute per-test timeout — so while the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -249,11 +249,24 @@ as an output so the matrix and `Report`'s download/aggregation loops read the sa
 Windows-only aggregation failure into a warning, so `needs.E2E.result` stays `success` and the chat
 notification does not fire on a Windows failure. Windows results still reach the step summary and the
 `e2e-metrics` history — `aggregate-e2e-results.js` runs once per platform, and every history row now
-carries an `os` field (absent on rows written before this). To make Windows a gate, drop the
-`continue-on-error` expression on the `E2E` job and the `windows` branch in `Report`'s aggregation
-loop. It is not a gate yet because parts of the suite are still Linux-only — a `zip` shell-out for
-failure snapshots, a `bal` invocation that does not resolve `bal.bat`, a hard-coded `/tmp` path in
-one spec, and `SIGKILL` teardown that leaves Windows file locks behind. Those are tracked separately.
+carries an `os` field (absent on rows written before this). It is not a gate yet because parts of
+the suite are still Linux-only — a `zip` shell-out for failure snapshots, a `bal` invocation that
+does not resolve `bal.bat`, a hard-coded `/tmp` path in one spec, and `SIGKILL` teardown that leaves
+Windows file locks behind. Those are tracked separately.
+
+There are three places that let Windows through, and making it a gate means reverting all three: the
+`continue-on-error` expression on the `E2E` job, the `windows` branch in `Report`'s download loop,
+and the `windows` branch in `Report`'s aggregation loop.
+
+**The Windows legs run with `BI_E2E_RETRIES: 0`.** `playwright.config.js` otherwise retries a failed
+test twice, and the suite is serial (`workers: 1`) with a 20-minute per-test timeout — so while the
+blockers above are still open, retries burn the 60-minute job budget re-running tests that fail for a
+platform reason rather than a flaky one. A leg killed by that timeout uploads no artifact, and the
+run records nothing. Zero retries reaches more distinct tests per run, which is the pass rate this
+phase exists to measure; the cost is that Windows flakiness is not distinguishable from Windows
+failure until retries are turned back on. `maxFailures: 10` is deliberately left alone: it truncates
+a badly-failing group early, which is what keeps a leg inside the job timeout and producing an
+artifact at all.
 
 **Handles GitHub's "Re-run failed jobs" across the whole pipeline.** A matrix group can be
 re-run independently, advancing only its own `github.run_attempt`; `run-e2e-group` restores the

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       groups: ${{ steps.groups.outputs.groups }}
+      platforms: ${{ steps.groups.outputs.platforms }}
       nightlySha: ${{ steps.nightly-commit.outputs.sha }}
     steps:
       - name: Checkout repository
@@ -30,7 +31,11 @@ jobs:
           sparse-checkout: .github/scripts
 
       - id: groups
-        run: echo 'groups=["group1","group2","group3","group4"]' >> "$GITHUB_OUTPUT"
+        run: |
+          echo 'groups=["group1","group2","group3","group4"]' >> "$GITHUB_OUTPUT"
+          # Also drives Report's per-platform download and aggregation, and matches the
+          # platform label run-e2e-group folds into every artifact name.
+          echo 'platforms=["linux","windows"]' >> "$GITHUB_OUTPUT"
 
       - name: Resolve nightly build commit
         id: nightly-commit
@@ -58,22 +63,37 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
   E2E:
-    name: Run Ballerina e2e Test (${{ matrix.group }})
+    name: Run Ballerina e2e Test (${{ matrix.os }} ${{ matrix.group }})
     needs: Prepare
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
+        os: ${{ fromJson(needs.Prepare.outputs.platforms) }}
         group: ${{ fromJson(needs.Prepare.outputs.groups) }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os == 'windows' && 'windows-latest' || 'ubuntu-latest' }}
+    # Windows is observed, not enforced: its legs report into the step summary and the
+    # e2e-metrics history but never fail the run or fire the chat notification, so a suite
+    # whose Windows pass rate is still unknown cannot redden every scheduled run. Flip this
+    # to a plain `false` (or delete it) once that pass rate justifies gating on it.
+    continue-on-error: ${{ matrix.os == 'windows' }}
     steps:
+      # pnpm/rush nest node_modules well past the 260-character legacy limit.
+      - name: Enable long paths for Git
+        if: runner.os == 'Windows'
+        shell: bash
+        run: git config --system core.longpaths true
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: recursive
 
+      # shell: bash here and below — the default shell on a Windows runner is pwsh, which
+      # parses neither this script nor the '@wso2/...' argument two steps down.
       - name: Download nightly VSIX
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -98,6 +118,7 @@ jobs:
           rush-install: true
 
       - name: Build playwright-vscode-tester
+        shell: bash
         run: node common/scripts/install-run-rush.js build --to @wso2/playwright-vscode-tester
 
       - name: Install Ballerina distribution
@@ -130,6 +151,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GROUPS_JSON: ${{ needs.Prepare.outputs.groups }}
+          PLATFORMS_JSON: ${{ needs.Prepare.outputs.platforms }}
         run: |
           set -euo pipefail
           source .github/scripts/retry.sh
@@ -144,19 +166,24 @@ jobs:
             echo "::error::Failed to list this run's artifacts after 3 attempts."
             exit 1
           fi
-          for group in $(echo "$GROUPS_JSON" | jq -r '.[]'); do
-            name=$(echo "$artifacts" | grep -E "^Ballerina-e2e-test-results-linux-${group}-[0-9]+$" | sort -V | tail -n1 || true)
-            if [ -z "${name:-}" ]; then
-              echo "No artifact found for ${group}; skipping."
-              continue
-            fi
-            echo "Downloading ${name} for ${group}"
-            mkdir -p "e2e-results/${group}"
-            if ! retry 3 5 gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" \
-              -n "${name}" -D "e2e-results/${group}"; then
-              echo "::error::Failed to download artifact ${name} for ${group} after 3 attempts."
-              exit 1
-            fi
+          # One root per platform: aggregate-e2e-results.js reads the group name from the
+          # first path segment under the root it is given, so the platform cannot be part
+          # of that segment without ending up in every history row's `group` field.
+          for platform in $(echo "$PLATFORMS_JSON" | jq -r '.[]'); do
+            for group in $(echo "$GROUPS_JSON" | jq -r '.[]'); do
+              name=$(echo "$artifacts" | grep -E "^Ballerina-e2e-test-results-${platform}-${group}-[0-9]+$" | sort -V | tail -n1 || true)
+              if [ -z "${name:-}" ]; then
+                echo "No artifact found for ${platform} ${group}; skipping."
+                continue
+              fi
+              echo "Downloading ${name} for ${platform} ${group}"
+              mkdir -p "e2e-results/${platform}/${group}"
+              if ! retry 3 5 gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" \
+                -n "${name}" -D "e2e-results/${platform}/${group}"; then
+                echo "::error::Failed to download artifact ${name} for ${platform} ${group} after 3 attempts."
+                exit 1
+              fi
+            done
           done
 
       - name: Aggregate results
@@ -166,10 +193,34 @@ jobs:
           E2E_SOURCE_TAG: nightly
           E2E_SOURCE_SHA: ${{ needs.Prepare.outputs.nightlySha }}
           EXPECTED_GROUPS_JSON: ${{ needs.Prepare.outputs.groups }}
+          PLATFORMS_JSON: ${{ needs.Prepare.outputs.platforms }}
         run: |
           set -o pipefail
-          node .github/scripts/aggregate-e2e-results.js e2e-results e2e-run-stats.jsonl \
-            | tee -a "$GITHUB_STEP_SUMMARY"
+          gate_status=0
+          for platform in $(echo "$PLATFORMS_JSON" | jq -r '.[]'); do
+            if ! E2E_OS="$platform" node .github/scripts/aggregate-e2e-results.js \
+              "e2e-results/${platform}" "e2e-run-stats-${platform}.jsonl" \
+              | tee -a "$GITHUB_STEP_SUMMARY"; then
+              # Mirrors the E2E job's continue-on-error: Windows results are summarised and
+              # persisted, but a Windows-only failure must not fail this job either, or the
+              # notification below would fire on a leg that is not a gate yet.
+              if [ "$platform" = "windows" ]; then
+                echo "::warning::Windows e2e results contain failures; recorded but not gating."
+              else
+                gate_status=1
+              fi
+            fi
+          done
+          # Concatenated rather than written in place: each platform's rows carry their own
+          # `os` field, and Persist below reads exactly one file. Left absent when no
+          # platform produced rows — Persist treats a missing file, not an empty one, as
+          # "nothing to record", and an empty one would make it try an empty commit.
+          shopt -s nullglob
+          parts=(e2e-run-stats-*.jsonl)
+          if [ ${#parts[@]} -gt 0 ]; then
+            cat "${parts[@]}" > e2e-run-stats.jsonl
+          fi
+          exit $gate_status
 
       - name: Persist run stats
         id: persist

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -77,8 +77,18 @@ jobs:
     # whose Windows pass rate is still unknown cannot redden every scheduled run. Flip this
     # to a plain `false` (or delete it) once that pass rate justifies gating on it.
     continue-on-error: ${{ matrix.os == 'windows' }}
+    env:
+      # Windows only: playwright.config.js retries a failed test twice by default, and the
+      # suite is serial (workers: 1) with a 20-minute per-test timeout. Until the known
+      # Windows blockers are fixed, those retries spend the 60-minute job budget re-running
+      # tests that are failing for a platform reason rather than a flaky one, and a leg
+      # killed by the timeout uploads no artifact at all — so the rollout collects nothing.
+      # Zero retries covers more distinct tests per run, which is the pass rate this phase
+      # is here to measure. Empty on Linux, which leaves the config default of 2 in place.
+      BI_E2E_RETRIES: ${{ matrix.os == 'windows' && '0' || '' }}
     steps:
-      # pnpm/rush nest node_modules well past the 260-character legacy limit.
+      # Only affects git's own file operations — here, the recursive submodule checkout,
+      # whose nested paths run past the 260-character legacy limit.
       - name: Enable long paths for Git
         if: runner.os == 'Windows'
         shell: bash
@@ -180,6 +190,13 @@ jobs:
               mkdir -p "e2e-results/${platform}/${group}"
               if ! retry 3 5 gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" \
                 -n "${name}" -D "e2e-results/${platform}/${group}"; then
+                # Same reason the E2E job and the aggregation below let Windows through: a
+                # failure on a non-gating platform must not fail this job, or the
+                # notification would fire on a leg that is not a gate yet.
+                if [ "$platform" = "windows" ]; then
+                  echo "::warning::Failed to download artifact ${name} for ${platform} ${group} after 3 attempts; skipping."
+                  continue
+                fi
                 echo "::error::Failed to download artifact ${name} for ${platform} ${group} after 3 attempts."
                 exit 1
               fi
@@ -205,7 +222,14 @@ jobs:
               # persisted, but a Windows-only failure must not fail this job either, or the
               # notification below would fire on a leg that is not a gate yet.
               if [ "$platform" = "windows" ]; then
-                echo "::warning::Windows e2e results contain failures; recorded but not gating."
+                # The script writes the stats file only when it read at least one test, so
+                # its absence separates "the suite ran and failed" from "the legs produced
+                # nothing" — the latter being the expected shape while Windows is new.
+                if [ -s "e2e-run-stats-${platform}.jsonl" ]; then
+                  echo "::warning::Windows e2e results contain failures; recorded but not gating."
+                else
+                  echo "::warning::No Windows e2e results were produced (legs killed before uploading, or no artifacts); nothing recorded."
+                fi
               else
                 gate_status=1
               fi

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -86,6 +86,11 @@ jobs:
       # Zero retries covers more distinct tests per run, which is the pass rate this phase
       # is here to measure. Empty on Linux, which leaves the config default of 2 in place.
       BI_E2E_RETRIES: ${{ matrix.os == 'windows' && '0' || '' }}
+      # playwright.config.js defaults to 'on-first-retry', which captures nothing once
+      # retries are 0. The suite writes its own failure screenshots and session video on
+      # both platforms, but the trace is the one artifact that depends on a retry, so
+      # Windows needs a mode that does not. Empty on Linux, keeping 'on-first-retry'.
+      BI_E2E_TRACE: ${{ matrix.os == 'windows' && 'retain-on-first-failure' || '' }}
     steps:
       # Only affects git's own file operations — here, the recursive submodule checkout,
       # whose nested paths run past the 260-character legacy limit.
@@ -176,10 +181,18 @@ jobs:
             echo "::error::Failed to list this run's artifacts after 3 attempts."
             exit 1
           fi
+          # Report runs with `if: always()`, so it also gets here when Prepare failed and
+          # published nothing. Without this the loops below would iterate zero times and
+          # the job would report success having aggregated nothing.
+          platforms=$(echo "$PLATFORMS_JSON" | jq -r '.[]')
+          if [ -z "$platforms" ]; then
+            echo "::error::Prepare published no platform list; nothing to download."
+            exit 1
+          fi
           # One root per platform: aggregate-e2e-results.js reads the group name from the
           # first path segment under the root it is given, so the platform cannot be part
           # of that segment without ending up in every history row's `group` field.
-          for platform in $(echo "$PLATFORMS_JSON" | jq -r '.[]'); do
+          for platform in $platforms; do
             for group in $(echo "$GROUPS_JSON" | jq -r '.[]'); do
               name=$(echo "$artifacts" | grep -E "^Ballerina-e2e-test-results-${platform}-${group}-[0-9]+$" | sort -V | tail -n1 || true)
               if [ -z "${name:-}" ]; then
@@ -213,8 +226,15 @@ jobs:
           PLATFORMS_JSON: ${{ needs.Prepare.outputs.platforms }}
         run: |
           set -o pipefail
+          # Same guard as the download step: a missing platform list must fail the gate
+          # rather than skip the loop and exit 0 having aggregated nothing.
+          platforms=$(echo "$PLATFORMS_JSON" | jq -r '.[]')
+          if [ -z "$platforms" ]; then
+            echo "::error::Prepare published no platform list; nothing to aggregate."
+            exit 1
+          fi
           gate_status=0
-          for platform in $(echo "$PLATFORMS_JSON" | jq -r '.[]'); do
+          for platform in $platforms; do
             if ! E2E_OS="$platform" node .github/scripts/aggregate-e2e-results.js \
               "e2e-results/${platform}" "e2e-run-stats-${platform}.jsonl" \
               | tee -a "$GITHUB_STEP_SUMMARY"; then
@@ -226,7 +246,10 @@ jobs:
                 # its absence separates "the suite ran and failed" from "the legs produced
                 # nothing" — the latter being the expected shape while Windows is new.
                 if [ -s "e2e-run-stats-${platform}.jsonl" ]; then
-                  echo "::warning::Windows e2e results contain failures; recorded but not gating."
+                  # Deliberately not "contains failures": the script also exits 1 for an
+                  # unreadable report, a missing group and a maxFailures truncation, and
+                  # a partly-missing Windows platform is the expected shape for now.
+                  echo "::warning::Windows e2e aggregation reported problems (see the report above); recorded but not gating."
                 else
                   echo "::warning::No Windows e2e results were produced (legs killed before uploading, or no artifacts); nothing recorded."
                 fi

--- a/packages/ballerina-extension/e2e-test/playwright.config.js
+++ b/packages/ballerina-extension/e2e-test/playwright.config.js
@@ -11,7 +11,9 @@ exports.default = (0, test_1.defineConfig)({
     workers: 1,
     reporter: [['html'], ['json', { outputFile: '../e2e-reports/e2e-results.json' }]],
     use: {
-        trace: 'on-first-retry',
+        // 'on-first-retry' captures nothing when retries are 0, which is how the
+        // non-gating Windows legs run — see BI_E2E_TRACE in e2e-scheduled.yml.
+        trace: process.env.BI_E2E_TRACE || 'on-first-retry',
     },
     timeout: 1200000,
 });


### PR DESCRIPTION
## Purpose
The E2E suite runs on Linux only, so a regression that appears only on Windows is caught by no automated test. This PR enables the Windows E2E run in the scheduled (6-hourly) E2E workflow. Enabling it for PR builds, behind the `Checks/Run Ballerina UI Tests` label, is left for a follow-up.

`e2e-scheduled.yml` is the workflow targeted here because it is the only one that runs the E2E suite on a schedule today — `schedule.yml` passes `runFrontendTests: false` and deliberately does not run E2E.

## Goals
- `e2e-scheduled.yml` runs the suite on `windows-latest` as well as `ubuntu-latest`.
- Windows results are visible (step summary, artifacts, `e2e-metrics` history) without gating the workflow, since the suite's Windows pass rate is not yet known.
- Linux behaviour, artifact names and gating are unchanged.

## Approach
**`.github/actions/run-e2e-group/action.yml`** — made platform-aware rather than forked into a second action:
- A new first step folds `runner.os` into a lowercase platform label (`linux` / `windows`) that replaces the hard-coded `linux` in all four artifact names. On a Linux runner the names are byte-identical to before.
- The `apt-get` install (xvfb, ffmpeg, gnome-keyring, libsecret, dbus-x11) is gated to `runner.os == 'Linux'`. `npx playwright install` moved to its own step and runs on both.
- Both test steps take a Windows guard clause that runs `pnpm exec playwright test` directly: the Windows runner has its own desktop session, so there is no virtual display to create and no `ffmpeg` X11 screen grab to wrap the run in. The Linux branch is unchanged. The suite captures its own failure screenshots (`setup.ts`) and session video (`test.list.ts`) on both platforms — these are not Playwright's `use.video`/`use.screenshot`, which are both `off` — and traces keep working on Windows via `BI_E2E_TRACE` below; only the whole-session `record.mp4` is Linux-only.
- The `--last-failed` re-run step is skipped on Windows for a first attempt (`runner.os != 'Windows'` added to that clause only). It is a second whole invocation whose condition is independent of the retry count, so it would re-execute up to ten platform failures against what is left of the 60-minute budget — the same cost `BI_E2E_RETRIES: 0` removes from the first pass. The `steps.check-results.outcome == 'success'` clause is kept, so a manual "Re-run failed jobs" on a Windows leg still resumes via `--last-failed`; without it a re-run would execute nothing, since the first-attempt step is already skipped on re-runs.

**`.github/workflows/e2e-scheduled.yml`**:
- `Prepare` publishes a `platforms` output (`["linux","windows"]`) so the `E2E` matrix and `Report`'s two loops read one list.
- `E2E` becomes a platform × group matrix (8 legs). `continue-on-error: ${{ matrix.os == 'windows' }}` keeps `needs.E2E.result` at `success` when only Windows fails, so the existing failure notification does not fire on it.
- Added `git config --system core.longpaths true` on Windows (it covers git's own file operations — here the recursive submodule checkout, whose nested paths run past the 260-character limit), and `shell: bash` on the two `run:` steps that had none — the default shell on a Windows runner is pwsh, which parses neither `set -euo pipefail`/`source` nor the bare `@wso2/...` argument (pwsh reads a leading `@` as splatting).
- `BI_E2E_RETRIES: 0` on the Windows legs only. `playwright.config.js` otherwise retries a failed test twice, and the suite is serial (`workers: 1`) with a 20-minute per-test timeout — while the blockers under *Learning* are open, those retries spend the 60-minute job budget re-running tests that fail for a platform reason rather than a flaky one, and a leg killed by the timeout uploads no artifact at all. Zero retries reaches more distinct tests per run, which is the pass rate this phase exists to measure. Linux gets an empty value, which leaves the config default of 2 in place. `maxFailures: 10` is deliberately untouched: truncating a badly-failing group early is what keeps a leg inside the job timeout and producing an artifact.
- `BI_E2E_TRACE: retain-on-first-failure` on the Windows legs only. `playwright.config.js` sets `trace: 'on-first-retry'`, which captures nothing once retries are 0 — and the trace is the one diagnostic that depends on a retry, since the screenshots and video are the suite's own. Linux gets an empty value and keeps `on-first-retry`.
- `Report` downloads into `e2e-results/<platform>/<group>` and aggregates once per platform. The per-platform root matters: `aggregate-e2e-results.js` derives the group name from the first path segment under its root, so the platform cannot share that segment without landing in every history row's `group` field. A Windows-only aggregation failure becomes a `::warning::` instead of failing the job, mirroring the matrix's `continue-on-error`, and a Windows artifact that will not download after 3 attempts is skipped with a warning rather than failing `Report` — otherwise that one path would still fire the notification on a leg that is not a gate. The two warnings are distinct: results that ran and failed, versus no results produced at all (the legs died before uploading), which is the expected shape while Windows is new.

**`packages/ballerina-extension/e2e-test/playwright.config.js`** — `trace` reads `BI_E2E_TRACE`, defaulting to the existing `on-first-retry`. One line; no change to any run that does not set the variable.

**`.github/scripts/aggregate-e2e-results.js`** — reads `E2E_OS` and adds an `os` field to every NDJSON history row and to the step-summary heading. Rows written before this carry no `os`.

**`.github/workflows/README.md`** — new paragraphs under *Scheduled E2E testing* covering the two-platform matrix, why Windows does not gate and where to flip it, and the retry/timeout reasoning behind `BI_E2E_RETRIES: 0`; plus the workflow and composite-action table rows.

Four places let Windows through, and making it a gate means reverting all four: the `continue-on-error` expression on the `E2E` job, the `windows` branch in `Report`'s download loop, the `windows` branch in `Report`'s aggregation loop, and the `runner.os != 'Windows'` guard on `run-e2e-group`'s re-run step. Turning `BI_E2E_RETRIES` and `BI_E2E_TRACE` back off is a separate call, and should happen once the Windows pass rate is high enough that a retry distinguishes flakiness rather than masking a platform failure.

## UI Component Development
N/A — CI configuration only, no UI change.

## User stories
As a developer, a Windows-only regression in the extension is surfaced by the scheduled E2E run instead of reaching users unnoticed.

## Release note
N/A — CI only, no user-facing change.

## Documentation
`.github/workflows/README.md` is updated in this PR. No product documentation impact.

## Training
N/A

## Certification
N/A — CI configuration change with no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — no product code changed.
- Integration tests
  > This PR *is* test infrastructure. Verified locally: both YAML files and the JS parse; the per-platform aggregation was exercised against fixtures — Linux-pass/Windows-fail exits 0 and emits 8 correctly `os`-tagged history rows; Linux-fail exits 1; missing Windows artifacts neither gate nor leave an empty stats file behind (an empty one would make the `Persist` step attempt an empty commit).
  > The gating branches were re-checked after each round of review changes, running the `Aggregate results` step extracted from the workflow itself rather than a hand-copy, over six scenarios: Linux-pass/Windows-fail exits 0, Linux-fail/Windows-pass exits 1, both-pass exits 0, Windows-absent exits 0 or 1 following Linux alone, and an empty `PLATFORMS_JSON` (the `Prepare`-failed shape) exits 1 instead of passing vacuously. Each emits the correct warning and writes only the platforms that produced rows.
  > Verified on a real Windows run: [33469593941](https://github.com/ballerina-platform/ballerina-vscode/actions/runs/33469593941), a `workflow_dispatch` on this branch. All 8 legs executed, all 8 uploaded artifacts, and both platforms aggregated. It also confirms that sourcing a checked-out `.sh` on a Windows runner works — the legs ran `retry.sh` twice before reaching the tests.
  > The `continue-on-error` behaviour is confirmed separately, by [33495692184](https://github.com/ballerina-platform/ballerina-vscode/actions/runs/33495692184) on a branch off this one. Run 33469593941 could not confirm it: with the re-run step skipped on Windows, no step in those legs ever failed, so the job succeeded on its own and the job-level `continue-on-error` was never reached. Once `Surface Windows first-attempt failure` made a Windows test failure fail its step, that run showed the mechanism end to end — all four Windows jobs report `conclusion: failure` and show red, while `needs.E2E.result` still evaluated to `success`, so `Notify on failure` was skipped and the workflow passed. A Windows failure is therefore visible without gating, which is exactly the posture this PR is aiming for.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None.

## Migrations (if applicable)
None. Existing `e2e-metrics` history rows remain valid; they simply have no `os` field, which a reader should treat as `linux`.

## Test environment
GitHub-hosted `ubuntu-latest` and `windows-latest` runners; Node 22.x, pnpm 10.10.0.

## Learning
The Windows legs do fail, as expected. The first run measured:

```
## E2E flakiness report (linux)
Groups reported: 4 · Total: 136 · Passed: 120 · Failed: 0  · Skipped: 16 · Flaky: 11

## E2E flakiness report (windows)
Groups reported: 4 · Total: 136 · Passed: 45  · Failed: 20 · Skipped: 71 · Flaky: 0
```

Windows sits at a 33% pass rate. The workflow is green because that is what the non-gating path is for — the failures are recorded in the step summary and the `e2e-metrics` history, and reported as a `::warning::` rather than failing `Report`.

Of the 20 failures, 12 are `EBUSY: resource busy or locked, rmdir ...\data\test_project` raised from `wipeAndRecreateDataFolder`, which is the `SIGKILL` teardown blocker below — note that it surfaces in the *next* test's setup, not in teardown, where the failure is caught and only warned about. The remaining 8 are locator timeouts (5) and assertion failures (3), not yet triaged. The 71 skips are `maxFailures` truncating groups once the `EBUSY` cascade starts, so fixing that one blocker should move the pass rate substantially on its own.

The audit found these blockers, all test-code rather than CI, and out of scope for this phase:
- `e2e-test/e2e-playwright-tests/utils/helpers/setup.ts` — `execFileSync('bal', ...)` cannot spawn `bal.bat` without `shell: true`.
- `e2e-test/e2e-playwright-tests/file-integration/directory.spec.ts` — a hard-coded `/tmp/wso2/bi/sample` path.
- `e2e-test/e2e-playwright-tests/utils/helpers/setup.ts` — a `zip -r` shell-out for failure snapshots; it is caught, so it only loses snapshots.
- `test.list.ts` teardown kills Electron with `SIGKILL`, which orphans its children on Windows and leaves file locks that make the subsequent `fs.rmSync` of the project folder fail.
- In `submodules/wso2-vscode-extensions`: `playwright-vscode-tester/src/utils.ts` gates the VS Code download on a macOS-only bundle name, so VS Code is re-downloaded on every launch. Pre-existing on Linux too, but the Windows `.zip` unpack is slower and brings the 60-minute job timeout closer.

What would make these expensive rather than merely noisy is the interaction with the run's shape: the suite is serial, each test may take 20 minutes, and Playwright retries a failure twice on top of a second `--last-failed` pass. A group with a handful of platform failures would spend its 60-minute budget on re-runs and could be killed before uploading anything, recording nothing at all — the opposite of the point. That is what `BI_E2E_RETRIES: 0` and the re-run guard are for, and the run bears it out: the Windows legs finished in 14–19 minutes against Linux's 14–19, and all four uploaded their artifacts. `.github/workflows/README.md` carries the full reasoning.

Running Windows non-blocking first is what makes it safe to land these one at a time and watch the pass rate move, rather than holding the whole platform back until every one is fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Extend scheduled E2E testing to Linux and Windows runners.
- Add platform-aware artifacts and conditional Linux setup.
- Run eight platform-and-group matrix jobs.
- Use Windows-compatible test execution with zero Playwright retries.
- Keep Windows failures non-blocking during the initial rollout.
- Aggregate results separately by platform and include `os` in history records.
- Update trace handling and workflow documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




