### PR TITLE
Stop the agent leaving a tab open for every file it edits

### DIFF
--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/edit-tabs.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/edit-tabs.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TabInputText, Uri, window, workspace } from 'vscode';
+
+/**
+ * Keeping a live workspace edit out of the user's tab bar.
+ *
+ * The agent writes `.bal` files through `workspace.applyEdit`, which is what keeps open editors,
+ * the diagrams and the Language Server's `file://` view in step — nothing else notifies the LS,
+ * since the language client registers no file watcher. The cost is that VS Code materialises a
+ * document for every file the edit touches and surfaces one the user never opened as a tab, so a
+ * generation writing twenty files buries the editor in twenty tabs.
+ */
+
+function textTabs(): { tab: unknown; uri: Uri }[] {
+    return window.tabGroups.all
+        .flatMap((group) => group.tabs)
+        .filter((tab) => tab.input instanceof TabInputText)
+        .map((tab) => ({ tab, uri: (tab.input as TabInputText).uri }));
+}
+
+function documentFor(uri: Uri) {
+    return workspace.textDocuments.find((document) => document.uri.fsPath === uri.fsPath);
+}
+
+/** Every file currently shown in a tab, so an edit can tell which tabs are its own doing. */
+export function openTabUris(): Set<string> {
+    return new Set(textTabs().map(({ uri }) => uri.toString()));
+}
+
+/** Saves what this edit touched; `workspace.saveAll` would also flush the user's own unsaved work. */
+export async function saveEditedDocuments(uris: Uri[]): Promise<void> {
+    for (const uri of uris) {
+        const document = documentFor(uri);
+        if (document?.isDirty) {
+            await document.save();
+        }
+    }
+}
+
+/** Closes the tabs this edit opened, leaving anything that was already on screen alone. */
+export async function closeTabsOpenedByEdit(uris: Uri[], tabsBeforeEdit: Set<string>): Promise<void> {
+    const edited = new Set(uris.map((uri) => uri.toString()));
+    for (const { tab, uri } of textTabs()) {
+        if (!edited.has(uri.toString()) || tabsBeforeEdit.has(uri.toString())) {
+            continue;
+        }
+        // A document that would not save still holds the only copy of the edit.
+        if (documentFor(uri)?.isDirty) {
+            continue;
+        }
+        try {
+            await window.tabGroups.close(tab as never, true);
+        } catch (error) {
+            console.error(`[EditTabs] Failed to close the tab opened for ${uri.fsPath}:`, error);
+        }
+    }
+}

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/edit-tabs.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/edit-tabs.ts
@@ -22,10 +22,11 @@ import { TabInputText, Uri, window, workspace } from 'vscode';
  * Keeping a live workspace edit out of the user's tab bar.
  *
  * The agent writes `.bal` files through `workspace.applyEdit`, which is what keeps open editors,
- * the diagrams and the Language Server's `file://` view in step — nothing else notifies the LS,
- * since the language client registers no file watcher. The cost is that VS Code materialises a
- * document for every file the edit touches and surfaces one the user never opened as a tab, so a
- * generation writing twenty files buries the editor in twenty tabs.
+ * the diagrams and the Language Server's `file://` view in step: the LS ignores disk-watcher events
+ * for files the client already syncs, so a plain disk write would silently desync any file the
+ * editor holds. The cost is that VS Code materialises a dirty document for every file the edit
+ * touches and, unless it is saved within ~800 ms, opens a tab for it — so a generation writing
+ * twenty files buried the editor in twenty tabs.
  */
 
 function textTabs(): { tab: unknown; uri: Uri }[] {
@@ -46,12 +47,12 @@ export function openTabUris(): Set<string> {
     return new Set(textTabs().map(({ uri }) => uri.toString()));
 }
 
-/** Saves what this edit touched; `workspace.saveAll` would also flush the user's own unsaved work. */
+/** Saves what this edit touched; `workspace.saveAll` skips editor-less documents and flushes the user's own unsaved work. */
 export async function saveEditedDocuments(uris: Uri[]): Promise<void> {
     for (const uri of uris) {
         const document = documentFor(uri);
-        if (document?.isDirty) {
-            await document.save();
+        if (document?.isDirty && !(await document.save())) {
+            console.warn(`[EditTabs] Failed to save ${uri.fsPath}; VS Code will surface it as a dirty tab.`);
         }
     }
 }

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/edit-tabs.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/edit-tabs.ts
@@ -35,8 +35,10 @@ function textTabs(): { tab: unknown; uri: Uri }[] {
         .map((tab) => ({ tab, uri: (tab.input as TabInputText).uri }));
 }
 
+/** A `git:` view of a file shares its fsPath with the real document, so match on the full URI. */
 function documentFor(uri: Uri) {
-    return workspace.textDocuments.find((document) => document.uri.fsPath === uri.fsPath);
+    const key = uri.toString();
+    return workspace.textDocuments.find((document) => document.uri.toString() === key);
 }
 
 /** Every file currently shown in a tab, so an edit can tell which tabs are its own doing. */

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/utils.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/utils.ts
@@ -28,6 +28,7 @@ import { getAskResponse } from "../../features/ai/ask/index";
 import { ArtifactNotificationHandler, ArtifactsUpdated } from "../../utils/project-artifacts-handler";
 import { VisualizerRpcManager } from "../visualizer/rpc-manager";
 import { renderDatamapper } from "../../../src/views/ai-panel/checkpoint/checkpointUtils";
+import { closeTabsOpenedByEdit, openTabUris, saveEditedDocuments } from "./edit-tabs";
 
 // Common functions
 
@@ -40,6 +41,7 @@ export function isErrorCode(error: any): boolean {
 export async function addToIntegration(workspaceFolderPath: string, fileChanges: FileChanges[]) {
     const formattedWorkspaceEdit = new WorkspaceEdit();
     const nonBalFiles: FileChanges[] = [];
+    const editedBalUris: Uri[] = [];
     let isBalFileAdded = false;
     for (const fileChange of fileChanges) {
         let balFilePath = path.join(workspaceFolderPath, fileChange.filePath);
@@ -55,6 +57,7 @@ export async function addToIntegration(workspaceFolderPath: string, fileChanges:
             continue;
         }
 
+        editedBalUris.push(fileUri);
         formattedWorkspaceEdit.createFile(fileUri, { ignoreIfExists: true });
 
         formattedWorkspaceEdit.replace(
@@ -69,22 +72,20 @@ export async function addToIntegration(workspaceFolderPath: string, fileChanges:
 
     // applyEdit signals failure by returning false rather than throwing, usually because the
     // document version changed underneath it. Gated on isBalFileAdded so an empty
-    // WorkspaceEdit isn't applied; saveAll stays ungated to keep the old flush behaviour.
+    // WorkspaceEdit isn't applied.
     if (isBalFileAdded) {
-        const applied = await workspace.applyEdit(formattedWorkspaceEdit);
+        const tabsBeforeEdit = openTabUris();
+        const applied = await workspace.applyEdit(formattedWorkspaceEdit, { isRefactoring: true });
         if (!applied) {
             throw new Error(
                 `Failed to apply workspace edit for: ${fileChanges.map(f => f.filePath).join(', ')}`
             );
         }
-    }
-    // saveAll also flushes unrelated dirty editors, so a false return is not proof that our
-    // file failed. Callers verify their own file against disk.
-    const saved = await workspace.saveAll();
-    if (!saved) {
-        console.warn(
-            `[addToIntegration] workspace.saveAll() reported a failure while saving: ${fileChanges.map(f => f.filePath).join(', ')}`
-        );
+        // applyEdit leaves each touched file as a dirty editor-less document, and VS Code opens a tab for
+        // one that stays dirty ~800 ms: save exactly what was touched, straight after. isRefactoring has
+        // VS Code do that save inside the edit itself, but only for edits spanning more than one resource.
+        await saveEditedDocuments(editedBalUris);
+        await closeTabsOpenedByEdit(editedBalUris, tabsBeforeEdit);
     }
 
     // Write non ballerina files separately as ls doesn't need to be notified of those changes

--- a/packages/ballerina-extension/src/test-support/__mocks__/vscode.ts
+++ b/packages/ballerina-extension/src/test-support/__mocks__/vscode.ts
@@ -19,18 +19,30 @@
 // Minimal `vscode` stub for host-side unit/contract tests (no real editor).
 // Extend as contract tests need more surface.
 
+/** Editor tab input, matched with `instanceof` by anything that filters tabs. */
+export class TabInputText {
+    constructor(public readonly uri: { fsPath: string; toString(): string }) {}
+}
+
 export const window = {
     showErrorMessage: () => Promise.resolve(undefined),
     showInformationMessage: () => Promise.resolve(undefined),
     showWarningMessage: () => Promise.resolve(undefined),
     createOutputChannel: () => ({ appendLine() {}, append() {}, show() {}, clear() {}, dispose() {} }),
     activeTextEditor: undefined,
+    // Tests assign `all` and spy on `close`.
+    tabGroups: {
+        all: [] as { tabs: { input: unknown }[] }[],
+        close: (_tab: unknown, _preserveFocus?: boolean) => Promise.resolve(true),
+    },
 };
 
 export const workspace = {
     getConfiguration: () => ({ get: () => undefined, update: () => Promise.resolve(), inspect: () => undefined }),
     workspaceFolders: [] as unknown[],
     isTrusted: true,
+    // Tests assign this to stand in for the documents VS Code has materialised.
+    textDocuments: [] as { uri: { fsPath: string }; isDirty: boolean; save(): Promise<boolean> }[],
     onDidChangeConfiguration: () => ({ dispose() {} }),
     onDidGrantWorkspaceTrust: () => ({ dispose() {} }),
 };

--- a/packages/ballerina-extension/src/test-support/__mocks__/vscode.ts
+++ b/packages/ballerina-extension/src/test-support/__mocks__/vscode.ts
@@ -42,7 +42,7 @@ export const workspace = {
     workspaceFolders: [] as unknown[],
     isTrusted: true,
     // Tests assign this to stand in for the documents VS Code has materialised.
-    textDocuments: [] as { uri: { fsPath: string }; isDirty: boolean; save(): Promise<boolean> }[],
+    textDocuments: [] as { uri: { fsPath: string; toString(): string }; isDirty: boolean; save(): Promise<boolean> }[],
     onDidChangeConfiguration: () => ({ dispose() {} }),
     onDidGrantWorkspaceTrust: () => ({ dispose() {} }),
 };

--- a/packages/ballerina-extension/src/test-support/editTabs.test.ts
+++ b/packages/ballerina-extension/src/test-support/editTabs.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// A generation writes through `workspace.applyEdit`, which materialises a document per file and
+// leaves the user staring at a tab per edited file. Closing those again is only safe while it
+// stays surgical: the user's own tabs stay, and so does anything still holding unsaved content.
+
+import { TabInputText, window, workspace } from "vscode";
+import { closeTabsOpenedByEdit, openTabUris, saveEditedDocuments } from "../rpc-managers/ai-panel/edit-tabs";
+
+const uri = (fsPath: string) => ({ fsPath, toString: () => `file://${fsPath}` }) as any;
+
+function tabFor(fsPath: string) {
+    return { input: new (TabInputText as any)(uri(fsPath)) };
+}
+
+function documentFor(fsPath: string, isDirty = false) {
+    return { uri: uri(fsPath), isDirty, save: jest.fn().mockResolvedValue(true) };
+}
+
+function setTabs(...fsPaths: string[]): void {
+    (window as any).tabGroups.all = [{ tabs: fsPaths.map(tabFor) }];
+}
+
+describe("edit tab cleanup", () => {
+    let closed: unknown[];
+
+    beforeEach(() => {
+        closed = [];
+        (window as any).tabGroups.close = jest.fn((tab: unknown) => {
+            closed.push(tab);
+            return Promise.resolve(true);
+        });
+        (workspace as any).textDocuments = [];
+        setTabs();
+    });
+
+    it("closes a tab the edit opened", async () => {
+        const before = openTabUris();
+        setTabs("/ws/main.bal");
+        (workspace as any).textDocuments = [documentFor("/ws/main.bal")];
+
+        await closeTabsOpenedByEdit([uri("/ws/main.bal")], before);
+
+        expect(closed).toHaveLength(1);
+    });
+
+    it("leaves a tab the user already had open", async () => {
+        setTabs("/ws/main.bal");
+        const before = openTabUris();
+        (workspace as any).textDocuments = [documentFor("/ws/main.bal")];
+
+        await closeTabsOpenedByEdit([uri("/ws/main.bal")], before);
+
+        expect(closed).toHaveLength(0);
+    });
+
+    it("leaves tabs for files this edit never touched", async () => {
+        const before = openTabUris();
+        setTabs("/ws/other.bal");
+        (workspace as any).textDocuments = [documentFor("/ws/other.bal")];
+
+        await closeTabsOpenedByEdit([uri("/ws/main.bal")], before);
+
+        expect(closed).toHaveLength(0);
+    });
+
+    it("keeps a tab whose document is still unsaved", async () => {
+        const before = openTabUris();
+        setTabs("/ws/main.bal");
+        (workspace as any).textDocuments = [documentFor("/ws/main.bal", true)];
+
+        await closeTabsOpenedByEdit([uri("/ws/main.bal")], before);
+
+        expect(closed).toHaveLength(0);
+    });
+});
+
+describe("saveEditedDocuments", () => {
+    it("saves the edited files and nothing else the user left unsaved", async () => {
+        const edited = documentFor("/ws/main.bal", true);
+        const untouched = documentFor("/ws/notes.md", true);
+        (workspace as any).textDocuments = [edited, untouched];
+
+        await saveEditedDocuments([uri("/ws/main.bal")]);
+
+        expect(edited.save).toHaveBeenCalled();
+        expect(untouched.save).not.toHaveBeenCalled();
+    });
+});

--- a/packages/ballerina-extension/src/test-support/editTabs.test.ts
+++ b/packages/ballerina-extension/src/test-support/editTabs.test.ts
@@ -20,21 +20,25 @@
 // leaves the user staring at a tab per edited file. Closing those again is only safe while it
 // stays surgical: the user's own tabs stay, and so does anything still holding unsaved content.
 
-import { TabInputText, window, workspace } from "vscode";
+import type { Uri } from "vscode";
+// The module jest maps `vscode` to, imported by path so its tabs and documents are typed as the
+// mutable stubs they are rather than the read-only API.
+import { TabInputText, window, workspace } from "./__mocks__/vscode";
 import { closeTabsOpenedByEdit, openTabUris, saveEditedDocuments } from "../rpc-managers/ai-panel/edit-tabs";
 
-const uri = (fsPath: string) => ({ fsPath, toString: () => `file://${fsPath}` }) as any;
+const uri = (fsPath: string, scheme = "file") =>
+    ({ fsPath, scheme, toString: () => `${scheme}://${fsPath}` }) as unknown as Uri;
 
 function tabFor(fsPath: string) {
-    return { input: new (TabInputText as any)(uri(fsPath)) };
+    return { input: new TabInputText(uri(fsPath)) };
 }
 
-function documentFor(fsPath: string, isDirty = false) {
-    return { uri: uri(fsPath), isDirty, save: jest.fn().mockResolvedValue(true) };
+function documentFor(fsPath: string, isDirty = false, scheme = "file") {
+    return { uri: uri(fsPath, scheme), isDirty, save: jest.fn().mockResolvedValue(true) };
 }
 
 function setTabs(...fsPaths: string[]): void {
-    (window as any).tabGroups.all = [{ tabs: fsPaths.map(tabFor) }];
+    window.tabGroups.all = [{ tabs: fsPaths.map(tabFor) }];
 }
 
 describe("edit tab cleanup", () => {
@@ -42,18 +46,18 @@ describe("edit tab cleanup", () => {
 
     beforeEach(() => {
         closed = [];
-        (window as any).tabGroups.close = jest.fn((tab: unknown) => {
+        window.tabGroups.close = jest.fn((tab: unknown) => {
             closed.push(tab);
             return Promise.resolve(true);
         });
-        (workspace as any).textDocuments = [];
+        workspace.textDocuments = [];
         setTabs();
     });
 
     it("closes a tab the edit opened", async () => {
         const before = openTabUris();
         setTabs("/ws/main.bal");
-        (workspace as any).textDocuments = [documentFor("/ws/main.bal")];
+        workspace.textDocuments = [documentFor("/ws/main.bal")];
 
         await closeTabsOpenedByEdit([uri("/ws/main.bal")], before);
 
@@ -63,7 +67,7 @@ describe("edit tab cleanup", () => {
     it("leaves a tab the user already had open", async () => {
         setTabs("/ws/main.bal");
         const before = openTabUris();
-        (workspace as any).textDocuments = [documentFor("/ws/main.bal")];
+        workspace.textDocuments = [documentFor("/ws/main.bal")];
 
         await closeTabsOpenedByEdit([uri("/ws/main.bal")], before);
 
@@ -73,7 +77,7 @@ describe("edit tab cleanup", () => {
     it("leaves tabs for files this edit never touched", async () => {
         const before = openTabUris();
         setTabs("/ws/other.bal");
-        (workspace as any).textDocuments = [documentFor("/ws/other.bal")];
+        workspace.textDocuments = [documentFor("/ws/other.bal")];
 
         await closeTabsOpenedByEdit([uri("/ws/main.bal")], before);
 
@@ -83,7 +87,17 @@ describe("edit tab cleanup", () => {
     it("keeps a tab whose document is still unsaved", async () => {
         const before = openTabUris();
         setTabs("/ws/main.bal");
-        (workspace as any).textDocuments = [documentFor("/ws/main.bal", true)];
+        workspace.textDocuments = [documentFor("/ws/main.bal", true)];
+
+        await closeTabsOpenedByEdit([uri("/ws/main.bal")], before);
+
+        expect(closed).toHaveLength(0);
+    });
+
+    it("keeps an unsaved tab even when a clean git: view shares the file's path", async () => {
+        const before = openTabUris();
+        setTabs("/ws/main.bal");
+        workspace.textDocuments = [documentFor("/ws/main.bal", false, "git"), documentFor("/ws/main.bal", true)];
 
         await closeTabsOpenedByEdit([uri("/ws/main.bal")], before);
 
@@ -95,11 +109,20 @@ describe("saveEditedDocuments", () => {
     it("saves the edited files and nothing else the user left unsaved", async () => {
         const edited = documentFor("/ws/main.bal", true);
         const untouched = documentFor("/ws/notes.md", true);
-        (workspace as any).textDocuments = [edited, untouched];
+        workspace.textDocuments = [edited, untouched];
 
         await saveEditedDocuments([uri("/ws/main.bal")]);
 
         expect(edited.save).toHaveBeenCalled();
         expect(untouched.save).not.toHaveBeenCalled();
+    });
+
+    it("saves the file itself, not a git: view that shares its path", async () => {
+        const edited = documentFor("/ws/main.bal", true);
+        workspace.textDocuments = [documentFor("/ws/main.bal", false, "git"), edited];
+
+        await saveEditedDocuments([uri("/ws/main.bal")]);
+
+        expect(edited.save).toHaveBeenCalled();
     });
 });

--- a/packages/ballerina-extension/src/test-support/editTabs.test.ts
+++ b/packages/ballerina-extension/src/test-support/editTabs.test.ts
@@ -125,4 +125,18 @@ describe("saveEditedDocuments", () => {
 
         expect(edited.save).toHaveBeenCalled();
     });
+
+    it("reports a save that failed and still saves the rest", async () => {
+        const failing = documentFor("/ws/a.bal", true);
+        failing.save.mockResolvedValue(false);
+        const next = documentFor("/ws/b.bal", true);
+        workspace.textDocuments = [failing, next];
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        await saveEditedDocuments([uri("/ws/a.bal"), uri("/ws/b.bal")]);
+
+        expect(next.save).toHaveBeenCalled();
+        expect(warn).toHaveBeenCalledTimes(1);
+        warn.mockRestore();
+    });
 });


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2231

Every `.bal` file the agent edited popped open as an editor tab. `addToIntegration` applies edits through `workspace.applyEdit`, which loads each file as an in-memory document and leaves it dirty with no editor; the `workspace.saveAll()` that followed saves only documents that have an editor, so those were never saved — and VS Code opens a tab for any dirty editor-less document after ~800 ms unless short-delay autosave covers it. A generation touching twenty files buried the editor in twenty tabs.

- Save exactly the documents the edit touched, straight after `applyEdit` (replacing `saveAll()`) — the document is clean before VS Code looks, in every autosave mode, and the user's own unrelated unsaved editors are no longer flushed. This is the fix.
- Mark the bulk edit `{ isRefactoring: true }`, so `files.refactoring.autoSave` saves as part of the edit where VS Code honours it (edits spanning more than one resource, e.g. a new file)
- As a safety net, close any tab the edit itself opened — never one the user already had open, and never one whose document is still unsaved
- Run the save and the tab cleanup only after `applyEdit` succeeds (a rejected edit now throws, from #1047), so a failed edit cannot save the user's pre-existing changes
- Makes the disk read-back in `verifyPersisted` (#1047) deterministic: the edited file is on disk before `addToIntegration` returns, whereas `saveAll()` never saved a document without an editor, so that check could only pass when the user's autosave happened to run first
- Match documents by full URI rather than `fsPath`, so a `git:` view of the same path cannot stand in for the real document (from review)
- Warn when a save fails — a failed save is the one case where VS Code surfaces a tab regardless of autosave
- Extract the tab helpers to `edit-tabs.ts` and cover them with `editTabs.test.ts`

Keeps the `applyEdit` write path deliberately: it is what keeps the Language Server's `file://` view (and therefore the review diff and diagrams) in sync. The LS does watch `.bal` files on disk, but its workspace manager ignores watcher events for files the client already syncs, so a plain disk write to a file the editor holds would silently desync it. VS Code's own chat editing (Copilot agent mode) takes the same approach: edit the model without opening an editor, then save the file immediately.

Note: verified via unit tests; still to confirm with a live check that no tab appears with autosave off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved `.bal` file edit handling in the AI panel.
- Enabled refactoring autosave for bulk edits.
- Saved only documents changed by the edit.
- Closed tabs opened by edits when autosave is disabled, while preserving existing and unsaved tabs.
- Added reusable tab-management helpers and unit tests.
- Preserved `workspace.applyEdit` to keep the Language Server file view synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
