### PR TITLE
Retrieve class members in Copilot library selection

### DIFF
--- a/packages/ballerina-extension/src/features/ai/utils/libs/class-typedefs.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/class-typedefs.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Class type definitions: recognising one, and collecting the types its members name.
+ *
+ * "Class" covers class declarations and object types alike — the language server maps
+ * `TypeDescKind.OBJECT` to `TypeCategory.CLASS`, so both arrive under one discriminator.
+ *
+ * Kept out of `function-registry` for the reason `library-selection` is: that module reaches the language
+ * server through `activator`, so importing it starts VS Code.
+ */
+
+import {
+    ClassTypeDefinition,
+    Parameter,
+    Type,
+    TypeDefinition,
+} from "./library-types";
+
+/** The `type` discriminator a class declaration or object type carries. */
+export const TYPE_CLASS = "Class";
+
+/**
+ * Whether a type definition should be treated as a class.
+ *
+ * Older language servers omitted the discriminator on class declarations, and `renderTypeDef` dispatches on
+ * it — an unlabelled class rendered as `// Unknown type: X`, silently dropping the whole API. `functions` is
+ * used as the fallback signal because no other category carries it.
+ */
+export function isClassTypeDef(typeDef: TypeDefinition): boolean {
+    if (typeDef.type === TYPE_CLASS) {
+        return true;
+    }
+    return !typeDef.type && Array.isArray((typeDef as ClassTypeDefinition).functions);
+}
+
+/**
+ * The types a class's members name — each method's parameter and return types, constructor included.
+ *
+ * A class is the one category whose members are API rather than shape, so the type closure has to descend
+ * into it: `Workbook.getSheet()` is the only path to `Sheet`, and without this the prompt renders a
+ * signature naming a type it never defines. The constructor is walked because it names the configuration
+ * record.
+ */
+export function collectClassMemberTypeRefs(typeDef: TypeDefinition): Type[] {
+    const refs: Type[] = [];
+    // `functions` is `any[]` and this runs on language-server output, so every hop is guarded.
+    const functions = (typeDef as ClassTypeDefinition).functions;
+    if (!Array.isArray(functions)) {
+        return refs;
+    }
+    for (const func of functions) {
+        if (!func) {
+            continue;
+        }
+        for (const param of (func.parameters ?? []) as Parameter[]) {
+            if (param?.type) {
+                refs.push(param.type);
+            }
+        }
+        if (func.return?.type) {
+            refs.push(func.return.type);
+        }
+    }
+    return refs;
+}

--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
@@ -30,11 +30,14 @@ import { Client, GetTypeResponse, GetTypesRequest, GetTypesResponse, getTypesRes
 import { TypeDefinition, AbstractFunction, Type, RecordTypeDefinition, UnionTypeDefinition } from "./library-types";
 import {
     getClientFunctionCount,
+    getSelectableMemberCount,
     hasNothingToSelect,
     selectServices,
+    selectClassTypeDefs,
     toSelectionRequest,
     withRestoredServiceLibraries,
 } from "./library-selection";
+import { collectClassMemberTypeRefs, TYPE_CLASS } from "./class-typedefs";
 import { getAnthropicClient, ANTHROPIC_HAIKU } from "../ai-client";
 import { GenerationType } from "./libraries";
 // import { getRequiredTypesFromLibJson } from "../healthcare/healthcare";
@@ -186,9 +189,14 @@ async function getRequiredFunctions(
     // restating it; `withRestoredServiceLibraries` removes it for the libraries that do get asked about.
     const passthroughLibs = libraryList.filter(hasNothingToSelect);
     const selectableLibs = libraryList.filter((lib) => !passthroughLibs.includes(lib));
-    const passthroughResp: GetFunctionResponse[] = passthroughLibs.map((lib) => ({ name: lib.name }));
+    // A passthrough library names its own classes: nothing chose to drop them, and a library whose whole
+    // API is classes has no clients or functions for the closure to walk from.
+    const passthroughResp: GetFunctionResponse[] = passthroughLibs.map((lib) => ({
+        name: lib.name,
+        ...(lib.classes && lib.classes.length > 0 ? { classes: lib.classes.map((cls) => cls.name) } : {}),
+    }));
 
-    const largeLibs = selectableLibs.filter((lib) => getClientFunctionCount(lib.clients) >= 100);
+    const largeLibs = selectableLibs.filter((lib) => getSelectableMemberCount(lib) >= 100);
     const smallLibs = selectableLibs.filter((lib) => !largeLibs.includes(lib));
 
     console.log(
@@ -271,8 +279,10 @@ CRITICAL RULES:
 2. Your ONLY task is selection - include or exclude items, NEVER modify field values.
 3. Copy all field values EXACTLY as provided - preserve every character including backslashes and special characters.
 4. For resource functions: "accessor" and "paths" are SEPARATE fields - NEVER combine them.
-5. A library is relevant if ANY of its clients, functions, or services match the query. A service matches when its "doc" (what the service is for), its "listenerDoc" (how it is triggered), its name, or ANY ONE of its handlers under "methods", is what the query needs. List each matching service under the library's "services" field, copying its "listener" and "name" verbatim; omit the services that do not match. If a library matches ONLY via its services, still include the library in the output with empty/omitted clients and functions.
-6. "doc", "listenerDoc" and a handler's "doc" are evidence to reason over, never fields to copy: the response carries only "listener" and "name" for a service.`;
+5. A library is relevant if ANY of its clients, functions, services, classes, or annotations match the query. A service matches when its "doc" (what the service is for), its "listenerDoc" (how it is triggered), its name, or ANY ONE of its handlers under "methods", is what the query needs. List each matching service under the library's "services" field, copying its "listener" and "name" verbatim; omit the services that do not match. If a library matches ONLY via its services, still include the library in the output with empty/omitted clients and functions.
+6. "doc", "listenerDoc" and a handler's "doc" are evidence to reason over, never fields to copy: the response carries only "listener" and "name" for a service.
+7. "classes" are types the library hands back that carry callable methods (a spreadsheet's Sheet, a connection's Session). A class matches when its name, its "description", or ANY ONE of its methods under "functions" is what the query needs. List each matching class under the library's "classes" field as its NAME ONLY, copied verbatim — never as an object, and never narrowed to selected methods. A query about a class method is one of the most common kinds: if the query asks to do something to a thing the library returns, look here before concluding the library does not match.
+8. "annotations" are evidence only and have NO response field. Never emit them. If a library matches only via an annotation, include the library with its other fields empty/omitted.`;
 
     const getLibUserPrompt = `You will be provided with a list of libraries, clients, and their functions, and a user query.
 
@@ -287,16 +297,18 @@ ${JSON.stringify(libraryList)}
 To process the user query and filter the libraries, clients, services and functions, follow these steps:
 
 1. Analyze the user query to understand the specific requirements or needs.
-2. Review the provided libraries, clients, services and functions in Library_Context_JSON.
-3. Select only the libraries, clients, services and functions that directly match the query's needs.
-4. Exclude any irrelevant libraries, clients, services or functions.
-5. If no relevant functions and services are found, return an empty array for libraries.
+2. Review the provided libraries, clients, services, functions, classes and annotations in Library_Context_JSON.
+3. Select only the libraries, clients, services, functions and classes that directly match the query's needs.
+4. Exclude any irrelevant libraries, clients, services, functions or classes.
+5. If no relevant functions, services and classes are found, return an empty array for libraries.
 6. Organize the remaining relevant information.
 
 CRITICAL - Field Preservation:
 - For resource functions: "accessor" contains ONLY the HTTP method (e.g., "post", "get") - do NOT put path info in it.
 - The "paths" field is separate - do NOT merge with accessor.
 - Copy all values exactly - preserve backslashes, dots, and special characters.
+- "classes" is an array of NAME STRINGS, not objects. Do not list a class's methods in the response.
+- "annotations" has no response field. Never emit one.
 
 Return the filtered subset with IDENTICAL field values.
 
@@ -434,6 +446,9 @@ export async function toMaximizedLibrariesFromLibJson(
         const filteredClients = selectClients(originalLib.clients, funcResponse);
         const filteredFunctions = selectFunctions(originalLib.functions, funcResponse);
         const filteredServices = selectServices(originalLib.services, funcResponse);
+        // Seeded into the closure rather than filtered, so a class no selected function references still
+        // reaches the catalog.
+        const selectedClasses = selectClassTypeDefs(originalLib.typeDefs, funcResponse);
 
         const maximizedLib: Library = {
             name: funcResponse.name,
@@ -444,7 +459,7 @@ export async function toMaximizedLibrariesFromLibJson(
             // The SELECTED services, not the library's whole set: the closure is what pulls a service's
             // parameter, return, annotation and binding types into `typeDefs`, so walking dropped services
             // would keep paying the larger half of their cost after dropping the services themselves.
-            typeDefs: getOwnTypeDefsForLib(filteredClients, filteredFunctions, originalLib.typeDefs, filteredServices ? filteredServices : undefined, originalLib.annotations),
+            typeDefs: getOwnTypeDefsForLib(filteredClients, filteredFunctions, originalLib.typeDefs, filteredServices ? filteredServices : undefined, originalLib.annotations, selectedClasses),
             services: filteredServices,
             annotations: originalLib.annotations ? originalLib.annotations : null,
             instructions: originalLib.instructions ? originalLib.instructions : null,
@@ -591,7 +606,8 @@ function getOwnTypeDefsForLib(
     functions: RemoteFunction[] | undefined,
     allTypeDefs: TypeDefinition[],
     services?: Service[],
-    annotations?: Annotation[]
+    annotations?: Annotation[],
+    selectedClasses?: TypeDefinition[]
 ): TypeDefinition[] {
     const allFunctions: AbstractFunction[] = [];
 
@@ -605,7 +621,7 @@ function getOwnTypeDefsForLib(
         allFunctions.push(...functions);
     }
 
-    return getOwnRecordRefs(allFunctions, allTypeDefs, services, annotations);
+    return getOwnRecordRefs(allFunctions, allTypeDefs, services, annotations, selectedClasses);
 }
 
 /**
@@ -707,8 +723,13 @@ function collectServiceTypeRefs(service: Service): Type[] {
     return refs;
 }
 
-function getOwnRecordRefs(functions: AbstractFunction[], allTypeDefs: TypeDefinition[], services?: Service[], annotations?: Annotation[]): TypeDefinition[] {
+function getOwnRecordRefs(functions: AbstractFunction[], allTypeDefs: TypeDefinition[], services?: Service[], annotations?: Annotation[], selectedClasses?: TypeDefinition[]): TypeDefinition[] {
     const ownRecords = new Map<string, TypeDefinition>();
+
+    // Seed with the classes the model named; the TYPE_CLASS arm below then reaches what their methods name.
+    for (const typeDef of selectedClasses ?? []) {
+        ownRecords.set(typeDef.name, typeDef);
+    }
 
     // Process all functions to find type references
     for (const func of functions) {
@@ -762,6 +783,13 @@ function getOwnRecordRefs(functions: AbstractFunction[], allTypeDefs: TypeDefini
             const unionDef = typeDef as UnionTypeDefinition;
             for (const member of unionDef.members) {
                 const foundTypes = addInternalRecord(member.type, ownRecords, allTypeDefs);
+                typesToProcess.push(...foundTypes);
+            }
+        } else if (typeDef.type === TYPE_CLASS) {
+            // A class's methods name types the reader needs. Without this arm a class was a leaf, and a
+            // type reachable only through one of its methods reached the prompt undefined.
+            for (const ref of collectClassMemberTypeRefs(typeDef)) {
+                const foundTypes = addInternalRecord(ref, ownRecords, allTypeDefs);
                 typesToProcess.push(...foundTypes);
             }
         }
@@ -937,6 +965,11 @@ function getExternalTypeDefRefs(
             const unionDef = typeDef as UnionTypeDefinition;
             for (const member of unionDef.members) {
                 addExternalRecord(member.type, externalRecords);
+            }
+        } else if (typeDef.type === TYPE_CLASS) {
+            // External counterpart of the internal arm, walking the same refs so the two cannot diverge.
+            for (const ref of collectClassMemberTypeRefs(typeDef)) {
+                addExternalRecord(ref, externalRecords);
             }
         }
     }

--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
@@ -37,7 +37,7 @@ import {
     toSelectionRequest,
     withRestoredServiceLibraries,
 } from "./library-selection";
-import { collectClassMemberTypeRefs, TYPE_CLASS } from "./class-typedefs";
+import { collectClassMemberTypeRefs, isClassTypeDef } from "./class-typedefs";
 import { getAnthropicClient, ANTHROPIC_HAIKU } from "../ai-client";
 import { GenerationType } from "./libraries";
 // import { getRequiredTypesFromLibJson } from "../healthcare/healthcare";
@@ -279,10 +279,10 @@ CRITICAL RULES:
 2. Your ONLY task is selection - include or exclude items, NEVER modify field values.
 3. Copy all field values EXACTLY as provided - preserve every character including backslashes and special characters.
 4. For resource functions: "accessor" and "paths" are SEPARATE fields - NEVER combine them.
-5. A library is relevant if ANY of its clients, functions, services, classes, or annotations match the query. A service matches when its "doc" (what the service is for), its "listenerDoc" (how it is triggered), its name, or ANY ONE of its handlers under "methods", is what the query needs. List each matching service under the library's "services" field, copying its "listener" and "name" verbatim; omit the services that do not match. If a library matches ONLY via its services, still include the library in the output with empty/omitted clients and functions.
-6. "doc", "listenerDoc" and a handler's "doc" are evidence to reason over, never fields to copy: the response carries only "listener" and "name" for a service.
-7. "classes" are types the library hands back that carry callable methods (a spreadsheet's Sheet, a connection's Session). A class matches when its name, its "description", or ANY ONE of its methods under "functions" is what the query needs. List each matching class under the library's "classes" field as its NAME ONLY, copied verbatim — never as an object, and never narrowed to selected methods. A query about a class method is one of the most common kinds: if the query asks to do something to a thing the library returns, look here before concluding the library does not match.
-8. "annotations" are evidence only and have NO response field. Never emit them. If a library matches only via an annotation, include the library with its other fields empty/omitted.`;
+5. A library is relevant if ANY of its clients, functions, services, classes, or annotations match the query. When a library matches via only one of these, still include it, leaving the other fields empty or omitted.
+6. A service matches on its "doc", its "listenerDoc", its name, or ANY ONE of its handlers under "methods". List each match under "services", copying "listener" and "name" verbatim. "doc", "listenerDoc" and a handler's "doc" are evidence to reason over, never fields to copy.
+7. A class - "classes" also carries the library's object types - matches on its name, its "description", or ANY ONE of its methods under "functions". List each match under "classes" as its NAME ONLY, copied verbatim: never as an object, and never narrowed to selected methods.
+8. "annotations" are evidence only and have NO response field. Never emit them.`;
 
     const getLibUserPrompt = `You will be provided with a list of libraries, clients, and their functions, and a user query.
 
@@ -308,7 +308,6 @@ CRITICAL - Field Preservation:
 - The "paths" field is separate - do NOT merge with accessor.
 - Copy all values exactly - preserve backslashes, dots, and special characters.
 - "classes" is an array of NAME STRINGS, not objects. Do not list a class's methods in the response.
-- "annotations" has no response field. Never emit one.
 
 Return the filtered subset with IDENTICAL field values.
 
@@ -726,7 +725,7 @@ function collectServiceTypeRefs(service: Service): Type[] {
 function getOwnRecordRefs(functions: AbstractFunction[], allTypeDefs: TypeDefinition[], services?: Service[], annotations?: Annotation[], selectedClasses?: TypeDefinition[]): TypeDefinition[] {
     const ownRecords = new Map<string, TypeDefinition>();
 
-    // Seed with the classes the model named; the TYPE_CLASS arm below then reaches what their methods name.
+    // Seed with the classes the model named; the class arm below then reaches what their methods name.
     for (const typeDef of selectedClasses ?? []) {
         ownRecords.set(typeDef.name, typeDef);
     }
@@ -785,7 +784,7 @@ function getOwnRecordRefs(functions: AbstractFunction[], allTypeDefs: TypeDefini
                 const foundTypes = addInternalRecord(member.type, ownRecords, allTypeDefs);
                 typesToProcess.push(...foundTypes);
             }
-        } else if (typeDef.type === TYPE_CLASS) {
+        } else if (isClassTypeDef(typeDef)) {
             // A class's methods name types the reader needs. Without this arm a class was a leaf, and a
             // type reachable only through one of its methods reached the prompt undefined.
             for (const ref of collectClassMemberTypeRefs(typeDef)) {
@@ -966,7 +965,7 @@ function getExternalTypeDefRefs(
             for (const member of unionDef.members) {
                 addExternalRecord(member.type, externalRecords);
             }
-        } else if (typeDef.type === TYPE_CLASS) {
+        } else if (isClassTypeDef(typeDef)) {
             // External counterpart of the internal arm, walking the same refs so the two cannot diverge.
             for (const ref of collectClassMemberTypeRefs(typeDef)) {
                 addExternalRecord(ref, externalRecords);

--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-types.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-types.ts
@@ -22,6 +22,33 @@ export interface GetFunctionsRequest {
     clients: MinifiedClient[];
     functions?: MinifiedRemoteFunction[];
     services?: MinifiedService[];
+    classes?: MinifiedClassTypeDef[];
+    annotations?: MinifiedAnnotation[];
+}
+
+/**
+ * One class or object type as the request states it.
+ *
+ * Without these the selection model never saw a library's class members, so a query about one matched
+ * nothing and the library was dropped whole. Shaped like {@link MinifiedClient}: structurally the same
+ * thing, and the difference (a client is invoked with `->`) is not one this model reasons about.
+ */
+export interface MinifiedClassTypeDef {
+    name: string;
+    description?: string;
+    functions: (MinifiedRemoteFunction | MinifiedResourceFunction)[];
+}
+
+/**
+ * One annotation as the request states it.
+ *
+ * Evidence only — annotations have no response field, because the library keeps all of them either way.
+ * Sending them lets a library be *matched* on one rather than depending on a function mentioning it.
+ */
+export interface MinifiedAnnotation {
+    name: string;
+    attachmentPoint: string;
+    description?: string;
 }
 
 export interface MinifiedClient {
@@ -125,11 +152,24 @@ export interface GetFunctionResponse {
     clients?: MinifiedClient[];
     functions?: MinifiedRemoteFunction[];
     services?: SelectedService[];
+    /**
+     * The classes the model judged relevant, by name only.
+     *
+     * Names, not member selections: a class already reaches the catalog whole when a selected function
+     * names it, so a member-level selection could only narrow what renders today. This field exists for
+     * the opposite case — pulling in a class nothing references.
+     */
+    classes?: (string | { name: string })[];
 }
 
 export interface PathParameter {
     name: string;
     type: string;
+}
+
+/** The response's class entries as plain names, whichever of the two accepted shapes the model used. */
+export function toSelectedClassNames(classes: GetFunctionResponse["classes"]): string[] {
+    return (classes ?? []).map((entry) => (typeof entry === "string" ? entry : entry?.name)).filter(Boolean) as string[];
 }
 
 const pathItemSchema = z.union([
@@ -173,6 +213,9 @@ const libraryResponseSchema = z.object({
     clients: z.array(clientSchema).optional(),
     functions: z.array(remoteFunctionSchema).optional(),
     services: z.array(selectedServiceSchema).optional(),
+    // Tolerant of the object form, because every sibling field here is an object and the model reaches for
+    // it by habit. A schema violation is total: `generateObject` throws and the agent is handed `[]`.
+    classes: z.array(z.union([z.string(), z.object({ name: z.string() })])).optional(),
 });
 
 export const getFunctionsResponseSchema = z.object({

--- a/packages/ballerina-extension/src/features/ai/utils/libs/library-selection.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/library-selection.ts
@@ -27,13 +27,27 @@
 import {
     GetFunctionResponse,
     GetFunctionsRequest,
+    MinifiedAnnotation,
+    MinifiedClassTypeDef,
     MinifiedClient,
     MinifiedHandler,
     MinifiedRemoteFunction,
     MinifiedResourceFunction,
     MinifiedService,
+    toSelectedClassNames,
 } from "./function-types";
-import { Client, FixedService, Library, RemoteFunction, ResourceFunction, Service } from "./library-types";
+import {
+    Annotation,
+    Client,
+    ClassTypeDefinition,
+    FixedService,
+    Library,
+    RemoteFunction,
+    ResourceFunction,
+    Service,
+    TypeDefinition,
+} from "./library-types";
+import { isClassTypeDef } from "./class-typedefs";
 
 /** The `type` a client's constructor carries; it is re-attached by `selectClients`, never selected. */
 const TYPE_CONSTRUCTOR = "Constructor";
@@ -49,6 +63,17 @@ export const MIN_SERVICES_TO_FILTER = 3;
 
 export function getClientFunctionCount(clients: MinifiedClient[]): number {
     return clients.reduce((count, client) => count + client.functions.length, 0);
+}
+
+/**
+ * The members a request entry offers the model, across clients and classes.
+ *
+ * Drives the large-library split. Counting clients alone was right while they were the only members sent;
+ * a library whose API lives in classes would otherwise be batched in bulk and risk truncation.
+ */
+export function getSelectableMemberCount(lib: GetFunctionsRequest): number {
+    const classMembers = (lib.classes ?? []).reduce((count, cls) => count + cls.functions.length, 0);
+    return getClientFunctionCount(lib.clients) + classMembers;
 }
 
 /**
@@ -297,7 +322,79 @@ export function toSelectionRequest(lib: Library, includeFunctionDescriptions: bo
         clients: toRequestClients(lib.clients),
         functions: toRequestFunctions(lib.functions, includeFunctionDescriptions),
         services: toServiceRequestEntries(lib.services),
+        classes: toRequestClasses(lib.typeDefs),
+        annotations: toRequestAnnotations(lib.annotations),
     };
+}
+
+/**
+ * The library's classes as the request states them; absent when it declares none.
+ *
+ * Read out of `typeDefs`, which holds class declarations and object types alike. A class with no members is
+ * skipped — it carries no evidence to match on, and the marker types of that shape (`kafka:Service`) are
+ * not things a reader calls.
+ */
+export function toRequestClasses(typeDefs: TypeDefinition[] | undefined): MinifiedClassTypeDef[] | undefined {
+    if (!typeDefs) {
+        return undefined;
+    }
+    const classes: MinifiedClassTypeDef[] = [];
+    for (const typeDef of typeDefs) {
+        if (!isClassTypeDef(typeDef)) {
+            continue;
+        }
+        const members = toRequestClientFunctions(
+            ((typeDef as ClassTypeDefinition).functions ?? []) as (RemoteFunction | ResourceFunction)[]
+        );
+        if (members.length === 0) {
+            continue;
+        }
+        const entry: MinifiedClassTypeDef = { name: typeDef.name, functions: members };
+        const doc = toRequestDoc(typeDef.description, MAX_SERVICE_DOC_CHARS);
+        if (doc) {
+            entry.description = doc;
+        }
+        classes.push(entry);
+    }
+    return classes.length > 0 ? classes : undefined;
+}
+
+/**
+ * The library's annotations as the request states them; absent when it declares none.
+ *
+ * Evidence only — `toMaximizedLibrariesFromLibJson` keeps them all either way, so there is no response
+ * counterpart. Capped at the service bound: an annotation states its purpose once per library.
+ */
+export function toRequestAnnotations(annotations: Annotation[] | undefined): MinifiedAnnotation[] | undefined {
+    if (!annotations || annotations.length === 0) {
+        return undefined;
+    }
+    return annotations.map((ann) => {
+        const entry: MinifiedAnnotation = { name: ann.name, attachmentPoint: ann.attachmentPoint };
+        const doc = toRequestDoc(ann.description, MAX_SERVICE_DOC_CHARS);
+        if (doc) {
+            entry.description = doc;
+        }
+        return entry;
+    });
+}
+
+/**
+ * The class type definitions the model named, re-resolved against the library's own and returned intact.
+ *
+ * Exists to pull in a class no selected function references — a query answered entirely by `Sheet` members
+ * otherwise has no path to it. An unresolvable name is skipped, never fatal.
+ */
+export function selectClassTypeDefs(
+    typeDefs: TypeDefinition[] | undefined,
+    funcResponse: GetFunctionResponse
+): TypeDefinition[] {
+    const selected = toSelectedClassNames(funcResponse.classes);
+    if (!typeDefs || selected.length === 0) {
+        return [];
+    }
+    const wanted = new Set(selected);
+    return typeDefs.filter((typeDef) => wanted.has(typeDef.name) && isClassTypeDef(typeDef));
 }
 
 /** Each client as the request states it: its name, its doc, and its functions minified. */

--- a/packages/ballerina-extension/src/features/ai/utils/libs/library-selection.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/library-selection.ts
@@ -79,6 +79,9 @@ export function getSelectableMemberCount(lib: GetFunctionsRequest): number {
 /**
  * Whether a request entry gives the selection model no choice to make.
  *
+ * Classes are deliberately not counted: a class-only library passes through with all of them kept, rather
+ * than being sent to a model that could drop it outright with no restore guard to undo that.
+ *
  * Three things must all be absent, and the third is the one that reads oddly. A library with no client
  * functions and no module-level functions has nothing *functional* to select — every trigger package is
  * that shape — but it may still declare many service types, and choosing among those is a decision.
@@ -416,20 +419,18 @@ function toRequestClientFunctions(
 ): (MinifiedRemoteFunction | MinifiedResourceFunction)[] {
     const output: (MinifiedRemoteFunction | MinifiedResourceFunction)[] = [];
 
-    for (const item of functions) {
+    // Guarded at every hop: this is also handed a class's `functions`, which is `any[]` off the wire, and
+    // a throw here costs the caller every library rather than one member.
+    for (const item of functions ?? []) {
+        if (!item) {
+            continue;
+        }
+        const parameters = (item.parameters ?? []).map((param) => param?.name).filter(Boolean) as string[];
+        const returnType = item.return?.type?.name;
         if ("accessor" in item) {
-            output.push({
-                accessor: item.accessor,
-                paths: item.paths,
-                parameters: item.parameters.map((param) => param.name),
-                returnType: item.return.type.name,
-            });
-        } else if (item.type !== TYPE_CONSTRUCTOR) {
-            output.push({
-                name: item.name,
-                parameters: item.parameters.map((param) => param.name),
-                returnType: item.return.type.name,
-            });
+            output.push({ accessor: item.accessor, paths: item.paths ?? [], parameters, returnType });
+        } else if (item.type !== TYPE_CONSTRUCTOR && item.name) {
+            output.push({ name: item.name, parameters, returnType });
         }
     }
 

--- a/packages/ballerina-extension/src/features/ai/utils/libs/to-syntax-string.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/to-syntax-string.ts
@@ -47,6 +47,7 @@ import {
     TypedescVariant,
     PlatformDependency,
 } from "./library-types";
+import { isClassTypeDef } from "./class-typedefs";
 
 /**
  * One `AnnotationAttachPoint` constant, as it must be written in a Ballerina annotation declaration.
@@ -562,8 +563,14 @@ function renderBaseTypeDefinition(typeDef: TypeDefinitionBase): string {
 
 /**
  * Renders a type definition to Ballerina syntax.
+ *
+ * The pre-switch class check is a backstop for older language servers, which omitted the discriminator on
+ * class declarations. Falling through to `// Unknown type:` discards a whole connector API silently.
  */
 function renderTypeDef(typeDef: TypeDefinition): string {
+    if (!typeDef.type && isClassTypeDef(typeDef)) {
+        return renderClass(typeDef as ClassTypeDefinition);
+    }
     switch (typeDef.type) {
         case "Record":
             return renderRecord(typeDef as RecordTypeDefinition);

--- a/packages/ballerina-extension/test/ai/unit_tests/libs/class-typedefs.test.ts
+++ b/packages/ballerina-extension/test/ai/unit_tests/libs/class-typedefs.test.ts
@@ -1,0 +1,271 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import * as assert from "assert";
+import {
+    TYPE_CLASS,
+    collectClassMemberTypeRefs,
+    isClassTypeDef,
+} from "../../../../src/features/ai/utils/libs/class-typedefs";
+import {
+    getSelectableMemberCount,
+    selectClassTypeDefs,
+    toRequestAnnotations,
+    toRequestClasses,
+    toSelectionRequest,
+} from "../../../../src/features/ai/utils/libs/library-selection";
+import { Annotation, Library, TypeDefinition } from "../../../../src/features/ai/utils/libs/library-types";
+import { toSyntaxString } from "../../../../src/features/ai/utils/libs/to-syntax-string";
+
+function method(name: string, params: { name: string; type: string }[], returnType: string): unknown {
+    return {
+        name,
+        type: "Normal Function",
+        description: "",
+        parameters: params.map((p) => ({
+            name: p.name,
+            description: "",
+            type: { name: p.type, links: [{ category: "internal", recordName: p.type }] },
+        })),
+        return: { type: { name: returnType, links: [{ category: "internal", recordName: returnType }] } },
+    };
+}
+
+/** A class as the language server sends it today: labelled `Class`, members in `functions`. */
+function classTypeDef(name: string, functions: unknown[], description = `The ${name}.`): TypeDefinition {
+    return { name, description, type: TYPE_CLASS, functions } as unknown as TypeDefinition;
+}
+
+/** The same class as an older language server sent it: no `type` key at all. */
+function unlabelledClass(name: string, functions: unknown[]): TypeDefinition {
+    return { name, description: `The ${name}.`, functions } as unknown as TypeDefinition;
+}
+
+suite("class typeDefs — recognising a class", () => {
+    test("a labelled class is believed as-is", () => {
+        assert.strictEqual(isClassTypeDef(classTypeDef("Workbook", [])), true);
+    });
+
+    test("an unlabelled entry carrying functions is still a class", () => {
+        assert.strictEqual(isClassTypeDef(unlabelledClass("Workbook", [])), true);
+    });
+
+    test("a record is not a class, even though it carries members of its own", () => {
+        const record = {
+            name: "CellRange", description: "", type: "Record",
+            fields: [{ name: "start", description: "", type: { name: "string" } }],
+        } as TypeDefinition;
+        assert.strictEqual(isClassTypeDef(record), false);
+    });
+
+    test("an unlabelled entry with no functions is left alone rather than guessed at", () => {
+        assert.strictEqual(isClassTypeDef({ name: "Mystery", description: "" } as TypeDefinition), false);
+    });
+});
+
+suite("class typeDefs — the types a class's members name", () => {
+    test("collects parameter and return types from every method", () => {
+        const workbook = classTypeDef("Workbook", [
+            method("getSheet", [{ name: "target", type: "string" }], "Sheet"),
+            method("getTable", [{ name: "name", type: "string" }], "Table"),
+        ]);
+        const names = collectClassMemberTypeRefs(workbook).map((t) => t.name);
+        assert.deepStrictEqual(names, ["string", "Sheet", "string", "Table"]);
+    });
+
+    test("collects the constructor's parameter types — a class the reader cannot construct is unusable", () => {
+        const workbook = classTypeDef("Workbook", [
+            {
+                type: "Constructor", description: "",
+                parameters: [{ name: "config", description: "", type: { name: "ConnectionConfig" } }],
+                return: { type: { name: "Workbook" } },
+            },
+        ]);
+        assert.ok(collectClassMemberTypeRefs(workbook).map((t) => t.name).includes("ConnectionConfig"));
+    });
+
+    test("a definition with no functions contributes nothing", () => {
+        const record = { name: "R", description: "", type: "Record" } as TypeDefinition;
+        assert.deepStrictEqual(collectClassMemberTypeRefs(record), []);
+    });
+
+    test("a malformed member does not throw — this runs on language-server output, not checked types", () => {
+        const broken = classTypeDef("Workbook", [null, {}, { parameters: null, return: null }]);
+        assert.deepStrictEqual(collectClassMemberTypeRefs(broken), []);
+    });
+});
+
+suite("class typeDefs — rendering", () => {
+    test("an unlabelled class renders its members instead of `// Unknown type:`", () => {
+        const library: Library = {
+            name: "ballerina/xlsx",
+            description: "Spreadsheets.",
+            typeDefs: [unlabelledClass("Workbook", [method("getSheet", [{ name: "target", type: "string" }], "Sheet")])],
+            clients: [],
+        };
+        const rendered = toSyntaxString([library]);
+        assert.ok(!rendered.includes("// Unknown type: Workbook"), `class discarded:\n${rendered}`);
+        assert.ok(rendered.includes("class Workbook {"), `class body missing:\n${rendered}`);
+        assert.ok(rendered.includes("getSheet"), `member API missing:\n${rendered}`);
+    });
+
+    test("a genuinely unknown type definition still renders as unknown", () => {
+        const library: Library = {
+            name: "ballerina/xlsx", description: "",
+            typeDefs: [{ name: "Mystery", description: "", type: "Bogus" } as TypeDefinition],
+            clients: [],
+        };
+        assert.ok(toSyntaxString([library]).includes("// Unknown type: Mystery"));
+    });
+});
+
+suite("selection request — classes and object types", () => {
+    const sheet = classTypeDef("Sheet", [
+        method("getCell", [{ name: "row", type: "int" }, { name: "col", type: "int" }], "CellValue"),
+        method("setCell", [{ name: "row", type: "int" }], "Error"),
+    ], "One worksheet in a workbook.");
+
+    test("a class reaches the selection model with its member names", () => {
+        const [entry] = toRequestClasses([sheet])!;
+        assert.strictEqual(entry.name, "Sheet");
+        assert.strictEqual(entry.description, "One worksheet in a workbook.");
+        assert.deepStrictEqual(entry.functions.map((f) => (f as { name: string }).name), ["getCell", "setCell"]);
+    });
+
+    test("member parameter names and return types are carried, as they are for a client", () => {
+        const [entry] = toRequestClasses([sheet])!;
+        const first = entry.functions[0] as { parameters?: string[]; returnType?: string };
+        assert.deepStrictEqual(first.parameters, ["row", "col"]);
+        assert.strictEqual(first.returnType, "CellValue");
+    });
+
+    /** Object types are the same wire category as classes. */
+    test("an object type is carried exactly like a class declaration", () => {
+        const objectType = classTypeDef("Table", [method("getHeaders", [], "string[]")]);
+        assert.deepStrictEqual(toRequestClasses([objectType])!.map((c) => c.name), ["Table"]);
+    });
+
+    test("a marker class with no members is skipped — it carries no evidence to match on", () => {
+        assert.strictEqual(toRequestClasses([classTypeDef("Service", [])]), undefined);
+    });
+
+    test("records are not offered as classes", () => {
+        const record = { name: "CellRange", description: "", type: "Record", fields: [] } as TypeDefinition;
+        assert.strictEqual(toRequestClasses([record]), undefined);
+    });
+
+    test("the constructor is omitted, as it is for clients — it is not a choice the model makes", () => {
+        const withCtor = classTypeDef("Workbook", [
+            { type: "Constructor", description: "", parameters: [], return: { type: { name: "Workbook" } } },
+            method("save", [], "Error"),
+        ]);
+        assert.deepStrictEqual(
+            toRequestClasses([withCtor])![0].functions.map((f) => (f as { name: string }).name),
+            ["save"]
+        );
+    });
+
+    test("a library's classes are part of the request it is judged on", () => {
+        const library = {
+            name: "ballerina/xlsx", description: "Spreadsheets.",
+            clients: [], typeDefs: [sheet],
+        } as Library;
+        assert.deepStrictEqual(toSelectionRequest(library, false).classes?.map((c) => c.name), ["Sheet"]);
+    });
+});
+
+suite("selection request — annotations", () => {
+    const annotations: Annotation[] = [
+        { name: "ServiceConfig", attachmentPoint: "service", description: "Configures the service." },
+        { name: "Cache", attachmentPoint: "return" },
+    ];
+
+    test("annotations reach the model with their attach point and doc", () => {
+        assert.deepStrictEqual(toRequestAnnotations(annotations), [
+            { name: "ServiceConfig", attachmentPoint: "service", description: "Configures the service." },
+            { name: "Cache", attachmentPoint: "return" },
+        ]);
+    });
+
+    test("a library declaring none states nothing", () => {
+        assert.strictEqual(toRequestAnnotations([]), undefined);
+        assert.strictEqual(toRequestAnnotations(undefined), undefined);
+    });
+});
+
+suite("selection response — resolving named classes", () => {
+    const sheet = classTypeDef("Sheet", [method("getCell", [], "CellValue")]);
+    const table = classTypeDef("Table", [method("getHeaders", [], "string[]")]);
+    const record = { name: "CellRange", description: "", type: "Record", fields: [] } as TypeDefinition;
+
+    test("named classes resolve to their full definitions", () => {
+        const resolved = selectClassTypeDefs([sheet, table, record], { name: "lib", classes: ["Sheet"] });
+        assert.deepStrictEqual(resolved.map((t) => t.name), ["Sheet"]);
+    });
+
+    test("a class is returned intact, never narrowed to selected members", () => {
+        const [resolved] = selectClassTypeDefs([sheet], { name: "lib", classes: ["Sheet"] });
+        assert.strictEqual(resolved, sheet);
+    });
+
+    test("a hallucinated name is skipped without costing the ones that resolved", () => {
+        const resolved = selectClassTypeDefs([sheet], { name: "lib", classes: ["Sheet", "Imaginary"] });
+        assert.deepStrictEqual(resolved.map((t) => t.name), ["Sheet"]);
+    });
+
+    test("a named non-class is not smuggled in as one", () => {
+        assert.deepStrictEqual(selectClassTypeDefs([record], { name: "lib", classes: ["CellRange"] }), []);
+    });
+
+    test("no classes named means none seeded — the closure still reaches them via selected functions", () => {
+        assert.deepStrictEqual(selectClassTypeDefs([sheet], { name: "lib" }), []);
+    });
+});
+
+suite("selection response — tolerating the shape the model actually returns", () => {
+    const sheet = classTypeDef("Sheet", [method("getCell", [], "CellValue")]);
+
+    test("the object form resolves too — every sibling field in the schema is an object", () => {
+        const resolved = selectClassTypeDefs([sheet], {
+            name: "lib", classes: [{ name: "Sheet" }],
+        } as unknown as Parameters<typeof selectClassTypeDefs>[1]);
+        assert.deepStrictEqual(resolved.map((t) => t.name), ["Sheet"]);
+    });
+
+    test("mixed shapes in one response both resolve", () => {
+        const table = classTypeDef("Table", [method("getHeaders", [], "string[]")]);
+        const resolved = selectClassTypeDefs([sheet, table], {
+            name: "lib", classes: ["Sheet", { name: "Table" }],
+        } as unknown as Parameters<typeof selectClassTypeDefs>[1]);
+        assert.deepStrictEqual(resolved.map((t) => t.name), ["Sheet", "Table"]);
+    });
+});
+
+suite("selection batching — class members count toward the large-library split", () => {
+    test("a library whose API lives in classes is treated as large", () => {
+        const members = Array.from({ length: 120 }, (_, i) => method(`m${i}`, [], "string"));
+        const request = toSelectionRequest({
+            name: "ballerina/xlsx", description: "", clients: [],
+            typeDefs: [classTypeDef("Sheet", members)],
+        } as Library, false);
+        assert.ok(getSelectableMemberCount(request) >= 100, "class members must count toward the split");
+    });
+
+    test("a library with neither clients nor classes counts zero", () => {
+        const request = toSelectionRequest({ name: "lib", description: "", clients: [], typeDefs: [] } as Library, false);
+        assert.strictEqual(getSelectableMemberCount(request), 0);
+    });
+});

--- a/packages/ballerina-extension/test/ai/unit_tests/libs/class-typedefs.test.ts
+++ b/packages/ballerina-extension/test/ai/unit_tests/libs/class-typedefs.test.ts
@@ -15,6 +15,8 @@
 // under the License.
 
 import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
 import {
     TYPE_CLASS,
     collectClassMemberTypeRefs,
@@ -267,5 +269,47 @@ suite("selection batching — class members count toward the large-library split
     test("a library with neither clients nor classes counts zero", () => {
         const request = toSelectionRequest({ name: "lib", description: "", clients: [], typeDefs: [] } as Library, false);
         assert.strictEqual(getSelectableMemberCount(request), 0);
+    });
+});
+
+suite("selection request — malformed class members", () => {
+    test("a null member, a missing parameter list and a missing return do not throw", () => {
+        const broken = classTypeDef("Sheet", [
+            null,
+            { name: "noParams", type: "Normal Function", return: { type: { name: "int" } } },
+            { name: "noReturn", type: "Normal Function", parameters: [] },
+            { name: "getCell", type: "Normal Function", parameters: [{ name: "row" }], return: { type: { name: "int" } } },
+        ]);
+        const entries = toRequestClasses([broken]);
+        assert.deepStrictEqual(
+            entries![0].functions.map((f) => (f as { name: string }).name),
+            ["noParams", "noReturn", "getCell"]
+        );
+    });
+
+    test("a member with no name is dropped rather than sent nameless", () => {
+        const broken = classTypeDef("Sheet", [
+            { type: "Normal Function", parameters: [], return: { type: { name: "int" } } },
+            { name: "ok", type: "Normal Function", parameters: [], return: { type: { name: "int" } } },
+        ]);
+        assert.deepStrictEqual(
+            toRequestClasses([broken])![0].functions.map((f) => (f as { name: string }).name),
+            ["ok"]
+        );
+    });
+});
+
+/** `function-registry` cannot be imported in a unit test (it pulls in vscode), so pin the invariant here. */
+suite("closure — class detection stays consistent with the rest of the module", () => {
+    test("function-registry compares no typeDef.type against TYPE_CLASS directly", () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, "../../../../src/features/ai/utils/libs/function-registry.ts"),
+            "utf-8"
+        );
+        assert.ok(
+            !/===\s*TYPE_CLASS/.test(source),
+            "use isClassTypeDef(); a direct === TYPE_CLASS check skips classes from older language servers"
+        );
+        assert.ok(source.includes("isClassTypeDef(typeDef)"), "the closure must guard on the shared predicate");
     });
 });


### PR DESCRIPTION
Fixes: https://github.com/wso2/product-integrator/issues/2283

## Problem

Copilot could not see the member APIs of types a connector hands back — things like a spreadsheet's `Sheet` or `Table`.

Before the agent fetches library docs, a smaller model picks which libraries are relevant. That picker was only ever shown a library's clients, module-level functions and services — never its classes. So a question like "read a cell" or "append a row" matched nothing it could see, no library was named, and the docs tool returned nothing at all.

The effect was worse than a missing detail. With no documentation and a prompt that forbids inventing APIs, Copilot treated real, supported APIs as unsupported: it reimplemented them by hand, asked whether an API that exists was available, and reached different designs for the same task across chats.

Reported while testing the `xlsx` connector, where 51 of its APIs live on classes and were invisible to the picker.

## Fix

- Classes and object types are now part of what the picker is shown, with their members — so a library can be chosen because of a method, not just a top-level function.
- Annotations are shown for the same reason. They are evidence only; a library still keeps all of them, so nothing that renders today can be dropped.
- A class the picker names is pulled into the docs whole, even when nothing else references it.
- The types a class's methods mention are now resolved too, so the docs no longer name a type they never define.
- Class members count toward the batching threshold that splits large libraries into their own requests.
- A class from an older language server, which omitted its type marker, renders as a class instead of being silently discarded.

## Testing

24 unit tests added; the library suite passes at 284.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Expanded Copilot library selection to include classes, class members, object types, and annotations.
- Included selected classes and types referenced by class methods in generated documentation.
- Updated batching thresholds to count class members.
- Preserved classes from older language-server versions without a type discriminator.
- Added defensive handling for malformed language-server output.
- Added 24 unit tests. The library test suite passes 284 tests.
- End-to-end testing remains pending until the language-server JAR is rebuilt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
