### PR TITLE
Fix overlay z-index collisions in modals with a shared allocator

### DIFF
--- a/packages/ballerina-side-panel/src/components/editors/ExpandedEditor/ExpandedEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/ExpandedEditor/ExpandedEditor.tsx
@@ -72,7 +72,7 @@ const ModalContainer = styled.div`
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 2100;
+    z-index: 2200;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/packages/ballerina-visualizer/src/Context.tsx
+++ b/packages/ballerina-visualizer/src/Context.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { ReactNode, useRef, useState, createContext, useContext } from "react";
+import React, { ReactNode, useRef, useState, useLayoutEffect, createContext, useContext } from "react";
 import { BallerinaRpcClient, VisualizerContext as RpcContext, Context } from "@wso2/ballerina-rpc-client";
 import { NodePosition, STNode } from "@wso2/syntax-tree";
 import { ConnectorInfo, TriggerModelsResponse } from "@wso2/ballerina-core";
@@ -187,3 +187,43 @@ export const ModalStackProvider = ({children}: {children: ReactNode}) => {
 }
 
 export const useModalStack = () => useContext(ModalStackContext);
+
+export const InsideModalContext = createContext(false);
+
+export const useInsideModal = () => useContext(InsideModalContext);
+
+// Shared allocator so a newly-opened overlay always renders above what's already open; resets to base once everything closes so it stays under ExpandedEditor's fixed fallback (used by callers outside this package that can't reach this hook).
+export const OVERLAY_ZINDEX_BASE = 2100;
+
+let overlayOpenCount = 0;
+let nextOverlayZIndex = OVERLAY_ZINDEX_BASE;
+
+function acquireOverlayZIndex(slots: number): number {
+    if (overlayOpenCount === 0) {
+        nextOverlayZIndex = OVERLAY_ZINDEX_BASE;
+    }
+    overlayOpenCount += 1;
+    const zIndex = nextOverlayZIndex;
+    nextOverlayZIndex += slots;
+    return zIndex;
+}
+
+function releaseOverlayZIndex(): void {
+    overlayOpenCount = Math.max(0, overlayOpenCount - 1);
+}
+
+// `slots` > 1 reserves consecutive values for an overlay that stacks its own backdrop + box locally.
+export function useOverlayZIndex(isOpen: boolean = true, slots: number = 1): number | undefined {
+    const [zIndex, setZIndex] = useState<number>();
+
+    useLayoutEffect(() => {
+        if (!isOpen) {
+            setZIndex(undefined);
+            return;
+        }
+        setZIndex(acquireOverlayZIndex(slots));
+        return () => releaseOverlayZIndex();
+    }, [isOpen]);
+
+    return zIndex;
+}

--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/useCreateNode.tsx
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/useCreateNode.tsx
@@ -21,7 +21,7 @@ import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { CodeData, FlowNode, isAgentDeclarationNode, LineRange } from "@wso2/ballerina-core";
 import { PanelOverlayContext } from "../../views/BI/FlowDiagram/context/PanelOverlayContext";
 import { getNodeTemplateForConnection } from "../../views/BI/FlowDiagram/utils";
-import { useModalStack } from "../../Context";
+import { InsideModalContext, useModalStack } from "../../Context";
 
 const CreateMemoryForm = lazy(() => import("../../views/BI/AIChatAgent/AddAgentPopup/CreateMemoryForm"));
 const CreateAgentForm = lazy(() => import("../../views/BI/AIChatAgent/AddAgentPopup/CreateAgentForm"));
@@ -46,7 +46,8 @@ export function useCreateNode(
 ) {
     const { rpcClient } = useRpcContext();
     const panelOverlayContext = useContext(PanelOverlayContext);
-    const panelOverlay = options?.preferModal ? undefined : panelOverlayContext;
+    const insideModal = useContext(InsideModalContext);
+    const panelOverlay = (options?.preferModal || insideModal) ? undefined : panelOverlayContext;
     const { addModal, closeModal } = useModalStack();
 
     const handleCreated = (variableName: string, onCreated: (variableName: string) => void) => {

--- a/packages/ballerina-visualizer/src/components/Modal/index.tsx
+++ b/packages/ballerina-visualizer/src/components/Modal/index.tsx
@@ -20,7 +20,7 @@ import React, { cloneElement, isValidElement, ReactNode, ReactElement, useEffect
 import { createPortal } from "react-dom";
 import styled from "@emotion/styled";
 import { Icon, Divider, ThemeColors, Typography, Tooltip, Button } from "@wso2/ui-toolkit";
-import { useVisualizerContext } from "../../Context";
+import { InsideModalContext, OVERLAY_ZINDEX_BASE, useOverlayZIndex, useVisualizerContext } from "../../Context";
 
 export type DynamicModalProps = {
     children: ReactNode;
@@ -42,7 +42,6 @@ const ModalContainer = styled.div<{ sx?: any }>`
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 2100;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -110,6 +109,7 @@ const DynamicModal: React.FC<DynamicModalProps> & { Trigger: typeof Trigger } = 
     closeButtonIcon = "close",
 }) => {
     const { setShowOverlay } = useVisualizerContext();
+    const zIndex = useOverlayZIndex(openState);
     let trigger: ReactElement | null = null;
     const content: ReactNode[] = [];
 
@@ -158,10 +158,11 @@ const DynamicModal: React.FC<DynamicModalProps> & { Trigger: typeof Trigger } = 
         <>
             {trigger}
             {openState && targetEl && createPortal(
-                <ModalContainer 
-                    ref={anchorRef} 
-                    className="unq-modal-overlay" 
+                <ModalContainer
+                    ref={anchorRef}
+                    className="unq-modal-overlay"
                     sx={sx}
+                    style={{ zIndex: zIndex ?? OVERLAY_ZINDEX_BASE }}
                     onClick={handleBackdropClick}
                 >
                     <ModalBox width={width} height={height}>
@@ -176,7 +177,9 @@ const DynamicModal: React.FC<DynamicModalProps> & { Trigger: typeof Trigger } = 
                             </Tooltip>
                         </ModalHeaderSection>
                         <Divider />
-                        {content}
+                        <InsideModalContext.Provider value={true}>
+                            {content}
+                        </InsideModalContext.Provider>
                     </ModalBox>
                 </ModalContainer>,
                 targetEl

--- a/packages/ballerina-visualizer/src/components/Popup/Form/index.tsx
+++ b/packages/ballerina-visualizer/src/components/Popup/Form/index.tsx
@@ -26,7 +26,6 @@ const PopupFormContainer = styled.div`
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 2100;
     background-color: color-mix(in srgb, ${ThemeColors.SECONDARY_CONTAINER} 70%, transparent);
     display: flex;
     justify-content: center;
@@ -46,7 +45,6 @@ const PopupFormBox = styled.div<{ width?: number; height?: number }>`
   border-radius: 10px;
   background-color: ${ThemeColors.SURFACE_DIM};
   box-shadow: 0 3px 8px rgb(0 0 0 / 0.2);
-  z-index: 2100;
 `;
 
 const PopupFormHeader = styled.header`
@@ -64,6 +62,7 @@ export type PopupFormProps = {
     title: string;
     children: React.ReactNode;
     onClose?: () => void;
+    zIndex?: number;
 };
 
 
@@ -77,11 +76,11 @@ const PopupFormContent = styled.div`
 
 
 export const PopupForm = (props: PopupFormProps) => {
-    const { width, height, title, children, onClose } = props;
+    const { width, height, title, children, onClose, zIndex } = props;
 
     return (
-        <PopupFormContainer>
-            <PopupFormBox width={width} height={height}>
+        <PopupFormContainer style={{ zIndex }}>
+            <PopupFormBox width={width} height={height} style={{ zIndex }}>
                 <PopupFormHeader>
                     <Typography
                         variant="h2"

--- a/packages/ballerina-visualizer/src/components/Popup/index.tsx
+++ b/packages/ballerina-visualizer/src/components/Popup/index.tsx
@@ -19,6 +19,7 @@
 import React, { ReactNode } from "react";
 import styled from "@emotion/styled";
 import { PopupForm } from "./Form";
+import { InsideModalContext, OVERLAY_ZINDEX_BASE, useOverlayZIndex } from "../../Context";
 
 export type PopupProps = {
     children: ReactNode;
@@ -34,7 +35,6 @@ const PopupContentContainer = styled.div`
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 2100;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -49,12 +49,14 @@ const Popup: React.FC<PopupProps> = ({
     height,
     title
 }) => {
-
+    const zIndex = useOverlayZIndex() ?? OVERLAY_ZINDEX_BASE;
 
     return (
-        <PopupContentContainer>
-            <PopupForm onClose={onClose} height={height} width={width} title={title}>
-                {children}
+        <PopupContentContainer style={{ zIndex }}>
+            <PopupForm onClose={onClose} height={height} width={width} title={title} zIndex={zIndex}>
+                <InsideModalContext.Provider value={true}>
+                    {children}
+                </InsideModalContext.Provider>
             </PopupForm>
         </PopupContentContainer>
     );

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
@@ -85,6 +85,7 @@ import {
     suggestToolName,
 } from "./toolForm";
 import { useCreateNode } from "../../../components/ConnectionSelector/useCreateNode";
+import { OVERLAY_ZINDEX_BASE, useOverlayZIndex } from "../../../Context";
 import { ConnectorIcon } from "@wso2/bi-diagram";
 import {
     BackButton,
@@ -1463,6 +1464,7 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
         sidePanelView === SidePanelView.CONNECTOR_SELECT ||
         sidePanelView === SidePanelView.DEPENDENCY_FORM ||
         sidePanelView === SidePanelView.CONNECTION_CONFIG;
+    const connectionPopupZIndex = useOverlayZIndex(isConnectionPopupOpen, 2) ?? OVERLAY_ZINDEX_BASE;
     const displayedCategories = dependencyMode && !categories.some((category) => category.title === "Connections")
         ? [{
             title: "Connections",
@@ -1526,12 +1528,12 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
                         sx={{
                             background: ThemeColors.SURFACE_CONTAINER,
                             opacity: 0.5,
-                            zIndex: 2050,
+                            zIndex: connectionPopupZIndex,
                         }}
                     />
                     <AgentConnectionPopupContainer
                         $compact={sidePanelView === SidePanelView.CONNECTION_METHOD}
-                        style={{ zIndex: 2051 }}
+                        style={{ zIndex: connectionPopupZIndex + 1 }}
                     >
                         <ConnectionModalStep
                             key={sidePanelView}

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AddAgentPopup/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AddAgentPopup/index.tsx
@@ -30,6 +30,7 @@ import {
     PopupTitle,
 } from "../../Connection/styles";
 import { AddAgentPopupContent, AddAgentView } from "./AddAgentPopupContent";
+import { InsideModalContext, OVERLAY_ZINDEX_BASE, useOverlayZIndex } from "../../../../Context";
 
 const AgentModalStep = styled.div<{ $direction: "forward" | "backward" }>`
     display: flex;
@@ -102,6 +103,8 @@ export function AddAgentPopup(props: AddAgentPopupProps) {
     const isDependencyToolForm = Boolean(dependencyToolForm);
     const isForm = isDependencyToolForm || view === "configure" || view === "create" || view === "createDefinition";
 
+    const zIndex = useOverlayZIndex(true, 2) ?? OVERLAY_ZINDEX_BASE;
+
     const changeView = (nextView: AddAgentView, direction: "forward" | "backward" = "forward") => {
         setTransitionDirection(direction);
         setView(nextView);
@@ -116,9 +119,9 @@ export function AddAgentPopup(props: AddAgentPopupProps) {
     };
 
     return (
-        <>
-            <PopupOverlay sx={{ background: `${ThemeColors.SURFACE_CONTAINER}`, opacity: `0.5`, zIndex: 2050 }} />
-            <PopupContainer style={{ zIndex: 2051 }}>
+        <InsideModalContext.Provider value={true}>
+            <PopupOverlay sx={{ background: `${ThemeColors.SURFACE_CONTAINER}`, opacity: `0.5`, zIndex }} />
+            <PopupContainer style={{ zIndex: zIndex + 1 }}>
                 <AgentModalStep key={isDependencyToolForm ? "agent-tool-form" : view} $direction={transitionDirection}>
                     <PopupHeader>
                         {isForm && (
@@ -160,7 +163,7 @@ export function AddAgentPopup(props: AddAgentPopupProps) {
                     )}
                 </AgentModalStep>
             </PopupContainer>
-        </>
+        </InsideModalContext.Provider>
     );
 }
 

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentTool.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/UseAgentTool.tsx
@@ -25,6 +25,7 @@ import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Category as PanelCategory, Node as PanelNode, NodeList } from "@wso2/ballerina-side-panel";
 import { RelativeLoader } from "../../../components/RelativeLoader";
 import AddAgentPopup from "./AddAgentPopup";
+import { OVERLAY_ZINDEX_BASE, useOverlayZIndex } from "../../../Context";
 
 const LoaderContainer = styled.div`
     display: flex;
@@ -35,7 +36,6 @@ const LoaderContainer = styled.div`
 
 const PopupLayer = styled.div`
     position: relative;
-    z-index: 2100;
 `;
 
 interface UseAgentToolProps {
@@ -70,6 +70,7 @@ export function UseAgentTool(props: UseAgentToolProps): JSX.Element {
     const [agentNames, setAgentNames] = useState<string[]>([]);
     const [projectPath, setProjectPath] = useState<string>("");
     const [showAddAgentPopup, setShowAddAgentPopup] = useState<boolean>(false);
+    const addAgentPopupZIndex = useOverlayZIndex(showAddAgentPopup);
 
     const hostAgentVar = String(agentNode?.properties?.variable?.value ?? "");
 
@@ -133,7 +134,7 @@ export function UseAgentTool(props: UseAgentToolProps): JSX.Element {
                 searchPlaceholder={"Search agents"}
             />
             {showAddAgentPopup && createPortal(
-                <PopupLayer>
+                <PopupLayer style={{ zIndex: addAgentPopupZIndex ?? OVERLAY_ZINDEX_BASE }}>
                     <AddAgentPopup
                         isPopup
                         inFlow

--- a/packages/ballerina-visualizer/src/views/BI/Connection/ConnectionConfigurationPopup/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/ConnectionConfigurationPopup/index.tsx
@@ -220,15 +220,16 @@ export interface ConnectionConfigurationPopupProps {
     filteredCategories?: Category[];
     customValidator?: (fieldKey: string, value: any, allValues: FormValues) => string | undefined;
     overrideFlowNode?: (node: FlowNode) => FlowNode;
+    zIndex?: number;
 }
 
 export function ConnectionConfigurationPopup(props: ConnectionConfigurationPopupProps) {
-    const { selectedConnector, onClose, onBack } = props;
+    const { selectedConnector, onClose, onBack, zIndex } = props;
 
     return (
         <>
-            <PopupOverlay sx={{ background: `${ThemeColors.SURFACE_CONTAINER}`, opacity: `0.5` }} />
-            <PopupContainer>
+            <PopupOverlay sx={{ background: `${ThemeColors.SURFACE_CONTAINER}`, opacity: `0.5`, ...(zIndex ? { zIndex } : {}) }} />
+            <PopupContainer style={zIndex ? { zIndex: zIndex + 1 } : undefined}>
                 <ConfigHeader>
                     <BackButton appearance="icon" onClick={onBack}>
                         <Codicon name="chevron-left" />

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -89,6 +89,7 @@ import { requestMiniChatOpen } from "../../../components/AgentStatusOrb/shared";
 import { AgentEditorView, useAgentEditorController } from "../AIChatAgent/useAgentEditorController";
 import { CloudKnowledgeBasePage } from "../Connection/DevantConnections/CloudKnowledgeBasePage";
 import { prepareDevantKnowledgeBase } from "../Connection/DevantConnections/devant-kb-utils";
+import { OVERLAY_ZINDEX_BASE, useOverlayZIndex } from "../../../Context";
 
 const Container = styled.div`
     width: 100%;
@@ -97,7 +98,6 @@ const Container = styled.div`
 
 const AddAgentPopupLayer = styled.div`
     position: relative;
-    z-index: 2100;
 `;
 
 export interface BIFlowDiagramProps {
@@ -306,6 +306,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     const [targetLineRange, setTargetLineRange] = useState<LineRange>(targetRef?.current);
 
     const [showAddAgentPopup, setShowAddAgentPopup] = useState(false);
+    const addAgentPopupZIndex = useOverlayZIndex(showAddAgentPopup);
     const isCreatingNewModelProvider = useRef<boolean>(false);
     const isCreatingNewVectorStore = useRef<boolean>(false);
     const isCreatingNewEmbeddingProvider = useRef<boolean>(false);
@@ -4260,7 +4261,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             <PanelOverlayRenderer />
 
             {showAddAgentPopup && (
-                <AddAgentPopupLayer>
+                <AddAgentPopupLayer style={{ zIndex: addAgentPopupZIndex ?? OVERLAY_ZINDEX_BASE }}>
                     <AddAgentPopup
                         isPopup
                         inFlow

--- a/packages/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -123,7 +123,7 @@ import React from "react";
 import { SidePanelView } from "../../FlowDiagram/PanelManager";
 import { ConnectionKind, useCreateNode } from "../../../../components/ConnectionSelector";
 import { getFilteredTypesByKind } from "../../TypeEditor/utils";
-import { useModalStack } from "../../../../Context";
+import { useModalStack, useOverlayZIndex } from "../../../../Context";
 import { getArraySubFormFieldFromTypes, stringToRawArrayElements, stringToRawObjectEntries } from "@wso2/ballerina-side-panel/lib/components/editors/utils";
 
 interface FlowNodeTypeEditorState {
@@ -362,6 +362,7 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
         selectedConnector: AvailableNode;
         onSaved: (variableName: string) => void;
     } | null>(null);
+    const connectionPopupZIndex = useOverlayZIndex(!!pendingConnectionPopup, 2);
 
     const handleRequestCreateConnection = (params: {
         selectedConnector: AvailableNode;
@@ -2258,6 +2259,7 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
                     target={targetLineRange?.startLine}
                     onClose={handleCloseConnectionPopup}
                     onBack={() => setPendingConnectionPopup(null)}
+                    zIndex={connectionPopupZIndex}
                 />,
                 document.body
             )}


### PR DESCRIPTION
## Summary
- Replace the hardcoded z-index tiers scattered across `DynamicModal`, `Popup`, `AddAgentPopup`, `AIAgentSidePanel`'s connection popup, and `FlowNodeForm`'s inline connection popup with a single shared allocator (`useOverlayZIndex` in `Context.tsx`) that guarantees a newly-opened overlay always renders above whatever's already open.
- Generalize `useCreateNode`'s docked-panel-vs-popup decision to check for any ancestor modal (`InsideModalContext`) instead of only an explicit `preferModal` flag, so a "Create New X" dialog opened from inside a nested popup no longer inherits the ambient docked-panel behavior of whatever hosts it.

## Test plan
- [ ] Role/Instructions expand-icon prompt editor, opened from "Add Agent" via the docked Agents side panel and via "Use Agent Tool" — renders above the agent popup.
- [ ] "New Function" / "New Variable" / "New Configurable" opened from a nested Create Agent context — renders above the agent popup.
- [ ] "Create Agent" → tool-creation flow's "Add a Connection Parameter" / connection-select step — renders above `AddAgentPopup`.
- [ ] "Create Agent" → a field that creates a new connection inline (`ConnectionConfigurationPopup`) — renders above `AddAgentPopup`.