### PR TITLE
Improve libraryGetTool with proper error handling and artifact managements

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/tools/library-get.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/library-get.ts
@@ -69,18 +69,20 @@ export async function LibraryGetTool(
     generationType: GenerationType,
     eventHandler: CopilotEventHandler,
     toolModelUsage: ToolModelUsage,
-    toolCallId: string
+    toolCallId: string,
+    abortSignal?: AbortSignal
 ): Promise<Library[]> {
     try {
         // Emit tool_call event with ID from AI SDK
         eventHandler({
             type: "tool_call",
             toolName: LIBRARY_GET_TOOL,
+            toolInput: { libraryNames: params.libraryNames },
             toolCallId
         });
 
         const startTime = Date.now();
-        const { libraries, usage } = await selectRequiredFunctions(params.userPrompt, params.libraryNames, generationType);
+        const { libraries, usage } = await selectRequiredFunctions(params.userPrompt, params.libraryNames, generationType, abortSignal);
         console.log(
             `[LibraryGetTool] Fetched ${libraries.length} libraries: ${libraries
                 .map((lib) => lib.name)
@@ -96,7 +98,7 @@ export async function LibraryGetTool(
     } catch (error) {
         console.error(`[LibraryGetTool] Error fetching libraries: ${error}`);
 
-        // Emit error result with same ID
+        // Emit error result with same ID so the UI closes this tool call's spinner
         eventHandler({
             type: "tool_result",
             toolName: LIBRARY_GET_TOOL,
@@ -104,7 +106,9 @@ export async function LibraryGetTool(
             toolCallId
         });
 
-        return [];
+        // Rethrow rather than return []: an empty result is a legitimate outcome of selection, and the
+        // caller must be able to tell "nothing matched" from "the fetch failed" to report each honestly.
+        throw error;
     }
 }
 
@@ -136,19 +140,46 @@ name, description, type definitions (records, objects, enums, type aliases), cli
 
 `,
         inputSchema: LibraryGetToolSchema,
-        execute: async (input: { libraryNames: string[]; userPrompt: string }, context?: { toolCallId?: string }) => {
+        execute: async (
+            input: { libraryNames: string[]; userPrompt: string },
+            context?: { toolCallId?: string; abortSignal?: AbortSignal }
+        ) => {
             // Extract toolCallId from AI SDK context
             const toolCallId = context?.toolCallId || `fallback-${Date.now()}`;
 
+            // The model occasionally repeats a name; a duplicate would be fetched, selected over
+            // and rendered twice.
+            const libraryNames = [...new Set(input.libraryNames.map((name) => name.trim()).filter(Boolean))];
+
             console.log(
-                `[LibraryGetTool] Called with ${input.libraryNames.length} libraries: ${input.libraryNames.join(
+                `[LibraryGetTool] Called with ${libraryNames.length} libraries: ${libraryNames.join(
                     ", "
                 )} and prompt: ${input.userPrompt} [toolCallId: ${toolCallId}]`
             );
-            const rawLibraries: Library[] = await LibraryGetTool(input, generationType, eventHandler, toolModelUsage, toolCallId);
-            const afterContent = toSyntaxString(rawLibraries);
-
-            return afterContent;
+            try {
+                const rawLibraries: Library[] = await LibraryGetTool(
+                    { libraryNames, userPrompt: input.userPrompt },
+                    generationType,
+                    eventHandler,
+                    toolModelUsage,
+                    toolCallId,
+                    context?.abortSignal
+                );
+                if (rawLibraries.length === 0) {
+                    // An empty string here reads as a blank tool result the model can make nothing of.
+                    return `No relevant functions, clients, services, or types were found in the requested libraries (${libraryNames.join(", ")}) for this query. Verify each name is in 'organization/libraryName' format and appeared in the LibrarySearchTool results; if so, retry with a more specific userPrompt or select different libraries.`;
+                }
+                return toSyntaxString(rawLibraries);
+            } catch (error) {
+                // A cancelled run must keep unwinding so the SDK can wind the step down.
+                if (context?.abortSignal?.aborted) {
+                    throw error;
+                }
+                // Tell the model the fetch FAILED — returning nothing here is indistinguishable from
+                // "these libraries matched nothing", and the agent is forbidden to invent API in that gap.
+                const message = error instanceof Error ? error.message : String(error);
+                return `Fetching library documentation for (${libraryNames.join(", ")}) failed: ${message}. This was an internal failure, not evidence the libraries are empty or missing — retry this tool call, and if it keeps failing, say so instead of inventing API details.`;
+            }
         },
     });
 }

--- a/packages/ballerina-extension/src/features/ai/agent/tools/library-get.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/library-get.ts
@@ -98,13 +98,21 @@ export async function LibraryGetTool(
     } catch (error) {
         console.error(`[LibraryGetTool] Error fetching libraries: ${error}`);
 
-        // Emit error result with same ID so the UI closes this tool call's spinner
-        eventHandler({
-            type: "tool_result",
-            toolName: LIBRARY_GET_TOOL,
-            toolOutput: [],
-            toolCallId
-        });
+        // On a cancelled run the rethrow below reaches the SDK as a `tool-error`, and AgentExecutor's
+        // handler for that part emits the failed `tool_result` for this toolCallId. Emitting one here as
+        // well would give the UI two results for one call.
+        if (!abortSignal?.aborted) {
+            // Emit a FAILED result with the same ID so the UI closes this tool call's spinner and shows the
+            // same thing the model is told below: a fetch that failed, not a lookup that matched nothing.
+            // An unflagged `toolOutput: []` is byte-for-byte the event the success path emits for zero matches.
+            eventHandler({
+                type: "tool_result",
+                toolName: LIBRARY_GET_TOOL,
+                toolOutput: [],
+                toolCallId,
+                failed: true
+            });
+        }
 
         // Rethrow rather than return []: an empty result is a legitimate outcome of selection, and the
         // caller must be able to tell "nothing matched" from "the fetch failed" to report each honestly.
@@ -148,8 +156,12 @@ name, description, type definitions (records, objects, enums, type aliases), cli
             const toolCallId = context?.toolCallId || `fallback-${Date.now()}`;
 
             // The model occasionally repeats a name; a duplicate would be fetched, selected over
-            // and rendered twice.
-            const libraryNames = [...new Set(input.libraryNames.map((name) => name.trim()).filter(Boolean))];
+            // and rendered twice. Lower-cased as well as trimmed: Ballerina org and package names are
+            // lower-case, so `Ballerina/http` is the same library mis-cased, and left as-is it would go
+            // to the LS as a name it cannot resolve.
+            const libraryNames = [...new Set(
+                input.libraryNames.map((name) => name.trim().toLowerCase()).filter(Boolean)
+            )];
 
             console.log(
                 `[LibraryGetTool] Called with ${libraryNames.length} libraries: ${libraryNames.join(

--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
@@ -71,10 +71,11 @@ const TYPE_CONSTRUCTOR = 'Constructor';
  * **What overflows is the response, not the request.** A selection reply echoes every kept function — its
  * name, its parameter names and its return type — so it scales with how much the query matches, not with
  * how large the library is. At the previous 8192 a broad query against a large connector ("wire up GitHub
- * issues, PRs, releases and webhooks") could exceed it, and the failure is the worst shape available: the
+ * issues, PRs, releases and webhooks") could exceed it, and the failure was the worst shape available: the
  * JSON is truncated mid-token, `generateObject` rejects it against the schema, the throw unwinds to
- * `LibraryGetTool`'s catch, and the agent is handed `[]` — indistinguishable from a library that matched
- * nothing. It then has no API documentation and a system prompt forbidding it to invent any.
+ * `LibraryGetTool`'s catch, and the agent was handed `[]` — indistinguishable from a library that matched
+ * nothing, with no API documentation and a system prompt forbidding it to invent any. The tool now reports
+ * a fetch failure explicitly, but the fetch still fails — the cap is what keeps it from failing at all.
  *
  * Raised rather than removed, and to 16384 rather than to the model's own ceiling, because these are
  * NON-streaming `generateObject` calls: a cap high enough to permit a multi-minute generation trades a
@@ -82,13 +83,13 @@ const TYPE_CONSTRUCTOR = 'Constructor';
  */
 const SELECTION_MAX_OUTPUT_TOKENS = 16384;
 
-export async function selectRequiredFunctions(prompt: string, selectedLibNames: string[], generationType: GenerationType): Promise<{ libraries: Library[], usage: ModelUsage[] }> {
+export async function selectRequiredFunctions(prompt: string, selectedLibNames: string[], generationType: GenerationType, abortSignal?: AbortSignal): Promise<{ libraries: Library[], usage: ModelUsage[] }> {
     const selectedLibs: Library[] = await getMaximizedSelectedLibs(selectedLibNames);
-    const { functionsResponse, usage: functionsUsage } = await getRequiredFunctions(selectedLibNames, prompt, selectedLibs, generationType);
+    const { functionsResponse, usage: functionsUsage } = await getRequiredFunctions(selectedLibNames, prompt, selectedLibs, generationType, abortSignal);
     let typeLibraries: Library[] = [];
     const allUsages: ModelUsage[] = [...functionsUsage];
     if (generationType === GenerationType.HEALTHCARE_GENERATION) {
-        const { types: resp, usage } = await getRequiredTypesFromLibJson(selectedLibNames, prompt, selectedLibs);
+        const { types: resp, usage } = await getRequiredTypesFromLibJson(selectedLibNames, prompt, selectedLibs, abortSignal);
         typeLibraries = toTypesToLibraries(resp, selectedLibs);
         allUsages.push(usage);
     }
@@ -161,7 +162,8 @@ async function getRequiredFunctions(
     libraries: string[],
     prompt: string,
     librariesJson: Library[],
-    generationType: GenerationType
+    generationType: GenerationType,
+    abortSignal?: AbortSignal
 ): Promise<{ functionsResponse: GetFunctionResponse[], usage: ModelUsage[] }> {
     if (librariesJson.length === 0) {
         return { functionsResponse: [], usage: [] };
@@ -199,12 +201,12 @@ async function getRequiredFunctions(
 
     // Create promises for large libraries (each processed individually)
     const largeLiberiesPromises = largeLibs.map((funcItem) =>
-        getSuggestedFunctions(prompt, [funcItem])
+        getSuggestedFunctions(prompt, [funcItem], abortSignal)
     );
 
     // Create promise for small libraries (processed in bulk)
     const smallLibrariesPromise =
-        smallLibs.length !== 0 ? getSuggestedFunctions(prompt, smallLibs) : Promise.resolve({ libraries: [] as GetFunctionResponse[], usage: { model: ANTHROPIC_HAIKU, inputTokens: 0, outputTokens: 0 } });
+        smallLibs.length !== 0 ? getSuggestedFunctions(prompt, smallLibs, abortSignal) : Promise.resolve({ libraries: [] as GetFunctionResponse[], usage: { model: ANTHROPIC_HAIKU, inputTokens: 0, outputTokens: 0 } });
 
     console.log(
         `[Parallel Execution Start] Starting ${largeLiberiesPromises.length} large library requests + 1 small libraries bulk request`
@@ -249,7 +251,8 @@ async function getRequiredFunctions(
 
 async function getSuggestedFunctions(
     prompt: string,
-    libraryList: GetFunctionsRequest[]
+    libraryList: GetFunctionsRequest[],
+    abortSignal?: AbortSignal
 ): Promise<{ libraries: GetFunctionResponse[], usage: ModelUsage }> {
     const startTime = Date.now();
     const libraryNames = libraryList.map((lib) => lib.name).join(", ");
@@ -310,7 +313,7 @@ Now, based on the provided libraries and the user query, please filter and retur
             temperature: 0,
             messages: messages,
             schema: getFunctionsResponseSchema,
-            abortSignal: new AbortController().signal,
+            abortSignal,
         });
 
         const libList = object as GetFunctionsResponse;
@@ -324,7 +327,7 @@ Now, based on the provided libraries and the user query, please filter and retur
 
         const callUsage: ModelUsage = { model: ANTHROPIC_HAIKU, inputTokens: usage.inputTokens || 0, outputTokens: usage.outputTokens || 0 };
         console.log(
-            `[AI Request Complete] Libraries: [${libraryNames}], Duration: ${duration}s, Selected Functions: ${libList.libraries.reduce(
+            `[AI Request Complete] Libraries: [${libraryNames}], Duration: ${duration}s, Selected Functions: ${filteredLibList.reduce(
                 (total, lib) =>
                     total +
                     (lib.clients?.reduce((clientTotal, client) => clientTotal + client.functions.length, 0) || 0) +
@@ -422,7 +425,10 @@ function mergeLibrariesWithoutDuplicates(maximizedLibraries: Library[], typeLibr
     for (const typeLib of typeLibraries) {
         const finalLib = findLibraryByName(typeLib.name, finalLibraries);
         if (finalLib) {
-            finalLib.typeDefs.push(...typeLib.typeDefs);
+            // A type selected by both the function closure and the healthcare type selection must not
+            // be declared twice in the rendered catalog.
+            const existingNames = new Set(finalLib.typeDefs.map((def) => def.name));
+            finalLib.typeDefs.push(...typeLib.typeDefs.filter((def) => !existingNames.has(def.name)));
         } else {
             finalLibraries.push(typeLib);
         }
@@ -999,7 +1005,8 @@ async function getExternalRecords(
 export async function getRequiredTypesFromLibJson(
     libraries: string[],
     prompt: string,
-    librariesJson: Library[]
+    librariesJson: Library[],
+    abortSignal?: AbortSignal
 ): Promise<{ types: GetTypeResponse[], usage: ModelUsage }> {
     const emptyUsage: ModelUsage = { model: ANTHROPIC_HAIKU, inputTokens: 0, outputTokens: 0 };
     if (librariesJson.length === 0) {
@@ -1066,7 +1073,7 @@ Think step-by-step to choose the required types in order to solve the given ques
             temperature: 0,
             messages: messages,
             schema: getTypesResponseSchema,
-            abortSignal: new AbortController().signal,
+            abortSignal,
         });
 
         const callUsage: ModelUsage = { model: ANTHROPIC_HAIKU, inputTokens: usage.inputTokens || 0, outputTokens: usage.outputTokens || 0 };

--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
@@ -74,8 +74,9 @@ const TYPE_CONSTRUCTOR = 'Constructor';
  * issues, PRs, releases and webhooks") could exceed it, and the failure was the worst shape available: the
  * JSON is truncated mid-token, `generateObject` rejects it against the schema, the throw unwinds to
  * `LibraryGetTool`'s catch, and the agent was handed `[]` — indistinguishable from a library that matched
- * nothing, with no API documentation and a system prompt forbidding it to invent any. The tool now reports
- * a fetch failure explicitly, but the fetch still fails — the cap is what keeps it from failing at all.
+ * nothing, with no API documentation and a system prompt forbidding it to invent any. The tool reports a
+ * fetch failure to the model, but a reported failure is still a failure — the cap is what keeps it from
+ * failing at all.
  *
  * Raised rather than removed, and to 16384 rather than to the model's own ceiling, because these are
  * NON-streaming `generateObject` calls: a cap high enough to permit a multi-minute generation trades a

--- a/packages/ballerina-extension/src/features/ai/utils/libs/library-types.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/library-types.ts
@@ -299,6 +299,16 @@ export interface Listener {
     deprecated?: string;
 }
 
+// Spec §2 `listeners[].services`: one other listener a service type may attach to, leaner than
+// `Listener` because an alternative is a pointer rather than a declaration — it carries no init
+// parameters and no `doc`, which the reader reads off the library's own listener class. `deprecated`
+// is carried: mcp's `Listener` is offered here but superseded by `StreamableHttpListener`, and the
+// reason has nowhere else to travel. Absent means the alternative is not deprecated.
+export interface AlternativeListener {
+    name: string;
+    deprecated?: string;
+}
+
 // Spec §2 `listeners[].requiredImports`: an import the generated code needs for its runtime side
 // effect even though nothing references it by name (bound to `_`). Scoped to the service that uses
 // the listener, not to the library.
@@ -421,7 +431,12 @@ export interface Service {
     // choice the reader may want to make differently. `ballerina/mcp` is the corpus case — all four of its
     // service types are listed under both `StreamableHttpListener` and `Listener` — and it is the only one,
     // so the field is absent for every other library.
-    alternativeListeners?: string[];
+    //
+    // Each entry is an `AlternativeListener`, not a bare name: a superseded listener is still offered here,
+    // and its `deprecated` reason travels with it. mcp's `Listener` is deprecated in favour of
+    // `StreamableHttpListener`, and it is exactly the transport that lands here rather than in the
+    // `on new …` clause — so the name alone would present a retired listener as an equal choice.
+    alternativeListeners?: AlternativeListener[];
     requiredImports?: RequiredImport[];
     // Spec §8: the annotations this service type must or may carry.
     annotations?: ServiceAnnotationRef[];

--- a/packages/ballerina-extension/src/features/ai/utils/libs/to-syntax-string.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/to-syntax-string.ts
@@ -2020,9 +2020,21 @@ function renderAlternativeListenerNote(service: Service): string[] {
     if (alternatives.length === 0) {
         return [];
     }
-    const names = alternatives.map((name) => `\`${name}\``).join(", ");
-    return [`# This service type may attach to ${names} instead of `
+    const names = alternatives.map((alt) => `\`${alt.name}\``).join(", ");
+    const lines = [`# This service type may attach to ${names} instead of `
         + `\`${service.listener.name}\`, which the declaration below uses.`];
+    // A superseded listener is still offered above, so its deprecation is stated here or nowhere — the
+    // `on new …` clause names the primary listener, and only that one's deprecation reaches
+    // `renderDeprecationSection`. mcp's `Listener` is the corpus case: without this it would read as an
+    // equal transport to `StreamableHttpListener`. One line per deprecated alternative, since the reason
+    // is specific to each.
+    for (const alt of alternatives) {
+        if (alt.deprecated && alt.deprecated.trim() !== "") {
+            lines.push(`# \`${alt.name}\` is deprecated: `
+                + `${alt.deprecated.split("\n").map((l) => l.trim()).join(" ")}`);
+        }
+    }
+    return lines;
 }
 
 /**

--- a/packages/ballerina-extension/test/ai/unit_tests/libs/to-syntax-string.test.ts
+++ b/packages/ballerina-extension/test/ai/unit_tests/libs/to-syntax-string.test.ts
@@ -3403,13 +3403,35 @@ suite("toSyntaxString", () => {
             // otherwise be shown only the HTTP one with nothing saying the other exists.
             const result = renderService(service({
                 listener: { name: "mcp:StreamableHttpListener", parameters: [] },
-                alternativeListeners: ["mcp:Listener"],
+                alternativeListeners: [{ name: "mcp:Listener" }],
             }));
             assert.strictEqual(line(result, "may attach to").trim(),
                 "# This service type may attach to `mcp:Listener` instead of "
                 + "`mcp:StreamableHttpListener`, which the declaration below uses.");
             // One entry, not one per listener: the two would differ by a single token.
             assert.strictEqual(result.split("\n").filter((l) => l.startsWith("service ")).length, 1);
+            // A non-deprecated alternative states nothing further.
+            noLine(result, "is deprecated:");
+        });
+
+        test("§2/§5.3: a deprecated alternative listener states why it is superseded", () => {
+            // mcp's `Listener` is exactly this case: it hosts the same service types as
+            // `StreamableHttpListener` but is deprecated in its favour, so it lands in `alternativeListeners`
+            // rather than the `on new …` clause. Only the primary listener's deprecation reaches
+            // `renderDeprecationSection`, so without this the retired transport reads as an equal choice.
+            const result = renderService(service({
+                listener: { name: "mcp:StreamableHttpListener", parameters: [] },
+                alternativeListeners: [{
+                    name: "mcp:Listener",
+                    deprecated: "Renamed to make the transport explicit. Use mcp:StreamableHttpListener instead.",
+                }],
+            }));
+            assert.strictEqual(line(result, "may attach to").trim(),
+                "# This service type may attach to `mcp:Listener` instead of "
+                + "`mcp:StreamableHttpListener`, which the declaration below uses.");
+            assert.strictEqual(line(result, "is deprecated:").trim(),
+                "# `mcp:Listener` is deprecated: Renamed to make the transport explicit. "
+                + "Use mcp:StreamableHttpListener instead.");
         });
 
         test("§2: a single-listener document states nothing, which is every other library", () => {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/AlternativeListener.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/AlternativeListener.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.copilot.model;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The spec §2 {@code listeners[].services} — one other listener a service type may attach to, as the
+ * {@code alias:ClassName} a reader would write.
+ *
+ * <p>Deliberately leaner than {@link Listener}: an alternative is a pointer ("this transport also works"),
+ * so it carries no init parameters and no {@code doc} — those are read off the library's own listener
+ * class. What it does carry, beyond the name, is {@code deprecated}: a listener the document supersedes is
+ * still offered as an alternative, but a reader choosing it needs to see the reason, and a bare name string
+ * had nowhere to put it. {@code ballerina/mcp} is the corpus case — its {@code Listener} is deprecated in
+ * favour of {@code StreamableHttpListener}, and it is exactly the transport that ends up here rather than in
+ * the {@code on new …} clause.
+ *
+ * @since 1.7.0
+ */
+public class AlternativeListener {
+
+    private String name;
+    /**
+     * The spec {@code deprecated} — why this listener is superseded, as the document's own prose. Text
+     * rather than a flag, mirroring {@link Listener#getDeprecationNote()}: the sentence names the
+     * replacement, which is the only part a reader can act on. Null, and so omitted, when the listener is
+     * not deprecated.
+     */
+    @SerializedName("deprecated")
+    private String deprecationNote;
+
+    public AlternativeListener() {
+    }
+
+    public AlternativeListener(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDeprecationNote() {
+        return deprecationNote;
+    }
+
+    public void setDeprecationNote(String deprecationNote) {
+        this.deprecationNote = deprecationNote;
+    }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/Service.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/model/Service.java
@@ -58,8 +58,12 @@ public class Service {
      * reader may want to make differently: {@code ballerina/mcp} lists all four of its service types under
      * both {@code StreamableHttpListener} and {@code Listener}, so rendering only the first would make the
      * other transport invisible. Absent for a single-listener document, which is every other one.
+     *
+     * <p>An {@link AlternativeListener} rather than a bare name: a superseded listener is still offered
+     * here, and the reason it is deprecated has to travel with it. {@code mcp}'s {@code Listener} is the
+     * corpus case.
      */
-    private List<String> alternativeListeners;
+    private List<AlternativeListener> alternativeListeners;
     // The spec: the org/module a cross-module service type belongs to (ballerinax/cdc). Null for a
     // home-module type. The renderer derives the prefix and the provenance note from it.
     private String serviceTypeModule;
@@ -175,11 +179,11 @@ public class Service {
         this.name = name;
     }
 
-    public List<String> getAlternativeListeners() {
+    public List<AlternativeListener> getAlternativeListeners() {
         return alternativeListeners;
     }
 
-    public void setAlternativeListeners(List<String> alternativeListeners) {
+    public void setAlternativeListeners(List<AlternativeListener> alternativeListeners) {
         this.alternativeListeners = alternativeListeners;
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/service/ServiceAspects.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/service/ServiceAspects.java
@@ -19,6 +19,7 @@
 package io.ballerina.flowmodelgenerator.core.copilot.service;
 
 import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.flowmodelgenerator.core.copilot.model.AlternativeListener;
 import io.ballerina.flowmodelgenerator.core.copilot.model.Listener;
 import io.ballerina.flowmodelgenerator.core.copilot.model.NativeLibrary;
 import io.ballerina.flowmodelgenerator.core.copilot.model.Parameter;
@@ -30,9 +31,11 @@ import io.ballerina.modelgenerator.commons.trigger.models.TriggerMetadataModel;
 import io.ballerina.modelgenerator.commons.trigger.utils.TypeRefResolver;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The service tier: everything stated once per service entry. Constraints are {@link ConstraintAspect}, the
@@ -236,7 +239,7 @@ final class ServiceAspects {
     void listener(TriggerScope scope, ServiceDraft draft) {
         Object key = scope.listener() != null ? scope.listener() : scope.listenerClass();
         draft.setListener(builtListeners.computeIfAbsent(key, unused -> buildListener(scope)));
-        draft.setAlternativeListeners(alternativeListenerNames(scope));
+        draft.setAlternativeListeners(alternativeListeners(scope));
         // The listener is still emitted either way — a consumer needs its types even when the service is
         // written some other way, and the type closure reaches them through it.
         if (scope.document() != null
@@ -258,14 +261,20 @@ final class ServiceAspects {
      * <p>Init parameters are deliberately <b>not</b> carried. The alternative is a pointer — "this also
      * works" — and a second full parameter list per service entry would double the listener surface of
      * every mcp service to say something the reader can read off the library's own listener class.
+     *
+     * <p>The document's {@code deprecated} <b>is</b> carried, because a superseded listener is still offered
+     * here and the reason travels with it or nowhere: the primary listener renders its own deprecation, but
+     * an alternative that dropped it would present {@code mcp:Listener} as an equal transport to
+     * {@code mcp:StreamableHttpListener} with nothing saying it is retired.
      */
-    private static List<String> alternativeListenerNames(TriggerScope scope) {
+    private static List<AlternativeListener> alternativeListeners(TriggerScope scope) {
         if (scope.document() == null) {
             return List.of();
         }
         String primary = TypeRefResolver.moduleAlias(scope.packageName()) + ":"
                 + scope.listenerClass().getName().orElse(DEFAULT_LISTENER_NAME);
-        List<String> names = new ArrayList<>();
+        List<AlternativeListener> alternatives = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
         for (TriggerMetadataModel.Listener alternative : ListenerPairingResolver.alternativeHosts(
                 scope.document().listeners(), scope.serviceType(), scope.listener())) {
             String declared = alternative.type() == null ? null : alternative.type().name();
@@ -278,11 +287,16 @@ final class ServiceAspects {
             // Two document entries can resolve to one class — `resolveListenerClass` falls back to the
             // canonical `Listener` for an unnamed one — and an alternative identical to the primary is not
             // an alternative at all.
-            if (!name.equals(primary) && !names.contains(name)) {
-                names.add(name);
+            if (name.equals(primary) || !seen.add(name)) {
+                continue;
             }
+            AlternativeListener entry = new AlternativeListener(name);
+            if (alternative.deprecated() != null && !alternative.deprecated().isBlank()) {
+                entry.setDeprecationNote(alternative.deprecated());
+            }
+            alternatives.add(entry);
         }
-        return names;
+        return alternatives;
     }
 
     private static Listener buildListener(TriggerScope scope) {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/service/ServiceAspects.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/service/ServiceAspects.java
@@ -31,11 +31,10 @@ import io.ballerina.modelgenerator.commons.trigger.models.TriggerMetadataModel;
 import io.ballerina.modelgenerator.commons.trigger.utils.TypeRefResolver;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * The service tier: everything stated once per service entry. Constraints are {@link ConstraintAspect}, the
@@ -273,8 +272,9 @@ final class ServiceAspects {
         }
         String primary = TypeRefResolver.moduleAlias(scope.packageName()) + ":"
                 + scope.listenerClass().getName().orElse(DEFAULT_LISTENER_NAME);
-        List<AlternativeListener> alternatives = new ArrayList<>();
-        Set<String> seen = new HashSet<>();
+        // Keyed by rendered name, in document order: two document entries can resolve to one class, and the
+        // merge below has to find the entry already made for it.
+        Map<String, AlternativeListener> alternatives = new LinkedHashMap<>();
         for (TriggerMetadataModel.Listener alternative : ListenerPairingResolver.alternativeHosts(
                 scope.document().listeners(), scope.serviceType(), scope.listener())) {
             String declared = alternative.type() == null ? null : alternative.type().name();
@@ -284,19 +284,22 @@ final class ServiceAspects {
                 continue;
             }
             String name = TypeRefResolver.moduleAlias(scope.packageName()) + ":" + className;
-            // Two document entries can resolve to one class — `resolveListenerClass` falls back to the
-            // canonical `Listener` for an unnamed one — and an alternative identical to the primary is not
-            // an alternative at all.
-            if (name.equals(primary) || !seen.add(name)) {
+            // An alternative identical to the primary is not an alternative at all.
+            if (name.equals(primary)) {
                 continue;
             }
-            AlternativeListener entry = new AlternativeListener(name);
-            if (alternative.deprecated() != null && !alternative.deprecated().isBlank()) {
-                entry.setDeprecationNote(alternative.deprecated());
+            // Two document entries can resolve to one class — `resolveListenerClass` falls back to the
+            // canonical `Listener` for an unnamed one. One entry per name, but the deprecation note is
+            // merged rather than taken from whichever entry came first: a note on the later duplicate is
+            // still the reason this listener is retired, and dropping it would present the listener as
+            // an equal choice.
+            AlternativeListener entry = alternatives.computeIfAbsent(name, AlternativeListener::new);
+            String deprecated = alternative.deprecated();
+            if (entry.getDeprecationNote() == null && deprecated != null && !deprecated.isBlank()) {
+                entry.setDeprecationNote(deprecated);
             }
-            alternatives.add(entry);
         }
-        return alternatives;
+        return new ArrayList<>(alternatives.values());
     }
 
     private static Listener buildListener(TriggerScope scope) {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/service/ServiceDraft.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/service/ServiceDraft.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.flowmodelgenerator.core.copilot.service;
 
+import io.ballerina.flowmodelgenerator.core.copilot.model.AlternativeListener;
 import io.ballerina.flowmodelgenerator.core.copilot.model.Listener;
 import io.ballerina.flowmodelgenerator.core.copilot.model.PlatformDependency;
 import io.ballerina.flowmodelgenerator.core.copilot.model.RequiredImport;
@@ -203,9 +204,9 @@ final class ServiceDraft {
      * <p>Omitted when there are none, which is every single-listener document — so the key appears only
      * where the document genuinely offers a choice.
      */
-    void setAlternativeListeners(List<String> names) {
-        if (names != null && !names.isEmpty()) {
-            service.setAlternativeListeners(List.copyOf(names));
+    void setAlternativeListeners(List<AlternativeListener> alternatives) {
+        if (alternatives != null && !alternatives.isEmpty()) {
+            service.setAlternativeListeners(List.copyOf(alternatives));
         }
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/CopilotSchemaServicesTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/CopilotSchemaServicesTest.java
@@ -946,6 +946,7 @@ public class CopilotSchemaServicesTest {
         JsonArray services = load(MCP);
         Set<String> declared = declaredNames(MCP);
         int stated = 0;
+        int deprecatedAlternatives = 0;
         for (JsonElement element : services) {
             JsonObject svc = element.getAsJsonObject();
             JsonArray alternatives = svc.getAsJsonArray("alternativeListeners");
@@ -953,16 +954,29 @@ public class CopilotSchemaServicesTest {
                 continue;
             }
             for (JsonElement alternative : alternatives) {
-                String name = alternative.getAsString();
+                JsonObject alt = alternative.getAsJsonObject();
+                String name = alt.get("name").getAsString();
                 assertListenerIsDeclared(name, declared);
                 Assert.assertNotEquals(name, svc.getAsJsonObject("listener").get("name").getAsString(),
                         "a listener is never an alternative to itself");
+                // A deprecated alternative carries the reason: mcp's `Listener` is superseded by
+                // `StreamableHttpListener`, and dropping it would present the retired transport as an equal.
+                if (alt.has("deprecated")) {
+                    Assert.assertFalse(alt.get("deprecated").getAsString().isBlank(),
+                            "a deprecated alternative states why, not just that: " + alt);
+                    deprecatedAlternatives++;
+                }
                 stated++;
             }
         }
         Assert.assertTrue(stated > 0,
                 "mcp declares two listeners hosting the same service types; the second must be stated: "
                         + services);
+        // `StreamableHttpListener` is the first listener, so `hostOf` writes it into the `on new …` clause
+        // and the deprecated `Listener` always lands here as the alternative. Its deprecation must survive.
+        Assert.assertTrue(deprecatedAlternatives > 0,
+                "mcp's `Listener` is deprecated and is the alternative on every service; its `deprecated` "
+                        + "note must reach the wire: " + services);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/2366

libraryGetTool reliability:
- Propagate the AI SDK abort signal through selectRequiredFunctions, getRequiredFunctions, getSuggestedFunctions and getRequiredTypesFromLibJson so a cancelled run actually cancels the underlying generateObject calls, which previously received a fresh AbortController().signal that never fired.
- Distinguish "no library matched" from "the fetch failed": LibraryGetTool rethrows instead of returning [], and execute() returns a distinct, actionable message for each so the agent never treats an internal failure as evidence to invent API.
- De-duplicate and trim requested library names before fetching.
- Emit the requested libraryNames on the tool_call event, and fix the [AI Request Complete] log to count the hallucination-filtered list.
- De-duplicate type definitions when merging healthcare type libraries.

Deprecated alternative listeners:
- A service type hosted by several listeners writes one into the `on new ...` clause and lists the rest as alternatives. A deprecated alternative (mcp:Listener, superseded by mcp:StreamableHttpListener) lost its deprecation reason because alternatives were carried as bare name strings.
- Carry an AlternativeListener { name, deprecated? } end to end (Java producer model, wire shape, and TS renderer) and render the reason in the catalog note.
- Update the renderer unit test and the LS-extension schema test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Improve `libraryGetTool` reliability with abort-signal propagation, input cleanup, clear failure handling, and accurate tool-call reporting.
- Distinguish unmatched libraries from lookup failures and prevent duplicate healthcare type definitions.
- Preserve alternative-listener deprecation metadata across Java models, wire schemas, and TypeScript catalog notes.
- Update renderer and language-server schema tests for structured alternative listeners and deprecation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->