### PR TITLE
Stop the orb tooltip repeating the product name

### DIFF
--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
@@ -294,7 +294,8 @@ export function AgentStatusOrb() {
     }
 
     const state = status.state;
-    const label = state === "idle" ? "Chat with WSO2 Integration Intelligence" : activeStateLabel(status);
+    // Idle has nothing to report, so the tooltip falls back to the bare product name.
+    const label = state === "idle" ? undefined : activeStateLabel(status);
     const dragging = dragPos !== null && !snapping;
     // Active states keep the pill visible the whole time. Idle shows the
     // invitation input; dismissing only collapses it into the orb — hovering

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.test.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.test.ts
@@ -27,7 +27,7 @@ import type { AgentRunStatus } from "@wso2/ballerina-core";
 // exist (as property-access targets), not any real value.
 jest.mock("@wso2/ballerina-core", () => ({ MACHINE_VIEW: {} }));
 
-import { useAgentRunState, __resetAgentRunStatusStoreForTests } from "./shared";
+import { activeStateLabel, useAgentRunState, __resetAgentRunStatusStoreForTests } from "./shared";
 
 // react-dom/test-utils' act() requires this flag; @testing-library/react sets
 // it automatically, but nothing does here since this package doesn't depend on it.
@@ -141,5 +141,23 @@ describe("useAgentRunState", () => {
         notify(makeStatus({ state: "error" }));
 
         expect(onRender.mock.calls.length).toBe(callsBeforeUnmount);
+    });
+});
+
+describe("activeStateLabel", () => {
+    // The orb tooltip and the extension's status bar both render "<product> — <label>",
+    // so a label that names the product again stutters: "WSO2 Integration Intelligence —
+    // WSO2 Integration Intelligence needs your input".
+    it.each(["completed", "running", "awaiting-input", "error", "idle"] as const)(
+        "leaves the product name to the surface showing it (%s)",
+        (state) => {
+            expect(activeStateLabel(makeStatus({ state }))).not.toMatch(/WSO2|Integration Intelligence/);
+        }
+    );
+
+    it("prefers the live label the extension pushes", () => {
+        expect(activeStateLabel(makeStatus({ state: "running", label: "Editing service.bal…" }))).toBe(
+            "Editing service.bal…"
+        );
     });
 });

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -133,21 +133,25 @@ export const AmbientFrame = styled.div<AmbientFrameProps>`
     }
 `;
 
-/** User-facing label for a non-idle run state, shared by the orb and the hero box. */
-export const AWAITING_INPUT_LABEL = "WSO2 Integration Intelligence needs your input";
+export const AWAITING_INPUT_LABEL = "Needs your input";
 
+/**
+ * User-facing label for a non-idle run state. Never names the product: every surface
+ * that shows one already does — the orb tooltip, and the status bar the extension
+ * builds from the same vocabulary.
+ */
 export function activeStateLabel(status: AgentRunStatus): string {
     switch (status.state) {
         case "completed":
-            return "Done — click to open WSO2 Integration Intelligence";
+            return "Done — click to open the chat";
         case "running":
             return status.label ?? "Working on it…";
         case "awaiting-input":
             return status.label ?? AWAITING_INPUT_LABEL;
         case "error":
-            return status.label ?? "WSO2 Integration Intelligence hit an error";
+            return status.label ?? "Something went wrong";
         default:
-            return "Chat with WSO2 Integration Intelligence";
+            return "Ready to chat";
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2228

Hovering the orb showed a tooltip that named the product twice, e.g. "WSO2 Integration Intelligence — Chat with WSO2 Integration Intelligence". The orb composes its tooltip as `<product> — <label>`, but several of the visualizer's fallback labels already embedded the product name.

This aligns the visualizer labels with the convention the extension's status bar already follows — bare state phrases, with the surrounding chrome naming the product once.

- Strip the product name from `activeStateLabel` and `AWAITING_INPUT_LABEL`
- Give the idle state no label, so its tooltip is just the product name
- Add a `shared.test.ts` case asserting no state label names the product


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated orb tooltip labels to avoid repeating the product name.
- Removed the idle-state label so idle tooltips display only the product name.
- Added tests to verify state labels and live extension labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->