### PR TITLE
Remove the support email from the quota-request UI and tidy the copy

### DIFF
--- a/packages/ballerina-extension/src/features/ai/utils/ai-client.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-client.ts
@@ -28,10 +28,8 @@ import { AIMachineEventType, AnthropicKeySecrets, AnthropicAwsSecrets, LoginMeth
 export const ANTHROPIC_HAIKU = "claude-haiku-4-5-20251001";
 export const ANTHROPIC_SONNET = "claude-sonnet-5";
 
-// Contact for requesting more Copilot quota once the usage limit is reached.
-export const QUOTA_REQUEST_CONTACT_EMAIL = "support@wso2.com";
 export const USAGE_LIMIT_EXCEEDED_MESSAGE =
-    `Usage limit exceeded. To request additional quota, contact ${QUOTA_REQUEST_CONTACT_EMAIL}.`;
+    "Usage limit exceeded. Request additional quota from the panel, or reach out to us on Discord: https://discord.com/invite/wso2";
 
 type AnthropicModel =
     | typeof ANTHROPIC_HAIKU

--- a/packages/ballerina-extension/src/features/ai/utils/ai-client.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-client.ts
@@ -28,8 +28,7 @@ import { AIMachineEventType, AnthropicKeySecrets, AnthropicAwsSecrets, LoginMeth
 export const ANTHROPIC_HAIKU = "claude-haiku-4-5-20251001";
 export const ANTHROPIC_SONNET = "claude-sonnet-5";
 
-export const USAGE_LIMIT_EXCEEDED_MESSAGE =
-    "Usage limit exceeded. Request additional quota from the panel, or reach out to us on Discord: https://discord.com/invite/wso2";
+export const USAGE_LIMIT_EXCEEDED_MESSAGE = "Usage limit exceeded.";
 
 type AnthropicModel =
     | typeof ANTHROPIC_HAIKU

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -599,7 +599,7 @@ const AIChat: React.FC = () => {
             if (result) {
                 setUsage({
                     ...result,
-                    resetsAtMs: result.resetsIn !== -1 ? Date.now() + result.resetsIn * 1000 : undefined,
+                    resetsAtMs: result.resetsIn > 0 ? Date.now() + result.resetsIn * 1000 : undefined,
                 });
                 setIsUsageExceeded(result.resetsIn !== -1 && result.remainingUsagePercentage < USAGE_EXCEEDED_THRESHOLD_PERCENT);
             } else {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -578,13 +578,9 @@ const AIChat: React.FC = () => {
     }, []);
 
 
-    const formatResetsIn = (seconds: number): string => {
-        const days = Math.floor(seconds / 86400);
-        if (days >= 1) return `${days} day${days > 1 ? 's' : ''}`;
-        const hours = Math.floor(seconds / 3600);
-        if (hours >= 1) return `${hours} hour${hours > 1 ? 's' : ''}`;
-        const mins = Math.floor(seconds / 60);
-        return `${mins} min${mins > 1 ? 's' : ''}`;
+    const formatResetsAt = (seconds: number): string => {
+        const resetDate = new Date(Date.now() + seconds * 1000);
+        return resetDate.toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
     };
 
     const formatResetsInExact = (seconds: number): string => {
@@ -2897,8 +2893,8 @@ const AIChat: React.FC = () => {
                         <UsageLimitNoticeContainer>
                             <span className="codicon codicon-warning" role="img" aria-hidden="true" />
                             <span>
-                                You've reached your Integrator Copilot usage limit
-                                {usage && usage.resetsIn !== -1 ? `, which resets in ${formatResetsIn(usage.resetsIn)}` : ""}.
+                                You've reached your usage limit.
+                                {usage && usage.resetsIn !== -1 ? ` Resets ${formatResetsAt(usage.resetsIn)}.` : ""}
                                 {usage?.alreadyRequested
                                     ? <>{" "}Your request for additional quota has been submitted. Need help in the meantime? Join our <a href={DISCORD_INVITE_URL} target="_blank" rel="noreferrer">Discord</a>.</>
                                     : <>{" "}<a href="#" onClick={(e) => { e.preventDefault(); setShowQuotaDialog(true); }}>Request additional quota</a>.</>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -111,7 +111,7 @@ const NO_DRIFT_FOUND = "No drift identified between the code and the documentati
 const DRIFT_CHECK_ERROR = "Failed to check drift between the code and the documentation. Please try again.";
 
 const USAGE_EXCEEDED_THRESHOLD_PERCENT = 3;
-const QUOTA_CONTACT_EMAIL = "support@wso2.com";
+const DISCORD_INVITE_URL = "https://discord.com/invite/wso2";
 
 //TODO: Add better error handling from backend. stream error type and non 200 status codes
 
@@ -639,11 +639,11 @@ const AIChat: React.FC = () => {
                 setShowQuotaDialog(false);
                 await fetchUsage();
             } else {
-                setQuotaRequestError(`Something went wrong. Please try again or email ${QUOTA_CONTACT_EMAIL}.`);
+                setQuotaRequestError("Something went wrong. Please try again.");
             }
         } catch (e) {
             console.error("Failed to submit quota request:", e);
-            setQuotaRequestError(`Something went wrong. Please try again or email ${QUOTA_CONTACT_EMAIL}.`);
+            setQuotaRequestError("Something went wrong. Please try again.");
         } finally {
             setQuotaRequestSubmitting(false);
         }
@@ -2900,7 +2900,7 @@ const AIChat: React.FC = () => {
                                 You've reached your Integrator Copilot usage limit
                                 {usage && usage.resetsIn !== -1 ? `, which resets in ${formatResetsIn(usage.resetsIn)}` : ""}.
                                 {usage?.alreadyRequested
-                                    ? <>{" "}Your request for additional quota has been submitted. Reach us at <a href={`mailto:${QUOTA_CONTACT_EMAIL}`}>{QUOTA_CONTACT_EMAIL}</a>.</>
+                                    ? <>{" "}Your request for additional quota has been submitted. Need help in the meantime? Join our <a href={DISCORD_INVITE_URL} target="_blank" rel="noreferrer">Discord</a>.</>
                                     : <>{" "}<a href="#" onClick={(e) => { e.preventDefault(); setShowQuotaDialog(true); }}>Request additional quota</a>.</>
                                 }
                             </span>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2896,7 +2896,7 @@ const AIChat: React.FC = () => {
                                 You've reached your usage limit.
                                 {usage && usage.resetsIn !== -1 ? ` Resets ${formatResetsAt(usage.resetsIn)}.` : ""}
                                 {usage?.alreadyRequested
-                                    ? <>{" "}Your request for additional quota has been submitted. Need help in the meantime? Join our <a href={DISCORD_INVITE_URL} target="_blank" rel="noreferrer">Discord</a>.</>
+                                    ? <>{" "}Your request for additional quota has been submitted. Need help in the meantime? Reach out to us on <a href={DISCORD_INVITE_URL} target="_blank" rel="noreferrer">Discord</a>.</>
                                     : <>{" "}<a href="#" onClick={(e) => { e.preventDefault(); setShowQuotaDialog(true); }}>Request additional quota</a>.</>
                                 }
                             </span>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -399,7 +399,7 @@ const AIChat: React.FC = () => {
 
     const [migrationSession, setMigrationSession] = useState<ActiveMigrationSession | null>(null);
     const [isMigrationEnhancementRunning, setIsMigrationEnhancementRunning] = useState(false);
-    const [usage, setUsage] = useState<{ remainingUsagePercentage: number; resetsIn: number; orgId?: string; alreadyRequested?: boolean } | null>(null);
+    const [usage, setUsage] = useState<{ remainingUsagePercentage: number; resetsIn: number; resetsAtMs?: number; orgId?: string; alreadyRequested?: boolean } | null>(null);
     const [isUsageExceeded, setIsUsageExceeded] = useState(false);
     const [showQuotaDialog, setShowQuotaDialog] = useState(false);
     const [quotaRequestSubmitting, setQuotaRequestSubmitting] = useState(false);
@@ -578,9 +578,8 @@ const AIChat: React.FC = () => {
     }, []);
 
 
-    const formatResetsAt = (seconds: number): string => {
-        const resetDate = new Date(Date.now() + seconds * 1000);
-        return resetDate.toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+    const formatResetsAt = (resetsAtMs: number): string => {
+        return new Date(resetsAtMs).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
     };
 
     const formatResetsInExact = (seconds: number): string => {
@@ -598,7 +597,10 @@ const AIChat: React.FC = () => {
         try {
             const result = await rpcClient.getAiPanelRpcClient().getUsage();
             if (result) {
-                setUsage(result);
+                setUsage({
+                    ...result,
+                    resetsAtMs: result.resetsIn !== -1 ? Date.now() + result.resetsIn * 1000 : undefined,
+                });
                 setIsUsageExceeded(result.resetsIn !== -1 && result.remainingUsagePercentage < USAGE_EXCEEDED_THRESHOLD_PERCENT);
             } else {
                 setUsage(null);
@@ -2894,7 +2896,7 @@ const AIChat: React.FC = () => {
                             <span className="codicon codicon-warning" role="img" aria-hidden="true" />
                             <span>
                                 You've reached your usage limit.
-                                {usage && usage.resetsIn !== -1 ? ` Resets ${formatResetsAt(usage.resetsIn)}.` : ""}
+                                {usage?.resetsAtMs != null ? ` Resets ${formatResetsAt(usage.resetsAtMs)}.` : ""}
                                 {usage?.alreadyRequested
                                     ? <>{" "}Your request for additional quota has been submitted. Need help in the meantime? Reach out to us on <a href={DISCORD_INVITE_URL} target="_blank" rel="noreferrer">Discord</a>.</>
                                     : <>{" "}<a href="#" onClick={(e) => { e.preventDefault(); setShowQuotaDialog(true); }}>Request additional quota</a>.</>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
@@ -20,7 +20,6 @@ import React, { useState } from "react";
 import styled from "@emotion/styled";
 import { Button } from "@wso2/ui-toolkit";
 
-const QUOTA_CONTACT_EMAIL = "support@wso2.com";
 const NOTE_MAX_LENGTH = 2000;
 
 const Overlay = styled.div`
@@ -153,9 +152,6 @@ const QuotaRequestDialog: React.FC<QuotaRequestDialogProps> = ({ submitting, err
                 />
                 <Notice>
                     Your WSO2 account email will be included with this request so the team can follow up.
-                </Notice>
-                <Notice>
-                    Reach us at {QUOTA_CONTACT_EMAIL}.
                 </Notice>
                 {error && <ErrorText role="alert">{error}</ErrorText>}
                 <ButtonContainer>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
@@ -141,7 +141,7 @@ const QuotaRequestDialog: React.FC<QuotaRequestDialogProps> = ({ submitting, err
                 aria-describedby="quota-request-desc"
             >
                 <Title id="quota-request-title">Request additional quota</Title>
-                <Text id="quota-request-desc">Let the team know you'd like more Integrator Copilot quota this week.</Text>
+                <Text id="quota-request-desc">Let the team know you'd like more quota this week.</Text>
                 <TextArea
                     value={note}
                     onChange={(e) => setNote(e.target.value)}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
@@ -151,7 +151,7 @@ const QuotaRequestDialog: React.FC<QuotaRequestDialogProps> = ({ submitting, err
                     autoFocus
                 />
                 <Notice>
-                    Your WSO2 account email will be included with this request so the team can follow up.
+                    Your account email will be included with this request so the team can follow up.
                 </Notice>
                 {error && <ErrorText role="alert">{error}</ErrorText>}
                 <ButtonContainer>


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2324

- Remove the support email (support@wso2.com) from the quota-request dialog, the over-quota banner, and the extension's usage-limit-exceeded error. Point users to the in-panel "Request additional quota" action and to Discord for help.
- Reword the dialog note "Your WSO2 account email" → "Your account email" — a user's login email can be any domain, not necessarily @wso2.com.
- Drop the hardcoded product name from the dialog copy ("more Integrator Copilot quota" → "more quota"), since the name isn't settled.
- Show the usage-limit reset as a local date and time (in the user's timezone) instead of a relative "resets in N days".
- Fix the reset time drifting forward on every re-render — anchor it to the fetch time rather than recomputing from Date.now() at render.

<img width="708" height="180" alt="quota-request-banner" src="https://github.com/user-attachments/assets/cb51f1fa-aeaa-444f-bc69-66e89125d8b3" />
<img width="478" height="276" alt="quota-request-form" src="https://github.com/user-attachments/assets/e8ae16a1-5664-4da4-8805-83ce5e7f3a07" />
<img width="697" height="191" alt="quota-request-submitted" src="https://github.com/user-attachments/assets/4782d668-4437-402e-abf5-8b75b2f62a94" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Removed support email references from quota-request and usage-limit messages.
- Directed users to the in-panel quota request action and WSO2 Discord.
- Updated account email guidance and removed product-specific wording.
- Displayed quota reset time as a localized date and time anchored to the usage fetch time.
- Added safeguards for zero and invalid reset durations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->