### PR TITLE
Add diagnostics hints and prompt updates for lock statements

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/concurrency-rules.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/concurrency-rules.ts
@@ -1,0 +1,24 @@
+/**
+ * System-prompt rules for writing concurrency-safe Ballerina code.
+ *
+ * These rules teach the agent to write code that satisfies the compiler's
+ * IsolationAnalyzer up front (isolated functions/variables/objects, lock
+ * statement restrictions, transfer in/out rules) so services are inferred
+ * `isolated` and dispatched concurrently, and so the agent avoids the most
+ * common isolation errors (BCE3943, BCE3956-BCE3964, BCE2080/BCE2081,
+ * BCE4042/BCE4043) instead of hitting them and repairing after the fact.
+ *
+ * Kept in its own module (no imports) so it can be unit-tested without loading
+ * the extension-host module graph. Interpolated into the system prompt by
+ * getSystemPrompt() in ./prompts.ts.
+ */
+export const CONCURRENCY_CODING_RULES = `## Concurrency Safety and Shared State
+Ballerina enforces isolation rules at compile time so services can safely handle requests concurrently. Follow these rules when the code involves module-level state, service fields, or workers:
+- \`configurable\` variables are implicitly final and safe to read from any isolated context — NEVER write \`final configurable\` (it is a compile error).
+- For other module-level variables: if the value is never mutated, declare it \`final\`; if it is also read from an \`isolated\` function or a service method, its type must ALSO be immutable — \`final\` alone is not sufficient (e.g. \`final int[] & readonly defaults = [1, 2];\`). If it is shared MUTABLE state, declare the variable \`isolated\` (e.g. \`isolated int[] requests = [];\`) and access it ONLY inside \`lock { }\` blocks. An \`isolated\` variable must be initialized at its declaration.
+- In a service or class holding mutable state, declare every mutable field \`private\`, initialize it with a fresh literal/constructor, and access it via \`self\` ONLY inside \`lock { }\` blocks. For requests to be dispatched concurrently, each resource/remote method must ALSO satisfy isolated-function rules itself: it may only call \`isolated\` functions and must not touch non-final module-level mutable state (use \`isolated\` variables with \`lock { }\` for that). The compiler then infers both the service and its methods as \`isolated\`.
+- One \`lock\` block may protect only ONE isolated root: never access two \`isolated\` variables (or an \`isolated\` variable plus \`self\`) in the same lock. Use separate lock statements and pass values between them via local variables. If two pieces of state must change together atomically, store them in ONE protected value (a single record/map behind one isolated variable).
+- In a lock that touches an isolated root (an \`isolated\` variable or \`self\` of an isolated object), a value crossing the lock boundary must not alias the protected state: when returning or assigning a value OUT of such a lock, or bringing an outside mutable value INTO it, use \`value.clone()\` (or \`value.cloneReadOnly()\`). Immutable (\`readonly\`) values may cross freely. An ordinary lock over non-isolated state has no such transfer restrictions — do not add gratuitous clones there.
+- Never use \`start\`, named \`worker\` declarations, or worker send/receive actions (\`->\`/\`<-\`) inside a \`lock\` block. Read the needed values into locals inside the lock, then do the async work after it.
+- Functions called from an \`isolated\` function, or from inside a lock protecting isolated state, must themselves be \`isolated\`. Write helper functions as \`isolated\` when they only work on their parameters and local state.
+- Keep lock blocks minimal: only the shared-state read/write belongs inside; perform I/O and remote calls outside the lock.`;

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -28,6 +28,7 @@ import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
 import { getRequirementAnalysisCodeGenPrefix, getRequirementAnalysisTestGenPrefix } from "./np/prompts";
+import { CONCURRENCY_CODING_RULES } from "./concurrency-rules";
 import { extractResourceDocumentContent, flattenProjectToFiles } from "../utils/ai-utils";
 import { BALLERINA_RUN_TOOL_NAME } from "./tools/ballerina-run";
 import { BALLERINA_STOP_TOOL_NAME } from "./tools/ballerina-stop";
@@ -216,6 +217,8 @@ When a connector authenticates via an OAuth2 refresh-token grant that includes a
 - Always use named arguments when providing values to any parameter (e.g., .get(key="value")).
 - Mention types EXPLICITLY in variable declarations and foreach statements. (Avoid var at all costs)
 - To narrow down a union type(or optional type), always declare a separate variable and then use that variable in the if condition.
+
+${CONCURRENCY_CODING_RULES}
 
 ## File modifications
 - You must apply changes to the existing source code using the provided ${[

--- a/packages/ballerina-extension/src/features/ai/agent/tools/diagnostic-hints.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/diagnostic-hints.ts
@@ -1,0 +1,297 @@
+import type { DiagnosticEntry, Diagnostics } from '@wso2/ballerina-core';
+import * as path from 'path';
+
+/**
+ * Diagnostic entry enriched with a resolving hint
+ */
+export interface EnrichedDiagnostic extends DiagnosticEntry {
+    hint?: string;
+}
+
+/**
+ * Service-concurrency hint codes (severity: Hint, not Error).
+ *
+ * These are emitted by the compiler's IsolationAnalyzer when a service's
+ * resource/remote methods cannot be dispatched concurrently because the
+ * service and/or the method could not be declared or inferred `isolated`.
+ * The code still compiles, so they must never be counted as compilation
+ * errors — they are surfaced separately as `concurrencyHints`.
+ */
+export const CONCURRENCY_HINT_CODES: ReadonlySet<string> = new Set([
+    "BCH2003", // concurrent calls will not be made to this method since the service and the method are not 'isolated'
+    "BCH2004", // concurrent calls will not be made to this method since the service is not an 'isolated' service
+    "BCH2005", // concurrent calls will not be made to this method since the method is not an 'isolated' method
+]);
+
+const SERVICE_ISOLATION_FIX =
+    "To enable concurrent dispatch, make the service isolated: (1) declare every mutable service field `private` " +
+    "and access it via `self` only inside `lock { }` blocks (clone values crossing the lock boundary with " +
+    "`.clone()`/`.cloneReadOnly()`); (2) ensure field initializers are isolated expressions (fresh literals/constructors); " +
+    "(3) ensure each resource/remote method only calls `isolated` functions and accesses no non-final module-level mutable state. " +
+    "Isolation is then inferred automatically — explicit `isolated` qualifiers on the service and methods also work. " +
+    "Only make this change if the user's request involves concurrency, throughput, or shared state.";
+
+/**
+ * Map of Ballerina diagnostic codes to resolving hints.
+ *
+ * Each entry maps a diagnostic code (e.g., "BCE3943") to a directive hint on how to
+ * resolve it. Hints ride along with the diagnostics returned by the
+ * getCompilationErrors tool so the agent can apply the canonical fix instead of
+ * guessing at the compiler's isolation/lock terminology.
+ *
+ * The isolation/lock/concurrency entries were derived from the ballerina-lang
+ * compiler sources (IsolationAnalyzer.java, DiagnosticErrorCode.java,
+ * compiler.properties) and the language server's quick-fix code actions
+ * (AddIsolatedQualifierCodeAction, AddLockCodeAction, AddReadonlyCodeAction,
+ * CloneValueCodeAction, ConvertToReadonlyCloneCodeAction). The comment above each
+ * entry quotes the compiler's message template for that code.
+ */
+export const DIAGNOSTIC_HINTS: Readonly<Record<string, string>> = {
+    "BCE2000": "This usually indicates a missing import statement. Please ensure that all necessary modules are imported in each file where they are used.",
+
+    // ---- Lock statement structural rules ----
+
+    // "cannot use a named worker inside a lock statement"
+    "BCE2080": "A lock statement must not start new strands. Move the `worker` declaration outside the lock: " +
+        "read the protected values into local variables inside `lock { }`, close the lock, then declare the worker using those locals.",
+
+    // "cannot use an async call inside a lock statement"
+    "BCE2081": "`start` is not allowed inside a `lock` statement. Read the protected values into local variables inside " +
+        "`lock { }`, close the lock, then call `start` with the locals (e.g. `int localN; lock { localN = n; } future<int> f = start compute(localN);`).",
+
+    // "using send action within the lock statement is not allowed to prevent possible deadlocks"
+    "BCE4042": "Worker send (`->`) is not allowed inside a `lock` statement (deadlock prevention). Use the lock only to " +
+        "read/write the shared state into local variables, then perform the send outside the lock.",
+
+    // "using receive action within the lock statement is not allowed to prevent possible deadlocks"
+    "BCE4043": "Worker receive (`<-`) is not allowed inside a `lock` statement (deadlock prevention). Receive the message " +
+        "into a local variable outside the lock, then update the shared state inside a `lock { }` block.",
+
+    // ---- Isolated functions ----
+
+    // "invalid access of mutable storage in an 'isolated' function"
+    "BCE3943": "An `isolated` function may only access module-level state that is (a) `final` with an immutable " +
+        "(`readonly`) or isolated-object type, or (b) declared `isolated` and accessed only inside `lock { }`. " +
+        "Fix: if the variable is never mutated, declare it `final` (immutable type); if it is shared mutable state, declare it " +
+        "`isolated` (e.g. `isolated int[] stack = [];`) and wrap every access in `lock { }`. `configurable` variables are already safe. " +
+        "Do NOT simply drop the `isolated` qualifier from a resource/remote method — that disables concurrent dispatch.",
+
+    // "invalid access of mutable storage in the default value of a record field"
+    "BCE3944": "A record field's default value must be an isolated expression. Replace the reference to mutable module " +
+        "state with a literal or a `final` readonly value, or require the field explicitly and set it where the record is created.",
+
+    // "invalid access of mutable storage in the initializer of an object field"
+    "BCE3945": "An object field initializer must be an isolated expression. Use a literal or `final` readonly value, or " +
+        "move the assignment into a non-`isolated` `init()` method (inside an `isolated` init the assigned value must " +
+        "still be an isolated expression, e.g. `self.f = v.clone();`).",
+
+    // "incompatible types: expected an 'isolated' function"
+    "BCE3946": "The function value passed here must be `isolated` (e.g. arguments to langlib functions like `array:forEach` " +
+        "called from an isolated context). Add the `isolated` qualifier to the function or anonymous function being passed.",
+
+    // "invalid invocation of a non-isolated function in an 'isolated' function"
+    "BCE3947": "An `isolated` function may only call `isolated` functions. Add the `isolated` qualifier to the called " +
+        "function (its own body must also satisfy isolation rules, transitively). If the callee is third-party and not isolated, " +
+        "restructure so the isolated function does not call it.",
+
+    // "invalid invocation of a non-isolated function in the default value of a record field"
+    "BCE3948": "A function invoked in a record field's default value must be `isolated`. Make the called function `isolated`, " +
+        "or replace the default with a literal and compute the value where the record is created.",
+
+    // "invalid invocation of a non-isolated function in the initializer of an object field"
+    "BCE3949": "A function invoked in an object field initializer must be `isolated`. Make the called function `isolated`, " +
+        "or move the computation into a non-`isolated` `init()` method (inside an `isolated` init the called function " +
+        "must still be `isolated`).",
+
+    // "invalid non-isolated initialization expression in an 'isolated' function"
+    "BCE3950": "`new` of a class whose `init` method is not `isolated` is not allowed here. Add the `isolated` qualifier " +
+        "to the class's `init` method (and make sure `init` itself follows isolated-function rules).",
+
+    // "invalid non-isolated initialization expression in the default value of a record field"
+    "BCE3951": "The class instantiated in this record field default must have an `isolated` `init` method. Make `init` isolated, " +
+        "or drop the default and construct the value where the record is created.",
+
+    // "invalid non-isolated initialization expression in the initializer of an object field"
+    "BCE3952": "The class instantiated in this object field initializer must have an `isolated` `init` method. Make `init` " +
+        "isolated, or move the construction into a non-`isolated` `init()` method of the enclosing object.",
+
+    // "'strand' annotation not allowed in a ... in an 'isolated' function"
+    "BCE3953": "Remove the `@strand` annotation — it is not allowed in an `isolated` function (and is deprecated in general).",
+
+    // "invalid start action calling a non-isolated function in an 'isolated' function"
+    "BCE3954": "`start` inside an `isolated` function may only call `isolated` functions. Add the `isolated` qualifier to " +
+        "the function being started.",
+
+    // "invalid start action accessing a non isolated expression in an argument..."
+    "BCE3955": "Arguments to `start` in an `isolated` function must be isolated expressions. Pass an immutable value, or a " +
+        "fresh copy of a local/parameter value: `start process(data.clone())` (or `.cloneReadOnly()`). Cloning module-level " +
+        "mutable state directly in the argument does NOT help (that reports BCE3943) — read it into a local inside a " +
+        "`lock { }` first, then pass a clone of that local: `start process(localData.clone())`.",
+
+    // ---- Isolated objects ----
+
+    // "invalid non-private mutable field in an isolated object"
+    "BCE3956": "Every mutable field of an isolated object/class must be `private`. Add the `private` qualifier, or make the " +
+        "field `final` with an immutable (`readonly`) or isolated-object type if it is never reassigned.",
+
+    // "invalid access of a mutable field of an 'isolated' object outside a 'lock' statement"
+    "BCE3957": "Access to a mutable `self` field of an isolated object must be inside a `lock` statement. Wrap the statement(s) " +
+        "in `lock { ... }` (group nearby accesses of the field into one lock; values leaving the lock must be cloned — see BCE3959).",
+
+    // "invalid initial value expression: expected an isolated expression"
+    "BCE3958": "The initial value of isolated state must be an isolated expression. This fires on (a) the initializer of an " +
+        "`isolated` variable, or (b) an assignment to a `self` field inside an `isolated` class's `init` method. Use a " +
+        "literal, a fresh constructor (e.g. `[]`, `{}`, `new Foo()` with an isolated `init`), or a copy — most commonly " +
+        "change `self.data = data;` to `self.data = data.clone();` (or `.cloneReadOnly()`).",
+
+    // ---- Restricted lock (transfer) rules ----
+
+    // "invalid attempt to transfer out a value from a 'lock' statement with restricted variable usage: expected an isolated expression"
+    "BCE3959": "A value leaving a lock that protects an isolated variable or `self` (via `return` or assignment to an outer " +
+        "variable) must not alias the protected state. Return/assign a copy: `return m[k].clone();` (or `.cloneReadOnly()` " +
+        "when an immutable result is acceptable). Alternatively declare the protected storage's member type as `T & readonly` " +
+        "so reads are already immutable.",
+
+    // "invalid attempt to transfer a value into a 'lock' statement with restricted variable usage"
+    "BCE3960": "A mutable value defined outside this lock must not be referenced inside it in a non-isolated expression " +
+        "(storing it — or even aliasing it to a local — could create an outside alias to protected state). Use a copy " +
+        "instead: `m[k] = v.clone();`, or declare the incoming parameter/variable as `readonly & T` so it is immutable.",
+
+    // "invalid invocation of a non-isolated function in a 'lock' statement with restricted variable usage"
+    "BCE3961": "Only `isolated` functions may be called inside a lock that accesses an isolated variable or `self` of an " +
+        "isolated object. Add the `isolated` qualifier to the called function, or move the call outside the lock.",
+
+    // "invalid access of an 'isolated' variable outside a 'lock' statement"
+    "BCE3962": "An `isolated` module variable may only be accessed inside a `lock` statement. Wrap the access in `lock { ... }`. " +
+        "Remember: one lock may access only ONE isolated variable, and values crossing the lock boundary must be cloned.",
+
+    // "cannot assign to a variable outside the 'lock' statement with restricted variable usage, if not just a variable name"
+    "BCE3963": "Inside a lock with restricted variable usage, a destructuring assignment to outer state is not allowed — " +
+        "an assignment out of the lock must target a plain variable name. Assign the (cloned) value to a simple outer " +
+        "variable inside the lock, or capture it in a local and update the outer structure after the lock. " +
+        "(Assignments through member/index access on outer state report BCE3960 instead.)",
+
+    // "cannot access more than one variable for which usage is restricted in a single 'lock' statement"
+    "BCE3964": "A single `lock` statement may access only ONE isolated variable (or `self` of an isolated object). Split the " +
+        "logic into separate lock statements, copying needed values into locals in between (e.g. `int bv; lock { bv = b; } " +
+        "lock { a += bv; }`). If two pieces of state must change atomically together, merge them into one protected value " +
+        "(e.g. a single isolated record/map holding both).",
+
+    // "an uninitialized module variable declaration cannot be marked as 'isolated'"
+    "BCE3965": "An `isolated` module variable must be initialized at the declaration. Add an initializer that is an isolated " +
+        "expression (e.g. `isolated int[] data = [];`).",
+
+    // "only a simple variable can be marked as 'isolated'"
+    "BCE3966": "`isolated` can only be applied to a simple variable declaration — not to destructuring/binding patterns. " +
+        "Declare a plain variable instead.",
+
+    // ---- Match guards ----
+
+    // "cannot call a non-isolated function/method in a match guard when the type of the action/expression being matched is not a subtype of 'readonly'"
+    "BCE4018": "A function called in a match guard must be `isolated` when the matched value is not `readonly`. Add the " +
+        "`isolated` qualifier to the guard function, or match over a `readonly` value.",
+
+    // "cannot call a function/method in a match guard with an argument of a type that is not a subtype of 'readonly'"
+    "BCE4019": "Arguments to a function call in a match guard must be `readonly` when the matched value is not itself " +
+        "`readonly`. Pass an immutable copy: replace `arg` with `arg.cloneReadOnly()`, or match over a `readonly` value.",
+
+    // "invalid access of an isolated variable outside a lock statement in the default value of a record field"
+    "BCE4025": "A record field's default value cannot reference an `isolated` variable directly. Use a literal default, or " +
+        "keep the default by calling an `isolated` function that reads the variable inside `lock { }` (e.g. " +
+        "`type R record {| int f = readCount(); |};` where `isolated function readCount() returns int { lock { return count; } }`).",
+
+    // ---- Service concurrency hints (not errors; surfaced as concurrencyHints) ----
+
+    // "concurrent calls will not be made to this method since the service and the method are not 'isolated'"
+    "BCH2003": "Neither the service nor this method is `isolated`, so the listener serializes calls to it. " + SERVICE_ISOLATION_FIX,
+
+    // "concurrent calls will not be made to this method since the service is not an 'isolated' service"
+    "BCH2004": "This method is `isolated` but the service is not, so the listener serializes calls to it. The blocker is the " +
+        "service's state: make every mutable service field `private`, initialized with an isolated expression, and accessed via " +
+        "`self` only inside `lock { }`. " + SERVICE_ISOLATION_FIX,
+
+    // "concurrent calls will not be made to this method since the method is not an 'isolated' method"
+    "BCH2005": "The service is isolated but this method is not, so the listener serializes calls to it. The blocker is the " +
+        "method body: it must only call `isolated` functions and must not access non-final module-level mutable state (use " +
+        "`isolated` variables with `lock { }` where shared state is needed). " + SERVICE_ISOLATION_FIX,
+};
+
+/**
+ * Builds the note appended to the diagnostics tool message when
+ * service-concurrency hints (BCH2003–BCH2005) are present. Explicitly framed as
+ * non-blocking so the agent does not loop trying to drive the diagnostic count
+ * to zero, and does not refactor services the user never asked about.
+ */
+export function buildConcurrencyHintNote(hintCount: number): string {
+    if (hintCount === 0) {
+        return "";
+    }
+    return ` Additionally, ${hintCount} service-concurrency hint(s) were reported (see concurrencyHints). ` +
+        `These are NOT compilation errors — the code compiles — but the listed resource/remote methods will NOT ` +
+        `be dispatched concurrently because the service and/or method is not 'isolated'. Address them ONLY if the ` +
+        `user's request involves concurrency, throughput, or shared mutable state; otherwise leave the code as is ` +
+        `(you may briefly mention the limitation to the user).`;
+}
+
+/**
+ * Result of transforming raw language-server diagnostics for the agent.
+ */
+export interface TransformedDiagnostics {
+    /** Compilation errors (severity === 1), enriched with resolving hints. */
+    errors: EnrichedDiagnostic[];
+    /**
+     * Service-concurrency hints (BCH2003–BCH2005), any severity. The code
+     * compiles — these indicate that requests will be dispatched serially.
+     */
+    concurrencyHints: EnrichedDiagnostic[];
+}
+
+/**
+ * Converts language server Diagnostics to EnrichedDiagnostic entries with hints.
+ *
+ * Routing: non-error-severity concurrency hint codes (BCH2003–BCH2005) go to
+ * `concurrencyHints`; everything else is included in `errors` only when it is
+ * an error-level diagnostic (severity === 1). A BCH code at error severity
+ * (unreachable today — the compiler hardcodes HINT — but defensive) stays in
+ * `errors` so a real error can never be downgraded to an ignorable hint.
+ */
+export function transformDiagnostics(diagnostics: Diagnostics[]): TransformedDiagnostics {
+    const errors: EnrichedDiagnostic[] = [];
+    const concurrencyHints: EnrichedDiagnostic[] = [];
+
+    for (const diagParam of diagnostics) {
+        for (const diag of diagParam.diagnostics) {
+            const code = diag.code === undefined || diag.code === null ? "" : diag.code.toString();
+            const isConcurrencyHint = CONCURRENCY_HINT_CODES.has(code) && diag.severity !== 1;
+
+            // Only include error-level diagnostics (plus the concurrency hints)
+            if (diag.severity !== 1 && !isConcurrencyHint) {
+                continue;
+            }
+
+            const fileName = path.basename(diagParam.uri);
+            const msgPrefix = `[${fileName}:${diag.range.start.line},${diag.range.start.character}:${diag.range.end.line},${diag.range.end.character}] `;
+
+            const diagnosticEntry: EnrichedDiagnostic = {
+                message: msgPrefix + diag.message
+            };
+            if (code !== "") {
+                diagnosticEntry.code = code;
+            }
+
+            // Add hint if available for this diagnostic code
+            const hint = DIAGNOSTIC_HINTS[code];
+            if (hint) {
+                diagnosticEntry.hint = hint;
+            }
+
+            if (isConcurrencyHint) {
+                concurrencyHints.push(diagnosticEntry);
+            } else {
+                errors.push(diagnosticEntry);
+            }
+        }
+    }
+
+    return { errors, concurrencyHints };
+}

--- a/packages/ballerina-extension/src/features/ai/agent/tools/diagnostics-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/diagnostics-utils.ts
@@ -1,77 +1,27 @@
-import { DiagnosticEntry, Diagnostics } from '@wso2/ballerina-core';
+import { Diagnostics } from '@wso2/ballerina-core';
 import { checkProjectDiagnostics, isModuleNotFoundDiagsExist as resolveModuleNotFoundDiagnostics } from '../../../../rpc-managers/ai-panel/repair-utils';
 import { StateMachine } from '../../../../stateMachine';
-import * as path from 'path';
 import { Uri } from 'vscode';
+import { buildConcurrencyHintNote, EnrichedDiagnostic, transformDiagnostics } from './diagnostic-hints';
+
+export type { EnrichedDiagnostic } from './diagnostic-hints';
 
 export const DIAGNOSTICS_TOOL_NAME = "getCompilationErrors";
-
-/**
- * Diagnostic entry enriched with resolving hints
- */
-export interface EnrichedDiagnostic extends DiagnosticEntry {
-    hint?: string;
-}
 
 /**
  * Result of diagnostic checking
  */
 export interface DiagnosticsCheckResult {
     diagnostics: EnrichedDiagnostic[];
+    /**
+     * Service-concurrency hints (BCH2003–BCH2005). Present only when the compiler
+     * reports that resource/remote methods will not be dispatched concurrently.
+     * These are NOT compilation errors — the code compiles.
+     */
+    concurrencyHints?: EnrichedDiagnostic[];
     message: string;
 }
 
-/**
- * Map of Ballerina diagnostic codes to resolving hints
- *
- * Each entry maps a diagnostic code (e.g., "BCE2000") to a helpful hint on how to resolve it.
- * These hints are shown alongside the diagnostic message to help developers fix issues quickly.
- *
- * TODO: Populate this map with actual Ballerina diagnostic codes and their corresponding hints.
- * Example structure:
- * {
- *   "BCE2000": "Add missing import statement for the module",
- *   "BCE2001": "Check variable type compatibility",
- *   "BCE2002": "Ensure function return type matches declaration",
- * }
- */
-const DIAGNOSTIC_HINTS: Record<string, string> = {
-    // Diagnostic code mappings to be populated
-    "BCE2000": "This usually indicates a missing import statement. Please ensure that all necessary modules are imported in each file where they are used.",
-};
-
-/**
- * Converts language server Diagnostics to EnrichedDiagnostic entries with hints
- * Filters for error-level diagnostics (severity === 1) only
- */
-function transformDiagnosticsToEnriched(diagnostics: Diagnostics[]): EnrichedDiagnostic[] {
-    const enrichedDiags: EnrichedDiagnostic[] = [];
-
-    for (const diagParam of diagnostics) {
-        for (const diag of diagParam.diagnostics) {
-            // Only include error-level diagnostics
-            if (diag.severity === 1) {
-                const fileName = path.basename(diagParam.uri);
-                const msgPrefix = `[${fileName}:${diag.range.start.line},${diag.range.start.character}:${diag.range.end.line},${diag.range.end.character}] `;
-
-                const diagnosticEntry: EnrichedDiagnostic = {
-                    code: diag.code.toString(),
-                    message: msgPrefix + diag.message
-                };
-
-                // Add hint if available for this diagnostic code
-                const hint = DIAGNOSTIC_HINTS[diag.code.toString()];
-                if (hint) {
-                    diagnosticEntry.hint = hint;
-                }
-
-                enrichedDiags.push(diagnosticEntry);
-            }
-        }
-    }
-
-    return enrichedDiags;
-}
 
 /**
  * Checks the Ballerina package for compilation errors using the language server
@@ -110,7 +60,7 @@ export async function checkCompilationErrors(
             // `ballerinax/.config` — omitting "client". As a workaround, we detect this and
             // instruct the agent to use the correct quoted form `import ballerinax/'client.config;`
             // instead of attempting to resolve the dependency automatically.
-            const enrichedDiagnosticsTry = transformDiagnosticsToEnriched(diagnostics);
+            const enrichedDiagnosticsTry = transformDiagnostics(diagnostics).errors;
             const hasInvalidClientModuleImport = enrichedDiagnosticsTry.some(
                 d => d.code === "BCE2003" && d.message.includes("ballerinax/.config")
             );
@@ -142,23 +92,26 @@ export async function checkCompilationErrors(
         }
 
         // Transform and enrich diagnostics with hints
-        const enrichedDiagnostics = transformDiagnosticsToEnriched(diagnostics);
+        const { errors: enrichedDiagnostics, concurrencyHints } = transformDiagnostics(diagnostics);
 
         const errorCount = enrichedDiagnostics.length;
-        console.log(`[DiagnosticsUtils] Found ${errorCount} compilation error(s).`);
+        const hintNote = buildConcurrencyHintNote(concurrencyHints.length);
+        console.log(`[DiagnosticsUtils] Found ${errorCount} compilation error(s) and ${concurrencyHints.length} concurrency hint(s).`);
 
         if (errorCount === 0) {
             console.log(`[DiagnosticsUtils] No compilation errors found.`);
             return {
                 diagnostics: [],
-                message: "No compilation errors found. Code compiles successfully.",
+                ...(concurrencyHints.length > 0 ? { concurrencyHints } : {}),
+                message: "No compilation errors found. Code compiles successfully." + hintNote,
             };
         }
 
         console.log(`[DiagnosticsUtils] Enriched Diagnostics:`, enrichedDiagnostics);
         return {
             diagnostics: enrichedDiagnostics,
-            message: `Found ${errorCount} compilation error(s). Review and fix the errors before proceeding.`
+            ...(concurrencyHints.length > 0 ? { concurrencyHints } : {}),
+            message: `Found ${errorCount} compilation error(s). Review and fix the errors before proceeding.` + hintNote
         };
     } catch (error) {
         console.error("[DiagnosticsUtils] Error checking compilation errors:", error);

--- a/packages/ballerina-extension/src/features/ai/agent/tools/diagnostics.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/diagnostics.ts
@@ -45,7 +45,8 @@ For single-package projects, omit the packagePath parameter.
 
 The tool analyzes the entire Ballerina package and returns:
 - Compilation errors with file location, error message, and diagnostic code
-- Resolving hints for common error codes to help fix issues quickly
+- Resolving hints for common error codes (including isolation/lock errors like BCE3943-BCE3966) to help fix issues quickly
+- A separate concurrencyHints list (BCH2003-BCH2005) when service methods will not be dispatched concurrently — these are NOT errors; only act on them if the task involves concurrency or shared state
 - Empty list if no errors are found
 `,
         inputSchema: DiagnosticsInputSchema,

--- a/packages/ballerina-extension/src/test-support/concurrencyPromptRules.test.ts
+++ b/packages/ballerina-extension/src/test-support/concurrencyPromptRules.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the concurrency-safety coding rules injected into the agent system
+ * prompt (src/features/ai/agent/concurrency-rules.ts) and their wiring into
+ * getSystemPrompt (src/features/ai/agent/prompts.ts).
+ *
+ * The wiring check reads prompts.ts as source text instead of importing it:
+ * prompts.ts transitively pulls in the extension-host module graph
+ * (StateMachine, language client), which must not load in this jest suite.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { CONCURRENCY_CODING_RULES } from '../features/ai/agent/concurrency-rules';
+
+describe('CONCURRENCY_CODING_RULES content', () => {
+    test('is a markdown section with the expected heading', () => {
+        expect(CONCURRENCY_CODING_RULES.startsWith('## Concurrency Safety and Shared State')).toBe(true);
+    });
+
+    test('teaches the isolated-variable + lock pattern for shared mutable state', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/declare the variable `isolated`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/ONLY inside `lock \{ \}` blocks/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/never mutated, declare it `final`/);
+    });
+
+    test('never suggests final on configurable variables (compile error)', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/NEVER write `final configurable`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/implicitly final/);
+    });
+
+    test('teaches that final alone is not sufficient for isolated reads', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/`final` alone is not sufficient/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/final int\[\] & readonly/);
+    });
+
+    test('teaches the isolated-object rules for service state, including the method side', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/mutable field `private`/);
+        // concurrent dispatch needs BOTH the service and its methods isolated
+        expect(CONCURRENCY_CODING_RULES).toMatch(/each resource\/remote method must ALSO satisfy isolated-function rules/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/infers both the service and its methods as `isolated`/);
+    });
+
+    test('teaches the one-root-per-lock rule', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/only ONE isolated root/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/never access two `isolated` variables/);
+    });
+
+    test('teaches clone-on-transfer across lock boundaries, scoped to restricted locks only', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/`value\.clone\(\)`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/`value\.cloneReadOnly\(\)`/);
+        // transfer rules apply only to locks touching an isolated root — an
+        // unconditional clone rule would sprinkle deep copies into ordinary locks
+        expect(CONCURRENCY_CODING_RULES).toMatch(/In a lock that touches an isolated root/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/ordinary lock over non-isolated state has no such transfer restrictions/);
+    });
+
+    test('forbids strand creation and worker message passing inside locks', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/Never use `start`, named `worker` declarations, or worker send\/receive/);
+    });
+
+    test('teaches transitive isolated-function requirements', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/must themselves be `isolated`/);
+    });
+
+    test('contains no unresolved interpolations or stray backtick escapes', () => {
+        expect(CONCURRENCY_CODING_RULES).not.toContain('${');
+        expect(CONCURRENCY_CODING_RULES).not.toContain('\\`');
+    });
+});
+
+describe('system prompt wiring', () => {
+    const promptsSource = fs.readFileSync(
+        path.join(__dirname, '../features/ai/agent/prompts.ts'),
+        'utf-8',
+    );
+
+    test('prompts.ts imports the rules constant', () => {
+        expect(promptsSource).toContain(
+            'import { CONCURRENCY_CODING_RULES } from "./concurrency-rules"');
+    });
+
+    test('prompts.ts interpolates the rules into the system prompt', () => {
+        expect(promptsSource).toContain('${CONCURRENCY_CODING_RULES}');
+    });
+
+    test('rules are placed between Coding Rules and File modifications', () => {
+        const codingRulesIdx = promptsSource.indexOf('## Coding Rules');
+        const concurrencyIdx = promptsSource.indexOf('${CONCURRENCY_CODING_RULES}');
+        const fileModsIdx = promptsSource.indexOf('## File modifications');
+        expect(codingRulesIdx).toBeGreaterThan(-1);
+        expect(concurrencyIdx).toBeGreaterThan(codingRulesIdx);
+        expect(fileModsIdx).toBeGreaterThan(concurrencyIdx);
+    });
+});

--- a/packages/ballerina-extension/src/test-support/isolationDiagnosticHints.test.ts
+++ b/packages/ballerina-extension/src/test-support/isolationDiagnosticHints.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for the isolation/lock/concurrency diagnostic hint catalog and the
+ * diagnostics transform (src/features/ai/agent/tools/diagnostic-hints.ts).
+ *
+ * The hint catalog was derived from the ballerina-lang compiler sources
+ * (DiagnosticErrorCode.java, DiagnosticHintCode.java, compiler.properties,
+ * IsolationAnalyzer.java) — these tests pin the exact code set and the
+ * canonical fix each hint must teach, so a hint can't silently drift away
+ * from the compiler's remediation (e.g. BCE3959 must mention clone()).
+ */
+import type { Diagnostics } from '@wso2/ballerina-core';
+import {
+    buildConcurrencyHintNote,
+    CONCURRENCY_HINT_CODES,
+    DIAGNOSTIC_HINTS,
+    transformDiagnostics,
+} from '../features/ai/agent/tools/diagnostic-hints';
+
+/**
+ * The complete, verified set of isolation/lock/concurrency diagnostic codes
+ * (from ballerina-lang master: DiagnosticErrorCode.java + DiagnosticHintCode.java).
+ */
+const ISOLATION_ERROR_CODES = [
+    // lock statement structural rules
+    'BCE2080', // named worker inside lock
+    'BCE2081', // async call (start) inside lock
+    'BCE4042', // worker send inside lock
+    'BCE4043', // worker receive inside lock
+    // isolated functions
+    'BCE3943', // mutable storage access in isolated function
+    'BCE3944', // mutable storage access in record field default
+    'BCE3945', // mutable storage access in object field initializer
+    'BCE3946', // expected an isolated function
+    'BCE3947', // non-isolated invocation in isolated function
+    'BCE3948', // non-isolated invocation in record field default
+    'BCE3949', // non-isolated invocation in object field initializer
+    'BCE3950', // non-isolated init expression in isolated function
+    'BCE3951', // non-isolated init expression in record field default
+    'BCE3952', // non-isolated init expression in object field initializer
+    'BCE3953', // @strand annotation in isolated function
+    'BCE3954', // start of non-isolated function in isolated function
+    'BCE3955', // non-isolated expression in async call args
+    // isolated objects
+    'BCE3956', // non-private mutable field in isolated object
+    'BCE3957', // mutable field access outside lock
+    'BCE3958', // initial value not an isolated expression
+    // restricted lock (transfer) rules
+    'BCE3959', // transfer out of lock
+    'BCE3960', // transfer into lock
+    'BCE3961', // non-isolated invocation in restricted lock
+    'BCE3962', // isolated variable access outside lock
+    'BCE3963', // invalid assignment in restricted lock
+    'BCE3964', // multiple restricted vars in one lock
+    'BCE3965', // uninitialized isolated module variable
+    'BCE3966', // isolated on non-simple variable
+    // match guards
+    'BCE4018', // non-isolated call in match guard
+    'BCE4019', // mutable args in match guard call
+    'BCE4025', // isolated variable access in record field default
+] as const;
+
+const CONCURRENCY_CODES = ['BCH2003', 'BCH2004', 'BCH2005'] as const;
+
+// ---------------------------------------------------------------------------
+// Catalog integrity
+// ---------------------------------------------------------------------------
+
+describe('DIAGNOSTIC_HINTS catalog', () => {
+    test('contains every verified isolation/lock error code', () => {
+        for (const code of ISOLATION_ERROR_CODES) {
+            expect(DIAGNOSTIC_HINTS[code]).toBeDefined();
+        }
+    });
+
+    test('contains every service-concurrency hint code', () => {
+        for (const code of CONCURRENCY_CODES) {
+            expect(DIAGNOSTIC_HINTS[code]).toBeDefined();
+        }
+    });
+
+    test('contains exactly the expected code set (no unverified codes)', () => {
+        const expected = new Set<string>([
+            'BCE2000', // pre-existing missing-import hint
+            ...ISOLATION_ERROR_CODES,
+            ...CONCURRENCY_CODES,
+        ]);
+        expect(new Set(Object.keys(DIAGNOSTIC_HINTS))).toEqual(expected);
+    });
+
+    test('all keys are well-formed Ballerina diagnostic codes', () => {
+        for (const code of Object.keys(DIAGNOSTIC_HINTS)) {
+            expect(code).toMatch(/^BC[EH]\d{4}$/);
+        }
+    });
+
+    test('all hints are substantial, single-purpose strings', () => {
+        for (const [code, hint] of Object.entries(DIAGNOSTIC_HINTS)) {
+            expect(typeof hint).toBe('string');
+            // long enough to be actionable, short enough to not blow up tool output
+            expect(hint.length).toBeGreaterThan(40);
+            expect(hint.length).toBeLessThan(1000);
+            // no accidental unresolved template placeholders
+            expect(hint).not.toContain('${');
+            expect(hint).not.toContain('undefined');
+            // hints must be self-contained prose, not truncated
+            expect(hint.trim()).toBe(hint);
+            expect(code).toBeTruthy();
+        }
+    });
+
+    test('CONCURRENCY_HINT_CODES is exactly BCH2003–BCH2005', () => {
+        expect([...CONCURRENCY_HINT_CODES].sort()).toEqual([...CONCURRENCY_CODES]);
+    });
+});
+
+describe('DIAGNOSTIC_HINTS canonical fixes', () => {
+    // Each hint must teach the fix the compiler/LS code actions prescribe.
+    const mustMention: Array<[string, RegExp[]]> = [
+        // pre-existing missing-import hint
+        ['BCE2000', [/import/i]],
+        // structural lock rules: move strand work outside the lock
+        ['BCE2080', [/worker/i, /outside the lock/i]],
+        ['BCE2081', [/`start`/, /lock/i, /local/i]],
+        ['BCE4042', [/send/i, /outside the lock/i]],
+        ['BCE4043', [/receive/i, /outside the lock/i]],
+        // isolated function rules
+        ['BCE3943', [/final/, /isolated/, /lock \{ \}/, /configurable/]],
+        ['BCE3944', [/isolated expression/, /literal/i]],
+        ['BCE3945', [/literal/i, /non-`isolated` `init\(\)`/, /clone\(\)/]],
+        ['BCE3946', [/isolated/, /qualifier/i]],
+        ['BCE3947', [/isolated/, /qualifier/i, /transitively/i]],
+        ['BCE3948', [/isolated/, /literal/i]],
+        ['BCE3949', [/isolated/, /non-`isolated` `init\(\)`/]],
+        ['BCE3950', [/init/, /isolated/]],
+        ['BCE3951', [/`init`/, /isolated/]],
+        ['BCE3952', [/`init`/, /isolated/, /non-`isolated`/]],
+        ['BCE3953', [/@strand/, /remove/i]],
+        ['BCE3954', [/start/i, /isolated/]],
+        // cloning module-level state in the start arg does NOT work (BCE3943); the
+        // clone must be applied to a local read under lock, at the start argument
+        ['BCE3955', [/clone\(\)/, /cloneReadOnly\(\)/, /BCE3943/, /lock \{ \}/, /localData\.clone\(\)/]],
+        // isolated object rules
+        ['BCE3956', [/private/, /final/]],
+        ['BCE3957', [/lock \{ \.\.\. \}/, /self/]],
+        // fires on isolated-variable initializers AND self-field assignments in isolated init
+        ['BCE3958', [/literal/i, /clone\(\)/, /`self`/, /`init`/]],
+        // transfer rules — the LS quick fixes are clone() / cloneReadOnly() / & readonly
+        ['BCE3959', [/clone\(\)/, /cloneReadOnly\(\)/, /& readonly/]],
+        ['BCE3960', [/clone\(\)/, /readonly/, /referenced inside/]],
+        ['BCE3961', [/isolated/, /lock/i]],
+        ['BCE3962', [/lock \{ \.\.\. \}/, /ONE isolated variable/i]],
+        // BCE3963 fires only for destructuring; member/index access reports BCE3960
+        ['BCE3963', [/destructuring/i, /variable name/i, /BCE3960/]],
+        ['BCE3964', [/ONE isolated variable/i, /separate lock/i]],
+        ['BCE3965', [/initializ/i]],
+        ['BCE3966', [/simple variable/i]],
+        // match guards
+        ['BCE4018', [/isolated/, /readonly/i]],
+        ['BCE4019', [/cloneReadOnly\(\)/, /matched value/i]],
+        ['BCE4025', [/literal/i, /lock \{ \}/, /isolated/]],
+        // service concurrency hints: fix is service isolation, gated on user intent.
+        // The leading trigger description must discriminate the three codes —
+        // BCH2003 = neither isolated, BCH2004 = service not, BCH2005 = method not.
+        ['BCH2003', [/^Neither the service nor this method/, /private/, /lock \{ \}/, /isolated/, /Only make this change/i]],
+        ['BCH2004', [/^This method is `isolated` but the service is not/, /private/, /Only make this change/i]],
+        ['BCH2005', [/^The service is isolated but this method is not/, /isolated/, /Only make this change/i]],
+    ];
+
+    test.each(mustMention)('%s hint teaches the canonical fix', (code, patterns) => {
+        const hint = DIAGNOSTIC_HINTS[code];
+        expect(hint).toBeDefined();
+        for (const pattern of patterns) {
+            expect(hint).toMatch(pattern);
+        }
+    });
+
+    test('concurrency hints never claim to be compilation errors', () => {
+        for (const code of CONCURRENCY_CODES) {
+            const hint = DIAGNOSTIC_HINTS[code];
+            expect(hint).not.toMatch(/compilation error/i);
+            // every BCH hint explains that dispatch is serialized
+            expect(hint).toMatch(/serial/i);
+        }
+    });
+
+    test('the three concurrency hints are pairwise distinct', () => {
+        const texts = CONCURRENCY_CODES.map(code => DIAGNOSTIC_HINTS[code]);
+        expect(new Set(texts).size).toBe(CONCURRENCY_CODES.length);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// transformDiagnostics
+// ---------------------------------------------------------------------------
+
+function makeDiag(
+    code: string | number | undefined,
+    severity: number | undefined,
+    message: string,
+    line = 5,
+): any {
+    return {
+        code,
+        severity,
+        message,
+        range: { start: { line, character: 4 }, end: { line, character: 20 } },
+    };
+}
+
+function wrap(uri: string, diags: any[]): Diagnostics {
+    return { uri, diagnostics: diags } as Diagnostics;
+}
+
+describe('transformDiagnostics', () => {
+    test('includes severity-1 diagnostics as errors with location prefix and hint', () => {
+        const input = [wrap('file:///proj/main.bal', [
+            makeDiag('BCE3962', 1, "invalid access of an 'isolated' variable outside a 'lock' statement"),
+        ])];
+        const { errors, concurrencyHints } = transformDiagnostics(input);
+
+        expect(errors).toHaveLength(1);
+        expect(concurrencyHints).toHaveLength(0);
+        expect(errors[0].code).toBe('BCE3962');
+        expect(errors[0].message).toBe(
+            "[main.bal:5,4:5,20] invalid access of an 'isolated' variable outside a 'lock' statement");
+        expect(errors[0].hint).toBe(DIAGNOSTIC_HINTS['BCE3962']);
+    });
+
+    test('excludes warnings and hints that are not concurrency hint codes', () => {
+        const input = [wrap('file:///proj/main.bal', [
+            makeDiag('BCE20406', 2, "the 'strand' annotation will be deprecated"),
+            makeDiag('BCH2000', 4, 'unnecessary condition'),
+        ])];
+        const { errors, concurrencyHints } = transformDiagnostics(input);
+        expect(errors).toHaveLength(0);
+        expect(concurrencyHints).toHaveLength(0);
+    });
+
+    test('routes non-error BCH2003–BCH2005 to concurrencyHints', () => {
+        const input = [wrap('file:///proj/service.bal', [
+            makeDiag('BCH2004', 4, "concurrent calls will not be made to this method since the service is not an 'isolated' service"),
+            makeDiag('BCH2003', 4, "concurrent calls will not be made to this method since the service and the method are not 'isolated'"),
+            makeDiag('BCH2005', undefined, "concurrent calls will not be made to this method since the method is not an 'isolated' method"),
+        ])];
+        const { errors, concurrencyHints } = transformDiagnostics(input);
+
+        expect(errors).toHaveLength(0);
+        expect(concurrencyHints).toHaveLength(3);
+        expect(concurrencyHints.map(h => h.code).sort()).toEqual(['BCH2003', 'BCH2004', 'BCH2005']);
+        for (const entry of concurrencyHints) {
+            expect(entry.hint).toBe(DIAGNOSTIC_HINTS[entry.code as string]);
+            expect(entry.message).toContain('[service.bal:');
+        }
+    });
+
+    test('a BCH code at error severity stays in errors (never downgraded to a hint)', () => {
+        const input = [wrap('file:///proj/service.bal', [
+            makeDiag('BCH2003', 1, 'hypothetical error-severity concurrency diagnostic'),
+        ])];
+        const { errors, concurrencyHints } = transformDiagnostics(input);
+        expect(concurrencyHints).toHaveLength(0);
+        expect(errors.map(e => e.code)).toEqual(['BCH2003']);
+    });
+
+    test('handles a diagnostic without a code (no crash, no hint, no code field)', () => {
+        const input = [wrap('file:///proj/main.bal', [
+            makeDiag(undefined, 1, 'some diagnostic without a code'),
+        ])];
+        const { errors } = transformDiagnostics(input);
+        expect(errors).toHaveLength(1);
+        expect(errors[0].code).toBeUndefined();
+        expect(errors[0].hint).toBeUndefined();
+        expect(errors[0].message).toContain('some diagnostic without a code');
+    });
+
+    test('stringifies numeric diagnostic codes', () => {
+        const input = [wrap('file:///proj/main.bal', [makeDiag(1234, 1, 'numeric code diag')])];
+        const { errors } = transformDiagnostics(input);
+        expect(errors[0].code).toBe('1234');
+    });
+
+    test('errors without a matching hint carry no hint field', () => {
+        const input = [wrap('file:///proj/main.bal', [makeDiag('BCE9999', 1, 'unknown error')])];
+        const { errors } = transformDiagnostics(input);
+        expect(errors[0].hint).toBeUndefined();
+    });
+
+    test('separates mixed errors and concurrency hints across files', () => {
+        const input = [
+            wrap('file:///proj/main.bal', [
+                makeDiag('BCE3959', 1, 'invalid attempt to transfer out a value', 10),
+                makeDiag('BCH2004', 4, 'concurrent calls will not be made to this method', 3),
+            ]),
+            wrap('file:///proj/utils.bal', [
+                makeDiag('BCE3964', 1, 'cannot access more than one variable', 7),
+            ]),
+        ];
+        const { errors, concurrencyHints } = transformDiagnostics(input);
+        expect(errors.map(e => e.code)).toEqual(['BCE3959', 'BCE3964']);
+        expect(concurrencyHints.map(h => h.code)).toEqual(['BCH2004']);
+        expect(errors[1].message).toContain('[utils.bal:7,');
+    });
+
+    test('returns empty results for empty input', () => {
+        expect(transformDiagnostics([])).toEqual({ errors: [], concurrencyHints: [] });
+    });
+});
+
+describe('buildConcurrencyHintNote', () => {
+    test('empty for zero hints', () => {
+        expect(buildConcurrencyHintNote(0)).toBe('');
+    });
+
+    test('frames hints as non-blocking and gated on user intent', () => {
+        const note = buildConcurrencyHintNote(2);
+        expect(note).toContain('2 service-concurrency hint(s)');
+        expect(note).toContain('NOT compilation errors');
+        expect(note).toMatch(/ONLY if the user's request involves concurrency/);
+    });
+});


### PR DESCRIPTION
Add diagnostics hints and prompt updates for lock statements

FIxes https://github.com/wso2/product-integrator/issues/2365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added concurrency-safety rules to the AI agent system prompt.
- Added diagnostic hints for isolation, lock, and service-concurrency diagnostics.
- Refactored diagnostic processing to separate errors from non-error concurrency hints.
- Updated tool descriptions and result types to expose concurrency hints.
- Added tests for prompt integration, diagnostic mappings, routing, and hint formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->