### PR TITLE
Teach the Copilot agent Ballerina module-init ordering rules

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/module-init-rules.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/module-init-rules.ts
@@ -1,0 +1,15 @@
+/**
+ * System-prompt rules for module-level variable initialization ordering.
+ *
+ * Copilot library testing produced compile errors ("uninitialized variable
+ * 'supportTicketAgent'") when generated code declared a module-level variable
+ * without an initializer and assigned it in init() in a way the dataflow
+ * analyzer could not prove — or read it from a module-level initializer, which
+ * is evaluated before init() runs.
+ *
+ * Kept in its own module (no imports) so it can be unit-tested without loading
+ * the extension-host module graph. Interpolated into the system prompt by
+ * getSystemPrompt() in ./prompts.ts.
+ */
+export const MODULE_INIT_CODING_RULES = `- Prefer initializing module-level variables at their declaration. When a value can only be built inside the module \`init()\` function (e.g. an \`ai:Agent\` whose construction can fail), declare the variable \`final\` (drop \`final\` only if it is reassigned after \`init()\`) without an initializer and assign it in \`init()\` exactly once, unconditionally, on every execution path — never only inside an \`if\`/\`match\` branch or a loop — otherwise the compiler reports the variable as uninitialized.
+- \`init()\` runs AFTER every module-level variable initializer and service/listener declaration has been evaluated. A module-level initializer, listener argument, or service declaration must never read a variable that is only assigned inside \`init()\`.`;

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -24,6 +24,7 @@ import { CONFIG_COLLECTOR_TOOL } from "./tools/config-collector";
 import { CLARIFY_TOOL } from "./tools/clarify";
 import { TEST_RUNNER_TOOL_NAME } from "./tools/test-runner";
 import { getLanglibInstructions } from "../utils/libs/langlibs";
+import { MODULE_INIT_CODING_RULES } from "./module-init-rules";
 import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
@@ -216,6 +217,7 @@ When a connector authenticates via an OAuth2 refresh-token grant that includes a
 - Always use named arguments when providing values to any parameter (e.g., .get(key="value")).
 - Mention types EXPLICITLY in variable declarations and foreach statements. (Avoid var at all costs)
 - To narrow down a union type(or optional type), always declare a separate variable and then use that variable in the if condition.
+${MODULE_INIT_CODING_RULES}
 
 ## File modifications
 - You must apply changes to the existing source code using the provided ${[

--- a/packages/ballerina-extension/src/test-support/moduleInitPromptRules.test.ts
+++ b/packages/ballerina-extension/src/test-support/moduleInitPromptRules.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for the module-init ordering rules injected into the agent system
+ * prompt (src/features/ai/agent/module-init-rules.ts) and their wiring into
+ * getSystemPrompt (src/features/ai/agent/prompts.ts).
+ *
+ * The wiring check reads prompts.ts as source text instead of importing it:
+ * prompts.ts transitively pulls in the extension-host module graph
+ * (StateMachine, language client), which must not load in this jest suite.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { MODULE_INIT_CODING_RULES } from '../features/ai/agent/module-init-rules';
+
+describe('MODULE_INIT_CODING_RULES content', () => {
+    test('teaches unconditional single assignment in init()', () => {
+        expect(MODULE_INIT_CODING_RULES).toMatch(/assign it in `init\(\)` exactly once, unconditionally/);
+        expect(MODULE_INIT_CODING_RULES).toMatch(/reports the variable as uninitialized/);
+    });
+
+    test('prefers initialization at declaration', () => {
+        expect(MODULE_INIT_CODING_RULES).toMatch(/Prefer initializing module-level variables at their declaration/);
+    });
+
+    test('keeps the init()-assigned variable final', () => {
+        expect(MODULE_INIT_CODING_RULES).toMatch(/declare the variable `final`/);
+    });
+
+    test('teaches that init() runs after module-level initializers and service declarations', () => {
+        expect(MODULE_INIT_CODING_RULES).toMatch(/`init\(\)` runs AFTER every module-level variable initializer/);
+        expect(MODULE_INIT_CODING_RULES).toMatch(/must never read a variable that is only assigned inside `init\(\)`/);
+    });
+
+    test('is a bullet list with no unresolved interpolations or stray backtick escapes', () => {
+        expect(MODULE_INIT_CODING_RULES.startsWith('- ')).toBe(true);
+        expect(MODULE_INIT_CODING_RULES).not.toContain('${');
+        expect(MODULE_INIT_CODING_RULES).not.toContain('\\`');
+    });
+});
+
+describe('system prompt wiring', () => {
+    const promptsSource = fs.readFileSync(
+        path.join(__dirname, '../features/ai/agent/prompts.ts'),
+        'utf-8',
+    );
+
+    test('prompts.ts imports the rules constant', () => {
+        const importStatement = promptsSource.match(/import \{[^}]*\} from "\.\/module-init-rules"/);
+        expect(importStatement).not.toBeNull();
+        expect(importStatement![0]).toContain('MODULE_INIT_CODING_RULES');
+    });
+
+    test('the rules sit inside the Coding Rules section', () => {
+        const codingRulesIdx = promptsSource.indexOf('## Coding Rules');
+        const rulesIdx = promptsSource.indexOf('${MODULE_INIT_CODING_RULES}');
+        const fileModsIdx = promptsSource.indexOf('## File modifications');
+        expect(codingRulesIdx).toBeGreaterThan(-1);
+        expect(rulesIdx).toBeGreaterThan(codingRulesIdx);
+        expect(rulesIdx).toBeLessThan(fileModsIdx);
+    });
+});


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/2319

Copilot-generated integrations that build a module-level value inside `init()` (e.g. an `ai:Agent` whose construction can fail) hit compile errors like `uninitialized variable 'supportTicketAgent'`: the variable is assigned behind a conditional path the dataflow analyzer cannot prove, or read from a module-level initializer that is evaluated before `init()` runs.

## Root cause

The agent system prompt carries no guidance on Ballerina's module-init ordering rules — nothing states that a module-level variable declared without an initializer must be assigned exactly once, unconditionally, on every path of `init()`, or that `init()` runs after all module-level initializers and service/listener declarations.

## Approach

- New `features/ai/agent/module-init-rules.ts` exporting `MODULE_INIT_CODING_RULES` (own module with no imports, mirroring the existing themed-rules pattern, so it is unit-testable without the extension-host module graph).
- Wired into the system prompt's `## Coding Rules` section in `prompts.ts`.

## Tests

`src/test-support/moduleInitPromptRules.test.ts` — 7 tests covering the rule content (unconditional single assignment, `final`, init-runs-last semantics) and the prompt wiring (import + placement inside Coding Rules). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `MODULE_INIT_CODING_RULES` to guide Copilot on Ballerina module-initialization ordering.
- Included the rules in the agent system prompt.
- Added tests for rule content and prompt integration.
- Helps prevent generated integrations from using uninitialized module-level values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->