### PR TITLE
Fix connector name casing in AI agent tool connection labels

### DIFF
--- a/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/NodeReferenceSelectEditor/NodeReferenceSelectEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/NodeReferenceSelectEditor/NodeReferenceSelectEditor.tsx
@@ -32,6 +32,7 @@ import { Button, Codicon, LinkButton, ProgressRing, ThemeColors } from "@wso2/ui
 import { FormField } from "../../../Form/types";
 import { NodeReferenceSelect, NodeReferenceSelectItem } from "../../NodeReferenceSelect";
 import { useFormContext } from "../../../../context";
+import { formatMethodName } from "../../../../utils/formatMethodName";
 
 const EmptyPrompt = styled.div`
     display: flex;
@@ -49,13 +50,6 @@ const EmptyPromptText = styled.div`
     font-size: 13px;
     color: var(--vscode-descriptionForeground);
 `;
-
-function humanizeKind(kind: string): string {
-    return kind
-        .split("_")
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-        .join(" ");
-}
 
 export type NodeReferenceFilter = { module?: string; object?: string };
 
@@ -258,11 +252,11 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
         : agentCodeData?.object
             ? agentCodeData.object
             : creationCodeData?.module && creationCodeData?.object
-                ? `${humanizeKind(creationCodeData.module.split(".").pop() ?? "")} ${creationCodeData.object}`
-                : humanizeKind(searchNodesKind);
+                ? `${formatMethodName(creationCodeData.module.split(".").pop() ?? "")} ${creationCodeData.object}`
+                : formatMethodName(searchNodesKind);
 
     const creationName = agentCodeData?.object
-        ?? (creationCodeData?.module ? humanizeKind(creationCodeData.module.split(".").pop() ?? "") : "");
+        ?? (creationCodeData?.module ? formatMethodName(creationCodeData.module.split(".").pop() ?? "") : "");
     const isAgentReference = !!agentCodeData;
     const qualifier = creationName ? `${creationName} ` : "";
     const emptyTitle = isAgentReference

--- a/packages/ballerina-side-panel/src/test/formatMethodName.test.ts
+++ b/packages/ballerina-side-panel/src/test/formatMethodName.test.ts
@@ -47,6 +47,16 @@ describe("formatMethodName", () => {
         expect(formatMethodName("method2Call")).toBe("Method2 Call");
     });
 
+    it("title-cases a SCREAMING_SNAKE_CASE constant instead of leaving it all-caps", () => {
+        expect(formatMethodName("MODEL_PROVIDER")).toBe("Model Provider");
+        expect(formatMethodName("NEW_CONNECTION")).toBe("New Connection");
+        expect(formatMethodName("USER_ID")).toBe("User ID");
+    });
+
+    it("keeps a bare all-caps acronym as-is", () => {
+        expect(formatMethodName("HTTP")).toBe("HTTP");
+    });
+
     it("lower-cases trailing words in sentence casing, acronyms excepted", () => {
         expect(formatMethodName("createPresignedUrl", { casing: "sentence" })).toBe("Create presigned URL");
         expect(formatMethodName("getUserId", { casing: "sentence" })).toBe("Get user ID");

--- a/packages/ballerina-side-panel/src/utils/formatMethodName.ts
+++ b/packages/ballerina-side-panel/src/utils/formatMethodName.ts
@@ -17,8 +17,10 @@
  */
 
 const ACRONYMS = new Set([
-    "ACL", "API", "CSV", "DNS", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "JWT", "MFA",
-    "OTP", "PDF", "SMS", "SQL", "SSH", "SSO", "TLS", "TTL", "UI", "URI", "URL", "UUID", "XML",
+    "ACL", "AMQP", "API", "CSV", "DNS", "FTP", "FTPS", "GRPC", "HTML", "HTTP", "HTTPS", "ID",
+    "IMAP", "IP", "JDBC", "JMS", "JSON", "JWT", "LDAP", "MFA", "MQTT", "ODBC", "OTP", "PDF",
+    "POP3", "RPC", "SFTP", "SMS", "SMTP", "SOAP", "SQL", "SSH", "SSO", "TCP", "TLS", "TTL",
+    "UDP", "UI", "URI", "URL", "UUID", "WS", "WSS", "XML",
 ]);
 
 export interface FormatMethodNameOptions {

--- a/packages/ballerina-side-panel/src/utils/formatMethodName.ts
+++ b/packages/ballerina-side-panel/src/utils/formatMethodName.ts
@@ -55,9 +55,7 @@ export function formatMethodName(methodName: string, options?: FormatMethodNameO
         return methodName;
     }
 
-    // SCREAMING_SNAKE_CASE constants (e.g. "MODEL_PROVIDER") carry no camelCase word
-    // boundaries, so every word looks like an acronym below; lower-case first and let
-    // the acronym set re-uppercase genuine acronyms during capitalization.
+    // Lower-case SCREAMING_SNAKE_CASE first so it doesn't all look like acronyms below.
     if (/^[A-Z0-9_]+$/.test(cleaned)) {
         cleaned = cleaned.toLowerCase();
     }

--- a/packages/ballerina-side-panel/src/utils/formatMethodName.ts
+++ b/packages/ballerina-side-panel/src/utils/formatMethodName.ts
@@ -55,6 +55,13 @@ export function formatMethodName(methodName: string, options?: FormatMethodNameO
         return methodName;
     }
 
+    // SCREAMING_SNAKE_CASE constants (e.g. "MODEL_PROVIDER") carry no camelCase word
+    // boundaries, so every word looks like an acronym below; lower-case first and let
+    // the acronym set re-uppercase genuine acronyms during capitalization.
+    if (/^[A-Z0-9_]+$/.test(cleaned)) {
+        cleaned = cleaned.toLowerCase();
+    }
+
     // Convert camelCase and snake_case to space-separated words
     // This regex:
     // 1. Inserts space before uppercase letters that follow lowercase letters (camelCase)


### PR DESCRIPTION
### Summary

Fixes https://github.com/wso2/product-integrator/issues/2329

Connector/module names shown in the "Add Tool - Use Connection" panel (e.g. "Create Http Connection", "No Ftp connection in this project") were title-cased with a naive helper, so acronyms like HTTP and FTP showed up as "Http" and "Ftp".

### Fix
Reuse the existing acronym-aware `formatMethodName` util instead of the local `humanizeKind` helper, and add the missing connector protocol acronyms (FTP, TCP, SMTP, LDAP, GRPC, MQTT, etc.) to its list.


https://github.com/user-attachments/assets/f7014a7e-1294-4927-b80b-6b8b37d756cb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Replaced the local `humanizeKind` helper with the acronym-aware `formatMethodName` utility.
- Updated AI agent tool connection labels to preserve connector acronym casing.
- Expanded acronym support for protocols and technologies including FTP, TCP, SMTP, LDAP, GRPC, and MQTT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->