### PR TITLE
Sanitize malformed tool-call inputs before sending agent history to Anthropic

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -453,8 +453,8 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                     }
                     // Anthropic requires tool_use.input to be an object; an unparseable or schema-invalid
                     // streamed input is left as a non-object on the tool-call part and 400s every later request.
-                    const { messages } = sanitizeMessages(stepMessages);
-                    return { messages: addCacheControlToMessages({ messages, model }) };
+                    sanitizeMessages(stepMessages);
+                    return { messages: addCacheControlToMessages({ messages: stepMessages, model }) };
                 },
 
                 // Emit per-step token usage for context usage widget + observability

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -451,10 +451,10 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                     if (cleanedCompactionSummary) {
                         stripAnalysisFromCompactionBlocks(stepMessages);
                     }
-                    // Anthropic requires tool_use.input to be an object; an unparseable streamed
-                    // input stays a string on the tool-call part and 400s every later request.
-                    sanitizeMessages(stepMessages);
-                    return { messages: addCacheControlToMessages({ messages: stepMessages, model }) };
+                    // Anthropic requires tool_use.input to be an object; an unparseable or schema-invalid
+                    // streamed input is left as a non-object on the tool-call part and 400s every later request.
+                    const { messages } = sanitizeMessages(stepMessages);
+                    return { messages: addCacheControlToMessages({ messages, model }) };
                 },
 
                 // Emit per-step token usage for context usage widget + observability

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -51,6 +51,7 @@ import {
     stripAnalysisFromCompactionBlocks,
     COMPACTION_BLOCK_PREFIX,
 } from '@wso2/copilot-utilities/context-management';
+import { sanitizeMessages } from './resilience';
 import { getLoginMethod } from '../../../utils/ai/auth';
 import {
     sendTelemetryEvent,
@@ -450,6 +451,9 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                     if (cleanedCompactionSummary) {
                         stripAnalysisFromCompactionBlocks(stepMessages);
                     }
+                    // Anthropic requires tool_use.input to be an object; an unparseable streamed
+                    // input stays a string on the tool-call part and 400s every later request.
+                    sanitizeMessages(stepMessages);
                     return { messages: addCacheControlToMessages({ messages: stepMessages, model }) };
                 },
 

--- a/packages/ballerina-extension/src/features/ai/agent/resilience/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/resilience/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { sanitizeMessages, repairToolCallInputs } from "./messageSanitization";

--- a/packages/ballerina-extension/src/features/ai/agent/resilience/messageSanitization.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/resilience/messageSanitization.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Repair passes that keep a model-message history provider-valid before it is sent to Anthropic.
+ * `sanitizeMessages` is the single entry point; individual repairs compose under it, so new failure
+ * modes can be handled by adding a pass rather than touching call sites.
+ */
+
+function isMalformedToolCallPart(part: any): boolean {
+    return part?.type === 'tool-call' && typeof part.input === 'string';
+}
+
+function coerceInput(raw: string): Record<string, unknown> {
+    try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed;
+        }
+    } catch {
+        // unparseable
+    }
+    return {};
+}
+
+/**
+ * Coerce every malformed (string) tool-call input to an object, in place. Returns the number
+ * repaired; clean histories are a no-op.
+ *
+ * When a streamed tool call's JSON is invalid — most often truncated at the output-token cap on a
+ * large file write — the AI SDK cannot parse it and keeps the raw text as a string on the
+ * `tool-call` part. Anthropic requires `tool_use.input` to be an object and rejects replay with
+ * `tool_use.input: Input should be an object`, which bricks the thread on every later request.
+ */
+export function repairToolCallInputs(messages: any[]): number {
+    let repaired = 0;
+    for (const message of messages ?? []) {
+        if (!Array.isArray(message?.content)) {
+            continue;
+        }
+        for (const part of message.content) {
+            if (isMalformedToolCallPart(part)) {
+                part.input = coerceInput(part.input);
+                repaired++;
+            }
+        }
+    }
+    if (repaired > 0) {
+        console.warn(`[messageSanitization] Coerced ${repaired} malformed tool-call input(s) to objects.`);
+    }
+    return repaired;
+}
+
+/**
+ * Run every repair pass over a message history, in place, so it stays provider-valid. Call before
+ * sending history to the provider (prepareStep, history load). Add new passes here as needed.
+ */
+export function sanitizeMessages(messages: any[]): void {
+    repairToolCallInputs(messages);
+}

--- a/packages/ballerina-extension/src/features/ai/agent/resilience/messageSanitization.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/resilience/messageSanitization.ts
@@ -23,18 +23,13 @@ import type { AssistantModelMessage, ModelMessage } from 'ai';
  * `sanitizeMessages` is the single entry point; individual repairs compose under it, so new failure
  * modes can be handled by adding a pass rather than touching call sites.
  *
- * Every pass is copy-on-write: only the messages it has to change are copied, and the input array
- * and its objects are never mutated. Replayed history is handed out by reference from the chat
- * store, so writing into it here would silently edit persisted state.
+ * Passes edit the history in place. The malformed input is corrupt stored state — the parts here
+ * are the chat store's own objects, held by reference on both the replay and the in-turn path — so
+ * repairing them heals the thread at the source: every alias is fixed at once, and the next thread
+ * save persists the clean value, rather than re-coercing the same corruption on every send.
  */
 
 type AssistantPart = Exclude<AssistantModelMessage['content'], string>[number];
-
-export interface SanitizedHistory {
-    messages: ModelMessage[];
-    /** Tool calls whose arguments had to be replaced with `{}` — each one a call that never ran. */
-    repaired: number;
-}
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -46,9 +41,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * parses but fails the tool's schema, the SDK keeps the parsed value instead, so an array, `null`
  * or a number can arrive here too. Anthropic requires `tool_use.input` to be an object and rejects
  * replay with `tool_use.input: Input should be an object`, which bricks the thread on every later
- * request. Either way the SDK ran nothing for the call.
+ * request. The paired tool-result already carries the parse error, so the model still learns the
+ * call failed; coercing the input just makes the history sendable again.
  */
-function coerceInput(raw: unknown): Record<string, unknown> {
+function coerceToObject(raw: unknown): Record<string, unknown> {
     if (typeof raw === 'string') {
         try {
             const parsed: unknown = JSON.parse(raw);
@@ -62,73 +58,32 @@ function coerceInput(raw: unknown): Record<string, unknown> {
     return {};
 }
 
-function repairAssistantMessage(
-    message: AssistantModelMessage
-): { message: AssistantModelMessage; toolNames: string[] } | undefined {
-    if (typeof message.content === 'string') {
-        return undefined;
-    }
-    const toolNames: string[] = [];
-    const content: AssistantPart[] = message.content.map((part) => {
-        if (part.type !== 'tool-call' || isPlainObject(part.input)) {
-            return part;
-        }
-        toolNames.push(part.toolName);
-        return { ...part, input: coerceInput(part.input) };
-    });
-    return toolNames.length > 0 ? { message: { ...message, content }, toolNames } : undefined;
-}
-
-/**
- * Follows the idiom `getChatHistoryForLLM` uses for interrupted generations: the coerced call now
- * reads as a real call made with no arguments, so the model is told outright that it never ran.
- */
-function droppedArgumentsReminder(toolNames: string[]): ModelMessage {
-    const calls = toolNames.map((name) => `\`${name}\``).join(', ');
-    const plural = toolNames.length > 1;
-    return {
-        role: 'user',
-        content:
-            `<system-reminder>\n` +
-            `The arguments of the earlier ${calls} tool call${plural ? 's' : ''} could not be read ` +
-            `(the output was cut off or malformed) and were replaced with an empty object. ` +
-            `${plural ? 'Those calls were' : 'That call was'} NOT performed — redo ` +
-            `${plural ? 'them' : 'it'} if still required.\n` +
-            `</system-reminder>`,
-    };
-}
-
-/** Coerce every non-object tool-call input to an object, and flag each such call to the model. */
-export function repairToolCallInputs(messages: readonly ModelMessage[] | null | undefined): SanitizedHistory {
-    const source = messages ?? [];
-    const out: ModelMessage[] = [];
+/** Coerce every non-object tool-call input to an object, in place. Returns how many were repaired. */
+export function repairToolCallInputs(messages: ModelMessage[] | null | undefined): number {
     let repaired = 0;
-    for (let i = 0; i < source.length; i++) {
-        const message = source[i];
-        const repair = message.role === 'assistant' ? repairAssistantMessage(message) : undefined;
-        if (!repair) {
-            out.push(message);
+    for (const message of messages ?? []) {
+        if (message.role !== 'assistant' || typeof message.content === 'string') {
             continue;
         }
-        repaired += repair.toolNames.length;
-        out.push(repair.message);
-        // A tool_use must stay adjacent to its tool_result, so the reminder goes after the result.
-        if (source[i + 1]?.role === 'tool') {
-            out.push(source[++i]);
+        for (const part of message.content as AssistantPart[]) {
+            if (part.type === 'tool-call' && !isPlainObject(part.input)) {
+                part.input = coerceToObject(part.input);
+                repaired++;
+            }
         }
-        out.push(droppedArgumentsReminder(repair.toolNames));
     }
     if (repaired > 0) {
         console.warn(`[messageSanitization] Coerced ${repaired} malformed tool-call input(s) to objects.`);
     }
-    return { messages: out, repaired };
+    return repaired;
 }
 
 /**
- * Run every repair pass over a message history so it stays provider-valid. Call before sending
- * history to the provider (prepareStep, history load) and send what comes back. Add new passes
- * here as needed.
+ * Run every repair pass over a message history in place, so it stays provider-valid. Call before
+ * sending history to the provider (prepareStep, history load). Returns how many tool-call inputs
+ * had to be repaired — each one a call whose arguments were lost — so callers can surface or count
+ * it. Add new passes here as needed.
  */
-export function sanitizeMessages(messages: readonly ModelMessage[] | null | undefined): SanitizedHistory {
+export function sanitizeMessages(messages: ModelMessage[] | null | undefined): number {
     return repairToolCallInputs(messages);
 }

--- a/packages/ballerina-extension/src/features/ai/agent/resilience/messageSanitization.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/resilience/messageSanitization.ts
@@ -16,60 +16,119 @@
  * under the License.
  */
 
+import type { AssistantModelMessage, ModelMessage } from 'ai';
+
 /**
  * Repair passes that keep a model-message history provider-valid before it is sent to Anthropic.
  * `sanitizeMessages` is the single entry point; individual repairs compose under it, so new failure
  * modes can be handled by adding a pass rather than touching call sites.
+ *
+ * Every pass is copy-on-write: only the messages it has to change are copied, and the input array
+ * and its objects are never mutated. Replayed history is handed out by reference from the chat
+ * store, so writing into it here would silently edit persisted state.
  */
 
-function isMalformedToolCallPart(part: any): boolean {
-    return part?.type === 'tool-call' && typeof part.input === 'string';
+type AssistantPart = Exclude<AssistantModelMessage['content'], string>[number];
+
+export interface SanitizedHistory {
+    messages: ModelMessage[];
+    /** Tool calls whose arguments had to be replaced with `{}` — each one a call that never ran. */
+    repaired: number;
 }
 
-function coerceInput(raw: string): Record<string, unknown> {
-    try {
-        const parsed = JSON.parse(raw);
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-            return parsed;
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * When a streamed tool call's JSON is invalid — most often truncated at the output-token cap on a
+ * large file write — the AI SDK keeps the raw text as a string on the `tool-call` part. When it
+ * parses but fails the tool's schema, the SDK keeps the parsed value instead, so an array, `null`
+ * or a number can arrive here too. Anthropic requires `tool_use.input` to be an object and rejects
+ * replay with `tool_use.input: Input should be an object`, which bricks the thread on every later
+ * request. Either way the SDK ran nothing for the call.
+ */
+function coerceInput(raw: unknown): Record<string, unknown> {
+    if (typeof raw === 'string') {
+        try {
+            const parsed: unknown = JSON.parse(raw);
+            if (isPlainObject(parsed)) {
+                return parsed;
+            }
+        } catch {
+            // unparseable
         }
-    } catch {
-        // unparseable
     }
     return {};
 }
 
+function repairAssistantMessage(
+    message: AssistantModelMessage
+): { message: AssistantModelMessage; toolNames: string[] } | undefined {
+    if (typeof message.content === 'string') {
+        return undefined;
+    }
+    const toolNames: string[] = [];
+    const content: AssistantPart[] = message.content.map((part) => {
+        if (part.type !== 'tool-call' || isPlainObject(part.input)) {
+            return part;
+        }
+        toolNames.push(part.toolName);
+        return { ...part, input: coerceInput(part.input) };
+    });
+    return toolNames.length > 0 ? { message: { ...message, content }, toolNames } : undefined;
+}
+
 /**
- * Coerce every malformed (string) tool-call input to an object, in place. Returns the number
- * repaired; clean histories are a no-op.
- *
- * When a streamed tool call's JSON is invalid — most often truncated at the output-token cap on a
- * large file write — the AI SDK cannot parse it and keeps the raw text as a string on the
- * `tool-call` part. Anthropic requires `tool_use.input` to be an object and rejects replay with
- * `tool_use.input: Input should be an object`, which bricks the thread on every later request.
+ * Follows the idiom `getChatHistoryForLLM` uses for interrupted generations: the coerced call now
+ * reads as a real call made with no arguments, so the model is told outright that it never ran.
  */
-export function repairToolCallInputs(messages: any[] | null | undefined): number {
+function droppedArgumentsReminder(toolNames: string[]): ModelMessage {
+    const calls = toolNames.map((name) => `\`${name}\``).join(', ');
+    const plural = toolNames.length > 1;
+    return {
+        role: 'user',
+        content:
+            `<system-reminder>\n` +
+            `The arguments of the earlier ${calls} tool call${plural ? 's' : ''} could not be read ` +
+            `(the output was cut off or malformed) and were replaced with an empty object. ` +
+            `${plural ? 'Those calls were' : 'That call was'} NOT performed — redo ` +
+            `${plural ? 'them' : 'it'} if still required.\n` +
+            `</system-reminder>`,
+    };
+}
+
+/** Coerce every non-object tool-call input to an object, and flag each such call to the model. */
+export function repairToolCallInputs(messages: readonly ModelMessage[] | null | undefined): SanitizedHistory {
+    const source = messages ?? [];
+    const out: ModelMessage[] = [];
     let repaired = 0;
-    for (const message of messages ?? []) {
-        if (!Array.isArray(message?.content)) {
+    for (let i = 0; i < source.length; i++) {
+        const message = source[i];
+        const repair = message.role === 'assistant' ? repairAssistantMessage(message) : undefined;
+        if (!repair) {
+            out.push(message);
             continue;
         }
-        for (const part of message.content) {
-            if (isMalformedToolCallPart(part)) {
-                part.input = coerceInput(part.input);
-                repaired++;
-            }
+        repaired += repair.toolNames.length;
+        out.push(repair.message);
+        // A tool_use must stay adjacent to its tool_result, so the reminder goes after the result.
+        if (source[i + 1]?.role === 'tool') {
+            out.push(source[++i]);
         }
+        out.push(droppedArgumentsReminder(repair.toolNames));
     }
     if (repaired > 0) {
         console.warn(`[messageSanitization] Coerced ${repaired} malformed tool-call input(s) to objects.`);
     }
-    return repaired;
+    return { messages: out, repaired };
 }
 
 /**
- * Run every repair pass over a message history, in place, so it stays provider-valid. Call before
- * sending history to the provider (prepareStep, history load). Add new passes here as needed.
+ * Run every repair pass over a message history so it stays provider-valid. Call before sending
+ * history to the provider (prepareStep, history load) and send what comes back. Add new passes
+ * here as needed.
  */
-export function sanitizeMessages(messages: any[] | null | undefined): void {
-    repairToolCallInputs(messages);
+export function sanitizeMessages(messages: readonly ModelMessage[] | null | undefined): SanitizedHistory {
+    return repairToolCallInputs(messages);
 }

--- a/packages/ballerina-extension/src/features/ai/agent/resilience/messageSanitization.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/resilience/messageSanitization.ts
@@ -47,7 +47,7 @@ function coerceInput(raw: string): Record<string, unknown> {
  * `tool-call` part. Anthropic requires `tool_use.input` to be an object and rejects replay with
  * `tool_use.input: Input should be an object`, which bricks the thread on every later request.
  */
-export function repairToolCallInputs(messages: any[]): number {
+export function repairToolCallInputs(messages: any[] | null | undefined): number {
     let repaired = 0;
     for (const message of messages ?? []) {
         if (!Array.isArray(message?.content)) {
@@ -70,6 +70,6 @@ export function repairToolCallInputs(messages: any[]): number {
  * Run every repair pass over a message history, in place, so it stays provider-valid. Call before
  * sending history to the provider (prepareStep, history load). Add new passes here as needed.
  */
-export function sanitizeMessages(messages: any[]): void {
+export function sanitizeMessages(messages: any[] | null | undefined): void {
     repairToolCallInputs(messages);
 }

--- a/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
@@ -83,8 +83,9 @@ export function populateHistoryForAgent(chatHistory: any[]): ModelMessage[] {
             });
         }
     }
-    // Keep replayed history provider-valid; the store's own message objects are left as they are.
-    return sanitizeMessages(messages).messages;
+    // Keep replayed history provider-valid (coerce malformed tool-call inputs in place).
+    sanitizeMessages(messages);
+    return messages;
 }
 
 /**

--- a/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
@@ -47,6 +47,7 @@ import { AiPanelWebview } from "../../../views/ai-panel/webview";
 import { MigrationPanelWebview } from "../../../views/migration-panel/webview";
 import { VisualizerWebview } from "../../../views/visualizer/webview";
 import { GenerationType } from "./libs/libraries";
+import { sanitizeMessages } from "../agent/resilience";
 import { runEventStore } from "./run-event-store";
 import { agentStatusManager } from "../state/AgentStatusManager";
 // import { REQUIREMENTS_DOCUMENT_KEY } from "./code/np_prompts";
@@ -82,6 +83,8 @@ export function populateHistoryForAgent(chatHistory: any[]): ModelMessage[] {
             });
         }
     }
+    // Keep replayed history provider-valid (e.g. coerce malformed tool-call inputs).
+    sanitizeMessages(messages);
     return messages;
 }
 

--- a/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
@@ -83,9 +83,8 @@ export function populateHistoryForAgent(chatHistory: any[]): ModelMessage[] {
             });
         }
     }
-    // Keep replayed history provider-valid (e.g. coerce malformed tool-call inputs).
-    sanitizeMessages(messages);
-    return messages;
+    // Keep replayed history provider-valid; the store's own message objects are left as they are.
+    return sanitizeMessages(messages).messages;
 }
 
 /**

--- a/packages/ballerina-extension/src/test-support/messageSanitization.test.ts
+++ b/packages/ballerina-extension/src/test-support/messageSanitization.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Guards the tool-call input sanitizer: when a streamed tool call's JSON is invalid, the AI SDK
+ * keeps the raw text as a string on the `tool-call` part, and Anthropic rejects every later
+ * request in the thread with `tool_use.input: Input should be an object`. The sanitizer coerces
+ * such inputs to objects before the history is sent.
+ */
+
+import {
+    repairToolCallInputs,
+    sanitizeMessages,
+} from "../features/ai/agent/resilience/messageSanitization";
+
+// The real bug shape: `"new_string">` (should be `":`) makes the input unparseable, so the SDK
+// keeps it as a string on the tool-call part.
+const MALFORMED_INPUT =
+    '{"file_path": "types.bal", "edits": [{"old_string": "a", "new_string">"b"}]}';
+
+const assistantWithMalformedCall = () => ({
+    role: "assistant",
+    content: [
+        { type: "text", text: "Editing the file." },
+        {
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "file_batch_edit",
+            input: MALFORMED_INPUT, // string — the bug
+        },
+    ],
+});
+
+describe("repairToolCallInputs", () => {
+    it("coerces an unparseable string input to an empty object", () => {
+        const messages = [assistantWithMalformedCall()];
+        const repaired = repairToolCallInputs(messages);
+        const call = (messages[0].content as any[])[1];
+        expect(repaired).toBe(1);
+        expect(typeof call.input).toBe("object");
+        expect(call.input).toEqual({});
+    });
+
+    it("parses a well-formed JSON string input into the object it represents", () => {
+        const messages = [
+            {
+                role: "assistant",
+                content: [
+                    {
+                        type: "tool-call",
+                        toolCallId: "c",
+                        toolName: "t",
+                        input: '{"file_path":"main.bal","edits":[]}',
+                    },
+                ],
+            },
+        ];
+        const repaired = repairToolCallInputs(messages);
+        expect(repaired).toBe(1);
+        expect((messages[0].content as any[])[0].input).toEqual({
+            file_path: "main.bal",
+            edits: [],
+        });
+    });
+
+    it("coerces a string truncated mid-JSON to {} (output-token cap on large writes)", () => {
+        // The common production trigger: a large file write whose tool-call JSON is cut off
+        // at the 8192 output-token limit, leaving unparseable text.
+        const messages = [
+            {
+                role: "assistant",
+                content: [
+                    {
+                        type: "tool-call",
+                        toolCallId: "c",
+                        toolName: "file_batch_edit",
+                        input: '{"file_path":"main.bal","content":"import ballerina/ht',
+                    },
+                ],
+            },
+        ];
+        expect(repairToolCallInputs(messages)).toBe(1);
+        expect((messages[0].content as any[])[0].input).toEqual({});
+    });
+
+    it("coerces an empty string input to {}", () => {
+        const messages = [
+            {
+                role: "assistant",
+                content: [{ type: "tool-call", toolCallId: "c", toolName: "t", input: "" }],
+            },
+        ];
+        expect(repairToolCallInputs(messages)).toBe(1);
+        expect((messages[0].content as any[])[0].input).toEqual({});
+    });
+
+    it("coerces a JSON array string to {} (provider requires an object, not an array)", () => {
+        const messages = [
+            {
+                role: "assistant",
+                content: [{ type: "tool-call", toolCallId: "c", toolName: "t", input: "[1,2,3]" }],
+            },
+        ];
+        repairToolCallInputs(messages);
+        expect((messages[0].content as any[])[0].input).toEqual({});
+    });
+
+    it("leaves a valid object input untouched and is a no-op (returns 0)", () => {
+        const original = { file_path: "main.bal", edits: [{ old_string: "a", new_string: "b" }] };
+        const messages = [
+            {
+                role: "assistant",
+                content: [{ type: "tool-call", toolCallId: "c", toolName: "t", input: original }],
+            },
+        ];
+        const repaired = repairToolCallInputs(messages);
+        expect(repaired).toBe(0);
+        expect((messages[0].content as any[])[0].input).toBe(original);
+    });
+
+    it("repairs multiple malformed calls across messages and counts them", () => {
+        const messages = [
+            assistantWithMalformedCall(),
+            { role: "user", content: "continue" },
+            assistantWithMalformedCall(),
+        ];
+        expect(repairToolCallInputs(messages)).toBe(2);
+    });
+
+    it("ignores messages with non-array content and tolerates empty input", () => {
+        expect(repairToolCallInputs([])).toBe(0);
+        expect(repairToolCallInputs(undefined as any)).toBe(0);
+        expect(repairToolCallInputs([{ role: "user", content: "hi" }])).toBe(0);
+    });
+
+    it("leaves non-tool-call parts untouched", () => {
+        const messages = [
+            {
+                role: "assistant",
+                content: [
+                    { type: "text", text: "some string content" },
+                    { type: "tool-result", toolCallId: "c", toolName: "t", output: "raw" },
+                ],
+            },
+        ];
+        expect(repairToolCallInputs(messages)).toBe(0);
+        expect((messages[0].content as any[])[0].text).toBe("some string content");
+        expect((messages[0].content as any[])[1].output).toBe("raw");
+    });
+});
+
+describe("sanitizeMessages", () => {
+    it("runs the repair passes over the history in place", () => {
+        const messages = [assistantWithMalformedCall()];
+        sanitizeMessages(messages);
+        expect((messages[0].content as any[])[1].input).toEqual({});
+    });
+
+    it("leaves a clean history untouched", () => {
+        const messages = [
+            {
+                role: "assistant",
+                content: [{ type: "tool-call", toolCallId: "c", toolName: "t", input: { ok: 1 } }],
+            },
+        ];
+        sanitizeMessages(messages);
+        expect((messages[0].content as any[])[0].input).toEqual({ ok: 1 });
+    });
+});

--- a/packages/ballerina-extension/src/test-support/messageSanitization.test.ts
+++ b/packages/ballerina-extension/src/test-support/messageSanitization.test.ts
@@ -19,12 +19,15 @@
 /**
  * @jest-environment node
  *
- * Guards the tool-call input sanitizer: when a streamed tool call's JSON is invalid, the AI SDK
- * keeps the raw text as a string on the `tool-call` part, and Anthropic rejects every later
- * request in the thread with `tool_use.input: Input should be an object`. The sanitizer coerces
- * such inputs to objects before the history is sent.
+ * Guards the tool-call input sanitizer. When a streamed tool call's JSON is invalid the AI SDK
+ * keeps the raw text as a string on the `tool-call` part; when it parses but fails the tool's
+ * schema, the parsed array/null/number is kept instead. Anthropic rejects every later request in
+ * the thread with `tool_use.input: Input should be an object`. The sanitizer coerces such inputs
+ * to objects before the history is sent, tells the model the call never ran, and never writes
+ * into the history it was given.
  */
 
+import type { AssistantModelMessage, ModelMessage, ToolCallPart } from "ai";
 import {
     repairToolCallInputs,
     sanitizeMessages,
@@ -35,152 +38,203 @@ import {
 const MALFORMED_INPUT =
     '{"file_path": "types.bal", "edits": [{"old_string": "a", "new_string">"b"}]}';
 
-const assistantWithMalformedCall = () => ({
-    role: "assistant",
+function assistantCalling(toolName: string, input: unknown, toolCallId = "call_1"): AssistantModelMessage {
+    return {
+        role: "assistant",
+        content: [
+            { type: "text", text: "Editing the file." },
+            { type: "tool-call", toolCallId, toolName, input },
+        ],
+    };
+}
+
+const toolResultFor = (toolCallId: string): ModelMessage => ({
+    role: "tool",
     content: [
-        { type: "text", text: "Editing the file." },
         {
-            type: "tool-call",
-            toolCallId: "call_1",
+            type: "tool-result",
+            toolCallId,
             toolName: "file_batch_edit",
-            input: MALFORMED_INPUT, // string — the bug
+            output: { type: "error-text", value: "Invalid JSON" },
         },
     ],
 });
 
+function toolCallAt(message: ModelMessage, index: number): ToolCallPart {
+    if (message.role !== "assistant" || typeof message.content === "string") {
+        throw new Error("expected an assistant message with parts");
+    }
+    const part = message.content[index];
+    if (part.type !== "tool-call") {
+        throw new Error(`expected a tool-call part at ${index}, got ${part.type}`);
+    }
+    return part;
+}
+
+const reminders = (messages: ModelMessage[]) =>
+    messages.filter(
+        (m) => m.role === "user" && typeof m.content === "string" && m.content.includes("<system-reminder>")
+    );
+
 describe("repairToolCallInputs", () => {
     it("coerces an unparseable string input to an empty object", () => {
-        const messages = [assistantWithMalformedCall()];
-        const repaired = repairToolCallInputs(messages);
-        const call = (messages[0].content as any[])[1];
+        const { messages, repaired } = repairToolCallInputs([assistantCalling("file_batch_edit", MALFORMED_INPUT)]);
+
         expect(repaired).toBe(1);
-        expect(typeof call.input).toBe("object");
-        expect(call.input).toEqual({});
+        expect(toolCallAt(messages[0], 1).input).toEqual({});
     });
 
     it("parses a well-formed JSON string input into the object it represents", () => {
-        const messages = [
-            {
-                role: "assistant",
-                content: [
-                    {
-                        type: "tool-call",
-                        toolCallId: "c",
-                        toolName: "t",
-                        input: '{"file_path":"main.bal","edits":[]}',
-                    },
-                ],
-            },
-        ];
-        const repaired = repairToolCallInputs(messages);
+        const { messages, repaired } = repairToolCallInputs([
+            assistantCalling("t", '{"file_path":"main.bal","edits":[]}'),
+        ]);
+
         expect(repaired).toBe(1);
-        expect((messages[0].content as any[])[0].input).toEqual({
-            file_path: "main.bal",
-            edits: [],
-        });
+        expect(toolCallAt(messages[0], 1).input).toEqual({ file_path: "main.bal", edits: [] });
     });
 
     it("coerces a string truncated mid-JSON to {} (output-token cap on large writes)", () => {
-        // The common production trigger: a large file write whose tool-call JSON is cut off
-        // at the 8192 output-token limit, leaving unparseable text.
-        const messages = [
-            {
-                role: "assistant",
-                content: [
-                    {
-                        type: "tool-call",
-                        toolCallId: "c",
-                        toolName: "file_batch_edit",
-                        input: '{"file_path":"main.bal","content":"import ballerina/ht',
-                    },
-                ],
-            },
-        ];
-        expect(repairToolCallInputs(messages)).toBe(1);
-        expect((messages[0].content as any[])[0].input).toEqual({});
+        const { messages } = repairToolCallInputs([
+            assistantCalling("file_batch_edit", '{"file_path":"main.bal","content":"import ballerina/ht'),
+        ]);
+
+        expect(toolCallAt(messages[0], 1).input).toEqual({});
     });
 
-    it("coerces an empty string input to {}", () => {
-        const messages = [
-            {
-                role: "assistant",
-                content: [{ type: "tool-call", toolCallId: "c", toolName: "t", input: "" }],
-            },
-        ];
-        expect(repairToolCallInputs(messages)).toBe(1);
-        expect((messages[0].content as any[])[0].input).toEqual({});
-    });
+    it.each([
+        ["an empty string", ""],
+        ["a JSON array string", "[1,2,3]"],
+        ["an actual array, the SDK's shape when the JSON parsed but failed the schema", [1, 2]],
+        ["null", null],
+        ["a number", 42],
+        ["undefined", undefined],
+    ])("coerces %s to {}", (_label, input) => {
+        const { messages, repaired } = repairToolCallInputs([assistantCalling("t", input)]);
 
-    it("coerces a JSON array string to {} (provider requires an object, not an array)", () => {
-        const messages = [
-            {
-                role: "assistant",
-                content: [{ type: "tool-call", toolCallId: "c", toolName: "t", input: "[1,2,3]" }],
-            },
-        ];
-        repairToolCallInputs(messages);
-        expect((messages[0].content as any[])[0].input).toEqual({});
+        expect(repaired).toBe(1);
+        expect(toolCallAt(messages[0], 1).input).toEqual({});
     });
 
     it("leaves a valid object input untouched and is a no-op (returns 0)", () => {
         const original = { file_path: "main.bal", edits: [{ old_string: "a", new_string: "b" }] };
-        const messages = [
-            {
-                role: "assistant",
-                content: [{ type: "tool-call", toolCallId: "c", toolName: "t", input: original }],
-            },
-        ];
-        const repaired = repairToolCallInputs(messages);
+        const source = [assistantCalling("t", original)];
+
+        const { messages, repaired } = repairToolCallInputs(source);
+
         expect(repaired).toBe(0);
-        expect((messages[0].content as any[])[0].input).toBe(original);
+        expect(toolCallAt(messages[0], 1).input).toBe(original);
+        expect(messages[0]).toBe(source[0]);
     });
 
-    it("repairs multiple malformed calls across messages and counts them", () => {
-        const messages = [
-            assistantWithMalformedCall(),
+    it("never writes into the history it was given", () => {
+        const source = [assistantCalling("file_batch_edit", MALFORMED_INPUT), toolResultFor("call_1")];
+
+        const { messages } = repairToolCallInputs(source);
+
+        expect(toolCallAt(source[0], 1).input).toBe(MALFORMED_INPUT);
+        expect(messages[0]).not.toBe(source[0]);
+        expect(messages[1]).toBe(source[1]);
+    });
+
+    it("tells the model the call never ran, after the tool result it is paired with", () => {
+        const { messages } = repairToolCallInputs([
+            assistantCalling("file_batch_edit", MALFORMED_INPUT),
+            toolResultFor("call_1"),
             { role: "user", content: "continue" },
-            assistantWithMalformedCall(),
-        ];
-        expect(repairToolCallInputs(messages)).toBe(2);
+        ]);
+
+        expect(messages.map((m) => m.role)).toEqual(["assistant", "tool", "user", "user"]);
+        const reminder = messages[2];
+        expect(reminder.content).toContain("<system-reminder>");
+        expect(reminder.content).toContain("`file_batch_edit`");
+        expect(reminder.content).toContain("NOT performed");
+        expect(messages[3].content).toBe("continue");
     });
 
-    it("ignores messages with non-array content and tolerates empty input", () => {
-        expect(repairToolCallInputs([])).toBe(0);
-        expect(repairToolCallInputs(undefined)).toBe(0);
-        expect(repairToolCallInputs([{ role: "user", content: "hi" }])).toBe(0);
+    it("places the reminder right after the assistant message when no tool result follows", () => {
+        const { messages } = repairToolCallInputs([
+            assistantCalling("t", MALFORMED_INPUT),
+            { role: "user", content: "continue" },
+        ]);
+
+        expect(messages.map((m) => m.role)).toEqual(["assistant", "user", "user"]);
+        expect(reminders(messages)).toHaveLength(1);
+    });
+
+    it("issues one reminder per assistant message, naming every dropped call", () => {
+        const twoCalls: AssistantModelMessage = {
+            role: "assistant",
+            content: [
+                { type: "tool-call", toolCallId: "a", toolName: "file_batch_edit", input: "" },
+                { type: "tool-call", toolCallId: "b", toolName: "file_write", input: [] },
+            ],
+        };
+
+        const { messages, repaired } = repairToolCallInputs([twoCalls]);
+
+        expect(repaired).toBe(2);
+        const [reminder] = reminders(messages);
+        expect(reminders(messages)).toHaveLength(1);
+        expect(reminder.content).toContain("`file_batch_edit`, `file_write`");
+        expect(reminder.content).toContain("Those calls were NOT performed");
+    });
+
+    it("repairs malformed calls across messages and counts them", () => {
+        const { repaired } = repairToolCallInputs([
+            assistantCalling("t", MALFORMED_INPUT),
+            { role: "user", content: "continue" },
+            assistantCalling("t", MALFORMED_INPUT, "call_2"),
+        ]);
+
+        expect(repaired).toBe(2);
+    });
+
+    it("adds no reminder to a clean history", () => {
+        const { messages } = repairToolCallInputs([assistantCalling("t", { ok: 1 }), toolResultFor("call_1")]);
+
+        expect(reminders(messages)).toHaveLength(0);
+    });
+
+    it("tolerates empty, missing and part-less input", () => {
+        expect(repairToolCallInputs([]).repaired).toBe(0);
+        expect(repairToolCallInputs(undefined).repaired).toBe(0);
+        expect(repairToolCallInputs(null).messages).toEqual([]);
+        expect(repairToolCallInputs([{ role: "user", content: "hi" }]).repaired).toBe(0);
+        expect(repairToolCallInputs([{ role: "assistant", content: "plain text" }]).repaired).toBe(0);
     });
 
     it("leaves non-tool-call parts untouched", () => {
-        const messages = [
+        const source: ModelMessage[] = [
             {
                 role: "assistant",
                 content: [
                     { type: "text", text: "some string content" },
-                    { type: "tool-result", toolCallId: "c", toolName: "t", output: "raw" },
+                    { type: "tool-call", toolCallId: "c", toolName: "t", input: "" },
                 ],
             },
         ];
-        expect(repairToolCallInputs(messages)).toBe(0);
-        expect((messages[0].content as any[])[0].text).toBe("some string content");
-        expect((messages[0].content as any[])[1].output).toBe("raw");
+
+        const { messages } = repairToolCallInputs(source);
+
+        const first = (messages[0] as AssistantModelMessage).content[0];
+        expect(first).toEqual({ type: "text", text: "some string content" });
     });
 });
 
 describe("sanitizeMessages", () => {
-    it("runs the repair passes over the history in place", () => {
-        const messages = [assistantWithMalformedCall()];
-        sanitizeMessages(messages);
-        expect((messages[0].content as any[])[1].input).toEqual({});
+    it("returns the repaired history and how many calls were dropped", () => {
+        const { messages, repaired } = sanitizeMessages([assistantCalling("t", MALFORMED_INPUT)]);
+
+        expect(repaired).toBe(1);
+        expect(toolCallAt(messages[0], 1).input).toEqual({});
     });
 
-    it("leaves a clean history untouched", () => {
-        const messages = [
-            {
-                role: "assistant",
-                content: [{ type: "tool-call", toolCallId: "c", toolName: "t", input: { ok: 1 } }],
-            },
-        ];
-        sanitizeMessages(messages);
-        expect((messages[0].content as any[])[0].input).toEqual({ ok: 1 });
+    it("hands a clean history back unchanged", () => {
+        const source = [assistantCalling("t", { ok: 1 })];
+
+        const { messages, repaired } = sanitizeMessages(source);
+
+        expect(repaired).toBe(0);
+        expect(messages).toEqual(source);
     });
 });

--- a/packages/ballerina-extension/src/test-support/messageSanitization.test.ts
+++ b/packages/ballerina-extension/src/test-support/messageSanitization.test.ts
@@ -146,7 +146,7 @@ describe("repairToolCallInputs", () => {
 
     it("ignores messages with non-array content and tolerates empty input", () => {
         expect(repairToolCallInputs([])).toBe(0);
-        expect(repairToolCallInputs(undefined as any)).toBe(0);
+        expect(repairToolCallInputs(undefined)).toBe(0);
         expect(repairToolCallInputs([{ role: "user", content: "hi" }])).toBe(0);
     });
 

--- a/packages/ballerina-extension/src/test-support/messageSanitization.test.ts
+++ b/packages/ballerina-extension/src/test-support/messageSanitization.test.ts
@@ -23,8 +23,8 @@
  * keeps the raw text as a string on the `tool-call` part; when it parses but fails the tool's
  * schema, the parsed array/null/number is kept instead. Anthropic rejects every later request in
  * the thread with `tool_use.input: Input should be an object`. The sanitizer coerces such inputs
- * to objects before the history is sent, tells the model the call never ran, and never writes
- * into the history it was given.
+ * to objects in place — the parts are the chat store's own corrupt objects — and returns how many
+ * it repaired.
  */
 
 import type { AssistantModelMessage, ModelMessage, ToolCallPart } from "ai";
@@ -48,18 +48,6 @@ function assistantCalling(toolName: string, input: unknown, toolCallId = "call_1
     };
 }
 
-const toolResultFor = (toolCallId: string): ModelMessage => ({
-    role: "tool",
-    content: [
-        {
-            type: "tool-result",
-            toolCallId,
-            toolName: "file_batch_edit",
-            output: { type: "error-text", value: "Invalid JSON" },
-        },
-    ],
-});
-
 function toolCallAt(message: ModelMessage, index: number): ToolCallPart {
     if (message.role !== "assistant" || typeof message.content === "string") {
         throw new Error("expected an assistant message with parts");
@@ -71,33 +59,27 @@ function toolCallAt(message: ModelMessage, index: number): ToolCallPart {
     return part;
 }
 
-const reminders = (messages: ModelMessage[]) =>
-    messages.filter(
-        (m) => m.role === "user" && typeof m.content === "string" && m.content.includes("<system-reminder>")
-    );
-
 describe("repairToolCallInputs", () => {
     it("coerces an unparseable string input to an empty object", () => {
-        const { messages, repaired } = repairToolCallInputs([assistantCalling("file_batch_edit", MALFORMED_INPUT)]);
+        const messages = [assistantCalling("file_batch_edit", MALFORMED_INPUT)];
 
-        expect(repaired).toBe(1);
+        expect(repairToolCallInputs(messages)).toBe(1);
         expect(toolCallAt(messages[0], 1).input).toEqual({});
     });
 
     it("parses a well-formed JSON string input into the object it represents", () => {
-        const { messages, repaired } = repairToolCallInputs([
-            assistantCalling("t", '{"file_path":"main.bal","edits":[]}'),
-        ]);
+        const messages = [assistantCalling("t", '{"file_path":"main.bal","edits":[]}')];
 
-        expect(repaired).toBe(1);
+        expect(repairToolCallInputs(messages)).toBe(1);
         expect(toolCallAt(messages[0], 1).input).toEqual({ file_path: "main.bal", edits: [] });
     });
 
     it("coerces a string truncated mid-JSON to {} (output-token cap on large writes)", () => {
-        const { messages } = repairToolCallInputs([
+        const messages = [
             assistantCalling("file_batch_edit", '{"file_path":"main.bal","content":"import ballerina/ht'),
-        ]);
+        ];
 
+        repairToolCallInputs(messages);
         expect(toolCallAt(messages[0], 1).input).toEqual({});
     });
 
@@ -109,102 +91,52 @@ describe("repairToolCallInputs", () => {
         ["a number", 42],
         ["undefined", undefined],
     ])("coerces %s to {}", (_label, input) => {
-        const { messages, repaired } = repairToolCallInputs([assistantCalling("t", input)]);
+        const messages = [assistantCalling("t", input)];
 
-        expect(repaired).toBe(1);
+        expect(repairToolCallInputs(messages)).toBe(1);
         expect(toolCallAt(messages[0], 1).input).toEqual({});
+    });
+
+    it("repairs the caller's own objects in place, healing every alias", () => {
+        const shared = assistantCalling("file_batch_edit", MALFORMED_INPUT);
+        // The chat store hands the same message object to more than one reader.
+        const replayA = [shared];
+        const replayB = [shared];
+
+        repairToolCallInputs(replayA);
+
+        expect(toolCallAt(shared, 1).input).toEqual({});
+        expect(toolCallAt(replayB[0], 1).input).toEqual({});
     });
 
     it("leaves a valid object input untouched and is a no-op (returns 0)", () => {
         const original = { file_path: "main.bal", edits: [{ old_string: "a", new_string: "b" }] };
-        const source = [assistantCalling("t", original)];
+        const messages = [assistantCalling("t", original)];
 
-        const { messages, repaired } = repairToolCallInputs(source);
-
-        expect(repaired).toBe(0);
+        expect(repairToolCallInputs(messages)).toBe(0);
         expect(toolCallAt(messages[0], 1).input).toBe(original);
-        expect(messages[0]).toBe(source[0]);
-    });
-
-    it("never writes into the history it was given", () => {
-        const source = [assistantCalling("file_batch_edit", MALFORMED_INPUT), toolResultFor("call_1")];
-
-        const { messages } = repairToolCallInputs(source);
-
-        expect(toolCallAt(source[0], 1).input).toBe(MALFORMED_INPUT);
-        expect(messages[0]).not.toBe(source[0]);
-        expect(messages[1]).toBe(source[1]);
-    });
-
-    it("tells the model the call never ran, after the tool result it is paired with", () => {
-        const { messages } = repairToolCallInputs([
-            assistantCalling("file_batch_edit", MALFORMED_INPUT),
-            toolResultFor("call_1"),
-            { role: "user", content: "continue" },
-        ]);
-
-        expect(messages.map((m) => m.role)).toEqual(["assistant", "tool", "user", "user"]);
-        const reminder = messages[2];
-        expect(reminder.content).toContain("<system-reminder>");
-        expect(reminder.content).toContain("`file_batch_edit`");
-        expect(reminder.content).toContain("NOT performed");
-        expect(messages[3].content).toBe("continue");
-    });
-
-    it("places the reminder right after the assistant message when no tool result follows", () => {
-        const { messages } = repairToolCallInputs([
-            assistantCalling("t", MALFORMED_INPUT),
-            { role: "user", content: "continue" },
-        ]);
-
-        expect(messages.map((m) => m.role)).toEqual(["assistant", "user", "user"]);
-        expect(reminders(messages)).toHaveLength(1);
-    });
-
-    it("issues one reminder per assistant message, naming every dropped call", () => {
-        const twoCalls: AssistantModelMessage = {
-            role: "assistant",
-            content: [
-                { type: "tool-call", toolCallId: "a", toolName: "file_batch_edit", input: "" },
-                { type: "tool-call", toolCallId: "b", toolName: "file_write", input: [] },
-            ],
-        };
-
-        const { messages, repaired } = repairToolCallInputs([twoCalls]);
-
-        expect(repaired).toBe(2);
-        const [reminder] = reminders(messages);
-        expect(reminders(messages)).toHaveLength(1);
-        expect(reminder.content).toContain("`file_batch_edit`, `file_write`");
-        expect(reminder.content).toContain("Those calls were NOT performed");
     });
 
     it("repairs malformed calls across messages and counts them", () => {
-        const { repaired } = repairToolCallInputs([
+        const messages = [
             assistantCalling("t", MALFORMED_INPUT),
-            { role: "user", content: "continue" },
+            { role: "user" as const, content: "continue" },
             assistantCalling("t", MALFORMED_INPUT, "call_2"),
-        ]);
+        ];
 
-        expect(repaired).toBe(2);
-    });
-
-    it("adds no reminder to a clean history", () => {
-        const { messages } = repairToolCallInputs([assistantCalling("t", { ok: 1 }), toolResultFor("call_1")]);
-
-        expect(reminders(messages)).toHaveLength(0);
+        expect(repairToolCallInputs(messages)).toBe(2);
     });
 
     it("tolerates empty, missing and part-less input", () => {
-        expect(repairToolCallInputs([]).repaired).toBe(0);
-        expect(repairToolCallInputs(undefined).repaired).toBe(0);
-        expect(repairToolCallInputs(null).messages).toEqual([]);
-        expect(repairToolCallInputs([{ role: "user", content: "hi" }]).repaired).toBe(0);
-        expect(repairToolCallInputs([{ role: "assistant", content: "plain text" }]).repaired).toBe(0);
+        expect(repairToolCallInputs([])).toBe(0);
+        expect(repairToolCallInputs(undefined)).toBe(0);
+        expect(repairToolCallInputs(null)).toBe(0);
+        expect(repairToolCallInputs([{ role: "user", content: "hi" }])).toBe(0);
+        expect(repairToolCallInputs([{ role: "assistant", content: "plain text" }])).toBe(0);
     });
 
     it("leaves non-tool-call parts untouched", () => {
-        const source: ModelMessage[] = [
+        const messages: ModelMessage[] = [
             {
                 role: "assistant",
                 content: [
@@ -214,7 +146,7 @@ describe("repairToolCallInputs", () => {
             },
         ];
 
-        const { messages } = repairToolCallInputs(source);
+        repairToolCallInputs(messages);
 
         const first = (messages[0] as AssistantModelMessage).content[0];
         expect(first).toEqual({ type: "text", text: "some string content" });
@@ -222,19 +154,18 @@ describe("repairToolCallInputs", () => {
 });
 
 describe("sanitizeMessages", () => {
-    it("returns the repaired history and how many calls were dropped", () => {
-        const { messages, repaired } = sanitizeMessages([assistantCalling("t", MALFORMED_INPUT)]);
+    it("repairs in place and returns the number of dropped calls", () => {
+        const messages = [assistantCalling("t", MALFORMED_INPUT)];
 
-        expect(repaired).toBe(1);
+        expect(sanitizeMessages(messages)).toBe(1);
         expect(toolCallAt(messages[0], 1).input).toEqual({});
     });
 
-    it("hands a clean history back unchanged", () => {
-        const source = [assistantCalling("t", { ok: 1 })];
+    it("returns 0 and touches nothing for a clean history", () => {
+        const original = { ok: 1 };
+        const messages = [assistantCalling("t", original)];
 
-        const { messages, repaired } = sanitizeMessages(source);
-
-        expect(repaired).toBe(0);
-        expect(messages).toEqual(source);
+        expect(sanitizeMessages(messages)).toBe(0);
+        expect(toolCallAt(messages[0], 1).input).toBe(original);
     });
 });


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2206

When a streamed tool call's JSON is invalid — most often a large `file_batch_edit` write truncated at the output-token cap — the AI SDK cannot parse it and keeps the raw text as a string on the `tool-call` part; when it parses but fails the tool's schema, the SDK keeps the parsed array/null/number instead. Anthropic requires `tool_use.input` to be an object and rejects every later request in the thread with `tool_use.input: Input should be an object`, permanently bricking the conversation (and the raw provider text is what the user sees in chat).

- Add a `resilience/messageSanitization` module: `repairToolCallInputs` replaces any non-object tool-call input with an object (parses a string if that yields a plain object, otherwise `{}`), behind a `sanitizeMessages` umbrella so later repair passes can compose without touching call sites
- Repair in place: the malformed input is corrupt stored state (the parts are the chat store's own objects, held by reference), so fixing them heals every alias at once and the next thread save persists the clean value, rather than re-coercing the same corruption on every send
- Return the repair count so callers can surface or count dropped calls (telemetry is a follow-up)
- Call it in `AgentExecutor`'s `prepareStep`, before `addCacheControlToMessages`, and at the end of `populateHistoryForAgent`
- Add a jest suite (`src/test-support/messageSanitization.test.ts`) covering every input shape, in-place repair across aliases, the count, and the no-op case

The server-side `normalizeToolUseInputs` fix in the LLM proxy only covers proxied requests, so this still occurs for users on their own Anthropic key — the case reported in #2206. Ported and extended from the approved-but-unmerged wso2/vscode-extensions#2378.
