### PR TITLE
Handle corrupted BIR cache

### DIFF
--- a/packages/ballerina-extension/src/core/extended-language-client.ts
+++ b/packages/ballerina-extension/src/core/extended-language-client.ts
@@ -321,6 +321,7 @@ import { debug, handlePullModuleProgress } from "../utils";
 import { CMP_LS_CLIENT_COMPLETIONS, CMP_LS_CLIENT_DIAGNOSTICS, getMessageObject, sendTelemetryEvent, TM_EVENT_LANG_CLIENT } from "../features/telemetry";
 import { DefinitionParams, InitializeParams, InitializeResult, Location, LocationLink, TextDocumentPositionParams } from 'vscode-languageserver-protocol';
 import { updateProjectArtifacts } from "../utils/project-artifacts";
+import { CorruptBirCachePayload, promptClearCorruptBirCache } from "../utils/bir-cache-recovery";
 import { RPCLayer } from "../../src/RPCLayer";
 import { VisualizerWebview } from "../../src/views/visualizer/webview";
 
@@ -534,7 +535,8 @@ enum EXTENDED_APIS {
     MULE_TO_BI = 'projectService/importMule',
     MIGRATION_TOOL_STATE = 'projectService/stateCallback',
     MIGRATION_TOOL_LOG = 'projectService/logCallback',
-    PUSH_MIGRATED_PROJECT = 'projectService/pushMigratedProject'
+    PUSH_MIGRATED_PROJECT = 'projectService/pushMigratedProject',
+    CORRUPT_BIR_CACHE = 'projectService/corruptBirCache'
 }
 
 enum EXTENDED_APIS_ORG {
@@ -653,6 +655,14 @@ export class ExtendedLangClient extends LanguageClient implements ExtendedLangCl
             } catch (error) {
                 console.error("Error in PUBLISH_ARTIFACTS handler:", error);
             }
+        });
+    }
+
+    registerCorruptBirCache(): void {
+        // A corrupt/incompatible cached BIR makes the project load empty. The LS
+        // reports the affected module here; offer to clear just that module's cache and reload.
+        this.onNotification(EXTENDED_APIS.CORRUPT_BIR_CACHE, (res: CorruptBirCachePayload) => {
+            void promptClearCorruptBirCache(res);
         });
     }
 

--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -583,6 +583,8 @@ const stateMachine = createMachine<MachineContext>(
                 try {
                     // Register the event driven listener to get the artifact changes
                     context.langClient.registerPublishArtifacts();
+                    // Register the corrupt-BIR-cache listener to recover from corrupted BIR cache failures
+                    context.langClient.registerCorruptBirCache();
                     // IF the project info is not set, we don't need to build the project structure
                     if (context.projectInfo) {
 

--- a/packages/ballerina-extension/src/test-support/birCacheRecovery.test.ts
+++ b/packages/ballerina-extension/src/test-support/birCacheRecovery.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ *  A corrupt cached BIR makes projects load empty. The LS sends a
+ * `projectService/corruptBirCache` notification with the affected module's coordinates and the
+ * running distribution version; the client clears that module's compiled cache under
+ * cache-<distVersion>. These L1 tests pin three invariants: (1) only a well-formed module
+ * coordinate is accepted (a malformed/hostile payload can never become an fs path); (2) the clear
+ * removes ONLY the affected module's compiled cache and only under the active distribution's
+ * cache-<distVersion> — never other distributions, the pulled bala/, other modules or versions, or
+ * the distribution itself.
+ */
+
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs/promises";
+import { isValidModule, resolveModuleCacheDirs, clearModuleBirCache } from "../utils/bir-cache-recovery";
+
+describe("isValidModule", () => {
+    it("accepts a well-formed coordinate", () => {
+        expect(isValidModule({ org: "ballerina", name: "ai", version: "1.14.1" })).toBe(true);
+        expect(isValidModule({ org: "ballerinax", name: "aws.s3", version: "2.1.0" })).toBe(true);
+    });
+
+    it("rejects missing or empty segments", () => {
+        expect(isValidModule(null)).toBe(false);
+        expect(isValidModule(undefined)).toBe(false);
+        expect(isValidModule({ org: "ballerina", name: "ai" })).toBe(false);
+        expect(isValidModule({ org: "ballerina", name: "ai", version: "" })).toBe(false);
+    });
+
+    it("rejects path-traversal / unsafe segments", () => {
+        expect(isValidModule({ org: "ballerina", name: "ai", version: ".." })).toBe(false);
+        expect(isValidModule({ org: "..", name: "ai", version: "1.0.0" })).toBe(false);
+        expect(isValidModule({ org: "ballerina", name: "a/i", version: "1.0.0" })).toBe(false);
+        expect(isValidModule({ org: "ballerina", name: "ai", version: "1.0.0/../../etc" })).toBe(false);
+    });
+});
+
+describe("clearModuleBirCache (targeted, cache-only)", () => {
+    let home: string;
+    const reposFor = (h: string) => path.join(h, ".ballerina", "repositories");
+
+    // Build a realistic ~/.ballerina tree under a temp home.
+    async function seed(h: string): Promise<void> {
+        const files = [
+            // target: two distribution caches for the corrupt module+version
+            "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir",
+            "repositories/central.ballerina.io/cache-2201.13.4/ballerina/ai/1.14.1/bir/ai.bir",
+            // keep: other version of same module
+            "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.13.0/bir/ai.bir",
+            // keep: other module
+            "repositories/central.ballerina.io/cache-2201.13.5/ballerina/io/1.6.0/bir/io.bir",
+            // keep: pulled bala source (never cleared)
+            "repositories/central.ballerina.io/bala/ballerina/ai/1.14.1/java21/pkg.json",
+            // keep: the distribution itself
+            "distributions/ballerina-2201.13.5/bin/bal",
+        ];
+        for (const rel of files) {
+            const full = path.join(h, ".ballerina", rel);
+            await fs.mkdir(path.dirname(full), { recursive: true });
+            await fs.writeFile(full, "x");
+        }
+    }
+
+    const exists = async (rel: string): Promise<boolean> => {
+        try {
+            await fs.stat(path.join(home, ".ballerina", rel));
+            return true;
+        } catch {
+            return false;
+        }
+    };
+
+    beforeEach(async () => {
+        home = await fs.mkdtemp(path.join(os.tmpdir(), "bir-cache-test-"));
+        await seed(home);
+    });
+
+    afterEach(async () => {
+        await fs.rm(home, { recursive: true, force: true });
+    });
+
+    it("scopes to the active distribution's cache-<distVersion> only", async () => {
+        const dirs = await resolveModuleCacheDirs(
+            reposFor(home),
+            { org: "ballerina", name: "ai", version: "1.14.1" },
+            "2201.13.5"
+        );
+        const rels = dirs.map((d) => path.relative(reposFor(home), d));
+        expect(rels).toEqual([path.join("central.ballerina.io", "cache-2201.13.5", "ballerina", "ai", "1.14.1")]);
+    });
+
+    it("considers every cache-* dir when no distVersion is given", async () => {
+        const dirs = await resolveModuleCacheDirs(reposFor(home), { org: "ballerina", name: "ai", version: "1.14.1" });
+        const rels = dirs.map((d) => path.relative(reposFor(home), d)).sort();
+        expect(rels).toEqual([
+            path.join("central.ballerina.io", "cache-2201.13.4", "ballerina", "ai", "1.14.1"),
+            path.join("central.ballerina.io", "cache-2201.13.5", "ballerina", "ai", "1.14.1"),
+        ]);
+    });
+
+    it("removes the corrupt module's cache only under the active distribution, nothing else", async () => {
+        const removed = await clearModuleBirCache(
+            { org: "ballerina", name: "ai", version: "1.14.1" },
+            { distVersion: "2201.13.5", homeDir: home }
+        );
+
+        expect(removed).toHaveLength(1);
+        // target gone from the active distribution's cache
+        expect(await exists("repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1")).toBe(false);
+        // OTHER distribution's cache for the same module is left intact
+        expect(await exists("repositories/central.ballerina.io/cache-2201.13.4/ballerina/ai/1.14.1/bir/ai.bir")).toBe(true);
+        // everything else intact
+        expect(await exists("repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.13.0/bir/ai.bir")).toBe(true);
+        expect(await exists("repositories/central.ballerina.io/cache-2201.13.5/ballerina/io/1.6.0/bir/io.bir")).toBe(true);
+        expect(await exists("repositories/central.ballerina.io/bala/ballerina/ai/1.14.1/java21/pkg.json")).toBe(true);
+        expect(await exists("distributions/ballerina-2201.13.5/bin/bal")).toBe(true);
+    });
+
+    it("removes nothing when the module is not cached", async () => {
+        const removed = await clearModuleBirCache(
+            { org: "ballerina", name: "nope", version: "9.9.9" },
+            { distVersion: "2201.13.5", homeDir: home }
+        );
+        expect(removed).toEqual([]);
+        expect(await exists("repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir")).toBe(true);
+    });
+});

--- a/packages/ballerina-extension/src/test-support/birCacheRecovery.test.ts
+++ b/packages/ballerina-extension/src/test-support/birCacheRecovery.test.ts
@@ -19,20 +19,26 @@
 /**
  * @jest-environment node
  *
- *  A corrupt cached BIR makes projects load empty. The LS sends a
+ * A corrupt cached BIR makes projects load empty. The LS sends a
  * `projectService/corruptBirCache` notification with the affected module's coordinates and the
  * running distribution version; the client clears that module's compiled cache under
- * cache-<distVersion>. These L1 tests pin three invariants: (1) only a well-formed module
- * coordinate is accepted (a malformed/hostile payload can never become an fs path); (2) the clear
- * removes ONLY the affected module's compiled cache and only under the active distribution's
- * cache-<distVersion> — never other distributions, the pulled bala/, other modules or versions, or
- * the distribution itself.
+ * cache-<distVersion>. These L1 tests pin two invariants: (1) only a well-formed module coordinate
+ * is accepted (a malformed/hostile payload can never become an fs path); (2) the clear removes ONLY
+ * the affected module's compiled cache and only under the active distribution's cache-<distVersion>
+ * — never other distributions, the pulled bala/, other modules or versions, or the distribution
+ * itself.
+ *
+ * The clear invariant is table-driven from JSON fixtures under fixtures/bir-cache/ (see
+ * docs/TEST_PLAN.md §5). Each fixture materializes a realistic ~/.ballerina tree in a temp home,
+ * runs the real clear against it, and asserts what is resolved, removed, and kept. Add a fixture
+ * (e.g. issue-2251.json) to guard a new case.
  */
 
 import * as os from "os";
 import * as path from "path";
 import * as fs from "fs/promises";
-import { isValidModule, resolveModuleCacheDirs, clearModuleBirCache } from "../utils/bir-cache-recovery";
+import { loadFixtures } from "@wso2/test-config/fixtures";
+import { CorruptModule, isValidModule, resolveModuleCacheDirs, clearModuleBirCache } from "../utils/bir-cache-recovery";
 
 describe("isValidModule", () => {
     it("accepts a well-formed coordinate", () => {
@@ -55,93 +61,66 @@ describe("isValidModule", () => {
     });
 });
 
-describe("clearModuleBirCache (targeted, cache-only)", () => {
-    let home: string;
-    const reposFor = (h: string) => path.join(h, ".ballerina", "repositories");
+// A single clear scenario: seed `tree` under a temp ~/.ballerina, clear `module` (optionally scoped
+// to `distVersion`), then assert the resolved/removed/kept paths. All paths are relative to the
+// .ballerina root and use "/" separators (normalized per-OS below).
+interface BirCacheFixture {
+    description?: string;
+    module: CorruptModule;
+    distVersion?: string;
+    tree: string[];
+    expectedResolved?: string[];
+    expectedRemoved: string[];
+    expectedKept: string[];
+}
 
-    // Build a realistic ~/.ballerina tree under a temp home.
-    async function seed(h: string): Promise<void> {
-        const files = [
-            // target: two distribution caches for the corrupt module+version
-            "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir",
-            "repositories/central.ballerina.io/cache-2201.13.4/ballerina/ai/1.14.1/bir/ai.bir",
-            // keep: other version of same module
-            "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.13.0/bir/ai.bir",
-            // keep: other module
-            "repositories/central.ballerina.io/cache-2201.13.5/ballerina/io/1.6.0/bir/io.bir",
-            // keep: pulled bala source (never cleared)
-            "repositories/central.ballerina.io/bala/ballerina/ai/1.14.1/java21/pkg.json",
-            // keep: the distribution itself
-            "distributions/ballerina-2201.13.5/bin/bal",
-        ];
-        for (const rel of files) {
-            const full = path.join(h, ".ballerina", rel);
-            await fs.mkdir(path.dirname(full), { recursive: true });
-            await fs.writeFile(full, "x");
-        }
-    }
+const fixtures = loadFixtures<BirCacheFixture>(__dirname, "fixtures", "bir-cache");
 
-    const exists = async (rel: string): Promise<boolean> => {
+describe("clearModuleBirCache (targeted, cache-only) — fixtures", () => {
+    const toOsPath = (rel: string): string => path.join(...rel.split("/"));
+
+    it("has fixtures to run", () => {
+        expect(fixtures.length).toBeGreaterThan(0);
+    });
+
+    it.each(fixtures.map((f) => [f.name, f.data] as [string, BirCacheFixture]))("%s", async (_name, fx) => {
+        const home = await fs.mkdtemp(path.join(os.tmpdir(), "bir-cache-test-"));
+        const ballerinaDir = path.join(home, ".ballerina");
+        const reposDir = path.join(ballerinaDir, "repositories");
+        const relToBallerina = (abs: string): string => path.relative(ballerinaDir, abs);
+        const exists = async (rel: string): Promise<boolean> => {
+            try {
+                await fs.stat(path.join(ballerinaDir, toOsPath(rel)));
+                return true;
+            } catch {
+                return false;
+            }
+        };
+
         try {
-            await fs.stat(path.join(home, ".ballerina", rel));
-            return true;
-        } catch {
-            return false;
+            // Seed the realistic ~/.ballerina tree.
+            for (const rel of fx.tree) {
+                const full = path.join(ballerinaDir, toOsPath(rel));
+                await fs.mkdir(path.dirname(full), { recursive: true });
+                await fs.writeFile(full, "x");
+            }
+
+            if (fx.expectedResolved) {
+                const resolved = await resolveModuleCacheDirs(reposDir, fx.module, fx.distVersion);
+                expect(resolved.map(relToBallerina).sort()).toEqual(fx.expectedResolved.map(toOsPath).sort());
+            }
+
+            const removed = await clearModuleBirCache(fx.module, { distVersion: fx.distVersion, homeDir: home });
+            expect(removed.map(relToBallerina).sort()).toEqual(fx.expectedRemoved.map(toOsPath).sort());
+
+            for (const rel of fx.expectedRemoved) {
+                expect(await exists(rel)).toBe(false);
+            }
+            for (const rel of fx.expectedKept) {
+                expect(await exists(rel)).toBe(true);
+            }
+        } finally {
+            await fs.rm(home, { recursive: true, force: true });
         }
-    };
-
-    beforeEach(async () => {
-        home = await fs.mkdtemp(path.join(os.tmpdir(), "bir-cache-test-"));
-        await seed(home);
-    });
-
-    afterEach(async () => {
-        await fs.rm(home, { recursive: true, force: true });
-    });
-
-    it("scopes to the active distribution's cache-<distVersion> only", async () => {
-        const dirs = await resolveModuleCacheDirs(
-            reposFor(home),
-            { org: "ballerina", name: "ai", version: "1.14.1" },
-            "2201.13.5"
-        );
-        const rels = dirs.map((d) => path.relative(reposFor(home), d));
-        expect(rels).toEqual([path.join("central.ballerina.io", "cache-2201.13.5", "ballerina", "ai", "1.14.1")]);
-    });
-
-    it("considers every cache-* dir when no distVersion is given", async () => {
-        const dirs = await resolveModuleCacheDirs(reposFor(home), { org: "ballerina", name: "ai", version: "1.14.1" });
-        const rels = dirs.map((d) => path.relative(reposFor(home), d)).sort();
-        expect(rels).toEqual([
-            path.join("central.ballerina.io", "cache-2201.13.4", "ballerina", "ai", "1.14.1"),
-            path.join("central.ballerina.io", "cache-2201.13.5", "ballerina", "ai", "1.14.1"),
-        ]);
-    });
-
-    it("removes the corrupt module's cache only under the active distribution, nothing else", async () => {
-        const removed = await clearModuleBirCache(
-            { org: "ballerina", name: "ai", version: "1.14.1" },
-            { distVersion: "2201.13.5", homeDir: home }
-        );
-
-        expect(removed).toHaveLength(1);
-        // target gone from the active distribution's cache
-        expect(await exists("repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1")).toBe(false);
-        // OTHER distribution's cache for the same module is left intact
-        expect(await exists("repositories/central.ballerina.io/cache-2201.13.4/ballerina/ai/1.14.1/bir/ai.bir")).toBe(true);
-        // everything else intact
-        expect(await exists("repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.13.0/bir/ai.bir")).toBe(true);
-        expect(await exists("repositories/central.ballerina.io/cache-2201.13.5/ballerina/io/1.6.0/bir/io.bir")).toBe(true);
-        expect(await exists("repositories/central.ballerina.io/bala/ballerina/ai/1.14.1/java21/pkg.json")).toBe(true);
-        expect(await exists("distributions/ballerina-2201.13.5/bin/bal")).toBe(true);
-    });
-
-    it("removes nothing when the module is not cached", async () => {
-        const removed = await clearModuleBirCache(
-            { org: "ballerina", name: "nope", version: "9.9.9" },
-            { distVersion: "2201.13.5", homeDir: home }
-        );
-        expect(removed).toEqual([]);
-        expect(await exists("repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir")).toBe(true);
     });
 });

--- a/packages/ballerina-extension/src/test-support/birCacheRecovery.test.ts
+++ b/packages/ballerina-extension/src/test-support/birCacheRecovery.test.ts
@@ -20,13 +20,14 @@
  * @jest-environment node
  *
  * A corrupt cached BIR makes projects load empty. The LS sends a
- * `projectService/corruptBirCache` notification with the affected module's coordinates and the
- * running distribution version; the client clears that module's compiled cache under
- * cache-<distVersion>. These L1 tests pin two invariants: (1) only a well-formed module coordinate
- * is accepted (a malformed/hostile payload can never become an fs path); (2) the clear removes ONLY
- * the affected module's compiled cache and only under the active distribution's cache-<distVersion>
- * — never other distributions, the pulled bala/, other modules or versions, or the distribution
- * itself.
+ * `projectService/corruptBirCache` notification with the affected *package's* coordinates and the
+ * running distribution version; the client clears that package's compiled cache under
+ * cache-<distVersion>. (The cache is keyed by package, not module: a package's submodule BIRs all
+ * live under `cache-<dist>/<org>/<packageName>/<version>/bir/` — see the submodule fixture.) These
+ * L1 tests pin two invariants: (1) only a well-formed package coordinate is accepted (a
+ * malformed/hostile payload can never become an fs path); (2) the clear removes ONLY the affected
+ * package's compiled cache and only under the active distribution's cache-<distVersion> — never
+ * other distributions, the pulled bala/, other packages or versions, or the distribution itself.
  *
  * The clear invariant is table-driven from JSON fixtures under fixtures/bir-cache/ (see
  * docs/TEST_PLAN.md §5). Each fixture materializes a realistic ~/.ballerina tree in a temp home,
@@ -38,35 +39,40 @@ import * as os from "os";
 import * as path from "path";
 import * as fs from "fs/promises";
 import { loadFixtures } from "@wso2/test-config/fixtures";
-import { CorruptModule, isValidModule, resolveModuleCacheDirs, clearModuleBirCache } from "../utils/bir-cache-recovery";
+import {
+    CorruptPackage,
+    isValidPackage,
+    resolvePackageCacheDirs,
+    clearPackageBirCache,
+} from "../utils/bir-cache-recovery";
 
-describe("isValidModule", () => {
+describe("isValidPackage", () => {
     it("accepts a well-formed coordinate", () => {
-        expect(isValidModule({ org: "ballerina", name: "ai", version: "1.14.1" })).toBe(true);
-        expect(isValidModule({ org: "ballerinax", name: "aws.s3", version: "2.1.0" })).toBe(true);
+        expect(isValidPackage({ org: "ballerina", packageName: "ai", version: "1.14.1" })).toBe(true);
+        expect(isValidPackage({ org: "ballerinax", packageName: "aws.s3", version: "2.1.0" })).toBe(true);
     });
 
     it("rejects missing or empty segments", () => {
-        expect(isValidModule(null)).toBe(false);
-        expect(isValidModule(undefined)).toBe(false);
-        expect(isValidModule({ org: "ballerina", name: "ai" })).toBe(false);
-        expect(isValidModule({ org: "ballerina", name: "ai", version: "" })).toBe(false);
+        expect(isValidPackage(null)).toBe(false);
+        expect(isValidPackage(undefined)).toBe(false);
+        expect(isValidPackage({ org: "ballerina", packageName: "ai" })).toBe(false);
+        expect(isValidPackage({ org: "ballerina", packageName: "ai", version: "" })).toBe(false);
     });
 
     it("rejects path-traversal / unsafe segments", () => {
-        expect(isValidModule({ org: "ballerina", name: "ai", version: ".." })).toBe(false);
-        expect(isValidModule({ org: "..", name: "ai", version: "1.0.0" })).toBe(false);
-        expect(isValidModule({ org: "ballerina", name: "a/i", version: "1.0.0" })).toBe(false);
-        expect(isValidModule({ org: "ballerina", name: "ai", version: "1.0.0/../../etc" })).toBe(false);
+        expect(isValidPackage({ org: "ballerina", packageName: "ai", version: ".." })).toBe(false);
+        expect(isValidPackage({ org: "..", packageName: "ai", version: "1.0.0" })).toBe(false);
+        expect(isValidPackage({ org: "ballerina", packageName: "a/i", version: "1.0.0" })).toBe(false);
+        expect(isValidPackage({ org: "ballerina", packageName: "ai", version: "1.0.0/../../etc" })).toBe(false);
     });
 });
 
-// A single clear scenario: seed `tree` under a temp ~/.ballerina, clear `module` (optionally scoped
-// to `distVersion`), then assert the resolved/removed/kept paths. All paths are relative to the
+// A single clear scenario: seed `tree` under a temp ~/.ballerina, clear `pkg` (optionally scoped to
+// `distVersion`), then assert the resolved/removed/kept paths. All paths are relative to the
 // .ballerina root and use "/" separators (normalized per-OS below).
 interface BirCacheFixture {
     description?: string;
-    module: CorruptModule;
+    pkg: CorruptPackage;
     distVersion?: string;
     tree: string[];
     expectedResolved?: string[];
@@ -76,7 +82,7 @@ interface BirCacheFixture {
 
 const fixtures = loadFixtures<BirCacheFixture>(__dirname, "fixtures", "bir-cache");
 
-describe("clearModuleBirCache (targeted, cache-only) — fixtures", () => {
+describe("clearPackageBirCache (targeted, cache-only) — fixtures", () => {
     const toOsPath = (rel: string): string => path.join(...rel.split("/"));
 
     it("has fixtures to run", () => {
@@ -106,11 +112,11 @@ describe("clearModuleBirCache (targeted, cache-only) — fixtures", () => {
             }
 
             if (fx.expectedResolved) {
-                const resolved = await resolveModuleCacheDirs(reposDir, fx.module, fx.distVersion);
+                const resolved = await resolvePackageCacheDirs(reposDir, fx.pkg, fx.distVersion);
                 expect(resolved.map(relToBallerina).sort()).toEqual(fx.expectedResolved.map(toOsPath).sort());
             }
 
-            const removed = await clearModuleBirCache(fx.module, { distVersion: fx.distVersion, homeDir: home });
+            const removed = await clearPackageBirCache(fx.pkg, { distVersion: fx.distVersion, homeDir: home });
             expect(removed.map(relToBallerina).sort()).toEqual(fx.expectedRemoved.map(toOsPath).sort());
 
             for (const rel of fx.expectedRemoved) {

--- a/packages/ballerina-extension/src/test-support/birCacheRecovery.test.ts
+++ b/packages/ballerina-extension/src/test-support/birCacheRecovery.test.ts
@@ -39,11 +39,18 @@ import * as os from "os";
 import * as path from "path";
 import * as fs from "fs/promises";
 import { loadFixtures } from "@wso2/test-config/fixtures";
+
+// The full @wso2/ballerina-core barrel drags in ESM LS-connection code jest can't transform, so mock
+// the one constant bir-cache-recovery imports (matches how other test-support suites mock this package).
+jest.mock("@wso2/ballerina-core", () => ({
+    PRODUCT_INTEGRATOR_ISSUES_URL: "https://github.com/wso2/product-integrator/issues",
+}));
 import {
     CorruptPackage,
     isValidPackage,
     resolvePackageCacheDirs,
     clearPackageBirCache,
+    buildCorruptBirIssueUrl,
 } from "../utils/bir-cache-recovery";
 
 describe("isValidPackage", () => {
@@ -160,5 +167,42 @@ describe("clearPackageBirCache — symlink containment", () => {
             await fs.rm(home, { recursive: true, force: true });
             await fs.rm(outside, { recursive: true, force: true });
         }
+    });
+});
+
+describe("buildCorruptBirIssueUrl", () => {
+    const decodeBody = (url: string): string => {
+        const body = new URL(url).searchParams.get("body");
+        return body ?? "";
+    };
+
+    it("targets the prefilled new-issue form with the coordinate in title and body", () => {
+        const url = buildCorruptBirIssueUrl(
+            { distVersion: "2201.13.0", stackTrace: "at foo.bar(Foo.java:1)" },
+            "ballerina/ai.observe:1.14.1"
+        );
+        expect(url.startsWith("https://github.com/wso2/product-integrator/issues/new?")).toBe(true);
+
+        const parsed = new URL(url);
+        expect(parsed.searchParams.get("title")).toBe("Corrupt BIR cache: ballerina/ai.observe:1.14.1");
+
+        const body = decodeBody(url);
+        expect(body).toContain("ballerina/ai.observe:1.14.1");
+        expect(body).toContain("2201.13.0");
+        expect(body).toContain("at foo.bar(Foo.java:1)");
+    });
+
+    it("stays usable without a coordinate or stack trace", () => {
+        const body = decodeBody(buildCorruptBirIssueUrl({}, undefined));
+        expect(body).toContain("(unknown)");
+        expect(body).toContain("Not available");
+    });
+
+    it("truncates an over-long stack trace", () => {
+        const url = buildCorruptBirIssueUrl({ stackTrace: "x".repeat(10000) }, "org/pkg:1.0.0");
+        const body = decodeBody(url);
+        expect(body).toContain("… (truncated)");
+        // The 10k-char trace must not survive in full.
+        expect(body).not.toContain("x".repeat(6000));
     });
 });

--- a/packages/ballerina-extension/src/test-support/birCacheRecovery.test.ts
+++ b/packages/ballerina-extension/src/test-support/birCacheRecovery.test.ts
@@ -130,3 +130,35 @@ describe("clearPackageBirCache (targeted, cache-only) — fixtures", () => {
         }
     });
 });
+
+describe("clearPackageBirCache — symlink containment", () => {
+    it("does not delete through a symlinked path component that escapes the repositories root", async () => {
+        const home = await fs.mkdtemp(path.join(os.tmpdir(), "bir-cache-home-"));
+        const outside = await fs.mkdtemp(path.join(os.tmpdir(), "bir-cache-outside-"));
+        try {
+            const cacheDir = path.join(home, ".ballerina", "repositories", "central.ballerina.io", "cache-1.0.0");
+            await fs.mkdir(cacheDir, { recursive: true });
+
+            // Victim data lives OUTSIDE the repositories root.
+            const victim = path.join(outside, "myorg", "mypkg", "1.0.0");
+            await fs.mkdir(victim, { recursive: true });
+            const sentinel = path.join(victim, "sentinel.txt");
+            await fs.writeFile(sentinel, "keep");
+
+            // Plant a symlink so <cache>/myorg resolves outside the root. The coordinate is a valid
+            // segment, so the lexical path is in-root; only realpath containment catches the escape.
+            await fs.symlink(path.join(outside, "myorg"), path.join(cacheDir, "myorg"), "dir");
+
+            const removed = await clearPackageBirCache(
+                { org: "myorg", packageName: "mypkg", version: "1.0.0" },
+                { distVersion: "1.0.0", homeDir: home }
+            );
+
+            expect(removed).toEqual([]); // escaping target must not be reported as removed
+            await expect(fs.stat(sentinel)).resolves.toBeDefined(); // victim outside the root is preserved
+        } finally {
+            await fs.rm(home, { recursive: true, force: true });
+            await fs.rm(outside, { recursive: true, force: true });
+        }
+    });
+});

--- a/packages/ballerina-extension/src/test-support/fixtures/bir-cache/issue-2251.json
+++ b/packages/ballerina-extension/src/test-support/fixtures/bir-cache/issue-2251.json
@@ -1,0 +1,26 @@
+{
+    "description": "#2251: corrupt ballerina/ai:1.14.1 BIR — clear only that module's compiled cache under the active distribution (cache-2201.13.5), leaving other distributions, other versions, other modules, the pulled bala source, and the distribution itself intact",
+    "module": { "org": "ballerina", "name": "ai", "version": "1.14.1" },
+    "distVersion": "2201.13.5",
+    "tree": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir",
+        "repositories/central.ballerina.io/cache-2201.13.4/ballerina/ai/1.14.1/bir/ai.bir",
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.13.0/bir/ai.bir",
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/io/1.6.0/bir/io.bir",
+        "repositories/central.ballerina.io/bala/ballerina/ai/1.14.1/java21/pkg.json",
+        "distributions/ballerina-2201.13.5/bin/bal"
+    ],
+    "expectedResolved": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1"
+    ],
+    "expectedRemoved": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1"
+    ],
+    "expectedKept": [
+        "repositories/central.ballerina.io/cache-2201.13.4/ballerina/ai/1.14.1/bir/ai.bir",
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.13.0/bir/ai.bir",
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/io/1.6.0/bir/io.bir",
+        "repositories/central.ballerina.io/bala/ballerina/ai/1.14.1/java21/pkg.json",
+        "distributions/ballerina-2201.13.5/bin/bal"
+    ]
+}

--- a/packages/ballerina-extension/src/test-support/fixtures/bir-cache/issue-2251.json
+++ b/packages/ballerina-extension/src/test-support/fixtures/bir-cache/issue-2251.json
@@ -1,6 +1,6 @@
 {
-    "description": "#2251: corrupt ballerina/ai:1.14.1 BIR — clear only that module's compiled cache under the active distribution (cache-2201.13.5), leaving other distributions, other versions, other modules, the pulled bala source, and the distribution itself intact",
-    "module": { "org": "ballerina", "name": "ai", "version": "1.14.1" },
+    "description": "#2251: corrupt ballerina/ai:1.14.1 BIR — clear only that package's compiled cache under the active distribution (cache-2201.13.5), leaving other distributions, other versions, other packages, the pulled bala source, and the distribution itself intact",
+    "pkg": { "org": "ballerina", "packageName": "ai", "version": "1.14.1" },
     "distVersion": "2201.13.5",
     "tree": [
         "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir",

--- a/packages/ballerina-extension/src/test-support/fixtures/bir-cache/no-dist-version.json
+++ b/packages/ballerina-extension/src/test-support/fixtures/bir-cache/no-dist-version.json
@@ -1,0 +1,20 @@
+{
+    "description": "No distVersion given: every cache-* directory holding the corrupt module is resolved and cleared across all distributions, but other versions of the module are left intact",
+    "module": { "org": "ballerina", "name": "ai", "version": "1.14.1" },
+    "tree": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir",
+        "repositories/central.ballerina.io/cache-2201.13.4/ballerina/ai/1.14.1/bir/ai.bir",
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.13.0/bir/ai.bir"
+    ],
+    "expectedResolved": [
+        "repositories/central.ballerina.io/cache-2201.13.4/ballerina/ai/1.14.1",
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1"
+    ],
+    "expectedRemoved": [
+        "repositories/central.ballerina.io/cache-2201.13.4/ballerina/ai/1.14.1",
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1"
+    ],
+    "expectedKept": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.13.0/bir/ai.bir"
+    ]
+}

--- a/packages/ballerina-extension/src/test-support/fixtures/bir-cache/no-dist-version.json
+++ b/packages/ballerina-extension/src/test-support/fixtures/bir-cache/no-dist-version.json
@@ -1,6 +1,6 @@
 {
-    "description": "No distVersion given: every cache-* directory holding the corrupt module is resolved and cleared across all distributions, but other versions of the module are left intact",
-    "module": { "org": "ballerina", "name": "ai", "version": "1.14.1" },
+    "description": "No distVersion given: every cache-* directory holding the corrupt package is resolved and cleared across all distributions, but other versions of the package are left intact",
+    "pkg": { "org": "ballerina", "packageName": "ai", "version": "1.14.1" },
     "tree": [
         "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir",
         "repositories/central.ballerina.io/cache-2201.13.4/ballerina/ai/1.14.1/bir/ai.bir",

--- a/packages/ballerina-extension/src/test-support/fixtures/bir-cache/submodule.json
+++ b/packages/ballerina-extension/src/test-support/fixtures/bir-cache/submodule.json
@@ -1,0 +1,22 @@
+{
+    "description": "#2251 submodule case: the corrupt BIR belongs to submodule 'ai.observe', whose compiled BIR lives under the *package* dir ballerina/ai/<version>/bir/ai.observe.bir — there is no ballerina/ai.observe/ dir. The LS resolves and sends the package name 'ai', so clearing the package cache dir removes the submodule BIR (and its siblings) in one shot, instead of resolving a nonexistent ai.observe dir and falling back to a full-cache wipe.",
+    "pkg": { "org": "ballerina", "packageName": "ai", "version": "1.14.1" },
+    "distVersion": "2201.13.5",
+    "tree": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir",
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.observe.bir",
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.intelligence.bir",
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/io/1.6.0/bir/io.bir",
+        "repositories/central.ballerina.io/bala/ballerina/ai/1.14.1/java21/pkg.json"
+    ],
+    "expectedResolved": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1"
+    ],
+    "expectedRemoved": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1"
+    ],
+    "expectedKept": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/io/1.6.0/bir/io.bir",
+        "repositories/central.ballerina.io/bala/ballerina/ai/1.14.1/java21/pkg.json"
+    ]
+}

--- a/packages/ballerina-extension/src/test-support/fixtures/bir-cache/uncached-module.json
+++ b/packages/ballerina-extension/src/test-support/fixtures/bir-cache/uncached-module.json
@@ -1,0 +1,12 @@
+{
+    "description": "Module not present in any cache: nothing is resolved or removed and the existing tree is left intact",
+    "module": { "org": "ballerina", "name": "nope", "version": "9.9.9" },
+    "distVersion": "2201.13.5",
+    "tree": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir"
+    ],
+    "expectedRemoved": [],
+    "expectedKept": [
+        "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir"
+    ]
+}

--- a/packages/ballerina-extension/src/test-support/fixtures/bir-cache/uncached-module.json
+++ b/packages/ballerina-extension/src/test-support/fixtures/bir-cache/uncached-module.json
@@ -1,6 +1,6 @@
 {
-    "description": "Module not present in any cache: nothing is resolved or removed and the existing tree is left intact",
-    "module": { "org": "ballerina", "name": "nope", "version": "9.9.9" },
+    "description": "Package not present in any cache: nothing is resolved or removed and the existing tree is left intact",
+    "pkg": { "org": "ballerina", "packageName": "nope", "version": "9.9.9" },
     "distVersion": "2201.13.5",
     "tree": [
         "repositories/central.ballerina.io/cache-2201.13.5/ballerina/ai/1.14.1/bir/ai.bir"

--- a/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
+++ b/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// A corrupt/incompatible cached BIR makes projects load empty. The LS reports the
+// condition via the `projectService/corruptBirCache` notification with the affected module's
+// coordinates and the running distribution version; here we offer to clear that module's compiled
+// BIR cache under cache-<distVersion> and reload.
+
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs/promises";
+import { commands, window } from "vscode";
+
+export interface CorruptModule {
+    org: string;
+    name: string;
+    version: string;
+}
+
+/** The `projectService/corruptBirCache` notification payload sent by the language server. */
+export interface CorruptBirCachePayload extends Partial<CorruptModule> {
+    distVersion?: string;
+    projectUri?: string;
+}
+
+interface ClearOptions {
+    distVersion?: string;
+    homeDir?: string;
+}
+
+// A cache path segment (org / package name / version / dist version) must be a single, simple token.
+// This guards against a malformed payload turning into path traversal ("..", "/", …) on disk.
+const SAFE_SEGMENT = /^[A-Za-z0-9_.+-]+$/;
+function isSafeSegment(segment: unknown): segment is string {
+    return typeof segment === "string" && segment !== "." && segment !== ".." && SAFE_SEGMENT.test(segment);
+}
+
+/** True when the notification payload names a module safe to turn into cache paths. */
+export function isValidModule(module: Partial<CorruptModule> | null | undefined): module is CorruptModule {
+    return !!module && isSafeSegment(module.org) && isSafeSegment(module.name) && isSafeSegment(module.version);
+}
+
+function reposDirFor(homeDir: string): string {
+    return path.join(homeDir, ".ballerina", "repositories");
+}
+
+function isWithin(parent: string, child: string): boolean {
+    const rel = path.relative(parent, child);
+    return !!rel && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+function cacheDirMatches(cacheDir: string, distVersion?: string): boolean {
+    if (!cacheDir.startsWith("cache-")) {
+        return false;
+    }
+    return !distVersion || cacheDir === `cache-${distVersion}`;
+}
+
+async function listSubDirs(dir: string): Promise<string[]> {
+    try {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+        return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+    } catch {
+        return [];
+    }
+}
+
+export async function resolveModuleCacheDirs(
+    reposDir: string,
+    module: CorruptModule,
+    distVersion?: string
+): Promise<string[]> {
+    const targets: string[] = [];
+    for (const repo of await listSubDirs(reposDir)) {
+        const repoDir = path.join(reposDir, repo);
+        for (const cacheDir of await listSubDirs(repoDir)) {
+            if (!cacheDirMatches(cacheDir, distVersion)) {
+                continue;
+            }
+            const target = path.join(repoDir, cacheDir, module.org, module.name, module.version);
+            if (isWithin(reposDir, target)) {
+                targets.push(target);
+            }
+        }
+    }
+    return targets;
+}
+
+async function removeIfExists(dir: string, reposDir: string): Promise<boolean> {
+    if (!isWithin(reposDir, dir)) {
+        return false;
+    }
+    try {
+        await fs.stat(dir);
+    } catch {
+        return false; // nothing to remove
+    }
+    await fs.rm(dir, { recursive: true, force: true });
+    return true;
+}
+
+/** Clears the compiled BIR cache for a single module under cache-<distVersion>. Returns removed dirs. */
+export async function clearModuleBirCache(module: CorruptModule, options: ClearOptions = {}): Promise<string[]> {
+    const reposDir = reposDirFor(options.homeDir ?? os.homedir());
+    const removed: string[] = [];
+    for (const dir of await resolveModuleCacheDirs(reposDir, module, options.distVersion)) {
+        if (await removeIfExists(dir, reposDir)) {
+            removed.push(dir);
+        }
+    }
+    return removed;
+}
+
+/** Fallback: clears every repositories/&ast;/cache-<distVersion> dir. */
+export async function clearAllBirCaches(options: ClearOptions = {}): Promise<string[]> {
+    const reposDir = reposDirFor(options.homeDir ?? os.homedir());
+    const removed: string[] = [];
+    for (const repo of await listSubDirs(reposDir)) {
+        const repoDir = path.join(reposDir, repo);
+        for (const cacheDir of await listSubDirs(repoDir)) {
+            if (!cacheDirMatches(cacheDir, options.distVersion)) {
+                continue;
+            }
+            const target = path.join(repoDir, cacheDir);
+            if (await removeIfExists(target, reposDir)) {
+                removed.push(target);
+            }
+        }
+    }
+    return removed;
+}
+
+let promptShown = false; // don't stack a prompt per repeated notification
+
+/**
+ * Surfaces the corrupt-BIR condition and, on confirmation, clears the affected module's compiled
+ * cache under the active distribution's cache directory (or all modules in that cache when the
+ * module can't be identified) and reloads the window.
+ */
+export async function promptClearCorruptBirCache(payload: CorruptBirCachePayload | null | undefined): Promise<void> {
+    if (promptShown) {
+        return;
+    }
+    promptShown = true;
+    try {
+        const distVersion = isSafeSegment(payload?.distVersion) ? payload.distVersion : undefined;
+        const target = isValidModule(payload)
+            ? { org: payload.org, name: payload.name, version: payload.version }
+            : null;
+        const coordinate = target ? `${target.org}/${target.name}:${target.version}` : undefined;
+        const action = "Clear cache & reload";
+        const prompt = coordinate
+            ? `The cache for module '${coordinate}' is corrupted, so the project may appear empty. ` +
+              `Clear the cache for this module and reload?`
+            : `A module cache is corrupted, so the project may appear empty. ` +
+              `Clear the module cache and reload?`;
+
+        const choice = await window.showErrorMessage(prompt, action);
+        if (choice !== action) {
+            return;
+        }
+
+        const removed = target
+            ? await clearModuleBirCache(target, { distVersion })
+            : await clearAllBirCaches({ distVersion });
+        // If the targeted clear matched nothing (unexpected layout), fall back to clearing the whole
+        // distribution cache so the user still recovers rather than reloading into the same state.
+        if (target && removed.length === 0) {
+            await clearAllBirCaches({ distVersion });
+        }
+
+        await commands.executeCommand("workbench.action.reloadWindow");
+    } finally {
+        // Reset so a later occurrence can prompt again if the window was not reloaded (dismissed/failed).
+        promptShown = false;
+    }
+}

--- a/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
+++ b/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
@@ -103,15 +103,18 @@ export async function resolvePackageCacheDirs(
 }
 
 async function removeIfExists(dir: string, reposDir: string): Promise<boolean> {
-    if (!isWithin(reposDir, dir)) {
-        return false;
-    }
+    let realReposDir: string;
+    let realDir: string;
     try {
-        await fs.stat(dir);
+        realReposDir = await fs.realpath(reposDir);
+        realDir = await fs.realpath(dir);
     } catch {
-        return false; // nothing to remove
+        return false; // missing target or unresolvable path — nothing safe to remove
     }
-    await fs.rm(dir, { recursive: true, force: true });
+    if (!isWithin(realReposDir, realDir)) {
+        return false; // target escapes the repositories root via a symlinked component
+    }
+    await fs.rm(realDir, { recursive: true, force: true });
     return true;
 }
 

--- a/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
+++ b/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
@@ -95,22 +95,28 @@ async function listSubDirs(dir: string): Promise<string[]> {
     }
 }
 
+/** Yields the absolute path of every `repositories/&ast;/cache-<distVersion>` dir under reposDir. */
+async function* eachCacheDir(reposDir: string, distVersion?: string): AsyncGenerator<string> {
+    for (const repo of await listSubDirs(reposDir)) {
+        const repoDir = path.join(reposDir, repo);
+        for (const cacheDir of await listSubDirs(repoDir)) {
+            if (cacheDirMatches(cacheDir, distVersion)) {
+                yield path.join(repoDir, cacheDir);
+            }
+        }
+    }
+}
+
 export async function resolvePackageCacheDirs(
     reposDir: string,
     pkg: CorruptPackage,
     distVersion?: string
 ): Promise<string[]> {
     const targets: string[] = [];
-    for (const repo of await listSubDirs(reposDir)) {
-        const repoDir = path.join(reposDir, repo);
-        for (const cacheDir of await listSubDirs(repoDir)) {
-            if (!cacheDirMatches(cacheDir, distVersion)) {
-                continue;
-            }
-            const target = path.join(repoDir, cacheDir, pkg.org, pkg.packageName, pkg.version);
-            if (isWithin(reposDir, target)) {
-                targets.push(target);
-            }
+    for await (const cacheDir of eachCacheDir(reposDir, distVersion)) {
+        const target = path.join(cacheDir, pkg.org, pkg.packageName, pkg.version);
+        if (isWithin(reposDir, target)) {
+            targets.push(target);
         }
     }
     return targets;
@@ -148,16 +154,9 @@ export async function clearPackageBirCache(pkg: CorruptPackage, options: ClearOp
 export async function clearAllBirCaches(options: ClearOptions = {}): Promise<string[]> {
     const reposDir = reposDirFor(options);
     const removed: string[] = [];
-    for (const repo of await listSubDirs(reposDir)) {
-        const repoDir = path.join(reposDir, repo);
-        for (const cacheDir of await listSubDirs(repoDir)) {
-            if (!cacheDirMatches(cacheDir, options.distVersion)) {
-                continue;
-            }
-            const target = path.join(repoDir, cacheDir);
-            if (await removeIfExists(target, reposDir)) {
-                removed.push(target);
-            }
+    for await (const cacheDir of eachCacheDir(reposDir, options.distVersion)) {
+        if (await removeIfExists(cacheDir, reposDir)) {
+            removed.push(cacheDir);
         }
     }
     return removed;

--- a/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
+++ b/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
@@ -37,11 +37,13 @@ export interface CorruptBirCachePayload extends Partial<CorruptPackage> {
     moduleName?: string;
     distVersion?: string;
     projectUri?: string;
+    reposPath?: string;
 }
 
 interface ClearOptions {
     distVersion?: string;
     homeDir?: string;
+    reposDir?: string;
 }
 
 // A cache path segment (org / package name / version / dist version) must be a single, simple token.
@@ -56,8 +58,16 @@ export function isValidPackage(pkg: Partial<CorruptPackage> | null | undefined):
     return !!pkg && isSafeSegment(pkg.org) && isSafeSegment(pkg.packageName) && isSafeSegment(pkg.version);
 }
 
-function reposDirFor(homeDir: string): string {
-    return path.join(homeDir, ".ballerina", "repositories");
+function reposDirFor(options: ClearOptions): string {
+    if (options.reposDir) {
+        return options.reposDir;
+    }
+    if (options.homeDir) {
+        return path.join(options.homeDir, ".ballerina", "repositories");
+    }
+    const envHome = process.env.BALLERINA_HOME_DIR;
+    const ballerinaHome = envHome && envHome.length > 0 ? envHome : path.join(os.homedir(), ".ballerina");
+    return path.join(ballerinaHome, "repositories");
 }
 
 function isWithin(parent: string, child: string): boolean {
@@ -114,13 +124,13 @@ async function removeIfExists(dir: string, reposDir: string): Promise<boolean> {
     if (!isWithin(realReposDir, realDir)) {
         return false; // target escapes the repositories root via a symlinked component
     }
-    await fs.rm(realDir, { recursive: true, force: true });
+    await fs.rm(realDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     return true;
 }
 
 /** Clears the compiled BIR cache for a single package under cache-<distVersion>. Returns removed dirs. */
 export async function clearPackageBirCache(pkg: CorruptPackage, options: ClearOptions = {}): Promise<string[]> {
-    const reposDir = reposDirFor(options.homeDir ?? os.homedir());
+    const reposDir = reposDirFor(options);
     const removed: string[] = [];
     for (const dir of await resolvePackageCacheDirs(reposDir, pkg, options.distVersion)) {
         if (await removeIfExists(dir, reposDir)) {
@@ -132,7 +142,7 @@ export async function clearPackageBirCache(pkg: CorruptPackage, options: ClearOp
 
 /** Fallback: clears every repositories/&ast;/cache-<distVersion> dir. */
 export async function clearAllBirCaches(options: ClearOptions = {}): Promise<string[]> {
-    const reposDir = reposDirFor(options.homeDir ?? os.homedir());
+    const reposDir = reposDirFor(options);
     const removed: string[] = [];
     for (const repo of await listSubDirs(reposDir)) {
         const repoDir = path.join(reposDir, repo);
@@ -163,6 +173,9 @@ export async function promptClearCorruptBirCache(payload: CorruptBirCachePayload
     promptShown = true;
     try {
         const distVersion = isSafeSegment(payload?.distVersion) ? payload.distVersion : undefined;
+        // The LS resolves this against $BALLERINA_HOME_DIR; prefer it over the client's home guess.
+        const reposDir =
+            typeof payload?.reposPath === "string" && payload.reposPath.length > 0 ? payload.reposPath : undefined;
         const target = isValidPackage(payload)
             ? { org: payload.org, packageName: payload.packageName, version: payload.version }
             : null;
@@ -171,24 +184,46 @@ export async function promptClearCorruptBirCache(payload: CorruptBirCachePayload
         const displayName = isSafeSegment(payload?.moduleName) ? payload.moduleName : target?.packageName;
         const coordinate = target ? `${target.org}/${displayName}:${target.version}` : undefined;
         const action = "Clear cache & reload";
-        const prompt = coordinate
-            ? `The cache for module '${coordinate}' is corrupted, so the project may appear empty. ` +
-              `Clear the cache for this module and reload?`
-            : `A module cache is corrupted, so the project may appear empty. ` +
-              `Clear the module cache and reload?`;
+        const message = coordinate
+            ? `The cache for module '${coordinate}' is corrupted.`
+            : `A module cache is corrupted.`;
+        const detail = coordinate
+            ? `Until it's cleared, the project may load without its components.\n\n` +
+              `Clearing removes this module's compiled cache and reloads the window to recover. ` +
+              `If the module's cache can't be located, all module caches for this distribution are cleared.`
+            : `Until it's cleared, the project may load without its components.\n\n` +
+              `Clearing removes the module cache and reloads the window to recover.`;
 
-        const choice = await window.showErrorMessage(prompt, action);
+        // A modal blocks interaction so the user can't keep working against the broken (empty)
+        // project; a dismissible notification could be ignored. Modals add their own Cancel button.
+        const choice = await window.showErrorMessage(message, { modal: true, detail }, action);
         if (choice !== action) {
             return;
         }
 
-        const removed = target
-            ? await clearPackageBirCache(target, { distVersion })
-            : await clearAllBirCaches({ distVersion });
-        // If the targeted clear matched nothing (unexpected layout), fall back to clearing the whole
-        // distribution cache so the user still recovers rather than reloading into the same state.
-        if (target && removed.length === 0) {
-            await clearAllBirCaches({ distVersion });
+        try {
+            const removed = target
+                ? await clearPackageBirCache(target, { distVersion, reposDir })
+                : await clearAllBirCaches({ distVersion, reposDir });
+            // The targeted clear matched nothing — the corrupt cache is on disk (that is why the LS
+            // reported it), but the coordinates did not resolve to it, e.g. a submodule where the LS
+            // fell back to the module name instead of the package name. Clear the whole distribution
+            // cache so the user still recovers; the prompt above states this broader scope up front.
+            if (target && removed.length === 0) {
+                await clearAllBirCaches({ distVersion, reposDir });
+            }
+        } catch (err) {
+            // A file lock (e.g. the JVM holding cache handles on Windows) or permission error can
+            // leave the cache partially cleared. Surface it instead of reloading into a broken state.
+            // Recovery failed, so the project is still broken — make this modal too so it isn't missed.
+            const reason = err instanceof Error ? err.message : String(err);
+            window.showErrorMessage("Failed to clear the corrupted module cache.", {
+                modal: true,
+                detail:
+                    `${reason}\n\nClose any running Ballerina processes and try again, ` +
+                    `or delete the cache manually.`,
+            });
+            return;
         }
 
         await commands.executeCommand("workbench.action.reloadWindow");

--- a/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
+++ b/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
@@ -17,8 +17,8 @@
  */
 
 // A corrupt/incompatible cached BIR makes projects load empty. The LS reports the
-// condition via the `projectService/corruptBirCache` notification with the affected module's
-// coordinates and the running distribution version; here we offer to clear that module's compiled
+// condition via the `projectService/corruptBirCache` notification with the affected package's
+// coordinates and the running distribution version; here we offer to clear that package's compiled
 // BIR cache under cache-<distVersion> and reload.
 
 import * as os from "os";
@@ -26,14 +26,15 @@ import * as path from "path";
 import * as fs from "fs/promises";
 import { commands, window } from "vscode";
 
-export interface CorruptModule {
+export interface CorruptPackage {
     org: string;
-    name: string;
+    packageName: string;
     version: string;
 }
 
 /** The `projectService/corruptBirCache` notification payload sent by the language server. */
-export interface CorruptBirCachePayload extends Partial<CorruptModule> {
+export interface CorruptBirCachePayload extends Partial<CorruptPackage> {
+    moduleName?: string;
     distVersion?: string;
     projectUri?: string;
 }
@@ -50,9 +51,9 @@ function isSafeSegment(segment: unknown): segment is string {
     return typeof segment === "string" && segment !== "." && segment !== ".." && SAFE_SEGMENT.test(segment);
 }
 
-/** True when the notification payload names a module safe to turn into cache paths. */
-export function isValidModule(module: Partial<CorruptModule> | null | undefined): module is CorruptModule {
-    return !!module && isSafeSegment(module.org) && isSafeSegment(module.name) && isSafeSegment(module.version);
+/** True when the notification payload names a package safe to turn into cache paths. */
+export function isValidPackage(pkg: Partial<CorruptPackage> | null | undefined): pkg is CorruptPackage {
+    return !!pkg && isSafeSegment(pkg.org) && isSafeSegment(pkg.packageName) && isSafeSegment(pkg.version);
 }
 
 function reposDirFor(homeDir: string): string {
@@ -80,9 +81,9 @@ async function listSubDirs(dir: string): Promise<string[]> {
     }
 }
 
-export async function resolveModuleCacheDirs(
+export async function resolvePackageCacheDirs(
     reposDir: string,
-    module: CorruptModule,
+    pkg: CorruptPackage,
     distVersion?: string
 ): Promise<string[]> {
     const targets: string[] = [];
@@ -92,7 +93,7 @@ export async function resolveModuleCacheDirs(
             if (!cacheDirMatches(cacheDir, distVersion)) {
                 continue;
             }
-            const target = path.join(repoDir, cacheDir, module.org, module.name, module.version);
+            const target = path.join(repoDir, cacheDir, pkg.org, pkg.packageName, pkg.version);
             if (isWithin(reposDir, target)) {
                 targets.push(target);
             }
@@ -114,11 +115,11 @@ async function removeIfExists(dir: string, reposDir: string): Promise<boolean> {
     return true;
 }
 
-/** Clears the compiled BIR cache for a single module under cache-<distVersion>. Returns removed dirs. */
-export async function clearModuleBirCache(module: CorruptModule, options: ClearOptions = {}): Promise<string[]> {
+/** Clears the compiled BIR cache for a single package under cache-<distVersion>. Returns removed dirs. */
+export async function clearPackageBirCache(pkg: CorruptPackage, options: ClearOptions = {}): Promise<string[]> {
     const reposDir = reposDirFor(options.homeDir ?? os.homedir());
     const removed: string[] = [];
-    for (const dir of await resolveModuleCacheDirs(reposDir, module, options.distVersion)) {
+    for (const dir of await resolvePackageCacheDirs(reposDir, pkg, options.distVersion)) {
         if (await removeIfExists(dir, reposDir)) {
             removed.push(dir);
         }
@@ -148,9 +149,9 @@ export async function clearAllBirCaches(options: ClearOptions = {}): Promise<str
 let promptShown = false; // don't stack a prompt per repeated notification
 
 /**
- * Surfaces the corrupt-BIR condition and, on confirmation, clears the affected module's compiled
- * cache under the active distribution's cache directory (or all modules in that cache when the
- * module can't be identified) and reloads the window.
+ * Surfaces the corrupt-BIR condition and, on confirmation, clears the affected package's compiled
+ * cache under the active distribution's cache directory (or all packages in that cache when the
+ * package can't be identified) and reloads the window.
  */
 export async function promptClearCorruptBirCache(payload: CorruptBirCachePayload | null | undefined): Promise<void> {
     if (promptShown) {
@@ -159,10 +160,13 @@ export async function promptClearCorruptBirCache(payload: CorruptBirCachePayload
     promptShown = true;
     try {
         const distVersion = isSafeSegment(payload?.distVersion) ? payload.distVersion : undefined;
-        const target = isValidModule(payload)
-            ? { org: payload.org, name: payload.name, version: payload.version }
+        const target = isValidPackage(payload)
+            ? { org: payload.org, packageName: payload.packageName, version: payload.version }
             : null;
-        const coordinate = target ? `${target.org}/${target.name}:${target.version}` : undefined;
+        // Prefer the failing module name for display (that is what the user saw fail); fall back to
+        // the package coordinate. The clear itself always targets the package cache dir.
+        const displayName = isSafeSegment(payload?.moduleName) ? payload.moduleName : target?.packageName;
+        const coordinate = target ? `${target.org}/${displayName}:${target.version}` : undefined;
         const action = "Clear cache & reload";
         const prompt = coordinate
             ? `The cache for module '${coordinate}' is corrupted, so the project may appear empty. ` +
@@ -176,7 +180,7 @@ export async function promptClearCorruptBirCache(payload: CorruptBirCachePayload
         }
 
         const removed = target
-            ? await clearModuleBirCache(target, { distVersion })
+            ? await clearPackageBirCache(target, { distVersion })
             : await clearAllBirCaches({ distVersion });
         // If the targeted clear matched nothing (unexpected layout), fall back to clearing the whole
         // distribution cache so the user still recovers rather than reloading into the same state.

--- a/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
+++ b/packages/ballerina-extension/src/utils/bir-cache-recovery.ts
@@ -25,6 +25,8 @@ import * as os from "os";
 import * as path from "path";
 import * as fs from "fs/promises";
 import { commands, window } from "vscode";
+import { PRODUCT_INTEGRATOR_ISSUES_URL } from "@wso2/ballerina-core";
+import { openExternalUrl } from "./runCommand";
 
 export interface CorruptPackage {
     org: string;
@@ -38,6 +40,8 @@ export interface CorruptBirCachePayload extends Partial<CorruptPackage> {
     distVersion?: string;
     projectUri?: string;
     reposPath?: string;
+    // Full failure stack trace, prefilled into the "Send Report" GitHub issue for diagnosis.
+    stackTrace?: string;
 }
 
 interface ClearOptions {
@@ -161,6 +165,35 @@ export async function clearAllBirCaches(options: ClearOptions = {}): Promise<str
 
 let promptShown = false; // don't stack a prompt per repeated notification
 
+// Keep the prefilled body comfortably under the practical GitHub issue URL length limit (~8k chars
+// once percent-encoded). The stack trace is the only unbounded field, so it is the one we cap.
+const MAX_STACKTRACE_CHARS = 4000;
+
+/**
+ * Builds a prefilled GitHub "new issue" URL for the corrupt-BIR condition, seeding the title and body
+ * with the module coordinate, distribution version, OS, and (truncated) stack trace so a report is
+ * one click away. Exported for unit testing.
+ */
+export function buildCorruptBirIssueUrl(
+    payload: CorruptBirCachePayload | null | undefined,
+    coordinate?: string
+): string {
+    const title = coordinate ? `Corrupt BIR cache: ${coordinate}` : "Corrupt BIR cache";
+    let stackTrace = typeof payload?.stackTrace === "string" ? payload.stackTrace.trim() : "";
+    if (stackTrace.length > MAX_STACKTRACE_CHARS) {
+        stackTrace = `${stackTrace.slice(0, MAX_STACKTRACE_CHARS)}\n… (truncated)`;
+    }
+    const body =
+        `**Module:** ${coordinate ?? "(unknown)"}\n` +
+        `**Distribution:** ${payload?.distVersion ?? "(unknown)"}\n` +
+        `**OS:** ${os.platform()} ${os.release()}\n\n` +
+        `**Description**\nA corrupted BIR cache was detected. _Add any extra context here._\n\n` +
+        `**Stack trace**\n` +
+        (stackTrace ? "```\n" + stackTrace + "\n```" : "_Not available._");
+    const query = `title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+    return `${PRODUCT_INTEGRATOR_ISSUES_URL}/new?${query}`;
+}
+
 /**
  * Surfaces the corrupt-BIR condition and, on confirmation, clears the affected package's compiled
  * cache under the active distribution's cache directory (or all packages in that cache when the
@@ -183,23 +216,28 @@ export async function promptClearCorruptBirCache(payload: CorruptBirCachePayload
         // the package coordinate. The clear itself always targets the package cache dir.
         const displayName = isSafeSegment(payload?.moduleName) ? payload.moduleName : target?.packageName;
         const coordinate = target ? `${target.org}/${displayName}:${target.version}` : undefined;
-        const action = "Clear cache & reload";
+        const clearAction = "Clear cache & reload";
+        const reportAction = "Report an Issue";
         const message = coordinate
-            ? `The cache for module '${coordinate}' is corrupted.`
-            : `A module cache is corrupted.`;
-        const detail = coordinate
-            ? `Until it's cleared, the project may load without its components.\n\n` +
-              `Clearing removes this module's compiled cache and reloads the window to recover. ` +
-              `If the module's cache can't be located, all module caches for this distribution are cleared.`
-            : `Until it's cleared, the project may load without its components.\n\n` +
+            ? `The cache for module '${coordinate}' is corrupted.\n` +
+              `The project will stay unresponsive until this is resolved.\n` +
+              `Clearing removes the module's cache (or all module caches for this distribution if it ` +
+              `can't be located) and reloads the window to recover.`
+            : `A module cache is corrupted.\n` +
+              `The project will stay unresponsive until this is resolved.\n` +
               `Clearing removes the module cache and reloads the window to recover.`;
 
-        // A modal blocks interaction so the user can't keep working against the broken (empty)
-        // project; a dismissible notification could be ignored. Modals add their own Cancel button.
-        const choice = await window.showErrorMessage(message, { modal: true, detail }, action);
-        if (choice !== action) {
+        // VS Code dismisses a notification whenever an action button is clicked; there is no way to
+        // keep it open. So "Report an Issue" just opens the prefilled issue and lets it close.
+        const choice = await window.showErrorMessage(message, clearAction, reportAction);
+        if (choice === reportAction) {
+            openExternalUrl(buildCorruptBirIssueUrl(payload, coordinate));
             return;
         }
+        if (choice !== clearAction) {
+            return; // Dismissed
+        }
+        // proceed to clear + reload
 
         try {
             const removed = target
@@ -215,14 +253,11 @@ export async function promptClearCorruptBirCache(payload: CorruptBirCachePayload
         } catch (err) {
             // A file lock (e.g. the JVM holding cache handles on Windows) or permission error can
             // leave the cache partially cleared. Surface it instead of reloading into a broken state.
-            // Recovery failed, so the project is still broken — make this modal too so it isn't missed.
             const reason = err instanceof Error ? err.message : String(err);
-            window.showErrorMessage("Failed to clear the corrupted module cache.", {
-                modal: true,
-                detail:
-                    `${reason}\n\nClose any running Ballerina processes and try again, ` +
-                    `or delete the cache manually.`,
-            });
+            window.showErrorMessage(
+                `Failed to clear the corrupted module cache: ${reason}. ` +
+                    `Close any running Ballerina processes and try again, or delete the cache manually.`
+            );
             return;
         }
 

--- a/packages/ballerina-language-server/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/client/ExtendedLanguageClient.java
+++ b/packages/ballerina-language-server/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/client/ExtendedLanguageClient.java
@@ -44,4 +44,7 @@ public interface ExtendedLanguageClient extends LanguageClient {
 
     @JsonNotification("projectService/pushMigratedProject")
     void pushMigratedProject(Object notification);
+
+    @JsonNotification("projectService/corruptBirCache")
+    void corruptBirCache(Object notification);
 }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CorruptBirCacheParams.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CorruptBirCacheParams.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.langserver.command.executors;
+
+/**
+ * Payload for the {@code projectService/corruptBirCache} notification.
+ */
+public class CorruptBirCacheParams {
+
+    private final String org;
+    private final String name;
+    private final String version;
+    private String distVersion;
+    private String projectUri;
+
+    public CorruptBirCacheParams(String org, String name, String version) {
+        this.org = org;
+        this.name = name;
+        this.version = version;
+    }
+
+    public String getOrg() {
+        return org;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getDistVersion() {
+        return distVersion;
+    }
+
+    public void setDistVersion(String distVersion) {
+        this.distVersion = distVersion;
+    }
+
+    public String getProjectUri() {
+        return projectUri;
+    }
+
+    public void setProjectUri(String projectUri) {
+        this.projectUri = projectUri;
+    }
+}

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CorruptBirCacheParams.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CorruptBirCacheParams.java
@@ -28,6 +28,7 @@ public class CorruptBirCacheParams {
     private String distVersion;
     private String projectUri;
     private String reposPath;
+    private String stackTrace;
 
     public CorruptBirCacheParams(String org, String packageName, String version) {
         this.org = org;
@@ -77,5 +78,13 @@ public class CorruptBirCacheParams {
 
     public void setReposPath(String reposPath) {
         this.reposPath = reposPath;
+    }
+
+    public String getStackTrace() {
+        return stackTrace;
+    }
+
+    public void setStackTrace(String stackTrace) {
+        this.stackTrace = stackTrace;
     }
 }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CorruptBirCacheParams.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CorruptBirCacheParams.java
@@ -22,14 +22,15 @@ package org.ballerinalang.langserver.command.executors;
 public class CorruptBirCacheParams {
 
     private final String org;
-    private final String name;
+    private final String packageName;
     private final String version;
+    private String moduleName;
     private String distVersion;
     private String projectUri;
 
-    public CorruptBirCacheParams(String org, String name, String version) {
+    public CorruptBirCacheParams(String org, String packageName, String version) {
         this.org = org;
-        this.name = name;
+        this.packageName = packageName;
         this.version = version;
     }
 
@@ -37,12 +38,20 @@ public class CorruptBirCacheParams {
         return org;
     }
 
-    public String getName() {
-        return name;
+    public String getPackageName() {
+        return packageName;
     }
 
     public String getVersion() {
         return version;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
     }
 
     public String getDistVersion() {

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CorruptBirCacheParams.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CorruptBirCacheParams.java
@@ -27,6 +27,7 @@ public class CorruptBirCacheParams {
     private String moduleName;
     private String distVersion;
     private String projectUri;
+    private String reposPath;
 
     public CorruptBirCacheParams(String org, String packageName, String version) {
         this.org = org;
@@ -68,5 +69,13 @@ public class CorruptBirCacheParams {
 
     public void setProjectUri(String projectUri) {
         this.projectUri = projectUri;
+    }
+
+    public String getReposPath() {
+        return reposPath;
+    }
+
+    public void setReposPath(String reposPath) {
+        this.reposPath = reposPath;
     }
 }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -346,7 +346,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
      * @param throwable the completion throwable to inspect
      * @return the corrupt-BIR parameters, or empty if this is not a corrupt-BIR failure
      */
-    private static Optional<CorruptBirCacheParams> detectCorruptBirCache(Throwable throwable) {
+    static Optional<CorruptBirCacheParams> detectCorruptBirCache(Throwable throwable) {
         for (Throwable cause = throwable; cause != null && cause != cause.getCause(); cause = cause.getCause()) {
             String message = cause.getMessage();
             if (message == null || !message.contains("invalid magic number") || !message.contains("BIR")) {

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -78,6 +78,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.ballerina.projects.util.ProjectUtils.getAccessTokenOfCLI;
@@ -288,6 +290,13 @@ public class PullModuleExecutor implements LSCommandExecutor {
                         clientLogger.logError(LSContextOperation.WS_EXEC_CMD,
                                 "Pull modules failed for project: " + project.sourceRoot().toString(),
                                 t, null, (Position) null);
+                        Optional<CorruptBirCacheParams> corruptBir = detectCorruptBirCache(t);
+                        if (corruptBir.isPresent()) {
+                            CorruptBirCacheParams params = corruptBir.get();
+                            params.setProjectUri(project.sourceRoot().toUri().toString());
+                            params.setDistVersion(RepoUtils.getBallerinaShortVersion());
+                            languageClient.corruptBirCache(params);
+                        }
                         if (t.getCause() instanceof UserErrorException) {
                             String errorMessage = t.getCause().getMessage();
                             CommandUtil.notifyClient(languageClient, MessageType.Error, errorMessage);
@@ -322,6 +331,34 @@ public class PullModuleExecutor implements LSCommandExecutor {
                     languageClient.notifyProgress(new ProgressParams(Either.forLeft(taskId),
                             Either.forLeft(endNotification)));
                 });
+    }
+
+    // The compiler's BIR reader throws with this signature when a cached BIR is corrupt/incompatible,
+    // e.g. "failed to load the module 'ballerina/ai:1.14.1' from its BIR due to: invalid magic number [...]".
+    private static final Pattern CORRUPT_BIR_MODULE_PATTERN = Pattern.compile(
+            "failed to load the module\\s+'([^'/:]+)/([^'/:]+):([^'/:\\s]+)'", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Detects a corrupt/incompatible cached-BIR failure anywhere in the throwable's cause chain and,
+     * when found, returns the coordinates of the affected module (best-effort; coordinates may be
+     * {@code null} if they cannot be parsed from the message).
+     *
+     * @param throwable the completion throwable to inspect
+     * @return the corrupt-BIR parameters, or empty if this is not a corrupt-BIR failure
+     */
+    private static Optional<CorruptBirCacheParams> detectCorruptBirCache(Throwable throwable) {
+        for (Throwable cause = throwable; cause != null && cause != cause.getCause(); cause = cause.getCause()) {
+            String message = cause.getMessage();
+            if (message == null || !message.contains("invalid magic number") || !message.contains("BIR")) {
+                continue;
+            }
+            Matcher matcher = CORRUPT_BIR_MODULE_PATTERN.matcher(message);
+            if (matcher.find()) {
+                return Optional.of(new CorruptBirCacheParams(matcher.group(1), matcher.group(2), matcher.group(3)));
+            }
+            return Optional.of(new CorruptBirCacheParams(null, null, null));
+        }
+        return Optional.empty();
     }
 
     /**

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -20,7 +20,10 @@ import com.google.gson.JsonSyntaxException;
 import io.ballerina.projects.CompilationOptions;
 import io.ballerina.projects.DependencyManifest;
 import io.ballerina.projects.JvmTarget;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.Package;
 import io.ballerina.projects.Project;
+import io.ballerina.projects.ResolvedPackageDependency;
 import io.ballerina.projects.Settings;
 import io.ballerina.projects.internal.bala.DependencyGraphJson;
 import io.ballerina.projects.internal.model.Dependency;
@@ -69,6 +72,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
@@ -290,7 +294,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
                         clientLogger.logError(LSContextOperation.WS_EXEC_CMD,
                                 "Pull modules failed for project: " + project.sourceRoot().toString(),
                                 t, null, (Position) null);
-                        Optional<CorruptBirCacheParams> corruptBir = detectCorruptBirCache(t);
+                        Optional<CorruptBirCacheParams> corruptBir = detectCorruptBirCache(t, project);
                         if (corruptBir.isPresent()) {
                             CorruptBirCacheParams params = corruptBir.get();
                             params.setProjectUri(project.sourceRoot().toUri().toString());
@@ -340,23 +344,60 @@ public class PullModuleExecutor implements LSCommandExecutor {
 
     /**
      * Detects a corrupt/incompatible cached-BIR failure anywhere in the throwable's cause chain and,
-     * when found, returns the coordinates of the affected module (best-effort; coordinates may be
+     * when found, returns the coordinates of the affected package (best-effort; coordinates may be
      * {@code null} if they cannot be parsed from the message).
      *
      * @param throwable the completion throwable to inspect
+     * @param project   the project whose resolution maps the failing module to its package
      * @return the corrupt-BIR parameters, or empty if this is not a corrupt-BIR failure
      */
-    static Optional<CorruptBirCacheParams> detectCorruptBirCache(Throwable throwable) {
+    static Optional<CorruptBirCacheParams> detectCorruptBirCache(Throwable throwable, Project project) {
         for (Throwable cause = throwable; cause != null && cause != cause.getCause(); cause = cause.getCause()) {
             String message = cause.getMessage();
             if (message == null || !message.contains("invalid magic number") || !message.contains("BIR")) {
                 continue;
             }
             Matcher matcher = CORRUPT_BIR_MODULE_PATTERN.matcher(message);
-            if (matcher.find()) {
-                return Optional.of(new CorruptBirCacheParams(matcher.group(1), matcher.group(2), matcher.group(3)));
+            if (!matcher.find()) {
+                return Optional.of(new CorruptBirCacheParams(null, null, null));
             }
-            return Optional.of(new CorruptBirCacheParams(null, null, null));
+            String org = matcher.group(1);
+            String moduleName = matcher.group(2);
+            String version = matcher.group(3);
+            String packageName = resolvePackageName(project, org, moduleName, version).orElse(moduleName);
+            CorruptBirCacheParams params = new CorruptBirCacheParams(org, packageName, version);
+            params.setModuleName(moduleName);
+            return Optional.of(params);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Resolves the package (cache directory) name for a failing module by matching it against the
+     * project's resolved dependency graph. For a default module the package name equals the module
+     * name; for a submodule (e.g. {@code ai.observe}) it is the owning package (e.g. {@code ai}).
+     *
+     * @return the package name, or empty if it cannot be resolved
+     */
+    private static Optional<String> resolvePackageName(Project project, String org, String moduleName,
+                                                       String version) {
+        try {
+            Collection<ResolvedPackageDependency> nodes =
+                    project.currentPackage().getResolution().dependencyGraph().getNodes();
+            for (ResolvedPackageDependency node : nodes) {
+                Package pkg = node.packageInstance();
+                if (!pkg.packageOrg().value().equals(org)
+                        || !pkg.packageVersion().value().toString().equals(version)) {
+                    continue;
+                }
+                for (Module module : pkg.modules()) {
+                    if (module.moduleName().toString().equals(moduleName)) {
+                        return Optional.of(pkg.packageName().value());
+                    }
+                }
+            }
+        } catch (Throwable e) {
+            // Best-effort resolution; fall back to the module name.
         }
         return Optional.empty();
     }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -66,7 +66,10 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -109,6 +112,9 @@ public class PullModuleExecutor implements LSCommandExecutor {
     // published in stage 4 below is also consumed by ResolveCompilationErrorsSubscriber, which
     // starts another pull for the same project, creating an endless pull loop on failures.
     private static final Set<String> PULL_IN_PROGRESS_PROJECTS = ConcurrentHashMap.newKeySet();
+    // Cap the trace we ship to the client: it only feeds a prefilled GitHub issue, whose URL has a
+    // practical length limit, and the client truncates further when building that URL.
+    private static final int MAX_STACK_TRACE_CHARS = 8000;
 
     /**
      * {@inheritDoc}
@@ -301,6 +307,8 @@ public class PullModuleExecutor implements LSCommandExecutor {
                             params.setDistVersion(RepoUtils.getBallerinaShortVersion());
                             params.setReposPath(RepoUtils.createAndGetHomeReposPath()
                                     .resolve(ProjectConstants.REPOSITORIES_DIR).toString());
+                            // Ship the stack trace so the client can prefill a "Send Report" GitHub issue.
+                            params.setStackTrace(stackTraceToString(t));
                             languageClient.corruptBirCache(params);
                         } else if (t.getCause() instanceof UserErrorException) {
                             String errorMessage = t.getCause().getMessage();
@@ -371,6 +379,25 @@ public class PullModuleExecutor implements LSCommandExecutor {
             return Optional.of(params);
         }
         return Optional.empty();
+    }
+
+    /**
+     * Renders a throwable (and its cause chain) as a stack-trace string for the corrupt-BIR report,
+     * truncated to a bounded length.
+     *
+     * @param throwable the failure to render (may be {@code null})
+     * @return the stack trace as a string, empty if {@code throwable} is {@code null}
+     */
+    private static String stackTraceToString(Throwable throwable) {
+        if (throwable == null) {
+            return "";
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(baos, true, StandardCharsets.UTF_8)) {
+            throwable.printStackTrace(ps);
+        }
+        String trace = baos.toString(StandardCharsets.UTF_8);
+        return trace.length() > MAX_STACK_TRACE_CHARS ? trace.substring(0, MAX_STACK_TRACE_CHARS) : trace;
     }
 
     /**

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -299,6 +299,8 @@ public class PullModuleExecutor implements LSCommandExecutor {
                             CorruptBirCacheParams params = corruptBir.get();
                             params.setProjectUri(project.sourceRoot().toUri().toString());
                             params.setDistVersion(RepoUtils.getBallerinaShortVersion());
+                            params.setReposPath(RepoUtils.createAndGetHomeReposPath()
+                                    .resolve(ProjectConstants.REPOSITORIES_DIR).toString());
                             languageClient.corruptBirCache(params);
                         }
                         if (t.getCause() instanceof UserErrorException) {

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -388,7 +388,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
      * @param throwable the failure to render (may be {@code null})
      * @return the stack trace as a string, empty if {@code throwable} is {@code null}
      */
-    private static String stackTraceToString(Throwable throwable) {
+    static String stackTraceToString(Throwable throwable) {
         if (throwable == null) {
             return "";
         }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -384,17 +384,23 @@ public class PullModuleExecutor implements LSCommandExecutor {
     private static Optional<String> resolvePackageName(Project project, String org, String moduleName,
                                                        String version) {
         try {
-            Collection<ResolvedPackageDependency> nodes =
-                    project.currentPackage().getResolution().dependencyGraph().getNodes();
-            for (ResolvedPackageDependency node : nodes) {
-                Package pkg = node.packageInstance();
-                if (!pkg.packageOrg().value().equals(org)
-                        || !pkg.packageVersion().value().toString().equals(version)) {
-                    continue;
-                }
-                for (Module module : pkg.modules()) {
-                    if (module.moduleName().toString().equals(moduleName)) {
-                        return Optional.of(pkg.packageName().value());
+            BallerinaCompilerApi compilerApi = BallerinaCompilerApi.getInstance();
+            List<Project> memberProjects = compilerApi.isWorkspaceProject(project)
+                    ? compilerApi.getWorkspaceProjectsInOrder(project)
+                    : List.of(project);
+            for (Project memberProject : memberProjects) {
+                Collection<ResolvedPackageDependency> nodes =
+                        memberProject.currentPackage().getResolution().dependencyGraph().getNodes();
+                for (ResolvedPackageDependency node : nodes) {
+                    Package pkg = node.packageInstance();
+                    if (!pkg.packageOrg().value().equals(org)
+                            || !pkg.packageVersion().value().toString().equals(version)) {
+                        continue;
+                    }
+                    for (Module module : pkg.modules()) {
+                        if (module.moduleName().toString().equals(moduleName)) {
+                            return Optional.of(pkg.packageName().value());
+                        }
                     }
                 }
             }

--- a/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/packages/ballerina-language-server/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -302,8 +302,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
                             params.setReposPath(RepoUtils.createAndGetHomeReposPath()
                                     .resolve(ProjectConstants.REPOSITORIES_DIR).toString());
                             languageClient.corruptBirCache(params);
-                        }
-                        if (t.getCause() instanceof UserErrorException) {
+                        } else if (t.getCause() instanceof UserErrorException) {
                             String errorMessage = t.getCause().getMessage();
                             CommandUtil.notifyClient(languageClient, MessageType.Error, errorMessage);
                         } else {

--- a/packages/ballerina-language-server/langserver-core/src/test/java/org/ballerinalang/langserver/command/executors/PullModuleExecutorCorruptBirTest.java
+++ b/packages/ballerina-language-server/langserver-core/src/test/java/org/ballerinalang/langserver/command/executors/PullModuleExecutorCorruptBirTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.command.executors;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+/**
+ * L1 tests for {@link PullModuleExecutor#detectCorruptBirCache(Throwable)}, the parser that turns a
+ * compiler failure into a {@code projectService/corruptBirCache} notification payload. The compiler's
+ * BIR reader throws with a fixed signature ("... invalid magic number ...") when a cached BIR is
+ * corrupt/incompatible; these tests pin the detection contract so it survives refactors of the
+ * surrounding pull flow and flags any drift in the error-message shape it depends on.
+ */
+public class PullModuleExecutorCorruptBirTest {
+
+    private static final String CORRUPT_WITH_COORDINATES =
+            "failed to load the module 'ballerina/ai:1.14.1' from its BIR due to: "
+                    + "invalid magic number [99, 111, 114, 114]";
+
+    @Test(description = "A nested corrupt-BIR cause is detected and its module coordinates extracted")
+    public void testNestedCorruptBirWithCoordinates() {
+        Throwable throwable = new RuntimeException("Pull modules failed",
+                new IllegalStateException(CORRUPT_WITH_COORDINATES));
+
+        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable);
+
+        Assert.assertTrue(result.isPresent(), "Corrupt-BIR cause should be detected in the cause chain");
+        CorruptBirCacheParams params = result.get();
+        Assert.assertEquals(params.getOrg(), "ballerina");
+        Assert.assertEquals(params.getName(), "ai");
+        Assert.assertEquals(params.getVersion(), "1.14.1");
+        // Detection only parses coordinates; the caller sets these before emitting the notification.
+        Assert.assertNull(params.getProjectUri());
+        Assert.assertNull(params.getDistVersion());
+    }
+
+    @Test(description = "A corrupt-BIR message without parseable coordinates is detected with null coordinates")
+    public void testCorruptBirWithoutCoordinates() {
+        Throwable throwable = new RuntimeException(
+                "failed to read the cached BIR: invalid magic number [99, 111, 114, 114]");
+
+        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable);
+
+        Assert.assertTrue(result.isPresent(), "Corrupt-BIR failure should be detected even without coordinates");
+        CorruptBirCacheParams params = result.get();
+        Assert.assertNull(params.getOrg());
+        Assert.assertNull(params.getName());
+        Assert.assertNull(params.getVersion());
+    }
+
+    @Test(description = "A non-corrupt failure is not mistaken for a corrupt-BIR condition")
+    public void testNonCorruptFailure() {
+        Throwable throwable = new RuntimeException("Failed to pull modules: connection timed out");
+
+        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable);
+
+        Assert.assertTrue(result.isEmpty(), "A generic failure must not be reported as corrupt BIR");
+    }
+
+    @Test(description = "An 'invalid magic number' error unrelated to BIR is not treated as corrupt BIR")
+    public void testInvalidMagicNumberWithoutBir() {
+        Throwable throwable = new RuntimeException("invalid magic number in class file");
+
+        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable);
+
+        Assert.assertTrue(result.isEmpty(), "The BIR marker is required, not just 'invalid magic number'");
+    }
+
+    @Test(description = "Null and empty-chain throwables are handled without error")
+    public void testNoCause() {
+        Assert.assertTrue(PullModuleExecutor.detectCorruptBirCache(null).isEmpty());
+        Assert.assertTrue(PullModuleExecutor.detectCorruptBirCache(new RuntimeException()).isEmpty());
+    }
+}

--- a/packages/ballerina-language-server/langserver-core/src/test/java/org/ballerinalang/langserver/command/executors/PullModuleExecutorCorruptBirTest.java
+++ b/packages/ballerina-language-server/langserver-core/src/test/java/org/ballerinalang/langserver/command/executors/PullModuleExecutorCorruptBirTest.java
@@ -15,16 +15,28 @@
  */
 package org.ballerinalang.langserver.command.executors;
 
+import io.ballerina.projects.DependencyGraph;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.ModuleName;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageName;
+import io.ballerina.projects.PackageOrg;
+import io.ballerina.projects.PackageResolution;
+import io.ballerina.projects.PackageVersion;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.ResolvedPackageDependency;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
- * L1 tests for {@link PullModuleExecutor#detectCorruptBirCache(Throwable)}, the parser that turns a
- * compiler failure into a {@code projectService/corruptBirCache} notification payload. The compiler's
- * BIR reader throws with a fixed signature ("... invalid magic number ...") when a cached BIR is
- * corrupt/incompatible; these tests pin the detection contract so it survives refactors of the
+ * L1 tests for {@link PullModuleExecutor#detectCorruptBirCache(Throwable, Project)}, the parser that
+ * turns a compiler failure into a {@code projectService/corruptBirCache} notification payload. The
+ * compiler's BIR reader throws with a fixed signature ("... invalid magic number ...") when a cached
+ * BIR is corrupt/incompatible; these tests pin the detection contract so it survives refactors of the
  * surrounding pull flow and flags any drift in the error-message shape it depends on.
  */
 public class PullModuleExecutorCorruptBirTest {
@@ -38,16 +50,70 @@ public class PullModuleExecutorCorruptBirTest {
         Throwable throwable = new RuntimeException("Pull modules failed",
                 new IllegalStateException(CORRUPT_WITH_COORDINATES));
 
-        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable);
+        // No dependency graph resolves the module here, so the package name falls back to the module
+        // name — which is correct for a default module (package name == module name).
+        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable, null);
 
         Assert.assertTrue(result.isPresent(), "Corrupt-BIR cause should be detected in the cause chain");
         CorruptBirCacheParams params = result.get();
         Assert.assertEquals(params.getOrg(), "ballerina");
-        Assert.assertEquals(params.getName(), "ai");
+        Assert.assertEquals(params.getPackageName(), "ai");
+        Assert.assertEquals(params.getModuleName(), "ai");
         Assert.assertEquals(params.getVersion(), "1.14.1");
         // Detection only parses coordinates; the caller sets these before emitting the notification.
         Assert.assertNull(params.getProjectUri());
         Assert.assertNull(params.getDistVersion());
+    }
+
+    @Test(description = "A corrupt submodule BIR resolves to its owning package name, not the module name")
+    public void testSubmoduleResolvesToPackageName() {
+        // The compiler names the failing *module* (ai.observe); its BIR lives under the *package* dir
+        // 'ai' (ballerina/ai/1.14.1/bir/ai.observe.bir). The parser must send the package name so the
+        // client clears the right cache dir instead of a nonexistent ballerina/ai.observe/... dir.
+        String message = "failed to load the module 'ballerina/ai.observe:1.14.1' from its BIR due to: "
+                + "invalid magic number [99, 111, 114, 114]";
+        Throwable throwable = new RuntimeException("Pull modules failed", new IllegalStateException(message));
+
+        PackageName packageName = PackageName.from("ai");
+        // Build the module mocks up front — stubbing them inline inside thenReturn(...) would nest an
+        // unfinished stubbing and trip Mockito.
+        Module defaultModule = mockModule(ModuleName.from(packageName));              // "ai"
+        Module submodule = mockModule(ModuleName.from(packageName, "observe"));       // "ai.observe"
+        Package aiPackage = Mockito.mock(Package.class);
+        Mockito.when(aiPackage.packageOrg()).thenReturn(PackageOrg.from("ballerina"));
+        Mockito.when(aiPackage.packageName()).thenReturn(packageName);
+        Mockito.when(aiPackage.packageVersion()).thenReturn(PackageVersion.from("1.14.1"));
+        Mockito.when(aiPackage.modules()).thenReturn(List.of(defaultModule, submodule));
+
+        Optional<CorruptBirCacheParams> result =
+                PullModuleExecutor.detectCorruptBirCache(throwable, mockProjectWith(aiPackage));
+
+        Assert.assertTrue(result.isPresent());
+        CorruptBirCacheParams params = result.get();
+        Assert.assertEquals(params.getOrg(), "ballerina");
+        Assert.assertEquals(params.getPackageName(), "ai", "cache dir is keyed by the package name");
+        Assert.assertEquals(params.getModuleName(), "ai.observe", "failing module retained for display");
+        Assert.assertEquals(params.getVersion(), "1.14.1");
+    }
+
+    @Test(description = "An unresolvable module falls back to the module name as the package name")
+    public void testUnresolvedModuleFallsBackToModuleName() {
+        String message = "failed to load the module 'ballerina/ai.observe:1.14.1' from its BIR due to: "
+                + "invalid magic number [99, 111, 114, 114]";
+        Throwable throwable = new RuntimeException("Pull modules failed", new IllegalStateException(message));
+
+        // Graph does not contain the failing package (e.g. it lives in another workspace member).
+        Package unrelated = Mockito.mock(Package.class);
+        Mockito.when(unrelated.packageOrg()).thenReturn(PackageOrg.from("ballerina"));
+        Mockito.when(unrelated.packageVersion()).thenReturn(PackageVersion.from("9.9.9"));
+
+        Optional<CorruptBirCacheParams> result =
+                PullModuleExecutor.detectCorruptBirCache(throwable, mockProjectWith(unrelated));
+
+        Assert.assertTrue(result.isPresent());
+        CorruptBirCacheParams params = result.get();
+        Assert.assertEquals(params.getPackageName(), "ai.observe", "falls back to the module name");
+        Assert.assertEquals(params.getModuleName(), "ai.observe");
     }
 
     @Test(description = "A corrupt-BIR message without parseable coordinates is detected with null coordinates")
@@ -55,12 +121,12 @@ public class PullModuleExecutorCorruptBirTest {
         Throwable throwable = new RuntimeException(
                 "failed to read the cached BIR: invalid magic number [99, 111, 114, 114]");
 
-        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable);
+        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable, null);
 
         Assert.assertTrue(result.isPresent(), "Corrupt-BIR failure should be detected even without coordinates");
         CorruptBirCacheParams params = result.get();
         Assert.assertNull(params.getOrg());
-        Assert.assertNull(params.getName());
+        Assert.assertNull(params.getPackageName());
         Assert.assertNull(params.getVersion());
     }
 
@@ -68,7 +134,7 @@ public class PullModuleExecutorCorruptBirTest {
     public void testNonCorruptFailure() {
         Throwable throwable = new RuntimeException("Failed to pull modules: connection timed out");
 
-        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable);
+        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable, null);
 
         Assert.assertTrue(result.isEmpty(), "A generic failure must not be reported as corrupt BIR");
     }
@@ -77,14 +143,35 @@ public class PullModuleExecutorCorruptBirTest {
     public void testInvalidMagicNumberWithoutBir() {
         Throwable throwable = new RuntimeException("invalid magic number in class file");
 
-        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable);
+        Optional<CorruptBirCacheParams> result = PullModuleExecutor.detectCorruptBirCache(throwable, null);
 
         Assert.assertTrue(result.isEmpty(), "The BIR marker is required, not just 'invalid magic number'");
     }
 
     @Test(description = "Null and empty-chain throwables are handled without error")
     public void testNoCause() {
-        Assert.assertTrue(PullModuleExecutor.detectCorruptBirCache(null).isEmpty());
-        Assert.assertTrue(PullModuleExecutor.detectCorruptBirCache(new RuntimeException()).isEmpty());
+        Assert.assertTrue(PullModuleExecutor.detectCorruptBirCache(null, null).isEmpty());
+        Assert.assertTrue(PullModuleExecutor.detectCorruptBirCache(new RuntimeException(), null).isEmpty());
+    }
+
+    private static Module mockModule(ModuleName moduleName) {
+        Module module = Mockito.mock(Module.class);
+        Mockito.when(module.moduleName()).thenReturn(moduleName);
+        return module;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Project mockProjectWith(Package dependencyPackage) {
+        ResolvedPackageDependency node = Mockito.mock(ResolvedPackageDependency.class);
+        Mockito.when(node.packageInstance()).thenReturn(dependencyPackage);
+        DependencyGraph<ResolvedPackageDependency> graph = Mockito.mock(DependencyGraph.class);
+        Mockito.when(graph.getNodes()).thenReturn(List.of(node));
+        PackageResolution resolution = Mockito.mock(PackageResolution.class);
+        Mockito.when(resolution.dependencyGraph()).thenReturn(graph);
+        Package rootPackage = Mockito.mock(Package.class);
+        Mockito.when(rootPackage.getResolution()).thenReturn(resolution);
+        Project project = Mockito.mock(Project.class);
+        Mockito.when(project.currentPackage()).thenReturn(rootPackage);
+        return project;
     }
 }

--- a/packages/ballerina-language-server/langserver-core/src/test/java/org/ballerinalang/langserver/command/executors/PullModuleExecutorCorruptBirTest.java
+++ b/packages/ballerina-language-server/langserver-core/src/test/java/org/ballerinalang/langserver/command/executors/PullModuleExecutorCorruptBirTest.java
@@ -154,6 +154,32 @@ public class PullModuleExecutorCorruptBirTest {
         Assert.assertTrue(PullModuleExecutor.detectCorruptBirCache(new RuntimeException(), null).isEmpty());
     }
 
+    @Test(description = "A null throwable renders to an empty stack-trace string")
+    public void testStackTraceToStringNull() {
+        Assert.assertEquals(PullModuleExecutor.stackTraceToString(null), "");
+    }
+
+    @Test(description = "A throwable renders to a stack trace carrying its type, message and cause")
+    public void testStackTraceToStringRendersTrace() {
+        Throwable throwable = new RuntimeException("outer failure", new IllegalStateException("inner cause"));
+
+        String trace = PullModuleExecutor.stackTraceToString(throwable);
+
+        Assert.assertTrue(trace.contains("java.lang.RuntimeException: outer failure"), trace);
+        Assert.assertTrue(trace.contains("at " + PullModuleExecutorCorruptBirTest.class.getName()), trace);
+        Assert.assertTrue(trace.contains("Caused by: java.lang.IllegalStateException: inner cause"), trace);
+    }
+
+    @Test(description = "An oversized stack trace is truncated to the bounded length")
+    public void testStackTraceToStringTruncates() {
+        // The message alone exceeds the 8000-char cap, so the rendered trace must be truncated.
+        Throwable throwable = new RuntimeException("x".repeat(20_000));
+
+        String trace = PullModuleExecutor.stackTraceToString(throwable);
+
+        Assert.assertEquals(trace.length(), 8000, "trace should be capped at MAX_STACK_TRACE_CHARS");
+    }
+
     private static Module mockModule(ModuleName moduleName) {
         Module module = Mockito.mock(Module.class);
         Mockito.when(module.moduleName()).thenReturn(moduleName);


### PR DESCRIPTION
## Purpose

When a module's compiled BIR cache is corrupted, the project loads empty because the compiler fails with an invalid magic number error while reading the cached `.bir`. Previously the only recovery was to manually delete ~/.ballerina, which isn't practical for low-code users.

This PR fixes this as follows:
- Language server: PullModuleExecutor now detects the corrupt-BIR failure, parses the affected module's coordinates (org/name/version) from the error, and emits a new `projectService/corruptBirCache` notification (payload CorruptBirCacheParams) to the client, along with the running distribution version.
- VS Code extension: On receiving the notification, we surface a user-friendly prompt (no internal "BIR" jargon) offering a one-click Clear cache & reload:
  - "The cache for module '<org>/<name>:<version>' is corrupted, so the project may appear empty. Clear the cache for this module and reload?"
  - Falls back to a generic message when the module can't be identified.
- Clicking the action clears only the affected module's cache under the active distribution's cache-<distVersion> directory, then reloads the window. If the module can't be identified — or the targeted clear matches nothing — it falls back to clearing the full module cache for that distribution so the user still recovers.



https://github.com/user-attachments/assets/dfd56f76-5bfc-4ace-9530-d4689024c4bc


<img width="534" height="308" alt="image" src="https://github.com/user-attachments/assets/29e87f45-38d9-4d4a-8658-f806cd2f507f" />






Fixes: https://github.com/wso2/product-integrator/issues/2251

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Detects corrupted BIR cache failures in the language server.
- Sends package and distribution details through `projectService/corruptBirCache`.
- Prompts users to clear the affected cache and reload VS Code.
- Clears all matching distribution caches when targeted recovery is unavailable.
- Resolves package-level cache paths, including submodules.
- Adds validation and test coverage for recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->