### PR TITLE
Teach Copilot the rules for declaring configurable variables

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/configurable-rules.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/configurable-rules.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * System-prompt rules for declaring `configurable` variables.
+ *
+ * The configuration collector that WSO2 Integrator uses to fill Config.toml supports scalar values only
+ * (string, int, decimal, boolean). A configurable declared with any other type — an `int:Signed32` port, a
+ * `string[]` of OAuth scopes, an enum, a `byte` — is written to Config.toml as a scalar the runtime rejects
+ * at startup ("configurable variable 'scopes' is expected to be of type 'string[] & readonly', but found
+ * 'string'"). Copilot followed a library API's parameter type into the configurable declaration because the
+ * prompt only listed the allowed types; it never said what to do when the API needs something else.
+ *
+ * Every conversion idiom below was compiled and run on Ballerina 2201.13.4, including the out-of-range case
+ * (which surfaces as a returned error, not a panic). Kept in its own module (no imports) so it can be
+ * unit-tested without loading the extension host.
+ */
+export const CONFIGURABLE_CODING_RULES = `## Configurable variables
+- Define a \`configurable\` variable for every value that must come from the environment: hosts, ports, credentials, tokens, queue and topic names, bucket names, file paths, timeouts, feature flags. Never hardcode such values.
+- A configurable variable may ONLY be declared with one of these types: \`string\`, \`int\`, \`decimal\`, \`boolean\`. The configuration collector cannot write any other type into Config.toml — not \`int:Signed32\`/\`int:Unsigned8\`/\`byte\`, not \`float\`, not arrays (\`string[]\`), not enums, not records, maps, unions or optional (\`string?\`) types. A configurable of any other type is written as a scalar and the program fails at startup with "configurable variable 'x' is expected to be of type '...' but found 'string'".
+- When a library API needs a value of another type, STILL declare the configurable with the nearest allowed type and convert it at the point of use with a langlib call. Do NOT change the configurable's type to match the API. Verified patterns:
+  - Integer subtypes: \`configurable int maxRetries = ?;\` then \`int:Signed32 retries = check maxRetries.ensureType();\` (same for \`int:Unsigned8\`, \`int:Signed16\`, \`byte\`: \`byte size = check bufferSize.ensureType();\`). \`ensureType\` returns an error, not a panic, when the value is out of range.
+  - \`float\` from \`decimal\`: \`configurable decimal timeoutSeconds = ?;\` then \`float timeout = <float>timeoutSeconds;\`.
+  - Enums and string-constant unions: \`configurable string logLevel = ?;\` then \`LogLevel level = check logLevel.ensureType();\`.
+  - Lists: declare ONE comma-separated \`string\` and split it: \`configurable string oauthScopes = ?;\` then \`string[] scopes = from string scope in re \`,\`.split(oauthScopes) let string trimmed = scope.trim() where trimmed.length() > 0 select trimmed;\`. Never declare \`configurable string[]\` and never build a colon- or space-delimited string where the API takes \`string[]\` — split into the array.
+  - Records and maps: declare one configurable per field the code needs and assemble the record in code.
+  - Do the conversion once, in a module-level \`final\` variable or at the start of \`init()\`/the function that needs it, so a bad value is reported once at startup rather than on every request.
+- Never assign a hardcoded default value to a configurable (\`configurable string host = ?;\`, not \`= "localhost"\`). The one exception: an OAuth2 refresh-token \`refreshUrl\` MAY carry the provider's token endpoint as its default when the library's type definition supplies one (\`configurable string refreshUrl = "<provider-token-endpoint-url>";\`); otherwise \`configurable string refreshUrl = ?;\`. Always reference it in the auth config (\`refreshUrl: refreshUrl\`).
+- Use one configurable per value and a two-word camelCase name that says what it configures (\`smtpHost\`, \`imapPollingIntervalSeconds\`, \`disruptionsQueueName\`); put the unit in the name for durations and sizes.
+- \`configurable\` variables are implicitly \`final\`: never write \`final configurable\`, and read them directly from any function or service (no \`lock\` needed).
+- Providing values is a runtime task done through the configuration collector, never by editing Config.toml yourself; secrets (passwords, tokens, client secrets) must be configurables, never literals in code.`;

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -27,6 +27,7 @@ import { getLanglibInstructions } from "../utils/libs/langlibs";
 import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
+import { CONFIGURABLE_CODING_RULES } from "./configurable-rules";
 import { getRequirementAnalysisCodeGenPrefix, getRequirementAnalysisTestGenPrefix } from "./np/prompts";
 import { extractResourceDocumentContent, flattenProjectToFiles } from "../utils/ai-utils";
 import { BALLERINA_RUN_TOOL_NAME } from "./tools/ballerina-run";
@@ -191,14 +192,11 @@ ${getLanglibInstructions()}
 
 ## Code Structure
 - In WSO2 Integrator, Automation is simply an app with a main method unless user specifically mentions a service. Cron Job kind of requirements are handled in the deployment level for Kubernetes or Integration platform level.
-- Define required configurables for the query. Use only string, int, decimal, boolean types in configurable variables. Never assign hardcoded default values to configurables.
+- Define required configurables for the query following the "Configurable variables" rules below.
 - Initialize any necessary clients with the correct configuration based on the retrieved libraries at the module level (before any function or service declarations).
 - Implement the main function OR service to address the query requirements.
 
-## OAuth refreshUrl configurable
-When a connector authenticates via an OAuth2 refresh-token grant that includes a refreshUrl:
-- Declare a \`configurable string\` for the refreshUrl and reference it in the auth config (e.g. \`refreshUrl: refreshUrl\`).
-- refreshUrl is the one configurable that MAY carry a default: if the library's type definition provides a default refreshUrl (the provider token endpoint), use it (\`configurable string refreshUrl = "<provider-token-endpoint-url>";\`); otherwise use \`configurable string refreshUrl = ?;\`.
+${CONFIGURABLE_CODING_RULES}
 
 ## Coding Rules
 - Use records as canonical representations of data structures. Always define records for data structures instead of using maps or json and navigate using the record fields.

--- a/packages/ballerina-extension/src/test-support/configurablePromptRules.test.ts
+++ b/packages/ballerina-extension/src/test-support/configurablePromptRules.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Pins the configurable-variable rules: the four allowed types, the declare-then-convert idioms for every
+ * other type (each compiled and run on Ballerina 2201.13.4), the no-default rule with its refreshUrl
+ * exception, and the wiring into the system prompt. `prompts.ts` cannot be imported here (extension-host
+ * module graph), so wiring is checked in the source.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { CONFIGURABLE_CODING_RULES } from '../features/ai/agent/configurable-rules';
+
+const promptsSource = fs.readFileSync(path.join(__dirname, '../features/ai/agent/prompts.ts'), 'utf-8');
+
+describe('CONFIGURABLE_CODING_RULES content', () => {
+    it('is a markdown section that limits configurables to the four collector-supported types', () => {
+        expect(CONFIGURABLE_CODING_RULES.startsWith('## Configurable variables')).toBe(true);
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/ONLY be declared with one of these types: `string`, `int`, `decimal`, `boolean`/);
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/not `int:Signed32`\/`int:Unsigned8`\/`byte`, not `float`, not arrays \(`string\[\]`\), not enums, not records, maps, unions or optional/);
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/expected to be of type '\.\.\.' but found 'string'/);
+    });
+
+    it('teaches declare-with-an-allowed-type-then-convert, never widening the configurable type', () => {
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/STILL declare the configurable with the nearest allowed type and convert it at the point of use/);
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/Do NOT change the configurable's type to match the API/);
+    });
+
+    it('carries the verified conversion idioms verbatim', () => {
+        expect(CONFIGURABLE_CODING_RULES).toContain('int:Signed32 retries = check maxRetries.ensureType();');
+        expect(CONFIGURABLE_CODING_RULES).toContain('byte size = check bufferSize.ensureType();');
+        expect(CONFIGURABLE_CODING_RULES).toContain('float timeout = <float>timeoutSeconds;');
+        expect(CONFIGURABLE_CODING_RULES).toContain('LogLevel level = check logLevel.ensureType();');
+        expect(CONFIGURABLE_CODING_RULES).toContain('string[] scopes = from string scope in re `,`.split(oauthScopes) let string trimmed = scope.trim() where trimmed.length() > 0 select trimmed;');
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/`ensureType` returns an error, not a panic, when the value is out of range/);
+    });
+
+    it('forbids array configurables and delimited strings passed where the API takes string[]', () => {
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/Never declare `configurable string\[\]`/);
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/never build a colon- or space-delimited string where the API takes `string\[\]`/);
+    });
+
+    it('keeps the no-default rule and the single refreshUrl exception', () => {
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/Never assign a hardcoded default value to a configurable/);
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/`configurable string refreshUrl = "<provider-token-endpoint-url>";`/);
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/otherwise `configurable string refreshUrl = \?;`/);
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/`refreshUrl: refreshUrl`/);
+    });
+
+    it('covers naming, implicit finality, and secrets', () => {
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/two-word camelCase name/);
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/never write `final configurable`/);
+        expect(CONFIGURABLE_CODING_RULES).toMatch(/secrets \(passwords, tokens, client secrets\) must be configurables, never literals in code/);
+    });
+
+    it('contains no unresolved interpolations or stray backtick escapes', () => {
+        expect(CONFIGURABLE_CODING_RULES).not.toMatch(/\$\{/);
+        expect(CONFIGURABLE_CODING_RULES).not.toMatch(/\\`/);
+    });
+});
+
+describe('system prompt wiring', () => {
+    it('imports the rules and interpolates them between Code Structure and Coding Rules', () => {
+        expect(promptsSource).toMatch(/import \{ CONFIGURABLE_CODING_RULES \} from "\.\/configurable-rules";/);
+        const codeStructure = promptsSource.indexOf('## Code Structure');
+        const interpolation = promptsSource.indexOf('${CONFIGURABLE_CODING_RULES}');
+        const codingRules = promptsSource.indexOf('## Coding Rules');
+        expect(interpolation).toBeGreaterThan(codeStructure);
+        expect(interpolation).toBeLessThan(codingRules);
+    });
+
+    it('replaces the old inline type list and refreshUrl section rather than duplicating them', () => {
+        expect(promptsSource).not.toMatch(/Use only string, int, decimal, boolean types in configurable variables/);
+        expect(promptsSource).not.toMatch(/## OAuth refreshUrl configurable/);
+        expect(promptsSource).toMatch(/following the "Configurable variables" rules below/);
+    });
+});


### PR DESCRIPTION
## Purpose

The configuration collector can only write `string`, `int`, `decimal` and `boolean` values into `Config.toml`. When a library API needed another type, Copilot declared the configurable with that type, for example `configurable string[] scopes = ?;` for OAuth scopes. The program then failed at startup:

```
configurable variable 'scopes' is expected to be of type 'string[] & readonly', but found 'string'
```

The prompt listed the allowed types but did not say what to do when an API needs a different type.

## Fix

A new rule section, "Configurable variables", is added to the Copilot system prompt (`configurable-rules.ts`). It gathers every rule about configurables in one place:

- Use configurables for hosts, ports, credentials, queue names, timeouts and flags.
- Declare them only as `string`, `int`, `decimal` or `boolean`.
- If the API needs another type, keep the allowed type and convert where the value is used:
  - `int:Signed32`, `byte` and other int subtypes: `check value.ensureType()`
  - `float`: `<float>value`
  - enums: `check value.ensureType()`
  - lists: one comma-separated `string`, split into an array
  - records: one configurable per field
- Never use `configurable string[]`, and never pass a delimited string where the API expects `string[]`.
- No hardcoded default values, except the existing OAuth2 `refreshUrl` case.
- Never write `final configurable`; keep secrets in configurables, not in code.

The old one-line type rule and the separate "OAuth refreshUrl configurable" section are removed, since the new section covers both. All conversion examples were compiled and run on Ballerina 2201.13.4.

## Tests

`src/test-support/configurablePromptRules.test.ts` checks the rule text and its place in the prompt. The full `test:unit` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
