### PR TITLE
Make the orb invite a hover affordance with no close button

### DIFF
--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.test.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.test.tsx
@@ -16,10 +16,10 @@
  * under the License.
  */
 
-// The idle invite is a hover affordance, and the box it offers is easy to lose in ways that
-// cost the user whatever they were about to type: a pointer on its way over crosses the gap
-// the wrapper leaves untouchable (bridged in the layout, so a leave never fires), and a
-// pointer wanders off mid-sentence (held by the focus/content pin, asserted here).
+// The idle invite stays in the tree the whole time the orb is idle and is only ever faded, so
+// what these cases pin is the visibility model: hover brings it in, focus or an unsent draft
+// holds it, and the two things that could otherwise resurface it on their own — the orb hiding,
+// a run starting — wipe the draft instead. Hidden, it must be neither clickable nor tabbable.
 
 import * as React from "react";
 import { act } from "react-dom/test-utils";
@@ -33,7 +33,7 @@ jest.mock("@wso2/ballerina-core", () => ({
     SHARED_COMMANDS: { OPEN_AI_PANEL: "ballerina.open.ai.panel" },
 }));
 
-let mockRpcClient: any;
+let mockRpcClient: ReturnType<typeof makeRpcClient>["client"] | undefined;
 
 jest.mock("@wso2/ballerina-rpc-client", () => ({
     useRpcContext: () => ({ rpcClient: mockRpcClient }),
@@ -46,12 +46,14 @@ jest.mock("./MiniChat", () => ({ MiniChat: (): null => null }));
 import { AgentStatusOrb } from "./index";
 import { __resetAgentRunStatusStoreForTests } from "./shared";
 
-(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+declare global {
+    // eslint-disable-next-line no-var
+    var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const INVITE_PLACEHOLDER = "How can I help?";
-/** Comfortably past INVITE_FADE_MS. */
-const AFTER_FADE_MS = 1000;
-const ONE_FRAME_MS = 32;
+const IDLE = { state: "idle", aiPanelOpen: false, timestamp: 0 } as AgentRunStatus;
 
 function makeRpcClient() {
     let pushed: ((status: AgentRunStatus) => void) | undefined;
@@ -79,30 +81,36 @@ function makeRpcClient() {
 describe("AgentStatusOrb idle invite", () => {
     let container: HTMLDivElement;
     let root: Root;
+    let notify: (status: AgentRunStatus) => void;
 
     /** The orb widget: what the pointer enters and leaves. */
     const wrapper = () => container.firstElementChild as HTMLElement;
-    const invite = () => container.querySelector(`input[placeholder="${INVITE_PLACEHOLDER}"]`) as HTMLInputElement;
-    /** The box itself, which outlives the invite being wanted by the length of its fade. */
-    const box = () => invite()?.parentElement ?? null;
+    const invite = () =>
+        container.querySelector(`input[placeholder="${INVITE_PLACEHOLDER}"]`) as HTMLInputElement | null;
+    /** The box carrying the fade, and the bridge deciding whether the pointer can reach it. */
+    const box = () => invite()!.parentElement as HTMLElement;
+    const bridge = () => box().parentElement as HTMLElement;
+    const clearButton = () =>
+        container.querySelector('button[aria-label="Clear the message"]') as HTMLButtonElement | null;
 
-    function fire(target: HTMLElement, event: Event): void {
+    function fire(target: EventTarget, event: Event): void {
         act(() => {
             target.dispatchEvent(event);
         });
     }
 
-    // React derives mouseenter/mouseleave (and focus/blur) from these, so both have to
-    // be driven as the native events they are built from.
+    // React derives mouseenter/mouseleave from these, so hover has to be driven natively.
     const hover = () =>
         fire(wrapper(), new MouseEvent("mouseover", { bubbles: true, relatedTarget: document.body }));
     const unhover = () =>
         fire(wrapper(), new MouseEvent("mouseout", { bubbles: true, relatedTarget: document.body }));
-    const focusInvite = () => fire(invite(), new FocusEvent("focusin", { bubbles: true }));
-    const blurInvite = () => fire(invite(), new FocusEvent("focusout", { bubbles: true }));
+    const focusInvite = () => act(() => invite()!.focus());
+    const blurInvite = () => act(() => invite()!.blur());
+    const press = (key: string) => fire(invite()!, new KeyboardEvent("keydown", { key, bubbles: true }));
+    const click = (element: HTMLElement) => fire(element, new MouseEvent("click", { bubbles: true }));
 
     function type(text: string): void {
-        const input = invite();
+        const input = invite()!;
         act(() => {
             const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
             setValue.call(input, text);
@@ -110,107 +118,150 @@ describe("AgentStatusOrb idle invite", () => {
         });
     }
 
-    function wait(ms: number): void {
-        act(() => {
-            jest.advanceTimersByTime(ms);
-        });
-    }
-
-    /** The box mounts transparent and turns visible a frame later, so the fade has a start. */
-    function settle(): void {
-        wait(ONE_FRAME_MS);
-    }
-
-    const opacityOf = (element: HTMLElement) => getComputedStyle(element).opacity;
+    const opacity = () => getComputedStyle(box()).opacity;
+    const visibility = () => getComputedStyle(box()).visibility;
+    const reachable = () => getComputedStyle(bridge()).pointerEvents;
 
     beforeEach(() => {
-        jest.useFakeTimers();
         __resetAgentRunStatusStoreForTests();
-        const { client, notify } = makeRpcClient();
-        mockRpcClient = client;
+        const rpc = makeRpcClient();
+        mockRpcClient = rpc.client;
+        notify = rpc.notify;
         container = document.createElement("div");
         document.body.appendChild(container);
         root = createRoot(container);
         act(() => root.render(React.createElement(AgentStatusOrb)));
-        notify({ state: "idle", aiPanelOpen: false, timestamp: 0 } as AgentRunStatus);
+        notify(IDLE);
     });
 
     afterEach(() => {
         act(() => root.unmount());
         container.remove();
         mockRpcClient = undefined;
-        jest.useRealTimers();
     });
 
-    it("keeps the idle orb bare until it is hovered", () => {
-        expect(invite()).toBeNull();
-    });
-
-    it("offers the invite while the pointer is on the orb", () => {
-        hover();
-        expect(opacityOf(box()!)).toBe("0");
-
-        settle();
-
+    it("is in the tree but hidden, untouchable and out of the tab order until the pointer arrives", () => {
         expect(invite()).not.toBeNull();
-        expect(opacityOf(box()!)).toBe("1");
+        expect(opacity()).toBe("0");
+        expect(visibility()).toBe("hidden");
+        expect(reachable()).toBe("none");
     });
 
-    it("starts fading the moment the pointer leaves, with nothing held back", () => {
+    it("shows the invite while the pointer is on the orb", () => {
         hover();
-        settle();
+
+        expect(opacity()).toBe("1");
+        expect(visibility()).toBe("visible");
+        expect(reachable()).toBe("auto");
+    });
+
+    it("starts hiding the moment the pointer leaves, and stops taking clicks at once", () => {
+        hover();
 
         unhover();
 
-        expect(opacityOf(box()!)).toBe("0");
+        expect(opacity()).toBe("0");
+        expect(reachable()).toBe("none");
     });
 
-    it("fades the same box back in when the pointer returns mid-fade", () => {
-        hover();
-        settle();
+    it("never remounts the box across a hover cycle", () => {
         const opened = box();
 
+        hover();
         unhover();
         hover();
-        settle();
 
         expect(box()).toBe(opened);
-        expect(opacityOf(box()!)).toBe("1");
     });
 
-    it("withdraws the invite once the pointer stays away", () => {
+    it("holds the invite while the input has focus", () => {
         hover();
-        settle();
-
-        unhover();
-        wait(AFTER_FADE_MS);
-
-        expect(invite()).toBeNull();
-    });
-
-    it("holds the invite open while it has focus", () => {
-        hover();
-        settle();
         focusInvite();
 
         unhover();
-        wait(AFTER_FADE_MS);
 
-        expect(invite()).not.toBeNull();
-        expect(opacityOf(box()!)).toBe("1");
+        expect(opacity()).toBe("1");
     });
 
-    it("holds the invite open while it holds what was typed", () => {
+    it("holds the invite while it carries an unsent draft", () => {
         hover();
-        settle();
         focusInvite();
         type("build me a service");
 
         blurInvite();
         unhover();
-        wait(AFTER_FADE_MS);
 
-        expect(invite()).not.toBeNull();
-        expect(invite().value).toBe("build me a service");
+        expect(opacity()).toBe("1");
+        expect(invite()!.value).toBe("build me a service");
+    });
+
+    it("wipes the draft when the orb hides, so nothing resurfaces when it returns", () => {
+        hover();
+        focusInvite();
+        type("stale draft");
+
+        notify({ ...IDLE, aiPanelOpen: true });
+        expect(invite()).toBeNull();
+        notify(IDLE);
+
+        expect(invite()!.value).toBe("");
+        expect(opacity()).toBe("0");
+    });
+
+    it("wipes the draft when a run starts, so nothing resurfaces when it ends", () => {
+        hover();
+        focusInvite();
+        type("stale draft");
+        blurInvite();
+        unhover();
+
+        notify({ ...IDLE, state: "running" });
+        expect(invite()).toBeNull();
+        notify(IDLE);
+
+        expect(invite()!.value).toBe("");
+        expect(opacity()).toBe("0");
+    });
+
+    it("clears the draft on Escape and lets the box go", () => {
+        hover();
+        focusInvite();
+        type("oops");
+
+        press("Escape");
+
+        expect(invite()!.value).toBe("");
+        expect(document.activeElement).not.toBe(invite());
+        unhover();
+        expect(opacity()).toBe("0");
+    });
+
+    it("offers a clear button only once there is text, and clearing leaves the box where it is", () => {
+        hover();
+        expect(clearButton()).toBeNull();
+        focusInvite();
+        type("oops");
+        expect(clearButton()).not.toBeNull();
+
+        click(clearButton()!);
+
+        expect(invite()!.value).toBe("");
+        expect(clearButton()).toBeNull();
+        expect(opacity()).toBe("1");
+        blurInvite();
+        unhover();
+        expect(opacity()).toBe("0");
+    });
+
+    it("hands the draft to the mini chat on Enter and releases the input", () => {
+        hover();
+        focusInvite();
+        type("build me a service");
+
+        press("Enter");
+
+        expect(invite()!.value).toBe("");
+        expect(document.activeElement).not.toBe(invite());
+        expect(opacity()).toBe("0");
     });
 });

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.test.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.test.tsx
@@ -92,6 +92,7 @@ describe("AgentStatusOrb idle invite", () => {
     const bridge = () => box().parentElement as HTMLElement;
     const clearButton = () =>
         container.querySelector('button[aria-label="Clear the message"]') as HTMLButtonElement | null;
+    const orb = () => wrapper().querySelector(":scope > button") as HTMLButtonElement;
 
     function fire(target: EventTarget, event: Event): void {
         act(() => {
@@ -263,5 +264,39 @@ describe("AgentStatusOrb idle invite", () => {
         expect(invite()!.value).toBe("");
         expect(document.activeElement).not.toBe(invite());
         expect(opacity()).toBe("0");
+    });
+
+    it("wipes the draft when the mini chat takes over, so nothing resurfaces when it closes", () => {
+        hover();
+        focusInvite();
+        type("stale draft");
+
+        // Clicking the orb moves focus onto it; the mini chat then takes it from there.
+        act(() => orb().focus());
+        click(orb());
+        expect(opacity()).toBe("0");
+        act(() => orb().blur());
+        unhover();
+        click(orb());
+
+        expect(invite()!.value).toBe("");
+        expect(opacity()).toBe("0");
+    });
+
+    it("reveals the invite while the orb has keyboard focus", () => {
+        act(() => orb().focus());
+        expect(opacity()).toBe("1");
+
+        act(() => orb().blur());
+
+        expect(opacity()).toBe("0");
+    });
+
+    it("keeps the invite when focus moves from the orb into the input", () => {
+        act(() => orb().focus());
+
+        focusInvite();
+
+        expect(opacity()).toBe("1");
     });
 });

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.test.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The idle invite is a hover affordance, and the box it offers is easy to lose in ways that
+// cost the user whatever they were about to type: a pointer on its way over crosses the gap
+// the wrapper leaves untouchable (bridged in the layout, so a leave never fires), and a
+// pointer wanders off mid-sentence (held by the focus/content pin, asserted here).
+
+import * as React from "react";
+import { act } from "react-dom/test-utils";
+import { createRoot, Root } from "react-dom/client";
+import type { AgentRunStatus } from "@wso2/ballerina-core";
+
+// The core barrel re-exports ESM-only LS transport modules jest cannot load. shared.ts
+// only property-accesses MACHINE_VIEW, and the orb only reads the open-panel command id.
+jest.mock("@wso2/ballerina-core", () => ({
+    MACHINE_VIEW: {},
+    SHARED_COMMANDS: { OPEN_AI_PANEL: "ballerina.open.ai.panel" },
+}));
+
+let mockRpcClient: any;
+
+jest.mock("@wso2/ballerina-rpc-client", () => ({
+    useRpcContext: () => ({ rpcClient: mockRpcClient }),
+}));
+
+// A WebGL surface jsdom has no renderer for, and a chat overlay irrelevant here.
+jest.mock("./CopilotOrb", () => ({ CopilotOrb: (): null => null }));
+jest.mock("./MiniChat", () => ({ MiniChat: (): null => null }));
+
+import { AgentStatusOrb } from "./index";
+import { __resetAgentRunStatusStoreForTests } from "./shared";
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const INVITE_PLACEHOLDER = "How can I help?";
+/** Comfortably past INVITE_FADE_MS. */
+const AFTER_FADE_MS = 1000;
+const ONE_FRAME_MS = 32;
+
+function makeRpcClient() {
+    let pushed: ((status: AgentRunStatus) => void) | undefined;
+    const client = {
+        getCommonRpcClient: () => ({
+            getAgentRunStatus: jest.fn().mockResolvedValue(undefined),
+            getCopilotOrbTheme: jest.fn().mockResolvedValue("animated"),
+            executeCommand: jest.fn().mockResolvedValue(undefined),
+        }),
+        onAgentRunStatusChanged: jest.fn((cb: (status: AgentRunStatus) => void) => {
+            pushed = cb;
+        }),
+    };
+    return {
+        client,
+        notify: (status: AgentRunStatus) => {
+            if (!pushed) {
+                throw new Error("onAgentRunStatusChanged callback was never registered");
+            }
+            act(() => pushed!(status));
+        },
+    };
+}
+
+describe("AgentStatusOrb idle invite", () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    /** The orb widget: what the pointer enters and leaves. */
+    const wrapper = () => container.firstElementChild as HTMLElement;
+    const invite = () => container.querySelector(`input[placeholder="${INVITE_PLACEHOLDER}"]`) as HTMLInputElement;
+    /** The box itself, which outlives the invite being wanted by the length of its fade. */
+    const box = () => invite()?.parentElement ?? null;
+
+    function fire(target: HTMLElement, event: Event): void {
+        act(() => {
+            target.dispatchEvent(event);
+        });
+    }
+
+    // React derives mouseenter/mouseleave (and focus/blur) from these, so both have to
+    // be driven as the native events they are built from.
+    const hover = () =>
+        fire(wrapper(), new MouseEvent("mouseover", { bubbles: true, relatedTarget: document.body }));
+    const unhover = () =>
+        fire(wrapper(), new MouseEvent("mouseout", { bubbles: true, relatedTarget: document.body }));
+    const focusInvite = () => fire(invite(), new FocusEvent("focusin", { bubbles: true }));
+    const blurInvite = () => fire(invite(), new FocusEvent("focusout", { bubbles: true }));
+
+    function type(text: string): void {
+        const input = invite();
+        act(() => {
+            const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+            setValue.call(input, text);
+            input.dispatchEvent(new Event("input", { bubbles: true }));
+        });
+    }
+
+    function wait(ms: number): void {
+        act(() => {
+            jest.advanceTimersByTime(ms);
+        });
+    }
+
+    /** The box mounts transparent and turns visible a frame later, so the fade has a start. */
+    function settle(): void {
+        wait(ONE_FRAME_MS);
+    }
+
+    const opacityOf = (element: HTMLElement) => getComputedStyle(element).opacity;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        __resetAgentRunStatusStoreForTests();
+        const { client, notify } = makeRpcClient();
+        mockRpcClient = client;
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        root = createRoot(container);
+        act(() => root.render(React.createElement(AgentStatusOrb)));
+        notify({ state: "idle", aiPanelOpen: false, timestamp: 0 } as AgentRunStatus);
+    });
+
+    afterEach(() => {
+        act(() => root.unmount());
+        container.remove();
+        mockRpcClient = undefined;
+        jest.useRealTimers();
+    });
+
+    it("keeps the idle orb bare until it is hovered", () => {
+        expect(invite()).toBeNull();
+    });
+
+    it("offers the invite while the pointer is on the orb", () => {
+        hover();
+        expect(opacityOf(box()!)).toBe("0");
+
+        settle();
+
+        expect(invite()).not.toBeNull();
+        expect(opacityOf(box()!)).toBe("1");
+    });
+
+    it("starts fading the moment the pointer leaves, with nothing held back", () => {
+        hover();
+        settle();
+
+        unhover();
+
+        expect(opacityOf(box()!)).toBe("0");
+    });
+
+    it("fades the same box back in when the pointer returns mid-fade", () => {
+        hover();
+        settle();
+        const opened = box();
+
+        unhover();
+        hover();
+        settle();
+
+        expect(box()).toBe(opened);
+        expect(opacityOf(box()!)).toBe("1");
+    });
+
+    it("withdraws the invite once the pointer stays away", () => {
+        hover();
+        settle();
+
+        unhover();
+        wait(AFTER_FADE_MS);
+
+        expect(invite()).toBeNull();
+    });
+
+    it("holds the invite open while it has focus", () => {
+        hover();
+        settle();
+        focusInvite();
+
+        unhover();
+        wait(AFTER_FADE_MS);
+
+        expect(invite()).not.toBeNull();
+        expect(opacityOf(box()!)).toBe("1");
+    });
+
+    it("holds the invite open while it holds what was typed", () => {
+        hover();
+        settle();
+        focusInvite();
+        type("build me a service");
+
+        blurInvite();
+        unhover();
+        wait(AFTER_FADE_MS);
+
+        expect(invite()).not.toBeNull();
+        expect(invite().value).toBe("build me a service");
+    });
+});

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
@@ -253,6 +253,8 @@ export function AgentStatusOrb() {
     const [status, setStatus] = useState<AgentRunStatus | null>(null);
     const statusRef = useRef<AgentRunStatus | null>(null);
     const [hovered, setHovered] = useState(false);
+    /** Tab-to-orb has no hover, so this is what lets the keyboard reach the invite. */
+    const [orbFocused, setOrbFocused] = useState(false);
     const [anchor, setAnchor] = useState<Anchor>(loadAnchor);
     /** Orb top-left in px while dragging/snapping; null when docked at an anchor. */
     const [dragPos, setDragPos] = useState<{ x: number; y: number } | null>(null);
@@ -310,6 +312,7 @@ export function AgentStatusOrb() {
             setMiniOpen(false);
             miniPromptRef.current = undefined;
             setHovered(false);
+            setOrbFocused(false);
         }
     }, [orbHidden]);
 
@@ -322,22 +325,30 @@ export function AgentStatusOrb() {
     const dragging = dragPos !== null && !snapping;
     // Active states keep the pill visible the whole time. Idle keeps the invitation input
     // in the tree and only ever fades it, so the transition always has a start value and a
-    // focused input is never pulled out from under the keyboard. Hover brings it in; focus
-    // or an unsent draft holds it while the pointer wanders. The mini chat replaces it, and
-    // it stays hidden mid-drag and mid-snap: `anchor` isn't committed until the snap timer
-    // fires, so showing it earlier would open the mini chat at the stale anchor.
+    // focused input is never pulled out from under the keyboard. Hover or keyboard focus on
+    // the orb brings it in; focus in the input or an unsent draft holds it while the pointer
+    // wanders. The mini chat replaces it, and it stays hidden mid-drag and mid-snap: `anchor`
+    // isn't committed until the snap timer fires, so showing it earlier would open the mini
+    // chat at the stale anchor.
     const inviteHosted = !orbHidden && status?.state === "idle";
     const inviteVisible =
-        inviteHosted && !dragging && !snapping && !miniOpen && (hovered || inviteFocused || inviteText.length > 0);
+        inviteHosted &&
+        !dragging &&
+        !snapping &&
+        !miniOpen &&
+        (hovered || orbFocused || inviteFocused || inviteText.length > 0);
 
-    // The input unmounts here without ever blurring, and a draft left behind would hold the
-    // box open the moment the orb came back with the pointer nowhere near it.
+    // A draft left behind when the orb hides, a run starts or the mini chat takes over would
+    // hold the box open the moment it came back with the pointer nowhere near it. In the first
+    // two cases the input also unmounts without ever blurring.
     useEffect(() => {
-        if (!inviteHosted) {
+        if (!inviteHosted || miniOpen) {
             setInviteText("");
+        }
+        if (!inviteHosted) {
             setInviteFocused(false);
         }
-    }, [inviteHosted]);
+    }, [inviteHosted, miniOpen]);
 
     if (orbHidden) {
         return null;
@@ -514,6 +525,8 @@ export function AgentStatusOrb() {
                 onPointerDown={handlePointerDown}
                 onPointerMove={handlePointerMove}
                 onPointerUp={handlePointerUp}
+                onFocus={() => setOrbFocused(true)}
+                onBlur={() => setOrbFocused(false)}
                 title={label ? `WSO2 Integration Intelligence — ${label}` : "WSO2 Integration Intelligence"}
                 aria-label={label ? `WSO2 Integration Intelligence: ${label}. Click to open the mini chat, double-click for the chat panel.` : "Click to open the WSO2 Integration Intelligence mini chat, double-click for the chat panel"}
             >

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
@@ -142,19 +142,25 @@ const LabelPill = styled.div`
     cursor: pointer;
 `;
 
+interface InviteVisibility {
+    visible: boolean;
+}
+
 /**
  * Carries the box's hit area across the gap the wrapper leaves untouchable, so a pointer
  * travelling from the orb to the input never counts as having left the widget. The negative
- * margin hands the padding back to the layout, leaving the box where it was.
+ * margin hands the padding back to the layout, leaving the box where it was. Only while the
+ * box is showing: hidden, it must neither catch a hover nor swallow a click meant for the
+ * diagram beneath.
  */
-const InviteHitBridge = styled.div`
-    pointer-events: auto;
+const InviteHitBridge = styled.div<InviteVisibility>`
     display: flex;
     padding: ${WIDGET_GAP}px;
     margin: -${WIDGET_GAP}px;
+    pointer-events: ${(props: InviteVisibility) => (props.visible ? "auto" : "none")};
 `;
 
-const InviteBox = styled.div<{ visible: boolean }>`
+const InviteBox = styled.div<InviteVisibility>`
     display: flex;
     align-items: center;
     gap: 4px;
@@ -163,11 +169,31 @@ const InviteBox = styled.div<{ visible: boolean }>`
     border-radius: 14px;
     padding: 5px 6px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-    opacity: ${(props: { visible: boolean }) => (props.visible ? 1 : 0)};
-    transform: translateX(${(props: { visible: boolean }) => (props.visible ? "0" : "6px")});
-    transition: opacity ${INVITE_FADE_MS}ms ease, transform ${INVITE_FADE_MS}ms ease;
+    opacity: ${(props: InviteVisibility) => (props.visible ? 1 : 0)};
+    transform: translateX(${(props: InviteVisibility) => (props.visible ? "0" : "6px")});
+    visibility: ${(props: InviteVisibility) => (props.visible ? "visible" : "hidden")};
+    /* visibility waits for the fade-out so the box leaves the tab order only once it is gone. */
+    transition:
+        opacity ${INVITE_FADE_MS}ms ease,
+        transform ${INVITE_FADE_MS}ms ease,
+        visibility 0s linear ${(props: InviteVisibility) => (props.visible ? 0 : INVITE_FADE_MS)}ms;
     @media (prefers-reduced-motion: reduce) {
         transition: none;
+    }
+`;
+
+const InviteClear = styled.button`
+    display: flex;
+    align-items: center;
+    background: transparent;
+    border: none;
+    color: var(--vscode-descriptionForeground);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    &:hover {
+        color: var(--vscode-foreground);
+        background: var(--vscode-toolbar-hoverBackground);
     }
 `;
 
@@ -235,10 +261,6 @@ export function AgentStatusOrb() {
     const snapTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
     const [inviteText, setInviteText] = useState("");
     const [inviteFocused, setInviteFocused] = useState(false);
-    /** Rendered — true through the fade-out, after the invite is no longer wanted. */
-    const [inviteMounted, setInviteMounted] = useState(false);
-    const [inviteVisible, setInviteVisible] = useState(false);
-    const inviteFadeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
     /** The current view opts out of the floating orb. */
     const [orbSuppressed, setOrbSuppressed] = useState(false);
     /** Mini chat overlay toggled by clicking the orb. */
@@ -275,13 +297,7 @@ export function AgentStatusOrb() {
 
     useEffect(() => subscribeOrbSuppressed(setOrbSuppressed), []);
 
-    useEffect(
-        () => () => {
-            clearTimeout(snapTimerRef.current);
-            clearTimeout(inviteFadeTimerRef.current);
-        },
-        []
-    );
+    useEffect(() => () => clearTimeout(snapTimerRef.current), []);
 
     // The orb hides without unmounting, so mini-chat state outlives it. Left alone,
     // `miniOpen` stays true and the mini resurfaces unprompted as soon as the orb
@@ -293,6 +309,7 @@ export function AgentStatusOrb() {
         if (orbHidden) {
             setMiniOpen(false);
             miniPromptRef.current = undefined;
+            setHovered(false);
         }
     }, [orbHidden]);
 
@@ -303,42 +320,24 @@ export function AgentStatusOrb() {
     useAmbientCopilotPresence(!orbHidden);
 
     const dragging = dragPos !== null && !snapping;
-    // Active states keep the pill visible the whole time. Idle offers the invitation
-    // input, which rides in with the pointer and fades out behind it — except while it
-    // is being written in, where the pointer is free to wander off.
-    // While the mini chat is open it replaces both.
-    // Also gate on `snapping`: during the snap-to-anchor animation `dragging` is
-    // intentionally false (so the CSS transition runs), but `anchor` isn't committed
-    // until the snap timer fires — showing the invite/label meanwhile would open the
-    // mini chat at the stale anchor. Keep them hidden until the orb settles.
-    const showInvite =
-        !orbHidden &&
-        status?.state === "idle" &&
-        !dragging &&
-        !snapping &&
-        !miniOpen &&
-        (hovered || inviteFocused || inviteText.length > 0);
+    // Active states keep the pill visible the whole time. Idle keeps the invitation input
+    // in the tree and only ever fades it, so the transition always has a start value and a
+    // focused input is never pulled out from under the keyboard. Hover brings it in; focus
+    // or an unsent draft holds it while the pointer wanders. The mini chat replaces it, and
+    // it stays hidden mid-drag and mid-snap: `anchor` isn't committed until the snap timer
+    // fires, so showing it earlier would open the mini chat at the stale anchor.
+    const inviteHosted = !orbHidden && status?.state === "idle";
+    const inviteVisible =
+        inviteHosted && !dragging && !snapping && !miniOpen && (hovered || inviteFocused || inviteText.length > 0);
 
-    // Removing a focused input fires no blur, so the pin would outlive the box it
-    // belongs to and reopen it with the pointer nowhere near.
+    // The input unmounts here without ever blurring, and a draft left behind would hold the
+    // box open the moment the orb came back with the pointer nowhere near it.
     useEffect(() => {
-        if (!showInvite) {
+        if (!inviteHosted) {
+            setInviteText("");
             setInviteFocused(false);
         }
-    }, [showInvite]);
-
-    // Mount a frame before turning visible so the transition has an opacity to leave from,
-    // and hold the box in the tree until the fade-out has run.
-    useEffect(() => {
-        clearTimeout(inviteFadeTimerRef.current);
-        if (showInvite) {
-            setInviteMounted(true);
-            const frame = requestAnimationFrame(() => setInviteVisible(true));
-            return () => cancelAnimationFrame(frame);
-        }
-        setInviteVisible(false);
-        inviteFadeTimerRef.current = setTimeout(() => setInviteMounted(false), INVITE_FADE_MS);
-    }, [showInvite]);
+    }, [inviteHosted]);
 
     if (orbHidden) {
         return null;
@@ -347,17 +346,18 @@ export function AgentStatusOrb() {
     const state = status.state;
     // Idle has nothing to report, so the tooltip falls back to the bare product name.
     const label = state === "idle" ? undefined : activeStateLabel(status);
-    const showLabel = !dragging && !snapping && !showInvite && state !== "idle" && !miniOpen;
+    const showLabel = !dragging && !snapping && state !== "idle" && !miniOpen;
 
     // Typing into the invite starts the conversation in the mini chat — every
     // orb interaction stays in the ambient surface; the full panel is reached
     // via the mini's maximize button.
-    const submitInvite = () => {
+    const submitInvite = (input: HTMLInputElement) => {
         const text = inviteText.trim();
         if (text) {
             miniPromptRef.current = createMiniChatPrompt(text, { autoSubmit: true });
         }
         setInviteText("");
+        input.blur();
         setMiniChatKey((key) => key + 1);
         setMiniOpen(true);
     };
@@ -472,15 +472,18 @@ export function AgentStatusOrb() {
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
         >
-            {inviteMounted && (
-                <InviteHitBridge>
+            {inviteHosted && (
+                <InviteHitBridge visible={inviteVisible}>
                     <InviteBox visible={inviteVisible}>
                         <InviteInput
                             value={inviteText}
                             onChange={(event) => setInviteText(event.target.value)}
                             onKeyDown={(event) => {
                                 if (event.key === "Enter") {
-                                    submitInvite();
+                                    submitInvite(event.currentTarget);
+                                } else if (event.key === "Escape") {
+                                    setInviteText("");
+                                    event.currentTarget.blur();
                                 }
                             }}
                             onFocus={() => setInviteFocused(true)}
@@ -488,6 +491,18 @@ export function AgentStatusOrb() {
                             placeholder="How can I help?"
                             aria-label="Message WSO2 Integration Intelligence"
                         />
+                        {inviteText.length > 0 && (
+                            <InviteClear
+                                type="button"
+                                title="Clear"
+                                aria-label="Clear the message"
+                                // Keep focus in the input so clearing never ends the typing.
+                                onMouseDown={(event) => event.preventDefault()}
+                                onClick={() => setInviteText("")}
+                            >
+                                <span className="codicon codicon-close" />
+                            </InviteClear>
+                        )}
                     </InviteBox>
                 </InviteHitBridge>
             )}

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
@@ -54,6 +54,8 @@ import { createMiniChatPrompt, MiniChatPrompt } from "./promptHandoff";
 
 const DRAG_THRESHOLD = 5;
 const SNAP_ANIMATION_MS = 250;
+const WIDGET_GAP = 10;
+const INVITE_FADE_MS = 160;
 
 const ANCHOR_CSS: Record<Anchor, React.CSSProperties> = {
     "top-left": { top: EDGE_MARGIN, left: EDGE_MARGIN },
@@ -117,7 +119,7 @@ const Wrapper = styled.div`
     z-index: 1800;
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: ${WIDGET_GAP}px;
     pointer-events: none;
 `;
 
@@ -140,8 +142,19 @@ const LabelPill = styled.div`
     cursor: pointer;
 `;
 
-const InviteBox = styled.div`
+/**
+ * Carries the box's hit area across the gap the wrapper leaves untouchable, so a pointer
+ * travelling from the orb to the input never counts as having left the widget. The negative
+ * margin hands the padding back to the layout, leaving the box where it was.
+ */
+const InviteHitBridge = styled.div`
     pointer-events: auto;
+    display: flex;
+    padding: ${WIDGET_GAP}px;
+    margin: -${WIDGET_GAP}px;
+`;
+
+const InviteBox = styled.div<{ visible: boolean }>`
     display: flex;
     align-items: center;
     gap: 4px;
@@ -150,7 +163,12 @@ const InviteBox = styled.div`
     border-radius: 14px;
     padding: 5px 6px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-    animation: ${fadeIn} 0.25s ease-out;
+    opacity: ${(props: { visible: boolean }) => (props.visible ? 1 : 0)};
+    transform: translateX(${(props: { visible: boolean }) => (props.visible ? "0" : "6px")});
+    transition: opacity ${INVITE_FADE_MS}ms ease, transform ${INVITE_FADE_MS}ms ease;
+    @media (prefers-reduced-motion: reduce) {
+        transition: none;
+    }
 `;
 
 const InviteInput = styled.input`
@@ -168,21 +186,6 @@ const InviteInput = styled.input`
     }
     &::placeholder {
         color: var(--vscode-input-placeholderForeground);
-    }
-`;
-
-const InviteDismiss = styled.button`
-    background: transparent;
-    border: none;
-    color: var(--vscode-descriptionForeground);
-    cursor: pointer;
-    font-size: 13px;
-    line-height: 1;
-    padding: 4px 5px;
-    border-radius: 4px;
-    &:hover {
-        color: var(--vscode-foreground);
-        background: var(--vscode-toolbar-hoverBackground);
     }
 `;
 
@@ -231,7 +234,11 @@ export function AgentStatusOrb() {
     const dragStateRef = useRef<{ startX: number; startY: number; wasDrag: boolean } | null>(null);
     const snapTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
     const [inviteText, setInviteText] = useState("");
-    const [inviteDismissed, setInviteDismissed] = useState(false);
+    const [inviteFocused, setInviteFocused] = useState(false);
+    /** Rendered — true through the fade-out, after the invite is no longer wanted. */
+    const [inviteMounted, setInviteMounted] = useState(false);
+    const [inviteVisible, setInviteVisible] = useState(false);
+    const inviteFadeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
     /** The current view opts out of the floating orb. */
     const [orbSuppressed, setOrbSuppressed] = useState(false);
     /** Mini chat overlay toggled by clicking the orb. */
@@ -268,7 +275,13 @@ export function AgentStatusOrb() {
 
     useEffect(() => subscribeOrbSuppressed(setOrbSuppressed), []);
 
-    useEffect(() => () => clearTimeout(snapTimerRef.current), []);
+    useEffect(
+        () => () => {
+            clearTimeout(snapTimerRef.current);
+            clearTimeout(inviteFadeTimerRef.current);
+        },
+        []
+    );
 
     // The orb hides without unmounting, so mini-chat state outlives it. Left alone,
     // `miniOpen` stays true and the mini resurfaces unprompted as soon as the orb
@@ -289,6 +302,44 @@ export function AgentStatusOrb() {
 
     useAmbientCopilotPresence(!orbHidden);
 
+    const dragging = dragPos !== null && !snapping;
+    // Active states keep the pill visible the whole time. Idle offers the invitation
+    // input, which rides in with the pointer and fades out behind it — except while it
+    // is being written in, where the pointer is free to wander off.
+    // While the mini chat is open it replaces both.
+    // Also gate on `snapping`: during the snap-to-anchor animation `dragging` is
+    // intentionally false (so the CSS transition runs), but `anchor` isn't committed
+    // until the snap timer fires — showing the invite/label meanwhile would open the
+    // mini chat at the stale anchor. Keep them hidden until the orb settles.
+    const showInvite =
+        !orbHidden &&
+        status?.state === "idle" &&
+        !dragging &&
+        !snapping &&
+        !miniOpen &&
+        (hovered || inviteFocused || inviteText.length > 0);
+
+    // Removing a focused input fires no blur, so the pin would outlive the box it
+    // belongs to and reopen it with the pointer nowhere near.
+    useEffect(() => {
+        if (!showInvite) {
+            setInviteFocused(false);
+        }
+    }, [showInvite]);
+
+    // Mount a frame before turning visible so the transition has an opacity to leave from,
+    // and hold the box in the tree until the fade-out has run.
+    useEffect(() => {
+        clearTimeout(inviteFadeTimerRef.current);
+        if (showInvite) {
+            setInviteMounted(true);
+            const frame = requestAnimationFrame(() => setInviteVisible(true));
+            return () => cancelAnimationFrame(frame);
+        }
+        setInviteVisible(false);
+        inviteFadeTimerRef.current = setTimeout(() => setInviteMounted(false), INVITE_FADE_MS);
+    }, [showInvite]);
+
     if (orbHidden) {
         return null;
     }
@@ -296,16 +347,6 @@ export function AgentStatusOrb() {
     const state = status.state;
     // Idle has nothing to report, so the tooltip falls back to the bare product name.
     const label = state === "idle" ? undefined : activeStateLabel(status);
-    const dragging = dragPos !== null && !snapping;
-    // Active states keep the pill visible the whole time. Idle shows the
-    // invitation input; dismissing only collapses it into the orb — hovering
-    // the orb expands it again, so it is never more than one hover away.
-    // While the mini chat is open it replaces both.
-    // Also gate on `snapping`: during the snap-to-anchor animation `dragging` is
-    // intentionally false (so the CSS transition runs), but `anchor` isn't committed
-    // until the snap timer fires — showing the invite/label meanwhile would open the
-    // mini chat at the stale anchor. Keep them hidden until the orb settles.
-    const showInvite = state === "idle" && !dragging && !snapping && !miniOpen && (!inviteDismissed || hovered);
     const showLabel = !dragging && !snapping && !showInvite && state !== "idle" && !miniOpen;
 
     // Typing into the invite starts the conversation in the mini chat — every
@@ -431,23 +472,24 @@ export function AgentStatusOrb() {
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
         >
-            {showInvite && (
-                <InviteBox>
-                    <InviteInput
-                        value={inviteText}
-                        onChange={(event) => setInviteText(event.target.value)}
-                        onKeyDown={(event) => {
-                            if (event.key === "Enter") {
-                                submitInvite();
-                            }
-                        }}
-                        placeholder="How can I help?"
-                        aria-label="Message WSO2 Integration Intelligence"
-                    />
-                    <InviteDismiss title="Hide" aria-label="Hide the WSO2 Integration Intelligence prompt" onClick={() => setInviteDismissed(true)}>
-                        ✕
-                    </InviteDismiss>
-                </InviteBox>
+            {inviteMounted && (
+                <InviteHitBridge>
+                    <InviteBox visible={inviteVisible}>
+                        <InviteInput
+                            value={inviteText}
+                            onChange={(event) => setInviteText(event.target.value)}
+                            onKeyDown={(event) => {
+                                if (event.key === "Enter") {
+                                    submitInvite();
+                                }
+                            }}
+                            onFocus={() => setInviteFocused(true)}
+                            onBlur={() => setInviteFocused(false)}
+                            placeholder="How can I help?"
+                            aria-label="Message WSO2 Integration Intelligence"
+                        />
+                    </InviteBox>
+                </InviteHitBridge>
             )}
             {showLabel && label && <LabelPill onClick={() => setMiniOpen(true)}>{label}</LabelPill>}
             <OrbButton


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2227

The idle orb offered a "How can I help?" input with a ✕ to dismiss it, but clicking ✕ did nothing while the pointer was still on the orb: the dismiss set a flag that `showInvite` immediately overrode with `|| hovered`, so the same hover re-opened what was just closed.

Rather than patch the flag, this drops the ✕ entirely and makes the invite a pure hover affordance — there is nothing to dismiss when hover is the only way in and out.

- Remove the ✕ button and the `inviteDismissed` state; the invite shows on hover and hides on leave
- Bridge the dead gap between the orb and the box (`InviteHitBridge`, padding + equal negative margin) so a pointer travelling from the orb to the input never reads as a leave — no timed grace needed
- Pin the invite open while the input has focus or holds typed text, so moving the mouse away mid-sentence never discards a draft
- Hide via an interruptible opacity/transform transition (160ms) instead of an unmount, so returning mid-fade reverses smoothly
- Add `AgentStatusOrb/index.test.tsx` covering the gap-crossing, the focus/content pin, and the immediate fade-out


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the orb invite to behave as a hover-only affordance.
- Added `InviteHitBridge` to preserve the invite while the pointer crosses the gap between the orb and input.
- Keeps the invite visible when the input has focus or content.
- Replaced unmounting with an interruptible 160ms opacity and transform transition.
- Replaced the close button with a conditional clear button.
- Added tests for pointer transitions, focus and content pinning, draft handling, and fade behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->