### PR TITLE
Fix custom tool creation redirecting agent flow diagram to `Overview` page

### DIFF
--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/NewTool.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/NewTool.tsx
@@ -18,7 +18,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
-import { EVENT_TYPE, FlowNode, Property } from "@wso2/ballerina-core";
+import { FlowNode, Property } from "@wso2/ballerina-core";
 import { Button } from "@wso2/ui-toolkit";
 import { NodePosition } from "@wso2/syntax-tree";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
@@ -92,34 +92,9 @@ export function NewTool(props: NewToolProps): JSX.Element {
                 segments: [updatedAgentNode.codedata.lineRange.fileName],
             });
             await rpcClient.getBIDiagramRpcClient().getSourceCode({ filePath: agentFile, flowNode: updatedAgentNode });
+            await rpcClient.getAIAgentRpcClient().fixMissingImports();
 
-            // Fetch the newly created function to get its source position
-            const agentsFileName = "agents.bal";
-            const { filePath: agentsFilePath } = await rpcClient.getVisualizerRpcClient().joinProjectPath({
-                segments: [agentsFileName],
-            });
-            const functionNodeResponse = await rpcClient.getBIDiagramRpcClient().getFunctionNode({
-                functionName,
-                fileName: agentsFileName,
-                projectPath: projectPath.current,
-            });
-            const linePosition = functionNodeResponse?.functionDefinition?.codedata?.lineRange?.startLine;
-
-            // Close the panel and navigate to the function's flow diagram
-            onSave?.();
-            if (!linePosition) {
-                // openView falls back to the overview without a position
-                console.error("Could not resolve the position of the created tool", { functionName });
-                return;
-            }
-            const position: NodePosition = {
-                startLine: linePosition.line,
-                startColumn: linePosition.offset,
-            };
-            rpcClient.getVisualizerRpcClient().openView({
-                type: EVENT_TYPE.OPEN_VIEW,
-                location: { documentUri: agentsFilePath, position },
-            });
+            onSave?.(await resolveAgentNodePosition(updatedAgentNode, rpcClient));
         } catch (error) {
             console.error("Error handling custom agent tool creation", { error });
         }


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/cd39b0b5-08a1-46fc-972a-83cab3fedf37

- Creating a custom tool for an AI agent (Add Tool → Create Custom Tool) redirected the visualizer to the Overview page instead of refreshing the agent's Focus Flow Diagram in place.
- `handleAgentToolCreated` closed the panel with no position and made a separate global `openView` call to the new tool's own location, which fell back to Overview because the extension's `projectStructure` cache hadn't indexed the new function yet.
- Fixed by mirroring the Function/Connection tool path: pass the agent's own resolved position through `onSave` so the FocusFlowDiagram refreshes locally instead of navigating globally.

Fixes wso2/product-integrator#2330

## Test plan
- [ ] Rebuild the visualizer and confirm creating a custom tool on an agent's Focus Flow Diagram keeps the view on the diagram with the new tool attached
- [ ] Confirm Function/Connection tool creation is unaffected
- [ ] Confirm custom tool creation from the Agent Definition Builder is unaffected (separate code path, not touched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed custom tool creation from an AI agent’s Focus Flow Diagram.
- The flow now passes the agent’s resolved position through `onSave`.
- The diagram refreshes in place and displays the new tool.
- Removed fallback navigation based on the new function’s source position.
- Function, Connection, and Agent Definition Builder tool creation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->