### PR TITLE
Fix the module imports of the BI Inteligence for package's modules

### DIFF
--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
@@ -952,9 +952,22 @@ async function getExternalRecords(
 
         let library = cachedLibraries.find((lib) => lib.name === libName);
         if (!library) {
-            const result = (await langClient.getCopilotFilteredLibraries({
-                libNames: [libName]
-            })) as { libraries: Library[] };
+            // A failed fetch of ONE external dependency must not cost the caller the libraries it
+            // already has. Without this catch, a rejected request unwound uncaught to LibraryGetTool's
+            // catch-all, which answers the WHOLE tool call with `[]` — `ballerinax/aws.sns` was lost
+            // because its `ConnectionConfig.auth` field links to `ballerinax/aws.auth`, whose fetch the
+            // language server answered with a JSON-RPC error. Skipping degrades to the same shape as a
+            // gracefully-empty response below: the referencing field still renders, with its Special
+            // Agent Note naming the owning module, so only this record's definition is missing.
+            let result: { libraries: Library[] };
+            try {
+                result = (await langClient.getCopilotFilteredLibraries({
+                    libNames: [libName]
+                })) as { libraries: Library[] };
+            } catch (error) {
+                console.warn(`Library ${libName} could not be fetched: ${error}. Skipping.`);
+                continue;
+            }
             if (result.libraries && result.libraries.length > 0) {
                 library = result.libraries[0];
             } else {

--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
@@ -352,10 +352,8 @@ export function libraryContains(library: string, libraries: string[]): boolean {
 }
 
 export async function getMaximizedSelectedLibs(libNames: string[]): Promise<Library[]> {
-    const result = (await langClient.getCopilotFilteredLibraries({
-        libNames: libNames
-    })) as { libraries: Library[] };
-    const normalizedLibraries: Library[] = result.libraries.map(lib => {
+    const libraries = await fetchFilteredLibraries(libNames);
+    const normalizedLibraries: Library[] = libraries.map(lib => {
             return {
                 name: lib.name,
                 description: lib.description,
@@ -370,6 +368,49 @@ export async function getMaximizedSelectedLibs(libNames: string[]): Promise<Libr
         });
 
     return normalizedLibraries;
+}
+
+/**
+ * Fetches the full catalogs of the given libraries in one request, degrading to one request per library
+ * when the batch is rejected.
+ *
+ * The language server already contains failures per library, so a rejected batch means the request as a
+ * whole failed. Retrying each library on its own lets every library that can still be served reach the
+ * caller instead of one bad entry costing the whole batch, e.g. `[salesforce, aws.sns]` losing both.
+ * Retries run one at a time: each compiles a package, so fanning them out would only contend for the
+ * language server. When no library can be served the original error propagates, so a dead language server
+ * still surfaces as a failure rather than an empty catalog.
+ */
+async function fetchFilteredLibraries(libNames: string[]): Promise<Library[]> {
+    const fetchLibraries = async (names: string[]): Promise<Library[]> => {
+        const result = (await langClient.getCopilotFilteredLibraries({
+            libNames: names
+        })) as { libraries: Library[] };
+        return result.libraries ?? [];
+    };
+
+    try {
+        return await fetchLibraries(libNames);
+    } catch (error) {
+        if (libNames.length <= 1) {
+            throw error;
+        }
+        console.warn(`Batch fetch of libraries [${libNames}] failed: ${error}. Retrying each library individually.`);
+        const libraries: Library[] = [];
+        let anyFetched = false;
+        for (const libName of libNames) {
+            try {
+                libraries.push(...await fetchLibraries([libName]));
+                anyFetched = true;
+            } catch (libError) {
+                console.warn(`Library ${libName} could not be fetched: ${libError}. Skipping.`);
+            }
+        }
+        if (!anyFetched) {
+            throw error;
+        }
+        return libraries;
+    }
 }
 
 export async function toMaximizedLibrariesFromLibJson(

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/CopilotLibraryManager.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/CopilotLibraryManager.java
@@ -34,6 +34,7 @@ import io.ballerina.flowmodelgenerator.core.copilot.service.ServiceLoader;
 import io.ballerina.flowmodelgenerator.core.copilot.util.SymbolProcessor;
 import io.ballerina.modelgenerator.commons.ModuleInfo;
 import io.ballerina.modelgenerator.commons.PackageUtil;
+import io.ballerina.projects.Module;
 import io.ballerina.projects.Package;
 
 import java.io.IOException;
@@ -121,7 +122,10 @@ public class CopilotLibraryManager {
      * Documentation is included only for packages of the organizations listed in
      * {@link #DOC_WHITELIST_ORGS}.
      *
-     * @param libraryNames Array of library names in "org/package_name" format to filter
+     * @param libraryNames Array of library names in "org/module" format to filter. A package's default
+     *                     module is addressed by the package name itself; a
+     *                     non-default exported module by its full module name ("ballerinax/aws.auth"),
+     *                     which resolves through its owning package ("ballerinax/aws")
      * @return List of Library objects with complete information
      */
     public List<Library> loadFilteredLibraries(String[] libraryNames) {
@@ -144,43 +148,58 @@ public class CopilotLibraryManager {
         List<Library> libraries = new ArrayList<>();
 
         for (String libraryName : libraryNames) {
-            // Parse library name "org/package_name"
+            // Parse library name "org/module_name"
             String[] parts = libraryName.split("/");
             if (parts.length != 2) {
                 continue; // Skip invalid format
             }
             String org = parts[0];
-            String packageName = parts[1];
+            String moduleName = parts[1];
 
-            // Create module info (use latest version by passing null)
-            ModuleInfo moduleInfo = new ModuleInfo(org, packageName, org + "/" +
-                    packageName, null);
-
-            // Resolve the package once; the README loader below reuses this same Package
-            // to avoid a second (potentially network-bound) resolution.
+            // Resolve the owning package once; the README loader below reuses this same Package
+            // to avoid a second (potentially network-bound) resolution. The requested name may be a
+            // package ("ballerinax/aws.sns") or a non-default exported module ("ballerinax/aws.auth"
+            // lives in "ballerinax/aws") — the coordinate cross-package type links carry. Resolution
+            // failure is contained per library, so one bad entry cannot abort the rest of the batch.
             String pinned = pinnedVersions == null ? null : pinnedVersions.get(libraryName);
-            Optional<Package> optPackage = pinned == null || pinned.isBlank()
-                    ? PackageUtil.getModulePackage(PackageUtil.getSampleProject(), org, packageName)
-                    : PackageUtil.getModulePackage(PackageUtil.getSampleProject(), org, packageName, pinned);
-            if (optPackage.isEmpty()) {
+            Optional<ResolvedModule> resolution = resolveModule(org, moduleName, pinned);
+            if (resolution.isEmpty()) {
+                LOGGER.warning("No package resolvable for '" + libraryName + "'. Skipping.");
                 continue;
             }
-            Package pkg = optPackage.get();
+            Package pkg = resolution.get().pkg();
+            Module module = resolution.get().module();
+            String packageName = pkg.packageName().value();
+            boolean isDefaultModule = moduleName.equals(packageName);
+
+            // Create module info (use latest version by passing null). The default-module form is
+            // unchanged; a submodule gets the real (org, packageName, moduleName) triple.
+            ModuleInfo moduleInfo = isDefaultModule
+                    ? new ModuleInfo(org, moduleName, org + "/" + moduleName, null)
+                    : new ModuleInfo(org, packageName, moduleName, null);
+
             SemanticModel semanticModel = PackageUtil.getCompilation(pkg)
-                    .getSemanticModel(pkg.getDefaultModule().moduleId());
+                    .getSemanticModel(module.moduleId());
 
-            // Get the package description from database
-            String description = LibraryDatabaseAccessor.getPackageDescription(org, packageName).orElse("");
+            // Get the package description from database; a submodule has no row of its own, so it
+            // falls back to the owning package's.
+            String description = LibraryDatabaseAccessor.getPackageDescription(org, moduleName)
+                    .filter(desc -> !desc.isBlank())
+                    .or(() -> LibraryDatabaseAccessor.getPackageDescription(org, packageName))
+                    .orElse("");
 
-            // Create library object
+            // Create library object, keyed by the requested name: it is also the import path the
+            // renderer emits and the source of the alias prefix ("auth:" for ballerinax/aws.auth).
             Library library = new Library(libraryName, description);
 
-            // Process module symbols to extract clients, functions, and typedefs
+            // Process module symbols to extract clients, functions, and typedefs. The module name is
+            // the "current package" identity, so the module's own types link internal while a sibling
+            // module of the same package links external.
             SymbolProcessor.SymbolProcessingResult symbolResult = SymbolProcessor.processModuleSymbols(
                     semanticModel,
                     moduleInfo,
                     org,
-                    packageName,
+                    moduleName,
                     pkg
             );
 
@@ -204,7 +223,9 @@ public class CopilotLibraryManager {
             library.setAnnotations(symbolResult.getAnnotations());
 
             if (DOC_WHITELIST_ORGS.contains(org)) {
-                readPackageDocumentation(pkg).ifPresent(library::setReadme);
+                // A submodule request carries its own module document, not the whole package's.
+                (isDefaultModule ? readPackageDocumentation(pkg) : readModuleDocumentation(pkg, moduleName))
+                        .ifPresent(library::setReadme);
             }
 
             libraries.add(library);
@@ -214,6 +235,69 @@ public class CopilotLibraryManager {
         augmentLibrariesWithInstructions(libraries);
 
         return libraries;
+    }
+
+    /**
+     * One resolved {@code org/module} request.
+     *
+     * @param pkg    the owning package
+     * @param module the requested module within it
+     */
+    private record ResolvedModule(Package pkg, Module module) {
+    }
+
+    /**
+     * Resolves an {@code org/module} path to its owning package and module: the name is tried as a
+     * package first (the default-module case), then trailing {@code .segment}s are stripped and retried
+     * ({@code aws.auth} → {@code aws}) — sound because a submodule's name always starts with its
+     * package's name. Within a resolved package the module is matched by its full name, so a package
+     * that does not export the requested module yields empty rather than a wrong catalog.
+     *
+     * @param moduleName    the requested module name, e.g. {@code "aws.auth"}
+     * @param pinnedVersion the pinned version, applied to whichever candidate resolves; may be null
+     * @return the owning package and module, or empty when nothing resolves
+     */
+    private Optional<ResolvedModule> resolveModule(String org, String moduleName, String pinnedVersion) {
+        String candidate = moduleName;
+        while (true) {
+            Optional<Package> optPackage = resolvePackageSafely(org, candidate, pinnedVersion);
+            if (optPackage.isPresent()) {
+                Package pkg = optPackage.get();
+                for (Module module : pkg.modules()) {
+                    if (module.moduleName().toString().equals(moduleName)) {
+                        return Optional.of(new ResolvedModule(pkg, module));
+                    }
+                }
+                // Defensive: a package's default module always shares its name, so for the exact-name
+                // candidate this preserves the previous behaviour. A shortened candidate that does not
+                // export the requested module yields empty instead of a wrong catalog.
+                return candidate.equals(moduleName)
+                        ? Optional.of(new ResolvedModule(pkg, pkg.getDefaultModule()))
+                        : Optional.empty();
+            }
+            int lastDot = candidate.lastIndexOf('.');
+            if (lastDot < 0) {
+                return Optional.empty();
+            }
+            candidate = candidate.substring(0, lastDot);
+        }
+    }
+
+    /**
+     * One package-resolution attempt that reports failure as empty instead of throwing:
+     * {@code getModulePackage} throws for a name Central has no package under (its latest-version
+     * lookup surfaces the 404), and for a non-final {@link #resolveModule} candidate — a module-only
+     * name such as {@code aws.auth} — that is a routine outcome, not an error.
+     */
+    private static Optional<Package> resolvePackageSafely(String org, String name, String pinnedVersion) {
+        try {
+            return pinnedVersion == null || pinnedVersion.isBlank()
+                    ? PackageUtil.getModulePackage(PackageUtil.getSampleProject(), org, name)
+                    : PackageUtil.getModulePackage(PackageUtil.getSampleProject(), org, name, pinnedVersion);
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.FINE, "Package resolution failed for " + org + "/" + name, e);
+            return Optional.empty();
+        }
     }
 
     /**
@@ -288,6 +372,21 @@ public class CopilotLibraryManager {
         readFirstAvailableDoc(docsDir, PACKAGE_DOC_NAMES).ifPresent(content::append);
         appendModuleDocumentation(docsDir, content);
         return content.isEmpty() ? Optional.empty() : Optional.of(content.toString());
+    }
+
+    /**
+     * Reads the documentation of one non-default module of a resolved .bala package —
+     * {@code docs/modules/<moduleName>/README.md} (or {@code Module.md}).
+     *
+     * @param pkg        the resolved owning package
+     * @param moduleName the full module name, e.g. {@code "aws.auth"}, which is also the docs
+     *                   directory name the bala layout uses
+     * @return an Optional containing the module documentation if present
+     */
+    private Optional<String> readModuleDocumentation(Package pkg, String moduleName) {
+        Path moduleDocsDir = pkg.project().sourceRoot()
+                .resolve(DOCS_DIR).resolve(MODULES_DIR).resolve(moduleName);
+        return readFirstAvailableDoc(moduleDocsDir, MODULE_DOC_NAMES);
     }
 
     /**

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/CopilotLibraryManager.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/CopilotLibraryManager.java
@@ -148,93 +148,108 @@ public class CopilotLibraryManager {
         List<Library> libraries = new ArrayList<>();
 
         for (String libraryName : libraryNames) {
-            // Parse library name "org/module_name"
-            String[] parts = libraryName.split("/");
-            if (parts.length != 2) {
-                continue; // Skip invalid format
-            }
-            String org = parts[0];
-            String moduleName = parts[1];
-
-            // Resolve the owning package once; the README loader below reuses this same Package
-            // to avoid a second (potentially network-bound) resolution. The requested name may be a
-            // package ("ballerinax/aws.sns") or a non-default exported module ("ballerinax/aws.auth"
-            // lives in "ballerinax/aws") — the coordinate cross-package type links carry. Resolution
-            // failure is contained per library, so one bad entry cannot abort the rest of the batch.
+            // Failure is contained per library: one entry that cannot be resolved, compiled or
+            // processed is skipped, so it cannot cost the caller the rest of the batch. Before this
+            // guard an exception here unwound through the JSON-RPC boundary and discarded every
+            // sibling library already built.
             String pinned = pinnedVersions == null ? null : pinnedVersions.get(libraryName);
-            Optional<ResolvedModule> resolution = resolveModule(org, moduleName, pinned);
-            if (resolution.isEmpty()) {
-                LOGGER.warning("No package resolvable for '" + libraryName + "'. Skipping.");
-                continue;
+            try {
+                loadLibrary(libraryName, pinned).ifPresent(libraries::add);
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING, "Failed to load library '" + libraryName + "'. Skipping.", e);
             }
-            Package pkg = resolution.get().pkg();
-            Module module = resolution.get().module();
-            String packageName = pkg.packageName().value();
-            boolean isDefaultModule = moduleName.equals(packageName);
-
-            // Create module info (use latest version by passing null). The default-module form is
-            // unchanged; a submodule gets the real (org, packageName, moduleName) triple.
-            ModuleInfo moduleInfo = isDefaultModule
-                    ? new ModuleInfo(org, moduleName, org + "/" + moduleName, null)
-                    : new ModuleInfo(org, packageName, moduleName, null);
-
-            SemanticModel semanticModel = PackageUtil.getCompilation(pkg)
-                    .getSemanticModel(module.moduleId());
-
-            // Get the package description from database; a submodule has no row of its own, so it
-            // falls back to the owning package's.
-            String description = LibraryDatabaseAccessor.getPackageDescription(org, moduleName)
-                    .filter(desc -> !desc.isBlank())
-                    .or(() -> LibraryDatabaseAccessor.getPackageDescription(org, packageName))
-                    .orElse("");
-
-            // Create library object, keyed by the requested name: it is also the import path the
-            // renderer emits and the source of the alias prefix ("auth:" for ballerinax/aws.auth).
-            Library library = new Library(libraryName, description);
-
-            // Process module symbols to extract clients, functions, and typedefs. The module name is
-            // the "current package" identity, so the module's own types link internal while a sibling
-            // module of the same package links external.
-            SymbolProcessor.SymbolProcessingResult symbolResult = SymbolProcessor.processModuleSymbols(
-                    semanticModel,
-                    moduleInfo,
-                    org,
-                    moduleName,
-                    pkg
-            );
-
-            library.setClients(symbolResult.getClients());
-            library.setFunctions(symbolResult.getFunctions());
-            library.setTypeDefs(symbolResult.getTypeDefs());
-
-            List<Service> services = ServiceLoader.loadAllServices(libraryName, pkg, semanticModel);
-            List<Symbol> moduleSymbols = semanticModel.moduleSymbols();
-            CopilotDeprecationEnricher.enrich(services, moduleSymbols);
-            CopilotListenerNameEnricher.enrich(services, moduleSymbols);
-            library.setServices(services);
-
-            // Annotations come from the Semantic Model alone: the compiler is authoritative for
-            // attachment points and type constraints, and it reports every annotation the module
-            // declares at every point it declares them (service, object function, type, record
-            // field, parameter, return, listener, ...). The curated service-index catalog covered
-            // only SERVICE/OBJECT_METHOD for six packages, and every row it holds is either
-            // reproduced by the compiler or contradicted by it (ftp's FunctionConfig, filed as
-            // OBJECT_METHOD where the compiler reports RESOURCE), so it is no longer consulted.
-            library.setAnnotations(symbolResult.getAnnotations());
-
-            if (DOC_WHITELIST_ORGS.contains(org)) {
-                // A submodule request carries its own module document, not the whole package's.
-                (isDefaultModule ? readPackageDocumentation(pkg) : readModuleDocumentation(pkg, moduleName))
-                        .ifPresent(library::setReadme);
-            }
-
-            libraries.add(library);
         }
 
         applyLibraryExclusions(libraries);
         augmentLibrariesWithInstructions(libraries);
 
         return libraries;
+    }
+
+    /**
+     * Loads the full catalog of one {@code org/module} request.
+     *
+     * @param libraryName   the requested library, in {@code "org/module"} form
+     * @param pinnedVersion the package version to resolve, or null for latest
+     * @return the loaded library, or empty when the name is malformed or nothing resolves for it
+     */
+    private Optional<Library> loadLibrary(String libraryName, String pinnedVersion) {
+        // Parse library name "org/module_name"
+        String[] parts = libraryName.split("/");
+        if (parts.length != 2) {
+            return Optional.empty(); // Skip invalid format
+        }
+        String org = parts[0];
+        String moduleName = parts[1];
+
+        // Resolve the owning package once; the README loader below reuses this same Package
+        // to avoid a second (potentially network-bound) resolution. The requested name may be a
+        // package ("ballerinax/aws.sns") or a non-default exported module ("ballerinax/aws.auth"
+        // lives in "ballerinax/aws") — the coordinate cross-package type links carry.
+        Optional<ResolvedModule> resolution = resolveModule(org, moduleName, pinnedVersion);
+        if (resolution.isEmpty()) {
+            return Optional.empty();
+        }
+        Package pkg = resolution.get().pkg();
+        Module module = resolution.get().module();
+        String packageName = pkg.packageName().value();
+        boolean isDefaultModule = moduleName.equals(packageName);
+
+        // The real (org, packageName, moduleName) triple, latest version. For the default module the
+        // module name equals the package name, as in ModuleInfo.from(ModuleID).
+        ModuleInfo moduleInfo = new ModuleInfo(org, packageName, moduleName, null);
+
+        SemanticModel semanticModel = PackageUtil.getCompilation(pkg)
+                .getSemanticModel(module.moduleId());
+
+        // Get the package description from database; a submodule has no row of its own, so it
+        // falls back to the owning package's.
+        String description = LibraryDatabaseAccessor.getPackageDescription(org, moduleName)
+                .filter(desc -> !desc.isBlank())
+                .or(() -> LibraryDatabaseAccessor.getPackageDescription(org, packageName))
+                .orElse("");
+
+        // Create library object, keyed by the requested name: it is also the import path the
+        // renderer emits and the source of the alias prefix ("auth:" for ballerinax/aws.auth).
+        Library library = new Library(libraryName, description);
+
+        // Process module symbols to extract clients, functions, and typedefs. The module name is
+        // the "current package" identity, so the module's own types link internal while a sibling
+        // module of the same package links external.
+        SymbolProcessor.SymbolProcessingResult symbolResult = SymbolProcessor.processModuleSymbols(
+                semanticModel,
+                moduleInfo,
+                org,
+                moduleName,
+                pkg
+        );
+
+        library.setClients(symbolResult.getClients());
+        library.setFunctions(symbolResult.getFunctions());
+        library.setTypeDefs(symbolResult.getTypeDefs());
+
+        List<Service> services = ServiceLoader.loadAllServices(libraryName, pkg, semanticModel);
+        List<Symbol> moduleSymbols = semanticModel.moduleSymbols();
+        CopilotDeprecationEnricher.enrich(services, moduleSymbols);
+        CopilotListenerNameEnricher.enrich(services, moduleSymbols);
+        library.setServices(services);
+
+        // Annotations come from the Semantic Model alone: the compiler is authoritative for
+        // attachment points and type constraints, and it reports every annotation the module
+        // declares at every point it declares them (service, object function, type, record
+        // field, parameter, return, listener, ...). The curated service-index catalog covered
+        // only SERVICE/OBJECT_METHOD for six packages, and every row it holds is either
+        // reproduced by the compiler or contradicted by it (ftp's FunctionConfig, filed as
+        // OBJECT_METHOD where the compiler reports RESOURCE), so it is no longer consulted.
+        library.setAnnotations(symbolResult.getAnnotations());
+
+        if (DOC_WHITELIST_ORGS.contains(org)) {
+            // A submodule request carries its own module document, not the whole package's.
+            (isDefaultModule ? readPackageDocumentation(pkg) : readModuleDocumentation(pkg, moduleName))
+                    .ifPresent(library::setReadme);
+        }
+
+        return Optional.of(library);
     }
 
     /**
@@ -253,14 +268,40 @@ public class CopilotLibraryManager {
      * package's name. Within a resolved package the module is matched by its full name, so a package
      * that does not export the requested module yields empty rather than a wrong catalog.
      *
+     * <p>An unresolvable request is logged at WARNING with the cause of the exact-name attempt, so a
+     * Central outage ("connection refused") stays distinguishable from a name Central has no package
+     * under (404). Failures of shortened candidates are routine and logged at FINE only.
+     *
+     * <p>Stripping is not short-circuited on a transient failure because the two cases are not
+     * distinguishable here: the Central client answers both a 404 and an I/O error with the same
+     * exception type, only the message differs. So a dotted package name such as
+     * {@code health.fhir.r4.international401} that fails to resolve costs one lookup per dot-segment
+     * before giving up, each against a real package. The cost is bounded by the segment count, and each
+     * lookup consults the local repository before Central, so a locally cached package never reaches
+     * the network.
+     *
      * @param moduleName    the requested module name, e.g. {@code "aws.auth"}
      * @param pinnedVersion the pinned version, applied to whichever candidate resolves; may be null
      * @return the owning package and module, or empty when nothing resolves
      */
     private Optional<ResolvedModule> resolveModule(String org, String moduleName, String pinnedVersion) {
+        RuntimeException exactNameFailure = null;
         String candidate = moduleName;
         while (true) {
-            Optional<Package> optPackage = resolvePackageSafely(org, candidate, pinnedVersion);
+            Optional<Package> optPackage;
+            try {
+                optPackage = pinnedVersion == null || pinnedVersion.isBlank()
+                        ? PackageUtil.getModulePackage(PackageUtil.getSampleProject(), org, candidate)
+                        : PackageUtil.getModulePackage(PackageUtil.getSampleProject(), org, candidate, pinnedVersion);
+            } catch (RuntimeException e) {
+                // getModulePackage throws for a name Central has no package under (its latest-version
+                // lookup surfaces the 404); for a module-only name such as aws.auth that is expected.
+                LOGGER.log(Level.FINE, "Package resolution failed for " + org + "/" + candidate, e);
+                if (candidate.equals(moduleName)) {
+                    exactNameFailure = e;
+                }
+                optPackage = Optional.empty();
+            }
             if (optPackage.isPresent()) {
                 Package pkg = optPackage.get();
                 for (Module module : pkg.modules()) {
@@ -268,35 +309,20 @@ public class CopilotLibraryManager {
                         return Optional.of(new ResolvedModule(pkg, module));
                     }
                 }
-                // Defensive: a package's default module always shares its name, so for the exact-name
-                // candidate this preserves the previous behaviour. A shortened candidate that does not
-                // export the requested module yields empty instead of a wrong catalog.
-                return candidate.equals(moduleName)
-                        ? Optional.of(new ResolvedModule(pkg, pkg.getDefaultModule()))
-                        : Optional.empty();
+                // Only reachable for a shortened candidate: the default module always shares the
+                // package's name, so the exact-name candidate matched above. The owning package exists
+                // but does not export the requested module; empty beats a wrong catalog.
+                LOGGER.warning("Package " + org + "/" + candidate + " does not export a module named '"
+                        + moduleName + "'. Skipping.");
+                return Optional.empty();
             }
             int lastDot = candidate.lastIndexOf('.');
             if (lastDot < 0) {
+                LOGGER.log(Level.WARNING, "No package resolvable for '" + org + "/" + moduleName + "'. Skipping.",
+                        exactNameFailure);
                 return Optional.empty();
             }
             candidate = candidate.substring(0, lastDot);
-        }
-    }
-
-    /**
-     * One package-resolution attempt that reports failure as empty instead of throwing:
-     * {@code getModulePackage} throws for a name Central has no package under (its latest-version
-     * lookup surfaces the 404), and for a non-final {@link #resolveModule} candidate — a module-only
-     * name such as {@code aws.auth} — that is a routine outcome, not an error.
-     */
-    private static Optional<Package> resolvePackageSafely(String org, String name, String pinnedVersion) {
-        try {
-            return pinnedVersion == null || pinnedVersion.isBlank()
-                    ? PackageUtil.getModulePackage(PackageUtil.getSampleProject(), org, name)
-                    : PackageUtil.getModulePackage(PackageUtil.getSampleProject(), org, name, pinnedVersion);
-        } catch (RuntimeException e) {
-            LOGGER.log(Level.FINE, "Package resolution failed for " + org + "/" + name, e);
-            return Optional.empty();
         }
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/CopilotLibraryFilterTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/CopilotLibraryFilterTest.java
@@ -124,6 +124,70 @@ public class CopilotLibraryFilterTest extends AbstractLSTest {
                 "trigger.salesforce should be excluded and return empty libraries");
     }
 
+    /**
+     * One unresolvable library must never cost the caller the rest of the batch.
+     *
+     * <p>{@code ballerinax/aws.auth} is the real-world shape this pins: a <b>module</b> of
+     * {@code ballerinax/aws}, not a package. Resolving it as a package used to <b>throw</b> (Central
+     * answers the latest-version lookup with a 404), and the exception unwound through the JSON-RPC
+     * boundary, discarding every sibling library in the request — the already-built {@code aws.sns}
+     * catalog was lost to its own dependency's coordinate. Resolution failures are now contained in
+     * {@code CopilotLibraryManager.resolvePackageSafely}, and an unresolvable entry is skipped.
+     */
+    @Test
+    public void testUnresolvableLibraryDoesNotAbortBatch() throws IOException {
+        GetSelectedLibrariesRequest request = new GetSelectedLibrariesRequest(
+                new String[]{"ballerinax/no.such.package", "ballerinax/salesforce"});
+        JsonObject response = getResponse(request);
+        JsonArray libraries = response.getAsJsonArray("libraries");
+
+        Assert.assertNotNull(libraries, "Libraries array should not be null");
+        Assert.assertEquals(libraries.size(), 1,
+                "the unresolvable entry should be skipped and the resolvable one still served");
+        JsonObject salesforce = libraries.get(0).getAsJsonObject();
+        Assert.assertEquals(salesforce.get("name").getAsString(), "ballerinax/salesforce");
+        // The surviving library must be the full catalog, not a stub built before the sibling failed.
+        assertHasNonEmptyArray(salesforce, "clients");
+        assertHasNonEmptyArray(salesforce, "typeDefs");
+    }
+
+    /**
+     * An {@code org/module} request whose module is <b>not</b> a package's default module must resolve
+     * through the owning package and serve <i>that module's</i> catalog.
+     *
+     * <p>{@code ballerinax/salesforce.types} is a module of {@code ballerinax/salesforce} and no package
+     * of its own (Central answers 404 for it) — the same shape as {@code ballerinax/aws.auth}, the
+     * coordinate every cross-package type link carries. Three things are pinned:
+     * <ul>
+     *   <li>the owning package is found by stripping dot-segments off the requested name;</li>
+     *   <li>the response identity stays the <b>requested</b> string — it is the import path the renderer
+     *       emits and the source of the {@code types:} prefix — never the owning package's name;</li>
+     *   <li>the catalog is the requested <b>module's</b> (its typeDefs and its own module README), not
+     *       the owning package's default module's.</li>
+     * </ul>
+     */
+    @Test
+    public void testSubmoduleLibraryResolvedThroughOwningPackage() throws IOException {
+        GetSelectedLibrariesRequest request = new GetSelectedLibrariesRequest(
+                new String[]{"ballerinax/salesforce.types"});
+        JsonObject response = getResponse(request);
+        JsonArray libraries = response.getAsJsonArray("libraries");
+
+        Assert.assertNotNull(libraries, "Libraries array should not be null");
+        Assert.assertEquals(libraries.size(), 1, "the submodule request should resolve to one library");
+
+        JsonObject lib = libraries.get(0).getAsJsonObject();
+        Assert.assertEquals(lib.get("name").getAsString(), "ballerinax/salesforce.types",
+                "the response identity must be the requested org/module path, not the owning package");
+        // salesforce.types is a generated type catalog: its whole surface is type definitions.
+        assertHasNonEmptyArray(lib, "typeDefs");
+        // The module's own document, not the whole owning package's (which describes every module).
+        Assert.assertTrue(lib.has("readme"),
+                "ballerinax is doc-whitelisted, so the module README should be attached");
+        Assert.assertFalse(lib.get("readme").getAsString().isEmpty(),
+                "the salesforce.types module README should not be empty");
+    }
+
     @Test
     public void testDocumentationIncludedForWhitelistedOrgs() throws IOException {
         // Documentation is whitelisted per organization (CopilotLibraryManager.DOC_WHITELIST_ORGS),

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/CopilotLibraryFilterTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/CopilotLibraryFilterTest.java
@@ -131,8 +131,9 @@ public class CopilotLibraryFilterTest extends AbstractLSTest {
      * {@code ballerinax/aws}, not a package. Resolving it as a package used to <b>throw</b> (Central
      * answers the latest-version lookup with a 404), and the exception unwound through the JSON-RPC
      * boundary, discarding every sibling library in the request — the already-built {@code aws.sns}
-     * catalog was lost to its own dependency's coordinate. Resolution failures are now contained in
-     * {@code CopilotLibraryManager.resolvePackageSafely}, and an unresolvable entry is skipped.
+     * catalog was lost to its own dependency's coordinate. {@code CopilotLibraryManager.loadFilteredLibraries}
+     * now contains every failure per library — resolution as well as compilation and symbol processing —
+     * and skips the failing entry.
      */
     @Test
     public void testUnresolvableLibraryDoesNotAbortBatch() throws IOException {


### PR DESCRIPTION
Fix the module imports of WI Intelligence for the package's modules

Fixes https://github.com/wso2/product-integrator/issues/2279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed library resolution for `ballerinax/aws` submodules, including `ballerinax/aws.sns`.
- Prevented failed library requests from stopping other libraries from loading.
- Preserved requested module identity and returned module-specific catalog data and documentation.
- Added regression tests for unresolved libraries and submodule resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->