### PR TITLE
Teach the Copilot agent to exhaust paginated connector list APIs

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/pagination-rules.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/pagination-rules.ts
@@ -1,0 +1,13 @@
+/**
+ * System-prompt rule for exhausting paginated connector APIs.
+ *
+ * Copilot library testing produced silently truncated results: generated code
+ * called paginated list APIs once with the connector's defaulted page size
+ * (e.g. the GitHub connector's per_page = 30, always sent), so a changelog
+ * that required every commit contained only the first 30.
+ *
+ * Kept in its own module (no imports) so it can be unit-tested without loading
+ * the extension-host module graph. Interpolated into the system prompt by
+ * getSystemPrompt() in ./prompts.ts.
+ */
+export const PAGINATION_LIBRARY_RULE = `- When a function or resource signature exposes pagination parameters (\`page\`, \`per_page\`/\`perPage\`, \`pageSize\`, \`limit\`/\`offset\`, or a cursor/next-token) and the requirement is to process ALL results, never rely on a single call or the parameter defaults — defaults silently cap the result set (e.g. 30 items per page). Loop: request the documented maximum page size, advance the page/cursor, and stop only when a page comes back short or empty (or no next-cursor is returned), aggregating the results.`;

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -24,6 +24,7 @@ import { CONFIG_COLLECTOR_TOOL } from "./tools/config-collector";
 import { CLARIFY_TOOL } from "./tools/clarify";
 import { TEST_RUNNER_TOOL_NAME } from "./tools/test-runner";
 import { getLanglibInstructions } from "../utils/libs/langlibs";
+import { PAGINATION_LIBRARY_RULE } from "./pagination-rules";
 import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
@@ -172,6 +173,7 @@ When generating Ballerina code strictly follow these syntax and structure guidel
 ## Library Usage and Importing libraries
 - Only use the libraries received from user query or discovered via ${LIBRARY_SEARCH_TOOL} and fetched via ${LIBRARY_GET_TOOL}, or langlibs.
 - Examine the library API documentation provided by ${LIBRARY_GET_TOOL} carefully. Strictly follow the type definitions, function signatures, and all the other details provided when writing the code.
+${PAGINATION_LIBRARY_RULE}
 - Each .bal file must include its own import statements for any external library references.
 - Do not import default langlibs (lang.string, lang.boolean, lang.float, lang.decimal, lang.int, lang.map).
 - For packages with dots in names, use aliases: \`import org/package.one as one;\`

--- a/packages/ballerina-extension/src/test-support/paginationPromptRule.test.ts
+++ b/packages/ballerina-extension/src/test-support/paginationPromptRule.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for the pagination rule injected into the agent system prompt
+ * (src/features/ai/agent/pagination-rules.ts) and its wiring into
+ * getSystemPrompt (src/features/ai/agent/prompts.ts).
+ *
+ * The wiring check reads prompts.ts as source text instead of importing it:
+ * prompts.ts transitively pulls in the extension-host module graph
+ * (StateMachine, language client), which must not load in this jest suite.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { PAGINATION_LIBRARY_RULE } from '../features/ai/agent/pagination-rules';
+
+describe('PAGINATION_LIBRARY_RULE content', () => {
+    test('names the common pagination parameter shapes', () => {
+        expect(PAGINATION_LIBRARY_RULE).toMatch(/`page`, `per_page`\/`perPage`, `pageSize`, `limit`\/`offset`, or a cursor\/next-token/);
+    });
+
+    test('forbids relying on defaults and mandates the exhaustion loop', () => {
+        expect(PAGINATION_LIBRARY_RULE).toMatch(/never rely on a single call or the parameter defaults/);
+        expect(PAGINATION_LIBRARY_RULE).toMatch(/stop only when a page comes back short or empty/);
+        expect(PAGINATION_LIBRARY_RULE).toMatch(/documented maximum page size/);
+    });
+
+    test('is a bullet with no unresolved interpolations or stray backtick escapes', () => {
+        expect(PAGINATION_LIBRARY_RULE.startsWith('- ')).toBe(true);
+        expect(PAGINATION_LIBRARY_RULE).not.toContain('${');
+        expect(PAGINATION_LIBRARY_RULE).not.toContain('\\`');
+    });
+});
+
+describe('system prompt wiring', () => {
+    const promptsSource = fs.readFileSync(
+        path.join(__dirname, '../features/ai/agent/prompts.ts'),
+        'utf-8',
+    );
+
+    test('prompts.ts imports the rule constant', () => {
+        const importStatement = promptsSource.match(/import \{[^}]*\} from "\.\/pagination-rules"/);
+        expect(importStatement).not.toBeNull();
+        expect(importStatement![0]).toContain('PAGINATION_LIBRARY_RULE');
+    });
+
+    test('the rule sits in the Library Usage section, before the Coding Rules', () => {
+        const libraryUsageIdx = promptsSource.indexOf('## Library Usage and Importing libraries');
+        const ruleIdx = promptsSource.indexOf('${PAGINATION_LIBRARY_RULE}');
+        const codingRulesIdx = promptsSource.indexOf('## Coding Rules');
+        expect(libraryUsageIdx).toBeGreaterThan(-1);
+        expect(ruleIdx).toBeGreaterThan(libraryUsageIdx);
+        expect(ruleIdx).toBeLessThan(codingRulesIdx);
+    });
+});


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/2321

When a requirement needs ALL items from a paginated connector list API, Copilot calls the API once with the connector's defaults. Generated-connector pagination parameters are defaulted (not optional) and always sent — e.g. ballerinax/github emits `?per_page=30&page=1` unconditionally — so results are silently capped: a release changelog built from "every commit between the previous tag and head" contained only the first 30 commits, with no error anywhere.

## Root cause

The system prompt contains no pagination guidance at all (verified: no pagination-related rule reaches the codegen agent), and the rendered API docs correctly show `per_page = 30` as a legal default — so the model has no reason to loop.

## Approach

New `features/ai/agent/pagination-rules.ts` exporting `PAGINATION_LIBRARY_RULE`: when a signature exposes page/per_page/pageSize/limit/cursor parameters and the requirement covers ALL results, loop with the documented maximum page size until a page comes back short or empty, aggregating results. Wired into the system prompt's `## Library Usage and Importing libraries` section, next to the rule that tells the model to follow the rendered API docs.

Connector-specific facts (GitHub per_page max 100, the compare endpoint's 250-commit cap, uploads.github.com for release assets) are proposed separately for the ballerinax/github package README, per the library-instructions-in-README policy.

## Tests

`src/test-support/paginationPromptRule.test.ts` — 5 tests covering the rule content and the prompt wiring (Library Usage placement). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
