### PR TITLE
Add keep structure flag to migration wizard

### DIFF
--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/resources/migration_tools.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/main/resources/migration_tools.json
@@ -11,7 +11,7 @@
         "label": "Keep Original Structure",
         "description": "Preserve the original source file structure (each .xml file in a separate .bal file).",
         "valueType": "boolean",
-        "defaultValue": false
+        "defaultValue": true
       },
       {
         "key": "forceVersion",
@@ -42,7 +42,7 @@
         "label": "Keep Original Structure",
         "description": "Preserve the original source file structure (each process in a separate .bal file).",
         "valueType": "boolean",
-        "defaultValue": false
+        "defaultValue": true
       },
       {
         "key": "multiRoot",

--- a/packages/ballerina-visualizer/src/views/BI/ImportIntegration/ConfigureProjectForm.test.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ImportIntegration/ConfigureProjectForm.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// L2: the wizard's one migration-specific question — "Output Structure" — as the step
+// actually renders it.
+//
+// Three things are pinned here because each is a silent failure on screen rather than a
+// type error. The section is gated on `keepStructureParam`, so a tool that does not declare
+// the option must show no checkbox at all; label and description come from that param, not
+// from a literal in this file, so a tool's wording change must reach the UI; and the
+// checkbox is fully controlled — it renders `keepStructure` and reports the *new* boolean
+// through `onKeepStructureChange`, never toggling itself.
+
+import React from "react";
+import { createRoot, Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+
+// Stubbed so the assertions read a real <input type="checkbox"> instead of the toolkit's
+// VSCode custom element, which jsdom does not define. `onChange` keeps the toolkit's
+// contract: it hands out the new checked state as a boolean.
+jest.mock("@wso2/ui-toolkit", () => ({
+    __esModule: true,
+    CheckBox: ({ label, checked, onChange }: any) => (
+        <label>
+            <input
+                type="checkbox"
+                checked={checked}
+                onChange={(e: any) => onChange(e.target.checked)}
+            />
+            {label}
+        </label>
+    ),
+    Codicon: (): null => null,
+    Typography: ({ children }: any) => <div>{children}</div>,
+    TextField: (): null => null,
+}));
+
+// The destination fields are the Create flow's own component, exercised by its own tests.
+// Stubbed down to the one seam this step uses: `additionalSection`, where the Output
+// Structure block is injected.
+jest.mock("../ProjectForm/embedded/integrator-form/shared/ProjectDestinationForm", () => ({
+    __esModule: true,
+    ProjectDestinationForm: ({ additionalSection }: any) => <div>{additionalSection}</div>,
+}));
+
+jest.mock("../wsManager/WsClientContext", () => ({
+    __esModule: true,
+    useBiWsContext: () => ({ wsClient: {}, onBack: (): void => undefined }),
+}));
+
+jest.mock("../../../providers/platform-ext-ctx-provider", () => ({
+    __esModule: true,
+    usePlatformExtContext: () => ({ platformExtState: { isLoggedIn: false } }),
+}));
+
+import { ConfigureProjectForm } from "./ConfigureProjectForm";
+import { ConfigureProjectFormProps } from "./types";
+
+(global as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The shared jest preset transforms TSX with the classic JSX runtime (`jsx: "react"`) while
+// this package builds with `react-jsx`, so a production module written against the automatic
+// runtime calls `React.createElement` without importing React. Put React in scope for it here
+// rather than adding a test-only import to the component.
+(globalThis as any).React = React;
+
+const KEEP_STRUCTURE_PARAM: NonNullable<ConfigureProjectFormProps["keepStructureParam"]> = {
+    key: "keepStructure",
+    label: "Keep the original project structure",
+    description: "Mirrors the source layout instead of grouping by artifact type.",
+    valueType: "boolean",
+    defaultValue: false,
+};
+
+describe("ConfigureProjectForm output structure option", () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        root = createRoot(container);
+    });
+
+    afterEach(() => {
+        act(() => root.unmount());
+        container.remove();
+    });
+
+    const renderForm = (props: Partial<ConfigureProjectFormProps> = {}) => {
+        const onKeepStructureChange = jest.fn();
+        act(() => {
+            root.render(
+                <ConfigureProjectForm
+                    isMultiProject={false}
+                    keepStructure={false}
+                    keepStructureParam={KEEP_STRUCTURE_PARAM}
+                    onKeepStructureChange={onKeepStructureChange}
+                    onNext={jest.fn()}
+                    onBack={jest.fn()}
+                    {...props}
+                />
+            );
+        });
+        return { onKeepStructureChange };
+    };
+
+    const checkbox = () => container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+
+    it("renders the section with the tool's own label and description", () => {
+        renderForm();
+
+        expect(container.textContent).toContain("Output Structure");
+        expect(container.textContent).toContain(KEEP_STRUCTURE_PARAM.label);
+        expect(container.textContent).toContain(KEEP_STRUCTURE_PARAM.description);
+    });
+
+    it.each<[string, ConfigureProjectFormProps["keepStructureParam"]]>([
+        ["a tool that does not declare it", undefined],
+        ["a tool whose declaration is null", null],
+    ])("renders no output structure section for %s", (_label, keepStructureParam) => {
+        renderForm({ keepStructureParam });
+
+        expect(container.textContent).not.toContain("Output Structure");
+        expect(checkbox()).toBeNull();
+    });
+
+    it.each([[false], [true]])("renders keepStructure=%s as the checked state", (keepStructure) => {
+        renderForm({ keepStructure });
+
+        expect(checkbox()?.checked).toBe(keepStructure);
+    });
+
+    // Controlled: the click reports the new value up and nothing else. Were the component to
+    // hold its own state, the box would move without the wizard's value following it.
+    it.each([
+        [false, true],
+        [true, false],
+    ])("reports the toggled boolean from keepStructure=%s", (keepStructure, expected) => {
+        const { onKeepStructureChange } = renderForm({ keepStructure });
+
+        act(() => {
+            // A native click, so React's own value tracking sees the flip and fires onChange.
+            checkbox()!.click();
+        });
+
+        expect(onKeepStructureChange).toHaveBeenCalledTimes(1);
+        expect(onKeepStructureChange).toHaveBeenCalledWith(expected);
+        // Still driven by the prop, which the parent has not changed.
+        expect(checkbox()?.checked).toBe(keepStructure);
+    });
+});

--- a/packages/ballerina-visualizer/src/views/BI/ImportIntegration/ConfigureProjectForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ImportIntegration/ConfigureProjectForm.tsx
@@ -16,8 +16,11 @@
  * under the License.
  */
 
-import { Typography } from "@wso2/ui-toolkit";
+import { useState } from "react";
+import styled from "@emotion/styled";
+import { CheckBox, Typography } from "@wso2/ui-toolkit";
 import { useBiWsContext } from "../wsManager/WsClientContext";
+import { CollapsibleSection } from "../ProjectForm/embedded/integrator-form/components";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
 import {
     ProjectDestinationForm,
@@ -25,6 +28,13 @@ import {
 } from "../ProjectForm/embedded/integrator-form/shared/ProjectDestinationForm";
 import { Organization } from "../ProjectForm/embedded/integrator-form/components";
 import { ConfigureProjectFormProps } from "./types";
+
+/** Sits under the checkbox label, indented past the box, like the form's other hints. */
+const OptionDescription = styled.div`
+    color: var(--vscode-list-deemphasizedForeground);
+    margin-top: 4px;
+    margin-left: 26px;
+`;
 
 /**
  * Step 3 of the migration wizard: where the converted sources land.
@@ -38,9 +48,25 @@ import { ConfigureProjectFormProps } from "./types";
  *
  * Nothing is written here. The resolved destination is handed back through `onNext` and
  * only used once the rule-based migration has run and the user picks an action.
+ *
+ * The one migration-specific question is "Output Structure": whether the migrated sources
+ * keep the original file layout. It belongs on this step rather than with the source
+ * settings because it describes the shape of what lands at the destination, and because
+ * the answer is only needed by the migration that runs after this step — the report
+ * generated before it is unaffected.
  */
-export function ConfigureProjectForm({ isMultiProject, onNext, onBack }: ConfigureProjectFormProps) {
+export function ConfigureProjectForm({
+    isMultiProject,
+    keepStructure,
+    keepStructureParam,
+    onKeepStructureChange,
+    onNext,
+    onBack,
+}: ConfigureProjectFormProps) {
     const { wsClient } = useBiWsContext();
+    // Open on arrival, unlike the package details below it: this is a decision about the
+    // migration's output that the user is expected to look at, not a rarely-touched default.
+    const [isOutputStructureExpanded, setIsOutputStructureExpanded] = useState(true);
     const { platformExtState } = usePlatformExtContext();
     const isLoggedIn = !!platformExtState?.isLoggedIn;
     const organizations = isLoggedIn
@@ -69,6 +95,26 @@ export function ConfigureProjectForm({ isMultiProject, onNext, onBack }: Configu
         );
     };
 
+    // Label and description come from the tool's own metadata, so a wording change ships
+    // with the migration tool instead of needing a matching edit here.
+    const outputStructureSection = keepStructureParam ? (
+        <CollapsibleSection
+            isExpanded={isOutputStructureExpanded}
+            onToggle={() => setIsOutputStructureExpanded((expanded) => !expanded)}
+            icon="gear"
+            title="Output Structure"
+        >
+            <CheckBox
+                label={keepStructureParam.label}
+                checked={keepStructure}
+                onChange={onKeepStructureChange}
+            />
+            {keepStructureParam.description && (
+                <OptionDescription>{keepStructureParam.description}</OptionDescription>
+            )}
+        </CollapsibleSection>
+    ) : undefined;
+
     return (
         <>
             <Typography variant="h2">
@@ -83,6 +129,7 @@ export function ConfigureProjectForm({ isMultiProject, onNext, onBack }: Configu
                 submitLabel="Start Migration"
                 submittingLabel="Starting..."
                 submitErrorPrefix="Failed to start the migration."
+                additionalSection={outputStructureSection}
                 secondaryButton={{ text: "Back", onClick: onBack }}
                 onSubmit={handleSubmit}
             />

--- a/packages/ballerina-visualizer/src/views/BI/ImportIntegration/components/IntegrationParameters.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ImportIntegration/components/IntegrationParameters.tsx
@@ -17,9 +17,10 @@
  */
 
 import { MigrationTool } from "@wso2/ballerina-core";
-import { Dropdown, OptionProps, TextField, Typography } from "@wso2/ui-toolkit";
+import { CheckBox, Dropdown, OptionProps, TextField, Typography } from "@wso2/ui-toolkit";
 import React from "react";
 import { BodyText, ParameterItem, ParametersSection } from "../styles";
+import { resolveKeepStructureParam, resolveSourceLayoutParam, toBooleanParamValue } from "../utils";
 import styled from "@emotion/styled";
 
 const ParametersContainer = styled.div`
@@ -27,6 +28,12 @@ const ParametersContainer = styled.div`
     flex-direction: column;
     gap: 16px;
     margin-top: 16px;
+`;
+
+const ParamDescription = styled.div`
+    color: var(--vscode-list-deemphasizedForeground);
+    margin-top: 4px;
+    margin-left: 26px;
 `;
 
 interface IntegrationParametersProps {
@@ -40,8 +47,17 @@ export const IntegrationParameters: React.FC<IntegrationParametersProps> = ({
     integrationParams,
     onParameterChange,
 }) => {
-    const nonBoolParams = selectedIntegration?.parameters.filter(p => p.valueType !== "boolean") ?? [];
-    if (!selectedIntegration || !nonBoolParams.length) return null;
+    // Every declared parameter except the two that have a dedicated home elsewhere in the
+    // wizard: the source-layout one, owned by the "Source Layout" radio group on this step,
+    // and `keepStructure`, owned by the "Output Structure" section on Configure Destination.
+    // Excluded BY KEY, not by value type — filtering out the whole `boolean` type is what
+    // silently dropped `keepStructure` from the wizard, and would drop the next boolean too.
+    const ownedElsewhere = new Set(
+        [resolveSourceLayoutParam(selectedIntegration)?.key, resolveKeepStructureParam(selectedIntegration)?.key]
+            .filter((key): key is string => !!key)
+    );
+    const configurableParams = selectedIntegration?.parameters.filter((p) => !ownedElsewhere.has(p.key)) ?? [];
+    if (!selectedIntegration || !configurableParams.length) return null;
 
     return (
         <ParametersSection>
@@ -50,9 +66,20 @@ export const IntegrationParameters: React.FC<IntegrationParametersProps> = ({
             </Typography>
             <BodyText>{`Configure additional settings for ${selectedIntegration.title} migration.`}</BodyText>
             <ParametersContainer>
-                {nonBoolParams.map((param) => (
+                {configurableParams.map((param) => (
                     <ParameterItem key={param.key}>
-                        {param.valueType === "enum" && param.options ? (
+                        {param.valueType === "boolean" ? (
+                            <>
+                                <CheckBox
+                                    label={param.label}
+                                    checked={toBooleanParamValue(
+                                        integrationParams[param.key] ?? param.defaultValue
+                                    )}
+                                    onChange={(checked) => onParameterChange(param.key, checked)}
+                                />
+                                {param.description && <ParamDescription>{param.description}</ParamDescription>}
+                            </>
+                        ) : param.valueType === "enum" && param.options ? (
                             <Dropdown
                                 id={`${param.key}-dropdown`}
                                 label={param.label}

--- a/packages/ballerina-visualizer/src/views/BI/ImportIntegration/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ImportIntegration/index.tsx
@@ -47,7 +47,7 @@ import {
     StepperWrapper,
 } from "./styles";
 import { FinalIntegrationParams } from "./types";
-import { isMultiRootSelected } from "./utils";
+import { isMultiRootSelected, resolveKeepStructureParam, toBooleanParamValue } from "./utils";
 
 export function ImportIntegration() {
     const { wsClient, onBack } = useBiWsContext();
@@ -68,6 +68,9 @@ export function ImportIntegration() {
     const [migrationSuccessful, setMigrationSuccessful] = useState(false);
     const [migrationResponse, setMigrationResponse] = useState<ImportIntegrationResponse | null>(null);
     const [storedProjectRequest, setStoredProjectRequest] = useState<ProjectRequest | null>(null);
+    // Chosen on Configure Destination (step 2), not with the source settings, so it is held
+    // here rather than in `importParams.parameters` and merged in when the migration runs.
+    const [keepStructure, setKeepStructure] = useState(false);
     const migrationStartedRef = useRef(false);
 
     // Dry-run state (step 1)
@@ -88,6 +91,15 @@ export function ImportIntegration() {
     const isMultiProjectFromConfig = isMultiRootSelected(selectedIntegration, importParams?.parameters);
     // isMultiProject for MigrationProgressView is derived from actual migration results
     const isMultiProject = migratedProjects.length > 0;
+    const keepStructureParam = resolveKeepStructureParam(selectedIntegration);
+
+    // Picking a different source platform re-seeds the choice from the new tool's own
+    // default; carrying the previous tool's answer over would silently apply it.
+    const handleSelectIntegration = (integration: MigrationTool) => {
+        setSelectedIntegration(integration);
+        setKeepStructure(toBooleanParamValue(resolveKeepStructureParam(integration)?.defaultValue));
+    };
+
     // Recorded in the enhancement toml so the AI migration prompts can target the source platform
     const sourcePlatform: MigrateRequest["sourcePlatform"] =
         selectedIntegration?.commandName === 'migrate-mule' ? 'mule'
@@ -142,7 +154,11 @@ export function ImportIntegration() {
             packageName: "",
             commandName: integration.commandName,
             sourcePath: params.importSourcePath,
-            parameters: params.parameters,
+            // The destination step's answer wins over the tool's declared default, which is
+            // all `params.parameters` carries for this key.
+            parameters: keepStructureParam
+                ? { ...params.parameters, [keepStructureParam.key]: keepStructure }
+                : params.parameters,
         };
         try {
             const response = await wsClient.importIntegration(rpcParams);
@@ -209,7 +225,7 @@ export function ImportIntegration() {
             projects: migratedProjects,
             aiFeatureUsed: true,
             sourcePath: importParams.importSourcePath,
-            keepStructure: importParams?.parameters?.["keepStructure"] as boolean | undefined,
+            keepStructure,
             sourcePlatform: sourcePlatform,
         };
         // Await the project write before advancing: the enhancement step calls
@@ -234,7 +250,7 @@ export function ImportIntegration() {
             projects: migratedProjects,
             aiFeatureUsed: false,
             sourcePath: importParams.importSourcePath,
-            keepStructure: importParams?.parameters?.["keepStructure"] as boolean | undefined,
+            keepStructure,
             sourcePlatform: sourcePlatform,
         };
         // Fire-and-forget: the extension opens the folder (VS Code reloads). Guard the
@@ -255,7 +271,7 @@ export function ImportIntegration() {
             projects: migratedProjects,
             aiFeatureUsed: true,
             sourcePath: importParams.importSourcePath,
-            keepStructure: importParams?.parameters?.["keepStructure"] as boolean | undefined,
+            keepStructure,
             sourcePlatform: sourcePlatform,
         };
         // Await the project write before navigating away, so a failure keeps the user
@@ -403,7 +419,7 @@ export function ImportIntegration() {
                                 pullIntegrationTool={pullIntegrationTool}
                                 pullingTool={pullingTool}
                                 toolPullProgress={toolPullProgress}
-                                onSelectIntegration={setSelectedIntegration}
+                                onSelectIntegration={handleSelectIntegration}
                                 onNext={() => setStep(1)}
                                 onBack={gotToWelcome}
                             />
@@ -429,6 +445,9 @@ export function ImportIntegration() {
                             <ConfigureProjectForm
                                 isMultiProject={isMultiProjectFromConfig}
                                 importSourcePath={importParams?.importSourcePath}
+                                keepStructure={keepStructure}
+                                keepStructureParam={keepStructureParam}
+                                onKeepStructureChange={setKeepStructure}
                                 onNext={handleConfigureDestinationDone}
                                 onBack={handleStepBack}
                             />

--- a/packages/ballerina-visualizer/src/views/BI/ImportIntegration/types.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ImportIntegration/types.ts
@@ -94,6 +94,14 @@ export interface ConfigureProjectFormProps {
     isMultiProject: boolean;
     /** Absolute path to the original source project (e.g. Mule XML directory). */
     importSourcePath?: string;
+    /** Whether the migration should preserve the original source file layout. */
+    keepStructure: boolean;
+    /**
+     * The selected tool's `keepStructure` declaration, supplying the checkbox label and
+     * description. Absent for a tool that does not declare it, which hides the section.
+     */
+    keepStructureParam?: MigrationTool["parameters"][number] | null;
+    onKeepStructureChange: (keepStructure: boolean) => void;
     onNext: (project: ProjectRequest, aiFeatureUsed: boolean) => Promise<void> | void;
     onBack: () => void;
 }

--- a/packages/ballerina-visualizer/src/views/BI/ImportIntegration/utils.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ImportIntegration/utils.test.ts
@@ -17,7 +17,13 @@
  */
 
 import { MigrationTool } from "@wso2/ballerina-core";
-import { isMultiRootSelected, MULTI_ROOT_PARAM_KEY, resolveSourceLayoutParam } from "./utils";
+import {
+    isMultiRootSelected,
+    KEEP_STRUCTURE_PARAM_KEY,
+    MULTI_ROOT_PARAM_KEY,
+    resolveKeepStructureParam,
+    resolveSourceLayoutParam,
+} from "./utils";
 
 type Param = MigrationTool["parameters"][number];
 
@@ -99,5 +105,24 @@ describe("isMultiRootSelected", () => {
         expect(isMultiRootSelected(muleTool, {})).toBe(false);
         expect(isMultiRootSelected(muleTool, undefined)).toBe(false);
         expect(isMultiRootSelected(null, { multiRoot: true })).toBe(false);
+    });
+});
+
+describe("resolveKeepStructureParam", () => {
+    it("finds keepStructure wherever the tool declares it", () => {
+        const resolved = resolveKeepStructureParam(
+            tool([boolParam(MULTI_ROOT_PARAM_KEY), boolParam(KEEP_STRUCTURE_PARAM_KEY)])
+        );
+        expect(resolved?.key).toBe(KEEP_STRUCTURE_PARAM_KEY);
+    });
+
+    it("never resolves to multiRoot, which owns the Source Layout choice instead", () => {
+        // No positional fallback here, unlike resolveSourceLayoutParam: a tool that does not
+        // declare keepStructure must hide the Output Structure section, not bind the
+        // checkbox to whichever other boolean happens to be declared.
+        expect(resolveKeepStructureParam(tool([boolParam(MULTI_ROOT_PARAM_KEY)]))).toBeNull();
+        expect(resolveKeepStructureParam(tool([]))).toBeNull();
+        expect(resolveKeepStructureParam(null)).toBeNull();
+        expect(resolveKeepStructureParam(undefined)).toBeNull();
     });
 });

--- a/packages/ballerina-visualizer/src/views/BI/ImportIntegration/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ImportIntegration/utils.ts
@@ -53,6 +53,29 @@ export const resolveSourceLayoutParam = (
     );
 };
 
+/**
+ * Parameter key the migration tools read to decide whether each source file keeps its own
+ * `.bal` output, rather than being folded into a combined package layout.
+ */
+export const KEEP_STRUCTURE_PARAM_KEY = "keepStructure";
+
+/**
+ * The parameter the "Output Structure" choice writes.
+ *
+ * Owned by the Configure Destination step rather than the generic settings list, because
+ * it describes the shape of what the migration produces — the same question that step
+ * already asks about. Returns `null` for a tool that does not declare it, which is what
+ * hides the section for that tool.
+ */
+export const resolveKeepStructureParam = (
+    tool: MigrationTool | null | undefined
+): MigrationTool["parameters"][number] | null =>
+    tool?.parameters?.find((param) => param.key === KEEP_STRUCTURE_PARAM_KEY) ?? null;
+
+/** Reads a tool parameter value that may arrive as a boolean or its stringified form. */
+export const toBooleanParamValue = (value: unknown): boolean =>
+    typeof value === "string" ? value === "true" : value === true;
+
 /** Whether the given parameter values select the multi-project source layout. */
 export const isMultiRootSelected = (
     tool: MigrationTool | null | undefined,
@@ -62,8 +85,7 @@ export const isMultiRootSelected = (
     if (!param) {
         return false;
     }
-    const value = parameters?.[param.key];
-    return typeof value === "string" ? value === "true" : value === true;
+    return toBooleanParamValue(parameters?.[param.key]);
 };
 
 export const sanitizeProjectName = (name: string): string => {

--- a/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/integrator-form/shared/ProjectDestinationForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/integrator-form/shared/ProjectDestinationForm.tsx
@@ -231,6 +231,13 @@ export interface ProjectDestinationFormProps {
     submitDisabled?: boolean;
     /** Tooltip explaining `submitDisabled`. */
     submitDisabledTooltip?: string;
+    /**
+     * Rendered above the package details, for a destination question this form does not own.
+     * The migration wizard puts its "Output Structure" choice here so it leads the optional
+     * sections — it is the one the user is most likely to act on, where the package details
+     * below it are usually left at their defaults.
+     */
+    additionalSection?: ReactNode;
     /** Rendered to the left of the primary button. */
     secondaryButton?: { text: string; onClick: () => void; disabled?: boolean };
     onSubmit: (values: ProjectDestinationValues) => Promise<void> | void;
@@ -258,6 +265,7 @@ export function ProjectDestinationForm({
     submitErrorPrefix = "Failed to continue.",
     submitDisabled,
     submitDisabledTooltip,
+    additionalSection,
     secondaryButton,
     onSubmit,
 }: ProjectDestinationFormProps) {
@@ -742,6 +750,8 @@ export function ProjectDestinationForm({
                                 <SectionDivider />
                             </>
                         )}
+
+                        {additionalSection}
 
                         <AdvancedConfigurationSection
                             isExpanded={isPackageInfoExpanded}


### PR DESCRIPTION
## Purpose
Addresses https://github.com/wso2/product-integrator/issues/2323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add a configurable “Output Structure” option to the migration wizard.
- Show the option only when the selected migration tool provides `keepStructure`.
- Pass the selected value to migration and project-opening requests.
- Render other boolean integration parameters as checkboxes with descriptions.
- Add reusable parameter helpers and test coverage.
- Extend `ProjectDestinationForm` with an optional additional section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->