### PR TITLE
Fix the icon codepoints that drifted from the generated font

### DIFF
--- a/packages/ballerina-extension/package.json
+++ b/packages/ballerina-extension/package.json
@@ -1290,14 +1290,14 @@
         ],
         "icons": {
             "bi-ai-agent": {
-                "description": "ai-agent",
+                "description": "bi-ai-agent",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
                     "fontCharacter": "\\f112"
                 }
             },
             "bi-ai-chat": {
-                "description": "ai-chat",
+                "description": "bi-ai-chat",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
                     "fontCharacter": "\\f113"
@@ -1349,14 +1349,14 @@
                 "description": "start",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f24a"
+                    "fontCharacter": "\\f255"
                 }
             },
             "ballerina-debug": {
                 "description": "debug",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1c1"
+                    "fontCharacter": "\\f1cb"
                 }
             },
             "ballerina-source-view": {
@@ -1370,7 +1370,7 @@
                 "description": "persist-diagram",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f220"
+                    "fontCharacter": "\\f22b"
                 }
             },
             "ballerina-cached-rounded": {
@@ -1384,42 +1384,42 @@
                 "description": "cached-round",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f107"
+                    "fontCharacter": "\\f1a9"
                 }
             },
             "ballerina-fit-to-screen": {
                 "description": "fit-to-screen",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f120"
+                    "fontCharacter": "\\f1ed"
                 }
             },
             "ballerina-explicit-outlined": {
                 "description": "explicit-outlined",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f11f"
+                    "fontCharacter": "\\f1e5"
                 }
             },
             "ballerina-error-icon": {
                 "description": "error-icon",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f11c"
+                    "fontCharacter": "\\f1df"
                 }
             },
             "ballerina-error-outline": {
                 "description": "error-outline",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f11d"
+                    "fontCharacter": "\\f1e1"
                 }
             },
             "ballerina-symbol-struct-icon": {
                 "description": "symbol-struct-icon",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f13d"
+                    "fontCharacter": "\\f259"
                 }
             },
             "ballerina-add-circle-outline": {
@@ -1433,21 +1433,21 @@
                 "description": "radio-button-checked",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f134"
+                    "fontCharacter": "\\f23a"
                 }
             },
             "ballerina-radio-button-unchecked": {
                 "description": "radio-button-unchecked",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f135"
+                    "fontCharacter": "\\f23b"
                 }
             },
             "ballerina-file-upload": {
                 "description": "file-upload",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f11f"
+                    "fontCharacter": "\\f1ea"
                 }
             },
             "ballerina-file-submodule": {
@@ -1468,7 +1468,7 @@
                 "description": "design-view",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1c6"
+                    "fontCharacter": "\\f1d0"
                 }
             },
             "distro-file-submodule": {

--- a/packages/ballerina-extension/src/test-support/iconCodepoints.test.ts
+++ b/packages/ballerina-extension/src/test-support/iconCodepoints.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Catches drift between the hardcoded codepoints in contributes.icons and the font the VSIX
+ * actually ships. fantasticon assigns codepoints sequentially over the SVGs in the font
+ * package's icons directory, so adding one icon upstream shifts the codepoint of every icon
+ * after it. The font is rebuilt from the wso2-vscode-extensions submodule on every build while
+ * the table in package.json is maintained by hand, so the two drifted and $(ballerina-debug)
+ * ended up rendering custom.svg — a blob that reads as a chat icon (wso2/product-integrator#2288).
+ *
+ * Nothing else notices: a shifted codepoint is still a valid glyph, so the icon renders, just
+ * the wrong one. Only a human looking at the toolbar catches it, which is how it shipped.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const WSO2_FONT = 'wso2-vscode.woff';
+const extensionRoot = path.resolve(__dirname, '..', '..');
+
+// Prefer the copy copyFonts stages into resources/ — that is the one the VSIX ships and the one
+// fontPath resolves against, so it also catches a stale staged copy. Fall back to the dependency's
+// own dist so the test still runs on a tree that has been installed but not packaged.
+const fontMapPath = [
+    path.join(extensionRoot, 'resources', 'font-wso2-vscode', 'dist', 'wso2-vscode.json'),
+    path.join(extensionRoot, 'node_modules', '@wso2', 'font-wso2-vscode', 'dist', 'wso2-vscode.json'),
+].find((candidate) => fs.existsSync(candidate));
+
+if (!fontMapPath) {
+    throw new Error(
+        'wso2-vscode.json not found in resources/font-wso2-vscode/dist or in the ' +
+            '@wso2/font-wso2-vscode dependency. The font is generated from the ' +
+            'wso2-vscode-extensions submodule, so build it first (rush build --to ballerina) or ' +
+            'run pnpm run copyFonts.'
+    );
+}
+
+interface IconContribution {
+    description: string;
+    default: { fontPath: string; fontCharacter: string };
+}
+
+// fantasticon keys this map by the source SVG's basename, and contributes.icons carries that
+// basename in 'description'. That is the only link between an icon id and a glyph, so keep
+// 'description' equal to the SVG name rather than making it a human-readable blurb.
+const fontMap: Record<string, number> = JSON.parse(fs.readFileSync(fontMapPath, 'utf-8'));
+const glyphAt = new Map(Object.entries(fontMap).map(([name, codepoint]): [number, string] => [codepoint, name]));
+
+const packageJson = JSON.parse(fs.readFileSync(path.join(extensionRoot, 'package.json'), 'utf-8'));
+const wso2Icons: [string, IconContribution][] = Object.entries(
+    packageJson.contributes.icons as Record<string, IconContribution>
+).filter(([, icon]) => icon.default.fontPath.endsWith(WSO2_FONT));
+
+// Icons whose SVG was renamed or dropped upstream, leaving the entry pointing at nothing. Nothing
+// references any of them via $(id) today, so they render nowhere; they are kept for a follow-up
+// that repoints or removes them. Anything new landing in this list is a regression — either a
+// description that stopped matching its SVG, or an icon that upstream took away while we use it.
+const KNOWN_STALE = [
+    'ballerina-agent-view',
+    'ballerina-cached-rounded',
+    'ballerina-delete',
+    'ballerina-new-module',
+    'ballerina-source-view',
+];
+
+describe('contributes.icons', () => {
+    it('uses the codepoint the shipped font assigns to each icon', () => {
+        const drifted = wso2Icons
+            .filter(([, icon]) => fontMap[icon.description] !== undefined)
+            .map(([id, icon]) => {
+                const expected = `\\${fontMap[icon.description].toString(16)}`;
+                if (icon.default.fontCharacter === expected) {
+                    return undefined;
+                }
+                const declared = parseInt(icon.default.fontCharacter.replace('\\', ''), 16);
+                const rendersAs = glyphAt.get(declared) ?? 'nothing';
+                return `${id} declares ${icon.default.fontCharacter} (renders ${rendersAs}), font puts '${icon.description}' at ${expected}`;
+            })
+            .filter((message): message is string => message !== undefined);
+
+        expect(drifted).toEqual([]);
+    });
+
+    it('names no icon the font has dropped, beyond the entries already known to be stale', () => {
+        const unresolvable = wso2Icons
+            .filter(([, icon]) => fontMap[icon.description] === undefined)
+            .map(([id, icon]) => `${id} (looked up '${icon.description}')`);
+
+        expect(unresolvable.sort()).toEqual(
+            KNOWN_STALE.map((id) => `${id} (looked up '${packageJson.contributes.icons[id].description}')`).sort()
+        );
+    });
+});


### PR DESCRIPTION
## Purpose
Resolves wso2/product-integrator#2288 — the Debug icon in the editor title bar renders a blob that reads as a chat icon.

**Why it drifted.** fantasticon assigns codepoints sequentially over the SVGs in `submodules/wso2-vscode-extensions/workspaces/common-libs/font-wso2-vscode/src/icons`, so adding one icon upstream shifts the codepoint of every icon after it. `copyFonts` rebuilds that font from the submodule on every build, while the codepoint table in `contributes.icons` was last hand-synced in 636d0319f0 (2026-03-04) and the submodule pin has moved repeatedly since.

The generator that used to keep them in sync, `font-wso2-vscode/src/plugin-icons/configurePlugins.js`, writes to `workspaces/ballerina/ballerina-extension/package.json` *inside* the vscode-extensions repo — a path that stopped existing when the extension moved to this repo. It says so on every font build, and nobody was reading it:

```
Icon not found in wso2-vscode font: delete
package.json not found at .../workspaces/ballerina/ballerina-extension/package.json. Skipping icon contribution update.
```

Choreo still lives in that repo, so the same build silently repairs *its* codepoint (`choreo-2`: `\f1ab` → `\f1b3`) while ours goes unpatched. That contrast is the whole bug.

## Goals
- Every icon in `contributes.icons` points at the glyph it names.
- A future upstream shift fails a test instead of shipping.

## Approach

**`Fix the contributes.icons codepoints that drifted from the font`** — 13 corrected `fontCharacter` values, taken from `dist/wso2-vscode.json` produced by `rush build --to @wso2/font-wso2-vscode`. Three of the 13 are actually referenced via `$(id)` and were visibly wrong:

| icon | declared | rendered | corrected |
|---|---|---|---|
| `ballerina-debug` (1 use) | `\f1c1` | `custom` | `\f1cb` |
| `ballerina-design-view` (4 uses) | `\f1c6` | `database-round` | `\f1d0` |
| `ballerina-persist-diagram` (1 use) | `\f220` | `nested` | `\f22b` |

The other 10 are unreferenced today and were corrected in the same pass so they are right whenever someone starts using them.

Also renames two `description` values — `ai-agent` → `bi-ai-agent`, `ai-chat` → `bi-ai-chat`. Those SVGs were renamed upstream. `description` carries the source SVG's basename and is the only link between an icon id and a glyph, so a description that no longer matches an SVG cannot be checked at all. Their codepoints were already correct; nothing renders differently.

**`Test contributes.icons against the generated font`** — `src/test-support/iconCodepoints.test.ts`, two assertions over the 21 wso2-font entries:

1. Every entry resolvable in the font uses the codepoint the font assigns it. A failure names the glyph you are getting: `ballerina-debug declares \f1c1 (renders custom), font puts 'debug' at \f1cb`.
2. No entry names an icon the font has dropped, beyond a `KNOWN_STALE` list — asserted by equality, so the list cannot grow silently.

It reads `resources/font-wso2-vscode/dist/wso2-vscode.json` — the copy `copyFonts` stages, which is what the VSIX ships and what `fontPath` resolves against, so a stale staged copy is caught too — and falls back to the dependency's own `dist`. The fallback is load-bearing rather than defensive: `resources/font-wso2-vscode` is not in `outputFolderNames` in `rush-config.json`, so on a build-cache hit for `ballerina-extension` the staged copy is not restored, whereas the font package's `dist` **is** a declared cache output and is always present after `rush install` + build.

### Deliberately not in this PR
Five entries name SVGs that no longer exist in the font at all (`ballerina-new-module`, `-delete`, `-agent-view`, `-source-view`, `-cached-rounded`). `git grep` finds them only in this icons block — nothing references any of them, so they render nowhere. They are listed as `KNOWN_STALE` and left for a follow-up that repoints or removes them, to keep this PR to the fix.

An earlier revision of this branch added a build step that rewrote `contributes.icons` from the font during `postbuild`. It was dropped: it mutates a git-tracked file mid-build, `package.json` is a rush build-cache input, and self-healing would have kept the wrong values committed forever while hiding the defect. A test asserts the same thing without any of that.

## UI Component Development
N/A — no UI components. The change is an icon codepoint table in `package.json`.

## User stories
As a developer, the Debug button in the editor title bar shows a bug rather than a shape that reads as a chat icon.

## Release note
Fixed the Debug, design-view and persist-diagram icons rendering the wrong glyph in the editor title bar.

## Documentation
N/A — no user-facing behaviour or configuration change.

## Training
N/A

## Certification
N/A — an icon codepoint fix has no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests
  > `src/test-support/iconCodepoints.test.ts` is added by this PR; it is picked up by the existing `packages/*/jest.config.js` sweep in the `fast-tests` job. No coverage change to product code — none was touched.
- Integration tests
  > N/A — no runtime code path changed.

Verified locally with `rush install` + `rush build --to @wso2/font-wso2-vscode`, then jest:

- On this branch: `Tests: 2 passed`.
- Against `HEAD`'s `package.json`: both assertions fail, listing all 13 drifted entries including `ballerina-debug declares \f1c1 (renders custom), font puts 'debug' at \f1cb`, plus the two renamed descriptions.
- Simulating an upstream insert (shifting every codepoint ≥ `\f1a0` by one): assertion 1 fails.
- Rewriting a `description` as a human blurb: assertion 2 fails and names it, so the one fragile assumption in the test is itself enforced.
- With `resources/font-wso2-vscode/dist` moved aside: still passes, off the dependency's `dist` — the build-cache-hit path.

The staged font map was diffed against the one `rush build` produces: identical, so every corrected codepoint comes from a genuine build output.

Full `jest` run in `packages/ballerina-extension`: 78 passed with this branch, 76 passed at `HEAD`. Seven suites fail to *run* in both, with `Cannot find module '@wso2/ballerina-core'` / `'@wso2/copilot-utilities/chat-persistence'` — pre-existing and environmental, from only having built the font package rather than the full workspace; `fast-tests` restores a complete build first.

Not verified: I did not launch VS Code, so there is no after-screenshot. The confirmation is that the corrected codepoints match fantasticon's own emitted `wso2-vscode.css` (`.fw-debug::before { content: "\f1cb" }`, `.fw-custom::before { content: "\f1c1" }`).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None yet. Two follow-ups are worth filing:
- **wso2/vscode-extensions** — pass a frozen `codepoints` map to `generateFonts` in `font-wso2-vscode/src/generate-font/generate-font.js`. fantasticon 3.0.0 supports it (`lib/utils/codepoints.js`: predefined names keep their codepoint, new names fill the gaps), so adding an SVG would stop shifting existing icons for every consumer. That is the actual defect; this PR compensates for it. Note choreo's *committed* `\f1ab` is stale too — the generator just papers over it at build time.
- This repo — repoint or remove the five `KNOWN_STALE` entries.

## Migrations (if applicable)
None.

## Test environment
macOS 15 (darwin 25.5.0), Node 22.16.0, pnpm 10.11.0, rush install + `rush build --to @wso2/font-wso2-vscode`, submodule at 09b37c8.

## Learning
The 21 wso2-font entries split three ways, and only the middle group was ever going to be noticed: 3 referenced and wrong (reported), 10 unreferenced and wrong (latent), 5 naming SVGs the font no longer has (dead). A shifted codepoint is still a valid glyph, so the icon renders — just the wrong one. Nothing in the build, the type system or the extension host can tell. Only a human looking at the toolbar catches it, which is how it shipped, and why the check belongs in CI rather than in a reviewer's eye.

`bi-ai-agent` and `bi-ai-chat` were correct throughout, by luck — their codepoints happened not to move — which is why the chat-bot icon sitting next to the broken Debug icon in the issue screenshot looks fine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Corrected 13 drifted `fontCharacter` values in `contributes.icons`.
- Updated two icon descriptions to match upstream SVG filenames.
- Added tests that compare icon contributions with staged and dependency font maps.
- Added checks for missing icons, with an explicit `KNOWN_STALE` list.
- Fixed the Debug icon so it renders the intended glyph.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->