### PR TITLE
Bump the submodule for the missing artifact icons and resync codepoints

### DIFF
--- a/packages/ballerina-extension/package.json
+++ b/packages/ballerina-extension/package.json
@@ -1349,14 +1349,14 @@
                 "description": "start",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f255"
+                    "fontCharacter": "\\f259"
                 }
             },
             "ballerina-debug": {
                 "description": "debug",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1cb"
+                    "fontCharacter": "\\f1cf"
                 }
             },
             "ballerina-source-view": {
@@ -1370,7 +1370,7 @@
                 "description": "persist-diagram",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f22b"
+                    "fontCharacter": "\\f22f"
                 }
             },
             "ballerina-cached-rounded": {
@@ -1384,42 +1384,42 @@
                 "description": "cached-round",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1a9"
+                    "fontCharacter": "\\f1ad"
                 }
             },
             "ballerina-fit-to-screen": {
                 "description": "fit-to-screen",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1ed"
+                    "fontCharacter": "\\f1f1"
                 }
             },
             "ballerina-explicit-outlined": {
                 "description": "explicit-outlined",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1e5"
+                    "fontCharacter": "\\f1e9"
                 }
             },
             "ballerina-error-icon": {
                 "description": "error-icon",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1df"
+                    "fontCharacter": "\\f1e3"
                 }
             },
             "ballerina-error-outline": {
                 "description": "error-outline",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1e1"
+                    "fontCharacter": "\\f1e5"
                 }
             },
             "ballerina-symbol-struct-icon": {
                 "description": "symbol-struct-icon",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f259"
+                    "fontCharacter": "\\f25d"
                 }
             },
             "ballerina-add-circle-outline": {
@@ -1433,21 +1433,21 @@
                 "description": "radio-button-checked",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f23a"
+                    "fontCharacter": "\\f23e"
                 }
             },
             "ballerina-radio-button-unchecked": {
                 "description": "radio-button-unchecked",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f23b"
+                    "fontCharacter": "\\f23f"
                 }
             },
             "ballerina-file-upload": {
                 "description": "file-upload",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1ea"
+                    "fontCharacter": "\\f1ee"
                 }
             },
             "ballerina-file-submodule": {
@@ -1468,7 +1468,7 @@
                 "description": "design-view",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1d0"
+                    "fontCharacter": "\\f1d4"
                 }
             },
             "distro-file-submodule": {


### PR DESCRIPTION
## Purpose
Resolves wso2/product-integrator#2297 — CDC for Oracle DB, SAP JCo, SMB and Azure Files show no icon in the Add Artifact view.

The code asks for icons the font doesn't have. `brand-icon-registry.ts` maps these modules to `bi-oracledb`, `bi-sap`, `bi-smb` and `bi-azure-files`, and the webview renders each as `<i class="fw-bi-oracledb">`. Those four SVGs were added upstream after the commit we pin, so they aren't in the font we ship and the cards come out blank. All the other 24 icons the registry uses are fine, which is why FTP/SFTP has an icon and SMB doesn't.

This is not the same bug as wso2/product-integrator#2288. That one showed the wrong icon; this one shows no icon.

## Goals
- The four artifacts get their icons.
- The Debug icon fixed in #988 stays fixed.

## Approach
One commit.

Bumps the submodule from `09b37c8` to `d3dcf45ae0` (current main), which has the four SVGs.

The bump also moves 13 codepoints, so `contributes.icons` is updated in the same commit. Adding icons upstream shifts the numbers of the icons after them, and the extension hardcodes those numbers. Without the update, Debug would have gone back to showing the wrong icon — `dataMapper` instead of the bug. The test from #988 catches this, so the two changes have to land together.

`d3dcf45ae0` is also what wso2/vscode-extensions#2470 pins its codepoints to, so these numbers stay right once that merges.

## UI Component Development
N/A — no new components. The icons come from the ui-toolkit font.

## User stories
As a developer, I see icons for CDC for Oracle DB, SAP JCo, SMB and Azure Files in the Add Artifact view.

## Release note
Fixed the missing icons for CDC for Oracle DB, SAP JCo, SMB and Azure Files in the Add Artifact view.

## Documentation
N/A — nothing changes for users beyond the icons appearing.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests
  > No new tests. The test added in #988 covers the codepoint part and is what caught the shift. Full `packages/ballerina-extension` suite passes: 78 tests.
- Integration tests
  > N/A — no code paths changed.

Checked locally with the bumped submodule:

- The four glyphs are now in the generated CSS (`bi-oracledb` at `0xf176`, `bi-sap` at `0xf188`, `bi-smb` at `0xf190`, `bi-azure-files` at `0xf11f`).
- All 28 glyphs the registry uses now resolve; before the bump, four did not.
- `iconCodepoints.test.ts` fails before the codepoint update and passes after.

Two things I did not check. The bump brings in 110 upstream commits, and I only tested the font side — the *Build repo* job is the real check on the rest. And I didn't run VS Code, so there's no screenshot; the evidence is that the four CSS classes now exist.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- #988 (merged) — fixed the drifted codepoints and added the test this relies on.
- wso2/vscode-extensions#2470 — stops codepoints moving when icons are added. Until it merges, every submodule bump needs a codepoint update like this one, and the test will fail if it's missed.

## Migrations (if applicable)
None.

## Test environment
macOS 15, Node 22.16.0, pnpm 10.11.0, submodule at `d3dcf45ae0`.
