### PR TITLE
Teach the Copilot agent open-record binding for external payloads

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/payload-binding-rules.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/payload-binding-rules.ts
@@ -1,0 +1,14 @@
+/**
+ * System-prompt rules for binding external JSON payloads.
+ *
+ * Copilot library testing produced runtime failures when generated code bound
+ * third-party JSON payloads (e.g. AWS S3 event notifications delivered over
+ * SQS) to CLOSED records missing real provider fields: cloneWithType /
+ * fromJsonStringWithType fail the moment the source carries a field the
+ * closed record does not declare.
+ *
+ * Kept in its own module (no imports) so it can be unit-tested without loading
+ * the extension-host module graph. Interpolated into the system prompt by
+ * getSystemPrompt() in ./prompts.ts.
+ */
+export const EXTERNAL_PAYLOAD_BINDING_RULES = `- Use closed records (\`record {| ... |}\`) only for data whose shape you fully control (your own request/response contracts). For JSON produced by an EXTERNAL system you do not control (cloud events such as AWS S3/SQS notifications, webhooks, third-party API responses), define OPEN records (\`record { ... }\`) so fields you did not model land in the rest field instead of failing the conversion — \`cloneWithType\`/\`fromJsonStringWithType\` fail at runtime when the source carries ANY field a closed record lacks. Model only the fields you need, and mark fields the provider may omit as optional (\`fieldName?\`).`;

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -24,6 +24,7 @@ import { CONFIG_COLLECTOR_TOOL } from "./tools/config-collector";
 import { CLARIFY_TOOL } from "./tools/clarify";
 import { TEST_RUNNER_TOOL_NAME } from "./tools/test-runner";
 import { getLanglibInstructions } from "../utils/libs/langlibs";
+import { EXTERNAL_PAYLOAD_BINDING_RULES } from "./payload-binding-rules";
 import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
@@ -216,6 +217,7 @@ When a connector authenticates via an OAuth2 refresh-token grant that includes a
 - Always use named arguments when providing values to any parameter (e.g., .get(key="value")).
 - Mention types EXPLICITLY in variable declarations and foreach statements. (Avoid var at all costs)
 - To narrow down a union type(or optional type), always declare a separate variable and then use that variable in the if condition.
+${EXTERNAL_PAYLOAD_BINDING_RULES}
 
 ## File modifications
 - You must apply changes to the existing source code using the provided ${[

--- a/packages/ballerina-extension/src/features/ai/utils/libs/langlibs.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/langlibs.ts
@@ -86,6 +86,7 @@ copy.push(4);  // original stays [1, 2, 3]
 To convert between types while preserving data, use cloneWithType():
 \`\`\`ballerina
 json cfg = {port: 8080};
+// Config is an owned shape (you control it), so a closed record is fine here.
 type Config record {| int port; int timeout = 60; |};
 Config config = check cfg.cloneWithType();
 
@@ -93,6 +94,8 @@ Config config = check cfg.cloneWithType();
 json[] arr = [1, 2, 3];
 int[] numbers = check arr.cloneWithType();
 \`\`\`
+
+Important: cloneWithType() and fromJsonStringWithType() into a CLOSED record (record {| ... |}) fail at runtime if the source value carries ANY field the record does not declare. When binding JSON from an external system you do not control (cloud events, webhooks, third-party API responses), use an OPEN record (record { ... }) with optional fields for anything the provider may omit, so unmodeled fields land in the rest field instead of failing the conversion.
 
 To validate that a value matches a specific type, use ensureType():
 \`\`\`ballerina

--- a/packages/ballerina-extension/src/test-support/externalPayloadRules.test.ts
+++ b/packages/ballerina-extension/src/test-support/externalPayloadRules.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the external-payload binding rules injected into the agent system
+ * prompt (src/features/ai/agent/payload-binding-rules.ts), their wiring into
+ * getSystemPrompt (src/features/ai/agent/prompts.ts), and the matching
+ * closed-record warning in the langlib instructions.
+ *
+ * The wiring check reads prompts.ts as source text instead of importing it:
+ * prompts.ts transitively pulls in the extension-host module graph
+ * (StateMachine, language client), which must not load in this jest suite.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { EXTERNAL_PAYLOAD_BINDING_RULES } from '../features/ai/agent/payload-binding-rules';
+import { LANGLIB_USAGE_INSTRUCTIONS } from '../features/ai/utils/libs/langlibs';
+
+describe('EXTERNAL_PAYLOAD_BINDING_RULES content', () => {
+    test('scopes closed records to owned schemas', () => {
+        expect(EXTERNAL_PAYLOAD_BINDING_RULES).toMatch(/closed records \(`record \{\| \.\.\. \|\}`\) only for data whose shape you fully control/);
+    });
+
+    test('mandates open records for external payloads with concrete examples', () => {
+        expect(EXTERNAL_PAYLOAD_BINDING_RULES).toMatch(/EXTERNAL system you do not control/);
+        expect(EXTERNAL_PAYLOAD_BINDING_RULES).toMatch(/AWS S3\/SQS notifications/);
+        expect(EXTERNAL_PAYLOAD_BINDING_RULES).toMatch(/OPEN records \(`record \{ \.\.\. \}`\)/);
+    });
+
+    test('names the failing conversions and the optional-field escape hatch', () => {
+        expect(EXTERNAL_PAYLOAD_BINDING_RULES).toMatch(/`cloneWithType`\/`fromJsonStringWithType` fail at runtime/);
+        expect(EXTERNAL_PAYLOAD_BINDING_RULES).toMatch(/optional \(`fieldName\?`\)/);
+    });
+
+    test('is a bullet list with no unresolved interpolations or stray backtick escapes', () => {
+        expect(EXTERNAL_PAYLOAD_BINDING_RULES.startsWith('- ')).toBe(true);
+        expect(EXTERNAL_PAYLOAD_BINDING_RULES).not.toContain('${');
+        expect(EXTERNAL_PAYLOAD_BINDING_RULES).not.toContain('\\`');
+    });
+});
+
+describe('system prompt wiring', () => {
+    const promptsSource = fs.readFileSync(
+        path.join(__dirname, '../features/ai/agent/prompts.ts'),
+        'utf-8',
+    );
+
+    test('prompts.ts imports the rules constant', () => {
+        const importStatement = promptsSource.match(/import \{[^}]*\} from "\.\/payload-binding-rules"/);
+        expect(importStatement).not.toBeNull();
+        expect(importStatement![0]).toContain('EXTERNAL_PAYLOAD_BINDING_RULES');
+    });
+
+    test('the rules sit inside the Coding Rules section', () => {
+        const codingRulesIdx = promptsSource.indexOf('## Coding Rules');
+        const rulesIdx = promptsSource.indexOf('${EXTERNAL_PAYLOAD_BINDING_RULES}');
+        const fileModsIdx = promptsSource.indexOf('## File modifications');
+        expect(codingRulesIdx).toBeGreaterThan(-1);
+        expect(rulesIdx).toBeGreaterThan(codingRulesIdx);
+        expect(rulesIdx).toBeLessThan(fileModsIdx);
+    });
+});
+
+describe('langlib closed-record warning', () => {
+    test('warns that cloneWithType into a closed record fails on unmodeled fields', () => {
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toMatch(/CLOSED record \(record \{\| \.\.\. \|\}\) fail at runtime/);
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toMatch(/use an OPEN record \(record \{ \.\.\. \}\)/);
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toMatch(/external system you do not control/);
+    });
+
+    test('marks the closed-record example as an owned shape so it cannot contradict the warning', () => {
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toMatch(/owned shape \(you control it\), so a closed record is fine here/);
+    });
+});


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/2320

Copilot generated CLOSED records for payloads produced by external systems (e.g. AWS S3 event notifications consumed from SQS), missing real provider fields. The runtime conversion then fails: `field 'Records[0].eventVersion' cannot be added to the closed record 's3_events:S3EventRecord'` (and a dozen siblings).

## Root cause

The system prompt pushes toward tight hand-written records ("ALWAYS define records instead of maps or json", "you can decide the structure") but never distinguishes schemas the code owns from external/third-party schemas — and the langlib guidance teaches `cloneWithType()` without warning that conversion into a closed record fails on any unmodeled field.

## Approach

- New `features/ai/agent/payload-binding-rules.ts` exporting `EXTERNAL_PAYLOAD_BINDING_RULES` (closed records only for owned schemas; OPEN records with optional fields for external payloads), wired into the system prompt's `## Coding Rules` section.
- Matching warning added directly beneath the `cloneWithType()` example in `langlibs.ts`, and the example itself annotated as an owned shape so it cannot read as a counter-example.

## Tests

`src/test-support/externalPayloadRules.test.ts` — 8 tests covering the rule content, the prompt wiring, and both langlib additions. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
