### PR TITLE
Fix the human-in-the-loop `decision` resource in chat agent services

### DIFF
--- a/packages/ballerina-core/src/interfaces/extended-lang-client.ts
+++ b/packages/ballerina-core/src/interfaces/extended-lang-client.ts
@@ -1937,6 +1937,10 @@ export interface ResourceSourceCodeResponse {
         [key: string]: TextEdit[];
     };
     validationErrors?: ValidationResult[];
+    // An unexpected failure the builder threw, distinct from a validation failure. `textEdits`
+    // is empty whenever this is set (see CommonSourceResponse(Throwable) on the language server).
+    errorMsg?: string;
+    stacktrace?: string;
 }
 
 export interface ResourceReturnTypesRequest {

--- a/packages/ballerina-core/src/utils/ai-utils.ts
+++ b/packages/ballerina-core/src/utils/ai-utils.ts
@@ -23,3 +23,10 @@ export const GET_DEFAULT_EMBEDDING_PROVIDER = "getDefaultEmbeddingProvider";
 export const DEFAULT_MODEL_PROVIDER_EXPR = "check ai:getDefaultModelProvider()";
 
 export const isDefaultModelProviderExpr = (value: unknown): boolean => value === DEFAULT_MODEL_PROVIDER_EXPR;
+
+// The fixed resource paths a chat agent service exposes (see AiChatServiceBuilder on the language
+// server): `chat` is the agent's entry point, and `decision` resumes a paused run once a human has
+// approved or rejected a gated tool call. A resource artifact's `name` and a CDResourceFunction's
+// `path` are the same string by construction, so one constant serves both.
+export const AI_CHAT_RESOURCE_NAME = "chat";
+export const AI_DECISION_RESOURCE_NAME = "decision";

--- a/packages/ballerina-extension/src/rpc-managers/service-designer/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/service-designer/rpc-manager.ts
@@ -359,6 +359,15 @@ export class ServiceDesignerRpcManager implements ServiceDesignerAPI {
         const context = StateMachine.context();
         try {
             const res: ResourceSourceCodeResponse = await context.langClient.addFunctionSourceCode(params);
+            if (res.errorMsg) {
+                // A builder threw (e.g. the AI decision-resource builder failing to resolve the
+                // agent's `run` call) rather than refusing at the save-time gate: `textEdits` is
+                // empty, so nothing downstream would otherwise tell the user this silently did
+                // nothing.
+                console.error(">>> error adding function source code", { errorMessage: res.errorMsg, stacktrace: res.stacktrace });
+                window.showErrorMessage(`Failed to add function: ${res.errorMsg}`);
+                return { artifacts: [], error: res.errorMsg };
+            }
             const blockingErrors = getBlockingValidationErrors(res.validationErrors);
             if (blockingErrors.length > 0) {
                 return { artifacts: [], validationErrors: blockingErrors };

--- a/packages/ballerina-extension/src/utils/project-artifacts.ts
+++ b/packages/ballerina-extension/src/utils/project-artifacts.ts
@@ -420,22 +420,16 @@ async function getEntryValue(artifact: BaseArtifact, projectPath: string, icon: 
             entryValue.iconLight = serviceIcon?.light;
             entryValue.iconDark = serviceIcon?.dark;
             entryValue.kind = serviceIcon?.kind;
-            if (artifact.module === "ai") {
-                entryValue.resources = [];
-                const aiResourceLocation = Object.values(artifact.children).find(child => child.type === DIRECTORY_MAP.RESOURCE)?.location;
-                entryValue.position = {
-                    endColumn: aiResourceLocation.endLine.offset,
-                    endLine: aiResourceLocation.endLine.line,
-                    startColumn: aiResourceLocation.startLine.offset,
-                    startLine: aiResourceLocation.startLine.line
-                };
-            } else {
-                // Get the children of the service
-                const resourceFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.RESOURCE, icon, artifact.module);
-                const remoteFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.REMOTE, icon, artifact.module);
-                const privateFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.FUNCTION, icon, artifact.module);
-                entryValue.resources = [...resourceFunctions, ...remoteFunctions, ...privateFunctions];
-            }
+            // Chat agent services (module `ai`) carry their resources (`chat`, and now the
+            // human-in-the-loop `decision` resource) as real children exactly like any other
+            // service, so they're listed the same way — no special-casing needed. Position-based
+            // click routing resolves an individual resource via its own entry in `resources`
+            // below, so the service's own position also stays untouched (its true declaration
+            // range), matching every other module.
+            const resourceFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.RESOURCE, icon, artifact.module);
+            const remoteFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.REMOTE, icon, artifact.module);
+            const privateFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.FUNCTION, icon, artifact.module);
+            entryValue.resources = [...resourceFunctions, ...remoteFunctions, ...privateFunctions];
             break;
         case DIRECTORY_MAP.TYPE:
             if (artifact.children && Object.keys(artifact.children).length > 0) {

--- a/packages/ballerina-extension/src/utils/project-artifacts.ts
+++ b/packages/ballerina-extension/src/utils/project-artifacts.ts
@@ -426,10 +426,12 @@ async function getEntryValue(artifact: BaseArtifact, projectPath: string, icon: 
             // click routing resolves an individual resource via its own entry in `resources`
             // below, so the service's own position also stays untouched (its true declaration
             // range), matching every other module.
-            const resourceFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.RESOURCE, icon, artifact.module);
-            const remoteFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.REMOTE, icon, artifact.module);
-            const privateFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.FUNCTION, icon, artifact.module);
-            entryValue.resources = [...resourceFunctions, ...remoteFunctions, ...privateFunctions];
+            {
+                const serviceResourceFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.RESOURCE, icon, artifact.module);
+                const serviceRemoteFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.REMOTE, icon, artifact.module);
+                const servicePrivateFunctions = await getComponents(artifact.children, projectPath, DIRECTORY_MAP.FUNCTION, icon, artifact.module);
+                entryValue.resources = [...serviceResourceFunctions, ...serviceRemoteFunctions, ...servicePrivateFunctions];
+            }
             break;
         case DIRECTORY_MAP.TYPE:
             if (artifact.children && Object.keys(artifact.children).length > 0) {

--- a/packages/ballerina-extension/src/utils/state-machine-utils.ts
+++ b/packages/ballerina-extension/src/utils/state-machine-utils.ts
@@ -463,18 +463,15 @@ function findViewByArtifact(
                             artifactType: DIRECTORY_MAP.SERVICE
                         }
                     };
-                } else if (dir.moduleName === "ai") {
-                    return {
-                        location: {
-                            view: MACHINE_VIEW.BIDiagram,
-                            identifier: dir.name,
-                            documentUri: currentDocumentUri,
-                            position: position,
-                            projectPath: projectPath,
-                            artifactType: DIRECTORY_MAP.SERVICE,
-                        }
-                    };
                 } else {
+                    // `ai` (chat agent) services used to force MACHINE_VIEW.BIDiagram here so that
+                    // clicking the service always landed straight on the chat flow. That's no
+                    // longer needed: a click on the `chat` or `decision` resource itself already
+                    // resolves to BIDiagram via the DIRECTORY_MAP.RESOURCE case below (matched
+                    // against `dir.resources` before this parent entry is even checked). This
+                    // branch is only reached for a click on the service's own declaration — the
+                    // component diagram's outer-box click for a HITL-wired agent — which should
+                    // land on the same resource listing every other service type gets.
                     return {
                         location: {
                             view: MACHINE_VIEW.ServiceDesigner,

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/FunctionBuilderRouter.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/FunctionBuilderRouter.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
+import io.ballerina.servicemodelgenerator.extension.builder.function.AiFunctionBuilder;
 import io.ballerina.servicemodelgenerator.extension.builder.function.DefaultFunctionBuilder;
 import io.ballerina.servicemodelgenerator.extension.builder.function.GraphqlFunctionBuilder;
 import io.ballerina.servicemodelgenerator.extension.builder.function.HttpFunctionBuilder;
@@ -44,9 +45,11 @@ import org.eclipse.lsp4j.TextEdit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.AI;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.DEFAULT;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.GRAPHQL;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.HTTP;
@@ -62,11 +65,12 @@ public class FunctionBuilderRouter {
     // FTP/KAFKA/RABBITMQ/MSSQL/POSTGRESQL/MYSQL/MCP/SOLACE are deliberately absent: each now ships a
     // bundled TriggerUISchemaModel schema (see TriggerModelReader.BUNDLED_TRIGGER_MODEL_RESOURCES), so
     // useSchemaDrivenPath always routes them to SchemaDrivenFunctionBuilder before this map is
-    // consulted — a hardcoded entry here would be dead code. HTTP/GRAPHQL are not (yet) schema-driven
-    // and keep their dedicated builders.
+    // consulted — a hardcoded entry here would be dead code. HTTP/GRAPHQL/AI are not (yet)
+    // schema-driven and keep their dedicated builders.
     private static final Map<String, Supplier<? extends NodeBuilder<Function>>> CONSTRUCTOR_MAP = new HashMap<>() {{
         put(HTTP, HttpFunctionBuilder::new);
         put(GRAPHQL, GraphqlFunctionBuilder::new);
+        put(AI, AiFunctionBuilder::new);
     }};
 
     private static NodeBuilder<Function> getFunctionBuilder(String protocol) {
@@ -138,18 +142,25 @@ public class FunctionBuilderRouter {
         if (functionNode.parent() instanceof ServiceDeclarationNode serviceDeclarationNode) {
             ServiceMetadata metadata = deriveServiceType(serviceDeclarationNode, semanticModel);
             ModuleID moduleID = metadata.moduleId();
-            context = new ModelFromSourceContext(functionNode, null, semanticModel, null, "",
-                    metadata.serviceTypeIdentifier(), moduleID.orgName(), moduleID.packageName(),
-                    moduleID.moduleName(), moduleID.version());
-            NodeBuilder<Function> functionBuilder = useSchemaDrivenPath(moduleID.orgName(), moduleID.moduleName())
-                            ? new SchemaDrivenFunctionBuilder()
-                            : getFunctionBuilder(moduleID.moduleName());
-            Function function = functionBuilder.getModelFromSource(context);
-            Codedata codedata = function.getCodedata();
-            codedata.setOrgName(moduleID.orgName());
-            codedata.setPackageName(moduleID.packageName());
-            codedata.setModuleName(moduleID.moduleName());
-            return function;
+            // deriveServiceType leaves moduleId null whenever the listener's symbol can't be
+            // resolved — an unresolved import, a file mid-edit. ServiceBuilderRouter already guards
+            // this (getServiceFromSource); dereferencing it here turned a recoverable miss into an
+            // NPE that surfaced as a JSON-RPC InternalError. Fall through to the module-name-only
+            // path instead: a function model is still derivable from the syntax alone.
+            if (Objects.nonNull(moduleID)) {
+                context = new ModelFromSourceContext(functionNode, null, semanticModel, null, "",
+                        metadata.serviceTypeIdentifier(), moduleID.orgName(), moduleID.packageName(),
+                        moduleID.moduleName(), moduleID.version());
+                NodeBuilder<Function> functionBuilder = useSchemaDrivenPath(moduleID.orgName(), moduleID.moduleName())
+                                ? new SchemaDrivenFunctionBuilder()
+                                : getFunctionBuilder(moduleID.moduleName());
+                Function function = functionBuilder.getModelFromSource(context);
+                Codedata codedata = function.getCodedata();
+                codedata.setOrgName(moduleID.orgName());
+                codedata.setPackageName(moduleID.packageName());
+                codedata.setModuleName(moduleID.moduleName());
+                return function;
+            }
         }
         context = new ModelFromSourceContext(functionNode, null, semanticModel, null, "",
                 moduleName, null, null, moduleName, null);

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/function/AiFunctionBuilder.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/function/AiFunctionBuilder.java
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.servicemodelgenerator.extension.builder.function;
+
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeList;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.servicemodelgenerator.extension.model.Codedata;
+import io.ballerina.servicemodelgenerator.extension.model.Function;
+import io.ballerina.servicemodelgenerator.extension.model.context.AddModelContext;
+import io.ballerina.servicemodelgenerator.extension.model.context.ModelFromSourceContext;
+import io.ballerina.servicemodelgenerator.extension.util.AiSourceUtils;
+import io.ballerina.servicemodelgenerator.extension.util.Utils;
+import io.ballerina.tools.text.LineRange;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.AI;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.BALLERINA;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.HTTP;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.NEW_LINE;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.RESOURCE;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.TWO_NEW_LINES;
+import static io.ballerina.servicemodelgenerator.extension.util.Utils.importExists;
+
+/**
+ * Function builder for AI chat agent services.
+ *
+ * <p>Exists for two reasons the generic builder cannot cover. Reading a resource back from source
+ * needs the resource path rather than the accessor token as its name, and adding the
+ * human-in-the-loop {@code decision} resource needs a real body wired to this service's agent
+ * rather than the empty skeleton {@code generateFunctionDefSource} produces.
+ *
+ * @since 1.2.0
+ */
+public final class AiFunctionBuilder extends AbstractFunctionBuilder {
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>A generated agent service carries no service-type descriptor, so
+     * {@code deriveServiceType} yields {@code "Service"} while the service index only knows
+     * {@code ChatService} — the {@code ServiceTypeFunction} lookup in
+     * {@code getFunctionInsideService} can never match. It then falls through to
+     * {@code getObjectFunctionFromSource}, which ignores {@code relativeResourcePath()} and names
+     * the model after the accessor token, yielding {@code kind=OBJECT_METHOD, name="post"} for
+     * every resource. {@link Utils#getFunctionModel} is the resource-correct reader the
+     * service-level extraction already uses; use it here so both paths agree.
+     */
+    @Override
+    public Function getModelFromSource(ModelFromSourceContext context) {
+        if (context.node() instanceof FunctionDefinitionNode functionDefinitionNode
+                && functionDefinitionNode.parent() instanceof ServiceDeclarationNode
+                && isResource(functionDefinitionNode)) {
+            Function functionModel = Utils.getFunctionModel(functionDefinitionNode, Map.of());
+            functionModel.setEditable(true);
+            return functionModel;
+        }
+        return super.getModelFromSource(context);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The {@code decision} resource is fixed boilerplate whose body must forward the human's
+     * decisions into this service's agent, so it is emitted from a template rather than the generic
+     * signature generator — which produces an empty body and cannot express {@code @http:Payload}.
+     */
+    @Override
+    public Map<String, List<TextEdit>> addModel(AddModelContext context) throws Exception {
+        Function function = context.function();
+        if (!(context.node() instanceof ServiceDeclarationNode serviceNode)
+                || Objects.isNull(function.getName())
+                || !AiSourceUtils.DECISION_RESOURCE_NAME.equals(function.getName().getValue())) {
+            return super.addModel(context);
+        }
+
+        // Read the agent off the existing chat resource rather than re-deriving it: the agent is
+        // usually declared in another file, and this way a hand-edited chat body still matches.
+        AiSourceUtils.AgentCall agentCall = AiSourceUtils.resolveAgentCall(serviceNode)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Cannot add the decision resource: no agent 'run' call found in this service."));
+
+        // The template is already indented one level, exactly as AiChatServiceBuilder's chat
+        // template is — so it is appended as-is rather than re-indented. Members are separated by a
+        // blank line, matching how buildServiceNodeBody joins them.
+        NodeList<Node> members = serviceNode.members();
+        String separator = members.isEmpty() ? NEW_LINE : TWO_NEW_LINES;
+        String resourceSource = separator
+                + AiSourceUtils.agentDecisionResourceSource(agentCall.agentVarName(), agentCall.operator());
+
+        LineRange anchor = members.isEmpty()
+                ? serviceNode.openBraceToken().lineRange()
+                : members.get(members.size() - 1).lineRange();
+
+        List<TextEdit> edits = new ArrayList<>();
+        edits.add(new TextEdit(Utils.toRange(anchor.endLine()), resourceSource));
+
+        addRequiredImports(context, function, edits);
+        return Map.of(context.filePath(), edits);
+    }
+
+    /**
+     * Any service with a chat resource already imports both modules, but a hand-assembled service
+     * might not.
+     */
+    private void addRequiredImports(AddModelContext context, Function function, List<TextEdit> edits) {
+        ModulePartNode rootNode = context.document().syntaxTree().rootNode();
+        Codedata codedata = function.getCodedata();
+        String orgName = Objects.nonNull(codedata) && Objects.nonNull(codedata.getOrgName())
+                ? codedata.getOrgName()
+                : BALLERINA;
+
+        Set<String> importStmts = new LinkedHashSet<>();
+        if (!importExists(rootNode, BALLERINA, HTTP)) {
+            importStmts.add(Utils.getImportStmt(BALLERINA, HTTP));
+        }
+        if (!importExists(rootNode, orgName, AI)) {
+            importStmts.add(Utils.getImportStmt(orgName, AI));
+        }
+        if (!importStmts.isEmpty()) {
+            edits.addFirst(new TextEdit(Utils.toRange(rootNode.lineRange().startLine()),
+                    String.join(NEW_LINE, importStmts)));
+        }
+    }
+
+    private static boolean isResource(FunctionDefinitionNode functionDefinitionNode) {
+        return functionDefinitionNode.qualifierList().stream()
+                .anyMatch(qualifier -> qualifier.text().equals(RESOURCE));
+    }
+
+    @Override
+    public String kind() {
+        return AI;
+    }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/AiChatServiceBuilder.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/AiChatServiceBuilder.java
@@ -19,10 +19,14 @@
 package io.ballerina.servicemodelgenerator.extension.builder.service;
 
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.servicemodelgenerator.extension.model.Function;
+import io.ballerina.servicemodelgenerator.extension.model.PropertyType;
 import io.ballerina.servicemodelgenerator.extension.model.Service;
 import io.ballerina.servicemodelgenerator.extension.model.Value;
 import io.ballerina.servicemodelgenerator.extension.model.context.AddModelContext;
 import io.ballerina.servicemodelgenerator.extension.model.context.GetModelContext;
+import io.ballerina.servicemodelgenerator.extension.model.context.ModelFromSourceContext;
+import io.ballerina.servicemodelgenerator.extension.util.AiSourceUtils;
 import io.ballerina.servicemodelgenerator.extension.util.ListenerUtil;
 import io.ballerina.servicemodelgenerator.extension.util.Utils;
 import org.eclipse.lsp4j.TextEdit;
@@ -54,22 +58,8 @@ public final class AiChatServiceBuilder extends AbstractServiceBuilder {
     private static final String AGENT_NAME_PROPERTY = "agentName";
     private static final String DEFAULT_AGENT_NAME = "chat";
 
-    private String buildAgentMethodCall(String agentVarName, String orgName) {
-        String operator = BALLERINA.equals(orgName) ? "." : "->";
-        return String.format("%s%srun(request.message, request.sessionId)", agentVarName, operator);
-    }
-
     private String getAgentChatFunction(String agentVarName, String orgName) {
-        String methodCall = buildAgentMethodCall(agentVarName, orgName);
-
-        return String.format(
-                "    resource function post chat(@http:Payload ai:ChatReqMessage request) " +
-                        "returns ai:ChatRespMessage|error {%s" +
-                        "        string stringResult = check %s;%s" +
-                        "        return {message: stringResult};%s" +
-                        "    }",
-                NEW_LINE, methodCall, NEW_LINE, NEW_LINE
-        );
+        return AiSourceUtils.agentChatResourceSource(agentVarName, AiSourceUtils.runOperator(orgName));
     }
 
     @Override
@@ -78,11 +68,46 @@ public final class AiChatServiceBuilder extends AbstractServiceBuilder {
             Map<String, Value> properties = service.getProperties();
             Value agentNameProperty = new Value.ValueBuilder()
                     .metadata("Agent Name", "The name of the agent variable")
+                    .types(List.of(PropertyType.types(Value.FieldType.IDENTIFIER)))
                     .enabled(true)
+                    .editable(true)
                     .build();
             properties.put(AGENT_NAME_PROPERTY, agentNameProperty);
             return service;
         });
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Drops {@code agentName}, which {@link #getModelTemplate} contributes for the add path only:
+     * {@link #getAgentNameFromService} reads it to name the agent variable in the generated
+     * {@code chat} body. An existing service has no corresponding source construct, so on the edit
+     * path it is a dead field that nothing writes back.
+     */
+    @Override
+    protected Service createBaseServiceModel(ModelFromSourceContext context) {
+        Service serviceModel = super.createBaseServiceModel(context);
+        if (Objects.nonNull(serviceModel)) {
+            serviceModel.getProperties().remove(AGENT_NAME_PROPERTY);
+        }
+        return serviceModel;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Seeds the optional {@code decision} handler before the usual merge. The service index has
+     * no {@code decision} row, and a generated agent service declares no type descriptor — so
+     * {@code deriveServiceType} yields {@code "Service"} and the service-type lookup in
+     * {@code populateServiceTypeFunctions} could never match {@code ChatService} regardless. Adding
+     * it here lets {@code updateServiceInfoNew} do its ordinary job: enable it when the source
+     * declares it, leave it disabled — that is, offered as addable — when it does not.
+     */
+    @Override
+    protected void mergeSourceFunctions(Service serviceModel, List<Function> functionsInSource) {
+        serviceModel.getFunctions().add(AiSourceUtils.decisionResourceTemplate(serviceModel.getOrgName()));
+        super.mergeSourceFunctions(serviceModel, functionsInSource);
     }
 
     @Override

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/core/ServiceModelGeneratorService.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/core/ServiceModelGeneratorService.java
@@ -607,9 +607,16 @@ public class ServiceModelGeneratorService implements ExtendedLanguageServerServi
             }
             String moduleName = (request.codedata().getModuleName() != null) ?
                     request.codedata().getModuleName() : DEFAULT;
-            Function function = FunctionBuilderRouter.getFunctionFromSource(moduleName, semanticModelOp.get(),
-                    functionDefinitionNode);
-            return new FunctionFromSourceResponse(function);
+            try {
+                Function function = FunctionBuilderRouter.getFunctionFromSource(moduleName, semanticModelOp.get(),
+                        functionDefinitionNode);
+                return new FunctionFromSourceResponse(function);
+            } catch (Exception e) {
+                // Matches updateFunction and getServiceFromSource: an unexpected failure here should
+                // reach the client as an error-carrying response, not an escaped RuntimeException
+                // that becomes an opaque JSON-RPC InternalError.
+                return new FunctionFromSourceResponse(e);
+            }
         });
     }
 

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/AiSourceUtils.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/AiSourceUtils.java
@@ -1,0 +1,282 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.servicemodelgenerator.extension.util;
+
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.servicemodelgenerator.extension.model.Codedata;
+import io.ballerina.servicemodelgenerator.extension.model.Function;
+import io.ballerina.servicemodelgenerator.extension.model.FunctionReturnType;
+import io.ballerina.servicemodelgenerator.extension.model.MetaData;
+import io.ballerina.servicemodelgenerator.extension.model.Parameter;
+import io.ballerina.servicemodelgenerator.extension.model.PropertyType;
+import io.ballerina.servicemodelgenerator.extension.model.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.AI;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.BALLERINA;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.KIND_REQUIRED;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.KIND_RESOURCE;
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.NEW_LINE;
+
+/**
+ * Source templates and syntax-tree helpers shared by the AI chat agent service and function
+ * builders.
+ *
+ * <p>A chat agent service exposes two fixed resources. {@code chat} is the agent's entry point and
+ * is emitted whenever the service is created. {@code decision} resumes a paused run once a human
+ * has approved or rejected a tool call the agent proposed, and is added on demand — a service
+ * without it compiles and serves chat perfectly well, and only fails at the moment someone clicks
+ * Approve.
+ *
+ * @since 1.2.0
+ */
+public final class AiSourceUtils {
+
+    public static final String CHAT_RESOURCE_NAME = "chat";
+    public static final String DECISION_RESOURCE_NAME = "decision";
+    private static final String RUN_METHOD = "run";
+    private static final String POST_ACCESSOR = "post";
+    private static final String REQUEST_PARAM = "request";
+    private static final String DECISION_MESSAGE_TYPE = "ai:DecisionMessage";
+    private static final String CHAT_RESPONSE_TYPE = "ai:ChatRespMessage|error";
+
+    private AiSourceUtils() {
+    }
+
+    /**
+     * The call operator an agent variable of the given org is invoked through: {@code ballerina/ai}
+     * agents expose {@code run} as an object method, {@code ballerinax/ai} agents as a remote method.
+     *
+     * @param orgName the organization owning the ai module
+     * @return {@code "."} or {@code "->"}
+     */
+    public static String runOperator(String orgName) {
+        return BALLERINA.equals(orgName) ? "." : "->";
+    }
+
+    /**
+     * The {@code chat} resource: one conversational turn against the agent.
+     *
+     * @param agentVarName the agent variable to invoke
+     * @param operator     the call operator, from {@link #runOperator(String)}
+     * @return the resource source, indented one level for a service body
+     */
+    public static String agentChatResourceSource(String agentVarName, String operator) {
+        return String.format(
+                "    resource function post chat(@http:Payload ai:ChatReqMessage request) " +
+                        "returns ai:ChatRespMessage|error {%s" +
+                        "        string stringResult = check %s%srun(request.message, request.sessionId);%s" +
+                        "        return {message: stringResult};%s" +
+                        "    }",
+                NEW_LINE, agentVarName, operator, NEW_LINE, NEW_LINE
+        );
+    }
+
+    /**
+     * The {@code decision} resource: the human-in-the-loop resume path.
+     *
+     * <p>Passing decisions rather than a query is what tells {@code run} to continue the paused run
+     * instead of starting a new turn. The raw pause error is returned as-is so the listener's
+     * dispatcher can turn it into the response shape the chat panel looks for.
+     *
+     * @param agentVarName the agent variable to invoke
+     * @param operator     the call operator, from {@link #runOperator(String)}
+     * @return the resource source, indented one level for a service body
+     */
+    public static String agentDecisionResourceSource(String agentVarName, String operator) {
+        return String.format(
+                "    resource function post decision(@http:Payload ai:DecisionMessage request) " +
+                        "returns ai:ChatRespMessage|error {%s" +
+                        "        string result = check %s%srun({decisions: request.decisions}, " +
+                        "request.sessionId);%s" +
+                        "        return {message: result};%s" +
+                        "    }",
+                NEW_LINE, agentVarName, operator, NEW_LINE, NEW_LINE
+        );
+    }
+
+    /**
+     * The addable {@code decision} handler shown in the service designer.
+     *
+     * <p>The service index has no {@code decision} row, and a generated agent service carries no
+     * type descriptor, so the service-type lookup could never surface one anyway. This stands in for
+     * the database-backed template a service type would otherwise provide, letting the ordinary
+     * merge in {@link ServiceModelUtils#updateServiceInfoNew} enable it when the source has it and
+     * leave it disabled — that is, offered as addable — when it does not.
+     *
+     * @param orgName the organization owning the ai module, stamped onto the codedata so an add
+     *                routes back to the AI function builder rather than the generic one
+     * @return a disabled, optional resource function model
+     */
+    public static Function decisionResourceTemplate(String orgName) {
+        String org = orgName == null ? BALLERINA : orgName;
+
+        Value accessor = new Value.ValueBuilder()
+                .metadata("Accessor", "The HTTP accessor of the resource")
+                .value(POST_ACCESSOR)
+                .types(List.of(PropertyType.types(Value.FieldType.IDENTIFIER)))
+                .enabled(true)
+                .editable(false)
+                .build();
+
+        Value name = new Value.ValueBuilder()
+                .metadata(DECISION_RESOURCE_NAME, "The resource path")
+                .value(DECISION_RESOURCE_NAME)
+                .types(List.of(PropertyType.types(Value.FieldType.IDENTIFIER)))
+                .setPlaceholder(DECISION_RESOURCE_NAME)
+                .enabled(true)
+                .editable(false)
+                .build();
+
+        Value returnValue = new Value.ValueBuilder()
+                .metadata("Return Type", "The return type of the resource")
+                .value(CHAT_RESPONSE_TYPE)
+                .types(List.of(PropertyType.types(Value.FieldType.TYPE)))
+                .setPlaceholder(CHAT_RESPONSE_TYPE)
+                .enabled(true)
+                .editable(false)
+                .optional(true)
+                .build();
+        FunctionReturnType returnType = new FunctionReturnType(returnValue);
+        returnType.setHasError(true);
+
+        List<Parameter> parameters = new ArrayList<>();
+        parameters.add(decisionPayloadParameter());
+
+        Codedata codedata = new Codedata.Builder()
+                .setOrgName(org)
+                .setPackageName(AI)
+                .setModuleName(AI)
+                .build();
+
+        return new Function.FunctionBuilder()
+                .setMetadata(new MetaData("Human Decision",
+                        "Resumes a paused agent run with the human's approve/reject decisions."))
+                .kind(KIND_RESOURCE)
+                .accessor(accessor)
+                .name(name)
+                .parameters(parameters)
+                .returnType(returnType)
+                .setCodedata(codedata)
+                .enabled(false)
+                .optional(true)
+                .editable(false)
+                .build();
+    }
+
+    private static Parameter decisionPayloadParameter() {
+        Value paramType = new Value.ValueBuilder()
+                .metadata("Type", "The type of the parameter")
+                .value(DECISION_MESSAGE_TYPE)
+                .types(List.of(PropertyType.types(Value.FieldType.TYPE)))
+                .enabled(true)
+                .editable(false)
+                .build();
+
+        Value paramName = new Value.ValueBuilder()
+                .metadata("Name", "The name of the parameter")
+                .value(REQUEST_PARAM)
+                .types(List.of(PropertyType.types(Value.FieldType.IDENTIFIER)))
+                .enabled(true)
+                .editable(false)
+                .build();
+
+        return new Parameter.Builder()
+                .metadata(new MetaData(REQUEST_PARAM, "The human's decisions for the pending tool calls"))
+                .kind(KIND_REQUIRED)
+                .type(paramType)
+                .name(paramName)
+                .httpParamType(Constants.HTTP_PARAM_TYPE_PAYLOAD)
+                .enabled(true)
+                .editable(false)
+                .optional(false)
+                .build();
+    }
+
+    /**
+     * The agent variable and call operator this service's existing resources already use.
+     *
+     * <p>Read off the source rather than re-derived from the organization, so a generated
+     * {@code decision} matches whatever the {@code chat} resource actually does even if it was
+     * hand-edited. The agent is commonly declared in a different file from the service, so the only
+     * reliable place to find its name is the call inside a resource body.
+     *
+     * @param serviceNode the service to inspect
+     * @return the resolved agent call, or empty when no {@code run} call can be found
+     */
+    public static Optional<AgentCall> resolveAgentCall(ServiceDeclarationNode serviceNode) {
+        List<FunctionDefinitionNode> resources = serviceNode.members().stream()
+                .filter(FunctionDefinitionNode.class::isInstance)
+                .map(FunctionDefinitionNode.class::cast)
+                .toList();
+
+        // Prefer the chat resource: it is the one the generator wrote, so it is the most faithful
+        // record of how this service calls its agent.
+        Optional<AgentCall> fromChat = resources.stream()
+                .filter(resource -> CHAT_RESOURCE_NAME.equals(Utils.getPath(resource.relativeResourcePath())))
+                .map(resource -> findRunCall(resource.functionBody()))
+                .flatMap(Optional::stream)
+                .findFirst();
+        if (fromChat.isPresent()) {
+            return fromChat;
+        }
+
+        return resources.stream()
+                .map(resource -> findRunCall(resource.functionBody()))
+                .flatMap(Optional::stream)
+                .findFirst();
+    }
+
+    private static Optional<AgentCall> findRunCall(Node node) {
+        if (node instanceof MethodCallExpressionNode call
+                && RUN_METHOD.equals(call.methodName().toSourceCode().trim())) {
+            return Optional.of(new AgentCall(call.expression().toSourceCode().trim(), "."));
+        }
+        if (node instanceof RemoteMethodCallActionNode call
+                && RUN_METHOD.equals(call.methodName().toSourceCode().trim())) {
+            return Optional.of(new AgentCall(call.expression().toSourceCode().trim(), "->"));
+        }
+        if (node instanceof NonTerminalNode nonTerminal) {
+            for (Node child : nonTerminal.children()) {
+                Optional<AgentCall> found = findRunCall(child);
+                if (found.isPresent()) {
+                    return found;
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * An agent variable together with the operator it is invoked through.
+     *
+     * @param agentVarName the agent variable name
+     * @param operator     {@code "."} for an object method, {@code "->"} for a remote method
+     */
+    public record AgentCall(String agentVarName, String operator) {
+    }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/AiSourceUtils.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/AiSourceUtils.java
@@ -109,12 +109,13 @@ public final class AiSourceUtils {
      */
     public static String agentDecisionResourceSource(String agentVarName, String operator) {
         return String.format(
-                "    resource function post decision(@http:Payload ai:DecisionMessage request) " +
-                        "returns ai:ChatRespMessage|error {%s" +
+                "    resource function %s %s(@http:Payload %s request) " +
+                        "returns %s {%s" +
                         "        string result = check %s%srun({decisions: request.decisions}, " +
                         "request.sessionId);%s" +
                         "        return {message: result};%s" +
                         "    }",
+                POST_ACCESSOR, DECISION_RESOURCE_NAME, DECISION_MESSAGE_TYPE, CHAT_RESPONSE_TYPE,
                 NEW_LINE, agentVarName, operator, NEW_LINE, NEW_LINE
         );
     }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/AiSourceUtils.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/AiSourceUtils.java
@@ -63,6 +63,8 @@ public final class AiSourceUtils {
     private static final String REQUEST_PARAM = "request";
     private static final String DECISION_MESSAGE_TYPE = "ai:DecisionMessage";
     private static final String CHAT_RESPONSE_TYPE = "ai:ChatRespMessage|error";
+    private static final String RESUME_TYPE = "ai:Resume";
+    private static final String RESUME_VAR = "resume";
 
     private AiSourceUtils() {
     }
@@ -111,12 +113,12 @@ public final class AiSourceUtils {
         return String.format(
                 "    resource function %s %s(@http:Payload %s request) " +
                         "returns %s {%s" +
-                        "        string result = check %s%srun({decisions: request.decisions}, " +
-                        "request.sessionId);%s" +
+                        "        %s %s = {decisions: request.decisions};%s" +
+                        "        string result = check %s%srun(%s, request.sessionId);%s" +
                         "        return {message: result};%s" +
                         "    }",
                 POST_ACCESSOR, DECISION_RESOURCE_NAME, DECISION_MESSAGE_TYPE, CHAT_RESPONSE_TYPE,
-                NEW_LINE, agentVarName, operator, NEW_LINE, NEW_LINE
+                NEW_LINE, RESUME_TYPE, RESUME_VAR, NEW_LINE, agentVarName, operator, RESUME_VAR, NEW_LINE, NEW_LINE
         );
     }
 

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/util/AiSourceUtilsTest.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/util/AiSourceUtilsTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.servicemodelgenerator.extension.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Direct unit tests for {@link AiSourceUtils#agentDecisionResourceSource(String, String)}.
+ *
+ * @since 1.9.0
+ */
+public class AiSourceUtilsTest {
+
+    @Test
+    public void testObjectMethodOperatorGeneratesResumeVariableAndDotCall() {
+        String source = AiSourceUtils.agentDecisionResourceSource("supportAgent", ".");
+
+        Assert.assertTrue(source.contains("resource function post decision(@http:Payload ai:DecisionMessage request)"),
+                "must declare the decision resource with the fixed accessor, name and payload type");
+        Assert.assertTrue(source.contains("returns ai:ChatRespMessage|error"),
+                "must declare the fixed return type");
+        Assert.assertTrue(source.contains("ai:Resume resume = {decisions: request.decisions};"),
+                "the ai:Resume value must be assigned to a local variable built from request.decisions");
+        Assert.assertTrue(source.contains("check supportAgent.run(resume, request.sessionId)"),
+                "an object-method agent must be invoked with '.', passing the resume variable and " +
+                        "request.sessionId");
+    }
+
+    @Test
+    public void testRemoteMethodOperatorGeneratesResumeVariableAndArrowCall() {
+        String source = AiSourceUtils.agentDecisionResourceSource("supportAgent", "->");
+
+        Assert.assertTrue(source.contains("ai:Resume resume = {decisions: request.decisions};"),
+                "the ai:Resume value must be assigned to a local variable built from request.decisions " +
+                        "regardless of the call operator");
+        Assert.assertTrue(source.contains("check supportAgent->run(resume, request.sessionId)"),
+                "a remote-method agent must be invoked with '->', passing the resume variable and " +
+                        "request.sessionId");
+    }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/testng.xml
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/testng.xml
@@ -63,6 +63,7 @@ under the License.
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerReadOnlyMetadataAdapterTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.IncludedRecordBinderTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.util.FunctionBadgeTest"/>
+            <class name="io.ballerina.servicemodelgenerator.extension.util.AiSourceUtilsTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerSourceMergerTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.connector.TriggerFunctionExpansionTest"/>
             <class name="io.ballerina.servicemodelgenerator.extension.builder.service.ListenerChoiceSelectionTest"/>

--- a/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIChatAgentWizard.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/AIChatAgent/AIChatAgentWizard.tsx
@@ -239,6 +239,10 @@ export function AIChatAgentWizard(props: AIChatAgentWizardProps) {
             setCurrentStep(5);
 
             if (newServiceArtifact) {
+                // Land on the Service Designer's resource listing, not the chat flow diagram: the
+                // very next thing most users do after creating a chat agent is check whether they
+                // need human-in-the-loop, and that control lives on this screen. Landing in the
+                // chat flow first would mean backing out to get here anyway.
                 rpcClient.getVisualizerRpcClient().openView({
                     type: EVENT_TYPE.OPEN_VIEW,
                     location: { documentUri: newServiceArtifact.path, position: newServiceArtifact.position }

--- a/packages/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
@@ -444,7 +444,10 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
     let isAutomation = parentMetadata?.kind === "Function" && parentMetadata?.label === "main";
     let isResource = parentMetadata?.kind === "Resource";
     let isRemote = parentMetadata?.kind === "Remote Function";
-    let isAgent = parentMetadata?.kind === "Chat Agent Service" && parentMetadata?.label === "chat";
+    // The language server reports this kind for every resource of an ai:Listener service — chat
+    // and decision alike (CodeAnalyzer#isAgent checks the service's listener type, not the resource
+    // name) — so both get the same Tracing/Chat title bar treatment.
+    let isAgent = parentMetadata?.kind === "Chat Agent Service";
     let isInitFunction = parentMetadata?.kind === "Function" && parentMetadata?.label === "init";
     let isWorkflow = parentMetadata?.kind === "Workflow";
     let isDurableAgent = parentMetadata?.kind === "Durable Agentic Workflow";

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -4028,11 +4028,13 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
 
     const flowModel = originalModel && suggestedModel ? suggestedModel : model;
 
-    // Hide "Chat" button on agent nodes when already inside a chat agent flow diagram
+    // Hide "Chat" button on agent nodes when already inside a chat agent service's flow diagram
+    // (chat or decision — the language server reports this kind for every resource of an
+    // ai:Listener service, not just chat), since the title bar already offers the same action.
     const isChatAgentFlow = (() => {
         const eventStartNode = flowModel?.nodes.find((node) => node.codedata.node === "EVENT_START");
         const meta = eventStartNode?.metadata?.data as { kind?: string; label?: string } | undefined;
-        return meta?.kind === "Chat Agent Service" && meta?.label === "chat";
+        return meta?.kind === "Chat Agent Service";
     })();
 
     // Durable Agentic Workflow agent-only view: the LS flow model carries the synthetic

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ServiceConfigForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ServiceConfigForm.tsx
@@ -278,6 +278,13 @@ function convertConfig(service: ServiceModel): FormField[] {
         if (key === "readOnlyMetadata") {
             continue;
         }
+        // A property with no input type has nothing renderable — it's metadata the language server
+        // carries for its own use (e.g. an add-time-only input echoed back on the edit model).
+        // FieldFactory throws outright on a type-less field, which would take the whole
+        // configuration view down, so drop it here rather than hand it to the renderer.
+        if (!getPrimaryInputType(expression.types)?.fieldType) {
+            continue;
+        }
         const formField: FormField = {
             key: key,
             label: expression?.metadata.label || key.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/^./, str => str.toUpperCase()),

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/components/ResourceAccordionV2.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/components/ResourceAccordionV2.tsx
@@ -181,8 +181,22 @@ export function ResourceAccordionV2(params: ResourceAccordionPropsV2) {
 
     const handleEditResource = async (e: React.MouseEvent<HTMLElement | SVGSVGElement>) => {
         e.stopPropagation(); // Stop the event propagation
-        const functionModel = await getFunctionModel();
-        onEditResource(functionModel.function);
+        // `onEditResource` is null for resources the designer doesn't let you edit (the init
+        // function, a chat agent's fixed resources); the button is disabled for those, but the
+        // click can still arrive via the accordion header, so check rather than assume.
+        if (!onEditResource) {
+            return;
+        }
+        try {
+            const functionModel = await getFunctionModel();
+            if (functionModel?.function) {
+                onEditResource(functionModel.function);
+            }
+        } catch (error) {
+            // The language server couldn't model this function. Nothing to open — log it rather
+            // than leaving an unhandled rejection to surface as a bare webview error.
+            console.error("Failed to load the function model for editing", error);
+        }
     };
 
     const handleOpenConfirm = () => {
@@ -210,8 +224,14 @@ export function ResourceAccordionV2(params: ResourceAccordionPropsV2) {
     };
 
     const handleResourceImplement = async () => {
-        const functionModel = await getFunctionModel();
-        onResourceImplement(functionModel.function);
+        try {
+            const functionModel = await getFunctionModel();
+            if (functionModel?.function) {
+                onResourceImplement(functionModel.function);
+            }
+        } catch (error) {
+            console.error("Failed to load the function model for navigation", error);
+        }
     }
 
     function getColorByMethod(method: string) {

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/index.tsx
@@ -18,6 +18,7 @@
 
 import styled from "@emotion/styled";
 import {
+    AI_DECISION_RESOURCE_NAME,
     DIRECTORY_MAP,
     EVENT_TYPE,
     FunctionModel,
@@ -198,6 +199,11 @@ export function ServiceDesigner(props: ServiceDesignerProps) {
     const [isMcpService, setIsMcpService] = useState<boolean>(false);
     const [isFtpService, setIsFtpService] = useState<boolean>(false);
     const [isCdcService, setIsCdcService] = useState<boolean>(false);
+    // A chat agent service's resources (`chat`, `decision`) are HTTP-payload-shaped exactly like
+    // an http:Service resource, so they're listed the same way (see the Resources section below).
+    // They're kept out of `isHttpService` itself so the http-only "Export OpenAPI Spec" option and
+    // free-form "Add Resource" affordance don't leak onto a chat agent's fixed chat/decision pair.
+    const [isAiService, setIsAiService] = useState<boolean>(false);
 
     // ----- handler/method/resource listings (populated by setServiceMetaInfo on each fetch) -----
     const [enabledHandlers, setEnabledHandlers] = useState<FunctionModel[]>([]);
@@ -368,6 +374,7 @@ export function ServiceDesigner(props: ServiceDesignerProps) {
             setIsHttpService(service.moduleName === "http");
             setIsMcpService(service.moduleName === "mcp");
             setIsCdcService(service.moduleName === "mssql" || service.moduleName === "postgresql");
+            setIsAiService(service.moduleName === "ai");
         }
 
         // Extract object methods if available (for service classes)
@@ -501,6 +508,19 @@ export function ServiceDesigner(props: ServiceDesignerProps) {
     const handleQuickAddTriggerHandler = (functionModel: FunctionModel) => {
         setShowFunctionConfigForm(false);
         handleFunctionSubmit(functionModel, false, true);
+    };
+
+    /**
+     * Opts an existing chat agent into human-in-the-loop by generating its `decision` resource.
+     * The generated resource is complete boilerplate (it forwards the human's decisions into the
+     * agent run), so there is nothing to configure first and nothing to implement afterwards —
+     * hence the quick-add, which leaves the user here watching the new row appear.
+     */
+    const handleEnableHitl = () => {
+        if (!addableDecisionHandler) {
+            return;
+        }
+        handleQuickAddTriggerHandler(addableDecisionHandler);
     };
 
     const getTriggerHandlerTitle = () => {
@@ -919,6 +939,19 @@ export function ServiceDesigner(props: ServiceDesignerProps) {
         ? (serviceModel?.name || "").replace(/\s*-\s*\/$/, "")
         : serviceModel?.name;
 
+    // The chat agent service model carries `decision` as a disabled RESOURCE function until the user
+    // opts into human-in-the-loop; once it exists in source the language server flips it to enabled
+    // and it drops out of `unusedHandlers`. Membership there is therefore the "not yet wired" signal.
+    // The artifact check is a second opinion, so an LS that under-reports `enabled` can't make us
+    // offer to generate a resource that is already in the file.
+    const addableDecisionHandler = isAiService
+        ? unusedHandlers.find((fn) => fn.name?.value === AI_DECISION_RESOURCE_NAME)
+        : undefined;
+    const hasDecisionResource = resources.some(
+        (resource) => resource.type === DIRECTORY_MAP.RESOURCE && resource.name === AI_DECISION_RESOURCE_NAME
+    );
+    const canEnableHitl = Boolean(addableDecisionHandler) && !hasDecisionResource;
+
     const resourcesCount = resources
         .filter((resource) => resource.type === DIRECTORY_MAP.RESOURCE)
         .filter((resource) => {
@@ -1059,20 +1092,33 @@ export function ServiceDesigner(props: ServiceDesignerProps) {
                             )}
 
 
-                            {/* Listing Resources in HTTP */}
-                            {isHttpService && (
+                            {/* Listing Resources in HTTP (and, read-only for adding, a chat agent's fixed chat/decision pair) */}
+                            {(isHttpService || isAiService) && (
                                 <>
 
                                     <>
                                         <SectionHeader
                                             title="Resources"
-                                            subtitle={`${resourcesCount === 0 ? `` : 'Define how the service responds to HTTP requests'}`}
+                                            subtitle={`${resourcesCount === 0 ? `` : isAiService
+                                                ? 'The agent\'s fixed chat and human-approval resources'
+                                                : 'Define how the service responds to HTTP requests'}`}
                                         >
                                             <ActionGroup>
                                                 {resources.length > 10 && (
                                                     <TextField placeholder="Search..." sx={{ width: 200 }} onChange={handleSearch} value={searchValue} />
                                                 )}
-                                                {!haveServiceTypeName && resourcesCount > 0 && (
+                                                {canEnableHitl && (
+                                                    <Button
+                                                        appearance="primary"
+                                                        tooltip="Add a decision resource so a human can approve or reject the agent's gated tool calls"
+                                                        onClick={handleEnableHitl}
+                                                        disabled={isSaving}
+                                                    >
+                                                        <Codicon name="add" sx={{ marginRight: 8 }} />
+                                                        <ButtonText>Human-in-the-Loop</ButtonText>
+                                                    </Button>
+                                                )}
+                                                {!isAiService && !haveServiceTypeName && resourcesCount > 0 && (
                                                     <Button appearance="primary" tooltip="Add Resource" onClick={handleNewResourceFunction}>
                                                         <Codicon name="add" sx={{ marginRight: 8 }} /> <ButtonText>Resource</ButtonText>
                                                     </Button>
@@ -1095,7 +1141,11 @@ export function ServiceDesigner(props: ServiceDesignerProps) {
                                                             key={`${index}-${resource.name}`}
                                                             resource={resource}
                                                             readOnly={serviceModel.properties.hasOwnProperty('serviceTypeName')}
-                                                            onEditResource={handleFunctionEdit}
+                                                            // A chat agent's chat/decision pair is fixed, generated surface (see
+                                                            // AiChatServiceBuilder) rather than something the user hand-edits
+                                                            // through the generic HTTP resource form, so editing is disabled —
+                                                            // deleting is still allowed, same as any other resource here.
+                                                            onEditResource={isAiService ? null : handleFunctionEdit}
                                                             onDeleteResource={handleFunctionDelete}
                                                             onResourceImplement={handleOpenDiagram}
                                                             deletionTypeLabel="resource"
@@ -1103,7 +1153,7 @@ export function ServiceDesigner(props: ServiceDesignerProps) {
                                                     ))}
                                             </FunctionsContainer>
                                         )}
-                                        {resourcesCount === 0 && (
+                                        {resourcesCount === 0 && !isAiService && (
                                             <EmptyReadmeContainer>
                                                 <Description variant="body2">
                                                     No resources found. Add a new resource.
@@ -1121,7 +1171,7 @@ export function ServiceDesigner(props: ServiceDesignerProps) {
                             )}
 
                             {/* Listing service type bound functions (event/file handlers, MCP tools, ...) */}
-                            {!isHttpService && (
+                            {!isHttpService && !isAiService && (
                                 <>
                                     <SectionHeader
                                         title={isFileService ? "File Handlers" : isMcpService ? "Tools" : "Event Handlers"}

--- a/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ServiceDesigner/index.tsx
@@ -1115,7 +1115,7 @@ export function ServiceDesigner(props: ServiceDesignerProps) {
                                                         disabled={isSaving}
                                                     >
                                                         <Codicon name="add" sx={{ marginRight: 8 }} />
-                                                        <ButtonText>Human-in-the-Loop</ButtonText>
+                                                        <ButtonText>Decision</ButtonText>
                                                     </Button>
                                                 )}
                                                 {!isAiService && !haveServiceTypeName && resourcesCount > 0 && (

--- a/packages/component-diagram/src/components/nodes/EntryNode/components/AIServiceWidget.tsx
+++ b/packages/component-diagram/src/components/nodes/EntryNode/components/AIServiceWidget.tsx
@@ -18,7 +18,8 @@
 
 import React, { useState } from "react";
 import styled from "@emotion/styled";
-import { CDService } from "@wso2/ballerina-core";
+import { PortWidget } from "@projectstorm/react-diagrams-core";
+import { AI_CHAT_RESOURCE_NAME, AI_DECISION_RESOURCE_NAME, CDResourceFunction, CDService } from "@wso2/ballerina-core";
 import { Item, Menu, MenuItem, Popover, Icon, ThemeColors } from "@wso2/ui-toolkit";
 import { useDiagramContext } from "../../../DiagramContext";
 import { MoreVertIcon } from "../../../../resources/icons/nodes/MoreVertIcon";
@@ -35,7 +36,11 @@ import {
     IconWrapper,
     MenuButton,
     TopPortWidget,
-    BottomPortWidget
+    BottomPortWidget,
+    FunctionBoxWrapper,
+    StyledServiceBox,
+    RowIconWrapper,
+    EventTypeText
 } from "./styles";
 
 type NodeStyleProp = { hovered: boolean };
@@ -98,11 +103,54 @@ const getNodeDescription = (model: EntryNodeModel) => {
         "";
 };
 
+// A single subordinate capability row, used for `chat` and for `decision`. Neither is rendered as a
+// resource with a method badge: both are fixed, code-generated surface (see AiChatServiceBuilder),
+// not something the user designs from scratch the way an HTTP resource is, so they read as
+// capabilities of the agent rather than peer endpoints.
+function AgentCapabilityBox(props: {
+    func: CDResourceFunction;
+    model: EntryNodeModel;
+    engine: any;
+    readonly?: boolean;
+    icon: string;
+    label: string;
+    tag: string;
+    title: string;
+}) {
+    const { func, model, engine, readonly, icon, label, tag, title } = props;
+    const [isHovered, setIsHovered] = useState(false);
+    const { onFunctionSelect } = useDiagramContext();
+
+    const handleOnClick = () => {
+        onFunctionSelect(func);
+    };
+
+    return (
+        <FunctionBoxWrapper>
+            <StyledServiceBox
+                hovered={isHovered}
+                onClick={() => !readonly ? handleOnClick() : undefined}
+                onMouseEnter={() => !readonly && setIsHovered(true)}
+                onMouseLeave={() => !readonly && setIsHovered(false)}
+                readonly={readonly}
+                title={title}
+            >
+                <RowIconWrapper>
+                    <Icon name={icon} sx={{ fontSize: 16, width: 16, height: 16 }} />
+                </RowIconWrapper>
+                <Title hovered={isHovered}>{label}</Title>
+                <EventTypeText>{tag}</EventTypeText>
+            </StyledServiceBox>
+            <PortWidget port={model.getPort(getEntryNodeFunctionPortName(func))!} engine={engine} />
+        </FunctionBoxWrapper>
+    );
+}
+
 export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
     const [isHovered, setIsHovered] = useState(false);
     const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | SVGSVGElement>(null);
 
-    const { onFunctionSelect, onDeleteComponent, readonly } = useDiagramContext();
+    const { onServiceSelect, onDeleteComponent, readonly } = useDiagramContext();
     const isMenuOpen = Boolean(menuAnchorEl);
 
     const serviceFunctions = [];
@@ -113,10 +161,18 @@ export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
         serviceFunctions.push(...(model.node as CDService).resourceFunctions);
     }
 
+    const resourceFunctions = (model.node as CDService).resourceFunctions ?? [];
+    // Resolve by path rather than array position — `serviceFunctions[0]` only happened to be
+    // `chat` because of incidental ordering upstream; matching the generated name is correct
+    // regardless of how many resources the service ends up with.
+    const chatFunction = resourceFunctions.find(fn => fn.path === AI_CHAT_RESOURCE_NAME) ?? serviceFunctions[0];
+    const decisionFunction = resourceFunctions.find(fn => fn.path === AI_DECISION_RESOURCE_NAME);
+
+    // The outer box always opens the service's resource listing, exactly as a REST service node
+    // does. Deliberately independent of whether HITL is wired: a node whose click target silently
+    // changed once a `decision` resource appeared would be unpredictable.
     const handleOnClick = () => {
-        if (serviceFunctions.length > 0) {
-            onFunctionSelect(serviceFunctions[0]);
-        }
+        onServiceSelect(model.node as CDService);
     };
 
     const { handleMouseDown, handleMouseUp } = useClickWithDragTolerance(handleOnClick);
@@ -179,6 +235,30 @@ export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
                         <MoreVertIcon />
                     </MenuButton>
                 </ServiceBox>
+                {chatFunction && (
+                    <AgentCapabilityBox
+                        func={chatFunction}
+                        model={model}
+                        engine={engine}
+                        readonly={readonly}
+                        icon="bi-chat"
+                        label="Agent Chat"
+                        tag="Chat"
+                        title="Handles a single conversational turn with the agent"
+                    />
+                )}
+                {decisionFunction && (
+                    <AgentCapabilityBox
+                        func={decisionFunction}
+                        model={model}
+                        engine={engine}
+                        readonly={readonly}
+                        icon="user-fill"
+                        label="Human Decision"
+                        tag="Decision"
+                        title="Resumes a paused run once a human approves or rejects a pending tool call"
+                    />
+                )}
             </BoxComponent>
 
             <Popover
@@ -198,12 +278,8 @@ export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
             </Popover>
 
             <BottomPortWidget port={model.getPort("out")!} engine={engine} />
-            {serviceFunctions.length > 0 && (
-                <BottomPortWidget
-                    port={model.getPort(getEntryNodeFunctionPortName(serviceFunctions[0]))!}
-                    engine={engine}
-                />
-            )}
+            {/* Every resource now has a visible row carrying its own inline PortWidget, so there is
+                no anonymous chat port here — registering the same port twice would conflict. */}
         </Node>
     );
 }

--- a/packages/component-diagram/src/components/nodes/EntryNode/components/AIServiceWidget.tsx
+++ b/packages/component-diagram/src/components/nodes/EntryNode/components/AIServiceWidget.tsx
@@ -18,14 +18,13 @@
 
 import React, { useState } from "react";
 import styled from "@emotion/styled";
-import { PortWidget } from "@projectstorm/react-diagrams-core";
-import { AI_CHAT_RESOURCE_NAME, AI_DECISION_RESOURCE_NAME, CDResourceFunction, CDService } from "@wso2/ballerina-core";
+import { AI_CHAT_RESOURCE_NAME, AI_DECISION_RESOURCE_NAME, CDService } from "@wso2/ballerina-core";
 import { Item, Menu, MenuItem, Popover, Icon, ThemeColors } from "@wso2/ui-toolkit";
 import { useDiagramContext } from "../../../DiagramContext";
 import { MoreVertIcon } from "../../../../resources/icons/nodes/MoreVertIcon";
-import { getEntryNodeFunctionPortName } from "../../../../utils/diagram";
 import { BaseNodeWidgetProps, EntryNodeModel } from "../EntryNodeModel";
 import { useClickWithDragTolerance } from "../../../../hooks/useClickWithDragTolerance";
+import { FunctionBox } from "./GeneralWidget";
 import {
     Node,
     Box,
@@ -37,10 +36,6 @@ import {
     MenuButton,
     TopPortWidget,
     BottomPortWidget,
-    FunctionBoxWrapper,
-    StyledServiceBox,
-    RowIconWrapper,
-    EventTypeText
 } from "./styles";
 
 type NodeStyleProp = { hovered: boolean };
@@ -102,49 +97,6 @@ const getNodeDescription = (model: EntryNodeModel) => {
         (model.node as any)?.name ||
         "";
 };
-
-// A single subordinate capability row, used for `chat` and for `decision`. Neither is rendered as a
-// resource with a method badge: both are fixed, code-generated surface (see AiChatServiceBuilder),
-// not something the user designs from scratch the way an HTTP resource is, so they read as
-// capabilities of the agent rather than peer endpoints.
-function AgentCapabilityBox(props: {
-    func: CDResourceFunction;
-    model: EntryNodeModel;
-    engine: any;
-    readonly?: boolean;
-    icon: string;
-    label: string;
-    tag: string;
-    title: string;
-}) {
-    const { func, model, engine, readonly, icon, label, tag, title } = props;
-    const [isHovered, setIsHovered] = useState(false);
-    const { onFunctionSelect } = useDiagramContext();
-
-    const handleOnClick = () => {
-        onFunctionSelect(func);
-    };
-
-    return (
-        <FunctionBoxWrapper>
-            <StyledServiceBox
-                hovered={isHovered}
-                onClick={() => !readonly ? handleOnClick() : undefined}
-                onMouseEnter={() => !readonly && setIsHovered(true)}
-                onMouseLeave={() => !readonly && setIsHovered(false)}
-                readonly={readonly}
-                title={title}
-            >
-                <RowIconWrapper>
-                    <Icon name={icon} sx={{ fontSize: 16, width: 16, height: 16 }} />
-                </RowIconWrapper>
-                <Title hovered={isHovered}>{label}</Title>
-                <EventTypeText>{tag}</EventTypeText>
-            </StyledServiceBox>
-            <PortWidget port={model.getPort(getEntryNodeFunctionPortName(func))!} engine={engine} />
-        </FunctionBoxWrapper>
-    );
-}
 
 export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
     const [isHovered, setIsHovered] = useState(false);
@@ -225,28 +177,10 @@ export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
                     </MenuButton>
                 </ServiceBox>
                 {chatFunction && (
-                    <AgentCapabilityBox
-                        func={chatFunction}
-                        model={model}
-                        engine={engine}
-                        readonly={readonly}
-                        icon="bi-chat"
-                        label="Agent Chat"
-                        tag="Chat"
-                        title="Handles a single conversational turn with the agent"
-                    />
+                    <FunctionBox func={chatFunction} model={model} engine={engine} readonly={readonly} />
                 )}
                 {decisionFunction && (
-                    <AgentCapabilityBox
-                        func={decisionFunction}
-                        model={model}
-                        engine={engine}
-                        readonly={readonly}
-                        icon="user-fill"
-                        label="Human Decision"
-                        tag="Decision"
-                        title="Resumes a paused run once a human approves or rejects a pending tool call"
-                    />
+                    <FunctionBox func={decisionFunction} model={model} engine={engine} readonly={readonly} />
                 )}
             </BoxComponent>
 

--- a/packages/component-diagram/src/components/nodes/EntryNode/components/AIServiceWidget.tsx
+++ b/packages/component-diagram/src/components/nodes/EntryNode/components/AIServiceWidget.tsx
@@ -153,19 +153,8 @@ export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
     const { onServiceSelect, onDeleteComponent, readonly } = useDiagramContext();
     const isMenuOpen = Boolean(menuAnchorEl);
 
-    const serviceFunctions = [];
-    if ((model.node as CDService).remoteFunctions?.length > 0) {
-        serviceFunctions.push(...(model.node as CDService).remoteFunctions);
-    }
-    if ((model.node as CDService).resourceFunctions?.length > 0) {
-        serviceFunctions.push(...(model.node as CDService).resourceFunctions);
-    }
-
     const resourceFunctions = (model.node as CDService).resourceFunctions ?? [];
-    // Resolve by path rather than array position — `serviceFunctions[0]` only happened to be
-    // `chat` because of incidental ordering upstream; matching the generated name is correct
-    // regardless of how many resources the service ends up with.
-    const chatFunction = resourceFunctions.find(fn => fn.path === AI_CHAT_RESOURCE_NAME) ?? serviceFunctions[0];
+    const chatFunction = resourceFunctions.find(fn => fn.path === AI_CHAT_RESOURCE_NAME);
     const decisionFunction = resourceFunctions.find(fn => fn.path === AI_DECISION_RESOURCE_NAME);
 
     // The outer box always opens the service's resource listing, exactly as a REST service node

--- a/packages/component-diagram/src/components/nodes/EntryNode/components/GeneralWidget.tsx
+++ b/packages/component-diagram/src/components/nodes/EntryNode/components/GeneralWidget.tsx
@@ -81,7 +81,7 @@ const getNodeDescription = (model: EntryNodeModel) => {
     return "Service";
 };
 
-function getColorByMethod(method: string) {
+export function getColorByMethod(method: string) {
     switch (method.toUpperCase()) {
         case "GET":
             return colors.GET;
@@ -116,7 +116,7 @@ function getCustomEntryNodeIcon(type: string) {
     return <Icon name={brand.glyph} sx={brand.color ? { color: brand.color } : undefined} />;
 }
 
-function FunctionBox(props: { func: any; model: EntryNodeModel; engine: any; readonly?: boolean }) {
+export function FunctionBox(props: { func: any; model: EntryNodeModel; engine: any; readonly?: boolean }) {
     const { func, model, engine, readonly } = props;
     const [isHovered, setIsHovered] = useState(false);
     const { onFunctionSelect } = useDiagramContext();

--- a/packages/component-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
+++ b/packages/component-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
 .css-9 {margin-top: -3px;}
 .css-5 {position: relative; cursor: move; overflow: hidden;}
 .css-20 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-foreground);}
-.css-36 {border-radius: 5px;}
+.css-39 {border-radius: 5px;}
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
@@ -23,8 +23,8 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
 .css-3>*:last-child {border-top-left-radius: 0; border-top-right-radius: 0;}
 .css-3>*:not(:first-child):not(:last-child) {border-radius: 0;}
 .css-3>*:not(:last-child) {border-bottom: 1px solid var(--vscode-dropdown-border);}
-.css-35 svg {fill: var(--vscode-foreground);}
-.css-35 {padding: 4px;}
+.css-38 svg {fill: var(--vscode-foreground);}
+.css-38 {padding: 4px;}
 .css-31 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-contrastBorder, var(--vscode-button-background)); height: 40px; width: 100%; cursor: pointer; font-family: "GilmerMedium"; font-size: 14px;}
 .css-31:hover {border: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-button-background)); border-radius: 8px;}
 .css-19 {margin-bottom: -2px;}
@@ -32,20 +32,21 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
 .css-12 svg {fill: var(--vscode-foreground);}
 .css-12 {width: 24px; height: 24px; font-size: 24px;}
 .css-28 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #3d7eff; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
-.css-40::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
+.css-43::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
 .css-16 {font-size: 12px; max-width: 136px; overflow: hidden; text-overflow: ellipsis; font-family: monospace; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; color: var(--vscode-foreground); opacity: 0.7;}
 .css-25 {font-size: 14px; max-width: 160px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
-.css-39 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
-.css-37 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
-.css-33 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
+.css-42 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
+.css-40 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
+.css-36 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
 .css-11 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); aspect-ratio: 1/1;}
 .css-2 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
-.css-38 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
+.css-33 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
+.css-41 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-23 >div:first-child {width: 24px; height: 24px; font-size: 24px;}
 .css-23 svg {fill: var(--vscode-foreground);}
 .css-23 {padding: 4px; max-width: 32px;}
 .css-17 {border-radius: 5px;}
-.css-34 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
+.css-37 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
 .css-22 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 56px; cursor: pointer;}
 .css-22:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
 .css-29 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #49cc90; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
@@ -55,8 +56,12 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
 .css-15 {font-size: 14px; max-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-13 {height: 16px; width: 14px; cursor: pointer;}
 .css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; gap: 6px; width: 100%; cursor: pointer;}
-.css-32 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
+.css-35 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
 .css-0 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 8px; position: absolute; left: 12px; bottom: 12px; z-index: 1000;}
+.css-32 >div:first-child {width: 16px; height: 16px; font-size: 16px;}
+.css-32 svg {fill: var(--vscode-foreground);}
+.css-32 {display: flex; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
+.css-34 {font-size: 12px; margin-left: auto; max-width: 90px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; color: var(--vscode-foreground); opacity: 0.7;}
 .css-10 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; width: 100%; cursor: pointer;}
 
 /* DOM */
@@ -559,15 +564,45 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
                   </vscode-button>
                 </div>
               </div>
+              <div
+                class="css-20"
+              >
+                <div
+                  class="css-27"
+                  title="Handles a single conversational turn with the agent"
+                >
+                  <div
+                    class="css-32"
+                  >
+                    <div
+                      class="css-33"
+                    >
+                      <i
+                        class="fw-bi-chat"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="css-25"
+                  >
+                    Agent Chat
+                  </div>
+                  <div
+                    class="css-34"
+                  >
+                    Chat
+                  </div>
+                </div>
+                <div
+                  class="port "
+                  data-name="post-chat"
+                />
+              </div>
             </div>
             <div />
             <div
               class="port css-19"
               data-name="out"
-            />
-            <div
-              class="port css-19"
-              data-name="post-chat"
             />
           </div>
         </div>
@@ -652,20 +687,20 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
           style="top: 332px; left: 250px;"
         >
           <div
-            class="css-32"
+            class="css-35"
           >
             <div
-              class="css-33"
+              class="css-36"
             >
               <div
-                class="css-34"
+                class="css-37"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-35"
+                  class="css-38"
                 >
                   <svg
                     height="24"
@@ -690,7 +725,7 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
                 />
               </div>
               <div
-                class="css-36 css-18"
+                class="css-39 css-18"
               >
                 <vscode-button>
                   <svg
@@ -711,10 +746,10 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
                 </vscode-button>
               </div>
               <div
-                class="css-37"
+                class="css-40"
               >
                 <div
-                  class="css-38"
+                  class="css-41"
                 />
                 <div
                   class="css-16"
@@ -731,20 +766,20 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
           style="top: 100px; left: 250px;"
         >
           <div
-            class="css-32"
+            class="css-35"
           >
             <div
-              class="css-33"
+              class="css-36"
             >
               <div
-                class="css-34"
+                class="css-37"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-35"
+                  class="css-38"
                 >
                   <svg
                     height="24"
@@ -769,7 +804,7 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
                 />
               </div>
               <div
-                class="css-36 css-18"
+                class="css-39 css-18"
               >
                 <vscode-button>
                   <svg
@@ -790,10 +825,10 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
                 </vscode-button>
               </div>
               <div
-                class="css-37"
+                class="css-40"
               >
                 <div
-                  class="css-38"
+                  class="css-41"
                 />
                 <div
                   class="css-16"
@@ -814,11 +849,11 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
           color="var(--vscode-foreground)"
         >
           <div
-            class="css-39"
+            class="css-42"
           >
             <vscode-progress-ring
               aria-live="assertive"
-              class="css-40"
+              class="css-43"
               color="var(--vscode-contrastBorder, var(--vscode-button-background))"
               role="alert"
             />
@@ -1666,11 +1701,11 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
 .css-4 svg:first-child {z-index: 1;}
 .css-4 {height: 100%; -webkit-background-size: 16px 16px; background-size: 16px 16px; display: flex; background-image: radial-gradient(var(--vscode-editor-inactiveSelectionBackground) 10%, transparent 0px); font-family: "GilmerRegular";}
 .css-26 {font-size: 12px; max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; color: var(--vscode-foreground); opacity: 0.7;}
-.css-31 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 100%;}
+.css-34 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 100%;}
 .css-9 {margin-top: -3px;}
 .css-5 {position: relative; cursor: move; overflow: hidden;}
 .css-20 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-foreground);}
-.css-37 {border-radius: 5px;}
+.css-40 {border-radius: 5px;}
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
@@ -1680,42 +1715,47 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
 .css-3>*:last-child {border-top-left-radius: 0; border-top-right-radius: 0;}
 .css-3>*:not(:first-child):not(:last-child) {border-radius: 0;}
 .css-3>*:not(:last-child) {border-bottom: 1px solid var(--vscode-dropdown-border);}
-.css-36 svg {fill: var(--vscode-foreground);}
-.css-36 {padding: 4px;}
-.css-32 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-contrastBorder, var(--vscode-button-background)); height: 40px; width: 100%; cursor: pointer; font-family: "GilmerMedium"; font-size: 14px;}
-.css-32:hover {border: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-button-background)); border-radius: 8px;}
+.css-39 svg {fill: var(--vscode-foreground);}
+.css-39 {padding: 4px;}
+.css-35 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-contrastBorder, var(--vscode-button-background)); height: 40px; width: 100%; cursor: pointer; font-family: "GilmerMedium"; font-size: 14px;}
+.css-35:hover {border: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-button-background)); border-radius: 8px;}
 .css-19 {margin-bottom: -2px;}
 .css-18 {display: flex; height: fit-content; width: fit-content;}
 .css-12 svg {fill: var(--vscode-foreground);}
 .css-12 {width: 24px; height: 24px; font-size: 24px;}
-.css-29 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #3d7eff; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
-.css-41::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
+.css-32 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #3d7eff; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
+.css-44::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
 .css-16 {font-size: 12px; max-width: 136px; overflow: hidden; text-overflow: ellipsis; font-family: monospace; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; color: var(--vscode-foreground); opacity: 0.7;}
 .css-25 {font-size: 14px; max-width: 160px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
-.css-40 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
-.css-38 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
-.css-34 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
+.css-43 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
+.css-41 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
+.css-37 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
 .css-11 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); aspect-ratio: 1/1;}
 .css-2 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
-.css-39 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
+.css-29 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
+.css-42 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-23 >div:first-child {width: 24px; height: 24px; font-size: 24px;}
 .css-23 svg {fill: var(--vscode-foreground);}
 .css-23 {padding: 4px; max-width: 32px;}
 .css-17 {border-radius: 5px;}
-.css-35 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
+.css-38 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
 .css-22 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 56px; cursor: pointer;}
 .css-22:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
-.css-30 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #49cc90; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
-.css-28 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 40px; cursor: pointer; padding: 0 12px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background);}
-.css-28:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
+.css-33 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #49cc90; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
+.css-27 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 40px; cursor: pointer; padding: 0 12px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background);}
+.css-27:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
 .css-7 {position: absolute; -webkit-touch-callout: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; cursor: move; pointer-events: all;}
 .css-15 {font-size: 14px; max-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-13 {height: 16px; width: 14px; cursor: pointer;}
 .css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; gap: 6px; width: 100%; cursor: pointer;}
-.css-33 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
+.css-36 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
 .css-0 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 8px; position: absolute; left: 12px; bottom: 12px; z-index: 1000;}
+.css-28 >div:first-child {width: 16px; height: 16px; font-size: 16px;}
+.css-28 svg {fill: var(--vscode-foreground);}
+.css-28 {display: flex; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
+.css-30 {font-size: 12px; margin-left: auto; max-width: 90px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; color: var(--vscode-foreground); opacity: 0.7;}
 .css-10 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; width: 100%; cursor: pointer;}
-.css-27 {height: 16px; width: 14px; cursor: pointer; color: #e535ab;}
+.css-31 {height: 16px; width: 14px; cursor: pointer; color: #e535ab;}
 
 /* DOM */
 <div>
@@ -2139,15 +2179,45 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                   </vscode-button>
                 </div>
               </div>
+              <div
+                class="css-20"
+              >
+                <div
+                  class="css-27"
+                  title="Handles a single conversational turn with the agent"
+                >
+                  <div
+                    class="css-28"
+                  >
+                    <div
+                      class="css-29"
+                    >
+                      <i
+                        class="fw-bi-chat"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="css-25"
+                  >
+                    Agent Chat
+                  </div>
+                  <div
+                    class="css-30"
+                  >
+                    Chat
+                  </div>
+                </div>
+                <div
+                  class="port "
+                  data-name="post-chat"
+                />
+              </div>
             </div>
             <div />
             <div
               class="port css-19"
               data-name="out"
-            />
-            <div
-              class="port css-19"
-              data-name="post-chat"
             />
           </div>
         </div>
@@ -2172,7 +2242,7 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                   class="css-23"
                 >
                   <div
-                    class="css-27"
+                    class="css-31"
                   >
                     <i
                       class="fw-bi-graphql"
@@ -2290,10 +2360,10 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 class="css-20"
               >
                 <div
-                  class="css-28"
+                  class="css-27"
                 >
                   <div
-                    class="css-29"
+                    class="css-32"
                     color="#3d7eff"
                   >
                     get
@@ -2313,10 +2383,10 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 class="css-20"
               >
                 <div
-                  class="css-28"
+                  class="css-27"
                 >
                   <div
-                    class="css-30"
+                    class="css-33"
                     color="#49cc90"
                   >
                     post
@@ -2333,10 +2403,10 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 />
               </div>
               <div
-                class="css-31"
+                class="css-34"
               >
                 <div
-                  class="css-32"
+                  class="css-35"
                 >
                   Show More Resources
                 </div>
@@ -2434,20 +2504,20 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
           style="top: 100px; left: 250px;"
         >
           <div
-            class="css-33"
+            class="css-36"
           >
             <div
-              class="css-34"
+              class="css-37"
             >
               <div
-                class="css-35"
+                class="css-38"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-36"
+                  class="css-39"
                 >
                   <svg
                     height="24"
@@ -2472,7 +2542,7 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 />
               </div>
               <div
-                class="css-37 css-18"
+                class="css-40 css-18"
               >
                 <vscode-button>
                   <svg
@@ -2493,10 +2563,10 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 </vscode-button>
               </div>
               <div
-                class="css-38"
+                class="css-41"
               >
                 <div
-                  class="css-39"
+                  class="css-42"
                 />
                 <div
                   class="css-16"
@@ -2513,20 +2583,20 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
           style="top: 244px; left: 250px;"
         >
           <div
-            class="css-33"
+            class="css-36"
           >
             <div
-              class="css-34"
+              class="css-37"
             >
               <div
-                class="css-35"
+                class="css-38"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-36"
+                  class="css-39"
                 >
                   <svg
                     height="24"
@@ -2551,7 +2621,7 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 />
               </div>
               <div
-                class="css-37 css-18"
+                class="css-40 css-18"
               >
                 <vscode-button>
                   <svg
@@ -2572,10 +2642,10 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 </vscode-button>
               </div>
               <div
-                class="css-38"
+                class="css-41"
               >
                 <div
-                  class="css-39"
+                  class="css-42"
                 />
                 <div
                   class="css-16"
@@ -2592,20 +2662,20 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
           style="top: 340px; left: 250px;"
         >
           <div
-            class="css-33"
+            class="css-36"
           >
             <div
-              class="css-34"
+              class="css-37"
             >
               <div
-                class="css-35"
+                class="css-38"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-36"
+                  class="css-39"
                 >
                   <svg
                     height="24"
@@ -2630,7 +2700,7 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 />
               </div>
               <div
-                class="css-37 css-18"
+                class="css-40 css-18"
               >
                 <vscode-button>
                   <svg
@@ -2651,10 +2721,10 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 </vscode-button>
               </div>
               <div
-                class="css-38"
+                class="css-41"
               >
                 <div
-                  class="css-39"
+                  class="css-42"
                 />
                 <div
                   class="css-16"
@@ -2675,11 +2745,11 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
           color="var(--vscode-foreground)"
         >
           <div
-            class="css-40"
+            class="css-43"
           >
             <vscode-progress-ring
               aria-live="assertive"
-              class="css-41"
+              class="css-44"
               color="var(--vscode-contrastBorder, var(--vscode-button-background))"
               role="alert"
             />
@@ -2700,11 +2770,11 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
 .css-4 svg:first-child {z-index: 1;}
 .css-4 {height: 100%; -webkit-background-size: 16px 16px; background-size: 16px 16px; display: flex; background-image: radial-gradient(var(--vscode-editor-inactiveSelectionBackground) 10%, transparent 0px); font-family: "GilmerRegular";}
 .css-26 {font-size: 12px; max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; color: var(--vscode-foreground); opacity: 0.7;}
-.css-31 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 100%;}
+.css-34 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 100%;}
 .css-9 {margin-top: -3px;}
 .css-5 {position: relative; cursor: move; overflow: hidden;}
 .css-20 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-foreground);}
-.css-37 {border-radius: 5px;}
+.css-40 {border-radius: 5px;}
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
@@ -2714,42 +2784,47 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
 .css-3>*:last-child {border-top-left-radius: 0; border-top-right-radius: 0;}
 .css-3>*:not(:first-child):not(:last-child) {border-radius: 0;}
 .css-3>*:not(:last-child) {border-bottom: 1px solid var(--vscode-dropdown-border);}
-.css-36 svg {fill: var(--vscode-foreground);}
-.css-36 {padding: 4px;}
-.css-32 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-contrastBorder, var(--vscode-button-background)); height: 40px; width: 100%; cursor: pointer; font-family: "GilmerMedium"; font-size: 14px;}
-.css-32:hover {border: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-button-background)); border-radius: 8px;}
+.css-39 svg {fill: var(--vscode-foreground);}
+.css-39 {padding: 4px;}
+.css-35 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-contrastBorder, var(--vscode-button-background)); height: 40px; width: 100%; cursor: pointer; font-family: "GilmerMedium"; font-size: 14px;}
+.css-35:hover {border: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-button-background)); border-radius: 8px;}
 .css-19 {margin-bottom: -2px;}
 .css-18 {display: flex; height: fit-content; width: fit-content;}
 .css-12 svg {fill: var(--vscode-foreground);}
 .css-12 {width: 24px; height: 24px; font-size: 24px;}
-.css-29 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #3d7eff; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
-.css-41::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
+.css-32 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #3d7eff; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
+.css-44::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
 .css-16 {font-size: 12px; max-width: 136px; overflow: hidden; text-overflow: ellipsis; font-family: monospace; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; color: var(--vscode-foreground); opacity: 0.7;}
 .css-25 {font-size: 14px; max-width: 160px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
-.css-40 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
-.css-38 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
-.css-34 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
+.css-43 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
+.css-41 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
+.css-37 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
 .css-11 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); aspect-ratio: 1/1;}
 .css-2 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
-.css-39 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
+.css-29 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
+.css-42 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-23 >div:first-child {width: 24px; height: 24px; font-size: 24px;}
 .css-23 svg {fill: var(--vscode-foreground);}
 .css-23 {padding: 4px; max-width: 32px;}
 .css-17 {border-radius: 5px;}
-.css-35 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
+.css-38 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
 .css-22 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 56px; cursor: pointer;}
 .css-22:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
-.css-30 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #49cc90; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
-.css-28 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 40px; cursor: pointer; padding: 0 12px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background);}
-.css-28:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
+.css-33 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #49cc90; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
+.css-27 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 40px; cursor: pointer; padding: 0 12px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background);}
+.css-27:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
 .css-7 {position: absolute; -webkit-touch-callout: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; cursor: move; pointer-events: all;}
 .css-15 {font-size: 14px; max-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-13 {height: 16px; width: 14px; cursor: pointer;}
 .css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; gap: 6px; width: 100%; cursor: pointer;}
-.css-33 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
+.css-36 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
 .css-0 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 8px; position: absolute; left: 12px; bottom: 12px; z-index: 1000;}
+.css-28 >div:first-child {width: 16px; height: 16px; font-size: 16px;}
+.css-28 svg {fill: var(--vscode-foreground);}
+.css-28 {display: flex; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
+.css-30 {font-size: 12px; margin-left: auto; max-width: 90px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; color: var(--vscode-foreground); opacity: 0.7;}
 .css-10 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; width: 100%; cursor: pointer;}
-.css-27 {height: 16px; width: 14px; cursor: pointer; color: #e535ab;}
+.css-31 {height: 16px; width: 14px; cursor: pointer; color: #e535ab;}
 
 /* DOM */
 <div>
@@ -3173,15 +3248,45 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                   </vscode-button>
                 </div>
               </div>
+              <div
+                class="css-20"
+              >
+                <div
+                  class="css-27"
+                  title="Handles a single conversational turn with the agent"
+                >
+                  <div
+                    class="css-28"
+                  >
+                    <div
+                      class="css-29"
+                    >
+                      <i
+                        class="fw-bi-chat"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="css-25"
+                  >
+                    Agent Chat
+                  </div>
+                  <div
+                    class="css-30"
+                  >
+                    Chat
+                  </div>
+                </div>
+                <div
+                  class="port "
+                  data-name="post-chat"
+                />
+              </div>
             </div>
             <div />
             <div
               class="port css-19"
               data-name="out"
-            />
-            <div
-              class="port css-19"
-              data-name="post-chat"
             />
           </div>
         </div>
@@ -3206,7 +3311,7 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                   class="css-23"
                 >
                   <div
-                    class="css-27"
+                    class="css-31"
                   >
                     <i
                       class="fw-bi-graphql"
@@ -3324,10 +3429,10 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 class="css-20"
               >
                 <div
-                  class="css-28"
+                  class="css-27"
                 >
                   <div
-                    class="css-29"
+                    class="css-32"
                     color="#3d7eff"
                   >
                     get
@@ -3347,10 +3452,10 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 class="css-20"
               >
                 <div
-                  class="css-28"
+                  class="css-27"
                 >
                   <div
-                    class="css-30"
+                    class="css-33"
                     color="#49cc90"
                   >
                     post
@@ -3367,10 +3472,10 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 />
               </div>
               <div
-                class="css-31"
+                class="css-34"
               >
                 <div
-                  class="css-32"
+                  class="css-35"
                 >
                   Show More Resources
                 </div>
@@ -3468,20 +3573,20 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
           style="top: 100px; left: 250px;"
         >
           <div
-            class="css-33"
+            class="css-36"
           >
             <div
-              class="css-34"
+              class="css-37"
             >
               <div
-                class="css-35"
+                class="css-38"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-36"
+                  class="css-39"
                 >
                   <svg
                     height="24"
@@ -3506,7 +3611,7 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 />
               </div>
               <div
-                class="css-37 css-18"
+                class="css-40 css-18"
               >
                 <vscode-button>
                   <svg
@@ -3527,10 +3632,10 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 </vscode-button>
               </div>
               <div
-                class="css-38"
+                class="css-41"
               >
                 <div
-                  class="css-39"
+                  class="css-42"
                 />
                 <div
                   class="css-16"
@@ -3547,20 +3652,20 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
           style="top: 244px; left: 250px;"
         >
           <div
-            class="css-33"
+            class="css-36"
           >
             <div
-              class="css-34"
+              class="css-37"
             >
               <div
-                class="css-35"
+                class="css-38"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-36"
+                  class="css-39"
                 >
                   <svg
                     height="24"
@@ -3585,7 +3690,7 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 />
               </div>
               <div
-                class="css-37 css-18"
+                class="css-40 css-18"
               >
                 <vscode-button>
                   <svg
@@ -3606,10 +3711,10 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 </vscode-button>
               </div>
               <div
-                class="css-38"
+                class="css-41"
               >
                 <div
-                  class="css-39"
+                  class="css-42"
                 />
                 <div
                   class="css-16"
@@ -3626,20 +3731,20 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
           style="top: 340px; left: 250px;"
         >
           <div
-            class="css-33"
+            class="css-36"
           >
             <div
-              class="css-34"
+              class="css-37"
             >
               <div
-                class="css-35"
+                class="css-38"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-36"
+                  class="css-39"
                 >
                   <svg
                     height="24"
@@ -3664,7 +3769,7 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 />
               </div>
               <div
-                class="css-37 css-18"
+                class="css-40 css-18"
               >
                 <vscode-button>
                   <svg
@@ -3685,10 +3790,10 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 </vscode-button>
               </div>
               <div
-                class="css-38"
+                class="css-41"
               >
                 <div
-                  class="css-39"
+                  class="css-42"
                 />
                 <div
                   class="css-16"
@@ -3709,11 +3814,11 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
           color="var(--vscode-foreground)"
         >
           <div
-            class="css-40"
+            class="css-43"
           >
             <vscode-progress-ring
               aria-live="assertive"
-              class="css-41"
+              class="css-44"
               color="var(--vscode-contrastBorder, var(--vscode-button-background))"
               role="alert"
             />

--- a/packages/component-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
+++ b/packages/component-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
 .css-9 {margin-top: -3px;}
 .css-5 {position: relative; cursor: move; overflow: hidden;}
 .css-20 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-foreground);}
-.css-39 {border-radius: 5px;}
+.css-36 {border-radius: 5px;}
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
@@ -23,8 +23,8 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
 .css-3>*:last-child {border-top-left-radius: 0; border-top-right-radius: 0;}
 .css-3>*:not(:first-child):not(:last-child) {border-radius: 0;}
 .css-3>*:not(:last-child) {border-bottom: 1px solid var(--vscode-dropdown-border);}
-.css-38 svg {fill: var(--vscode-foreground);}
-.css-38 {padding: 4px;}
+.css-35 svg {fill: var(--vscode-foreground);}
+.css-35 {padding: 4px;}
 .css-31 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-contrastBorder, var(--vscode-button-background)); height: 40px; width: 100%; cursor: pointer; font-family: "GilmerMedium"; font-size: 14px;}
 .css-31:hover {border: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-button-background)); border-radius: 8px;}
 .css-19 {margin-bottom: -2px;}
@@ -32,21 +32,20 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
 .css-12 svg {fill: var(--vscode-foreground);}
 .css-12 {width: 24px; height: 24px; font-size: 24px;}
 .css-28 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #3d7eff; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
-.css-43::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
+.css-40::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
 .css-16 {font-size: 12px; max-width: 136px; overflow: hidden; text-overflow: ellipsis; font-family: monospace; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; color: var(--vscode-foreground); opacity: 0.7;}
 .css-25 {font-size: 14px; max-width: 160px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
-.css-42 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
-.css-40 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
-.css-36 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
+.css-39 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
+.css-37 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
+.css-33 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
 .css-11 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); aspect-ratio: 1/1;}
 .css-2 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
-.css-33 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
-.css-41 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
+.css-38 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-23 >div:first-child {width: 24px; height: 24px; font-size: 24px;}
 .css-23 svg {fill: var(--vscode-foreground);}
 .css-23 {padding: 4px; max-width: 32px;}
 .css-17 {border-radius: 5px;}
-.css-37 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
+.css-34 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
 .css-22 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 56px; cursor: pointer;}
 .css-22:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
 .css-29 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #49cc90; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
@@ -56,12 +55,8 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
 .css-15 {font-size: 14px; max-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-13 {height: 16px; width: 14px; cursor: pointer;}
 .css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; gap: 6px; width: 100%; cursor: pointer;}
-.css-35 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
+.css-32 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
 .css-0 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 8px; position: absolute; left: 12px; bottom: 12px; z-index: 1000;}
-.css-32 >div:first-child {width: 16px; height: 16px; font-size: 16px;}
-.css-32 svg {fill: var(--vscode-foreground);}
-.css-32 {display: flex; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
-.css-34 {font-size: 12px; margin-left: auto; max-width: 90px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; color: var(--vscode-foreground); opacity: 0.7;}
 .css-10 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; width: 100%; cursor: pointer;}
 
 /* DOM */
@@ -569,28 +564,17 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
               >
                 <div
                   class="css-27"
-                  title="Handles a single conversational turn with the agent"
                 >
                   <div
-                    class="css-32"
+                    class="css-29"
+                    color="#49cc90"
                   >
-                    <div
-                      class="css-33"
-                    >
-                      <i
-                        class="fw-bi-chat"
-                      />
-                    </div>
+                    post
                   </div>
                   <div
                     class="css-25"
                   >
-                    Agent Chat
-                  </div>
-                  <div
-                    class="css-34"
-                  >
-                    Chat
+                    /chat
                   </div>
                 </div>
                 <div
@@ -687,20 +671,20 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
           style="top: 332px; left: 250px;"
         >
           <div
-            class="css-35"
+            class="css-32"
           >
             <div
-              class="css-36"
+              class="css-33"
             >
               <div
-                class="css-37"
+                class="css-34"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-38"
+                  class="css-35"
                 >
                   <svg
                     height="24"
@@ -725,7 +709,7 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
                 />
               </div>
               <div
-                class="css-39 css-18"
+                class="css-36 css-18"
               >
                 <vscode-button>
                   <svg
@@ -746,10 +730,10 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
                 </vscode-button>
               </div>
               <div
-                class="css-40"
+                class="css-37"
               >
                 <div
-                  class="css-41"
+                  class="css-38"
                 />
                 <div
                   class="css-16"
@@ -766,20 +750,20 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
           style="top: 100px; left: 250px;"
         >
           <div
-            class="css-35"
+            class="css-32"
           >
             <div
-              class="css-36"
+              class="css-33"
             >
               <div
-                class="css-37"
+                class="css-34"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-38"
+                  class="css-35"
                 >
                   <svg
                     height="24"
@@ -804,7 +788,7 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
                 />
               </div>
               <div
-                class="css-39 css-18"
+                class="css-36 css-18"
               >
                 <vscode-button>
                   <svg
@@ -825,10 +809,10 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
                 </vscode-button>
               </div>
               <div
-                class="css-40"
+                class="css-37"
               >
                 <div
-                  class="css-41"
+                  class="css-38"
                 />
                 <div
                   class="css-16"
@@ -849,11 +833,11 @@ exports[`Component Diagram - Snapshot Tests renders ai agent complex correctly: 
           color="var(--vscode-foreground)"
         >
           <div
-            class="css-42"
+            class="css-39"
           >
             <vscode-progress-ring
               aria-live="assertive"
-              class="css-43"
+              class="css-40"
               color="var(--vscode-contrastBorder, var(--vscode-button-background))"
               role="alert"
             />
@@ -1701,11 +1685,11 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
 .css-4 svg:first-child {z-index: 1;}
 .css-4 {height: 100%; -webkit-background-size: 16px 16px; background-size: 16px 16px; display: flex; background-image: radial-gradient(var(--vscode-editor-inactiveSelectionBackground) 10%, transparent 0px); font-family: "GilmerRegular";}
 .css-26 {font-size: 12px; max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; color: var(--vscode-foreground); opacity: 0.7;}
-.css-34 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 100%;}
+.css-31 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 100%;}
 .css-9 {margin-top: -3px;}
 .css-5 {position: relative; cursor: move; overflow: hidden;}
 .css-20 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-foreground);}
-.css-40 {border-radius: 5px;}
+.css-37 {border-radius: 5px;}
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
@@ -1715,47 +1699,42 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
 .css-3>*:last-child {border-top-left-radius: 0; border-top-right-radius: 0;}
 .css-3>*:not(:first-child):not(:last-child) {border-radius: 0;}
 .css-3>*:not(:last-child) {border-bottom: 1px solid var(--vscode-dropdown-border);}
-.css-39 svg {fill: var(--vscode-foreground);}
-.css-39 {padding: 4px;}
-.css-35 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-contrastBorder, var(--vscode-button-background)); height: 40px; width: 100%; cursor: pointer; font-family: "GilmerMedium"; font-size: 14px;}
-.css-35:hover {border: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-button-background)); border-radius: 8px;}
+.css-36 svg {fill: var(--vscode-foreground);}
+.css-36 {padding: 4px;}
+.css-32 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-contrastBorder, var(--vscode-button-background)); height: 40px; width: 100%; cursor: pointer; font-family: "GilmerMedium"; font-size: 14px;}
+.css-32:hover {border: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-button-background)); border-radius: 8px;}
 .css-19 {margin-bottom: -2px;}
 .css-18 {display: flex; height: fit-content; width: fit-content;}
 .css-12 svg {fill: var(--vscode-foreground);}
 .css-12 {width: 24px; height: 24px; font-size: 24px;}
-.css-32 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #3d7eff; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
-.css-44::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
+.css-30 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #3d7eff; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
+.css-41::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
 .css-16 {font-size: 12px; max-width: 136px; overflow: hidden; text-overflow: ellipsis; font-family: monospace; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; color: var(--vscode-foreground); opacity: 0.7;}
 .css-25 {font-size: 14px; max-width: 160px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
-.css-43 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
-.css-41 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
-.css-37 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
+.css-40 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
+.css-38 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
+.css-34 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
 .css-11 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); aspect-ratio: 1/1;}
 .css-2 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
-.css-29 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
-.css-42 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
+.css-39 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-23 >div:first-child {width: 24px; height: 24px; font-size: 24px;}
 .css-23 svg {fill: var(--vscode-foreground);}
 .css-23 {padding: 4px; max-width: 32px;}
 .css-17 {border-radius: 5px;}
-.css-38 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
+.css-35 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
 .css-22 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 56px; cursor: pointer;}
 .css-22:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
-.css-33 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #49cc90; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
+.css-28 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #49cc90; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
 .css-27 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 40px; cursor: pointer; padding: 0 12px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background);}
 .css-27:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
 .css-7 {position: absolute; -webkit-touch-callout: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; cursor: move; pointer-events: all;}
 .css-15 {font-size: 14px; max-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-13 {height: 16px; width: 14px; cursor: pointer;}
 .css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; gap: 6px; width: 100%; cursor: pointer;}
-.css-36 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
+.css-33 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
 .css-0 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 8px; position: absolute; left: 12px; bottom: 12px; z-index: 1000;}
-.css-28 >div:first-child {width: 16px; height: 16px; font-size: 16px;}
-.css-28 svg {fill: var(--vscode-foreground);}
-.css-28 {display: flex; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
-.css-30 {font-size: 12px; margin-left: auto; max-width: 90px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; color: var(--vscode-foreground); opacity: 0.7;}
 .css-10 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; width: 100%; cursor: pointer;}
-.css-31 {height: 16px; width: 14px; cursor: pointer; color: #e535ab;}
+.css-29 {height: 16px; width: 14px; cursor: pointer; color: #e535ab;}
 
 /* DOM */
 <div>
@@ -2184,28 +2163,17 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
               >
                 <div
                   class="css-27"
-                  title="Handles a single conversational turn with the agent"
                 >
                   <div
                     class="css-28"
+                    color="#49cc90"
                   >
-                    <div
-                      class="css-29"
-                    >
-                      <i
-                        class="fw-bi-chat"
-                      />
-                    </div>
+                    post
                   </div>
                   <div
                     class="css-25"
                   >
-                    Agent Chat
-                  </div>
-                  <div
-                    class="css-30"
-                  >
-                    Chat
+                    /chat
                   </div>
                 </div>
                 <div
@@ -2242,7 +2210,7 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                   class="css-23"
                 >
                   <div
-                    class="css-31"
+                    class="css-29"
                   >
                     <i
                       class="fw-bi-graphql"
@@ -2363,7 +2331,7 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                   class="css-27"
                 >
                   <div
-                    class="css-32"
+                    class="css-30"
                     color="#3d7eff"
                   >
                     get
@@ -2386,7 +2354,7 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                   class="css-27"
                 >
                   <div
-                    class="css-33"
+                    class="css-28"
                     color="#49cc90"
                   >
                     post
@@ -2403,10 +2371,10 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 />
               </div>
               <div
-                class="css-34"
+                class="css-31"
               >
                 <div
-                  class="css-35"
+                  class="css-32"
                 >
                   Show More Resources
                 </div>
@@ -2504,20 +2472,20 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
           style="top: 100px; left: 250px;"
         >
           <div
-            class="css-36"
+            class="css-33"
           >
             <div
-              class="css-37"
+              class="css-34"
             >
               <div
-                class="css-38"
+                class="css-35"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-39"
+                  class="css-36"
                 >
                   <svg
                     height="24"
@@ -2542,7 +2510,7 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 />
               </div>
               <div
-                class="css-40 css-18"
+                class="css-37 css-18"
               >
                 <vscode-button>
                   <svg
@@ -2563,10 +2531,10 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 </vscode-button>
               </div>
               <div
-                class="css-41"
+                class="css-38"
               >
                 <div
-                  class="css-42"
+                  class="css-39"
                 />
                 <div
                   class="css-16"
@@ -2583,20 +2551,20 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
           style="top: 244px; left: 250px;"
         >
           <div
-            class="css-36"
+            class="css-33"
           >
             <div
-              class="css-37"
+              class="css-34"
             >
               <div
-                class="css-38"
+                class="css-35"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-39"
+                  class="css-36"
                 >
                   <svg
                     height="24"
@@ -2621,7 +2589,7 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 />
               </div>
               <div
-                class="css-40 css-18"
+                class="css-37 css-18"
               >
                 <vscode-button>
                   <svg
@@ -2642,10 +2610,10 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 </vscode-button>
               </div>
               <div
-                class="css-41"
+                class="css-38"
               >
                 <div
-                  class="css-42"
+                  class="css-39"
                 />
                 <div
                   class="css-16"
@@ -2662,20 +2630,20 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
           style="top: 340px; left: 250px;"
         >
           <div
-            class="css-36"
+            class="css-33"
           >
             <div
-              class="css-37"
+              class="css-34"
             >
               <div
-                class="css-38"
+                class="css-35"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-39"
+                  class="css-36"
                 >
                   <svg
                     height="24"
@@ -2700,7 +2668,7 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 />
               </div>
               <div
-                class="css-40 css-18"
+                class="css-37 css-18"
               >
                 <vscode-button>
                   <svg
@@ -2721,10 +2689,10 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
                 </vscode-button>
               </div>
               <div
-                class="css-41"
+                class="css-38"
               >
                 <div
-                  class="css-42"
+                  class="css-39"
                 />
                 <div
                   class="css-16"
@@ -2745,11 +2713,11 @@ exports[`Component Diagram - Snapshot Tests renders graphql complex correctly: g
           color="var(--vscode-foreground)"
         >
           <div
-            class="css-43"
+            class="css-40"
           >
             <vscode-progress-ring
               aria-live="assertive"
-              class="css-44"
+              class="css-41"
               color="var(--vscode-contrastBorder, var(--vscode-button-background))"
               role="alert"
             />
@@ -2770,11 +2738,11 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
 .css-4 svg:first-child {z-index: 1;}
 .css-4 {height: 100%; -webkit-background-size: 16px 16px; background-size: 16px 16px; display: flex; background-image: radial-gradient(var(--vscode-editor-inactiveSelectionBackground) 10%, transparent 0px); font-family: "GilmerRegular";}
 .css-26 {font-size: 12px; max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; color: var(--vscode-foreground); opacity: 0.7;}
-.css-34 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 100%;}
+.css-31 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 100%;}
 .css-9 {margin-top: -3px;}
 .css-5 {position: relative; cursor: move; overflow: hidden;}
 .css-20 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-foreground);}
-.css-40 {border-radius: 5px;}
+.css-37 {border-radius: 5px;}
 .css-1 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; padding: 8px; border-radius: 4px; background-color: var(--vscode-sideBar-background); fill: var(--vscode-foreground); width: 32px; height: 32px; cursor: pointer;}
 .css-1:active {background-color: var(--vscode-editor-inactiveSelectionBackground);}
 .css-1:hover {background-color: var(--vscode-editor-inactiveSelectionBackground);}
@@ -2784,47 +2752,42 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
 .css-3>*:last-child {border-top-left-radius: 0; border-top-right-radius: 0;}
 .css-3>*:not(:first-child):not(:last-child) {border-radius: 0;}
 .css-3>*:not(:last-child) {border-bottom: 1px solid var(--vscode-dropdown-border);}
-.css-39 svg {fill: var(--vscode-foreground);}
-.css-39 {padding: 4px;}
-.css-35 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-contrastBorder, var(--vscode-button-background)); height: 40px; width: 100%; cursor: pointer; font-family: "GilmerMedium"; font-size: 14px;}
-.css-35:hover {border: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-button-background)); border-radius: 8px;}
+.css-36 svg {fill: var(--vscode-foreground);}
+.css-36 {padding: 4px;}
+.css-32 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-contrastBorder, var(--vscode-button-background)); height: 40px; width: 100%; cursor: pointer; font-family: "GilmerMedium"; font-size: 14px;}
+.css-32:hover {border: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-button-background)); border-radius: 8px;}
 .css-19 {margin-bottom: -2px;}
 .css-18 {display: flex; height: fit-content; width: fit-content;}
 .css-12 svg {fill: var(--vscode-foreground);}
 .css-12 {width: 24px; height: 24px; font-size: 24px;}
-.css-32 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #3d7eff; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
-.css-44::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
+.css-30 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #3d7eff; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
+.css-41::part(indeterminate-indicator-1) {stroke: var(--vscode-contrastBorder, var(--vscode-button-background));}
 .css-16 {font-size: 12px; max-width: 136px; overflow: hidden; text-overflow: ellipsis; font-family: monospace; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; color: var(--vscode-foreground); opacity: 0.7;}
 .css-25 {font-size: 14px; max-width: 160px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
-.css-43 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
-.css-41 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
-.css-37 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
+.css-40 {-webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; height: 100%; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; width: 100%; background-color: var(--vscode-menu-background); z-index: 1000;}
+.css-38 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: flex-end; -webkit-box-align: flex-end; -ms-flex-align: flex-end; align-items: flex-end; gap: 6px;}
+.css-34 {display: flex; -webkit-flex-direction: row-reverse; -ms-flex-direction: row-reverse; flex-direction: row-reverse; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; cursor: pointer;}
 .css-11 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); aspect-ratio: 1/1;}
 .css-2 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
-.css-29 {height: 16px; width: 16px; cursor: pointer; font-size: 16px;}
-.css-42 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
+.css-39 {font-size: 14px; max-width: 136px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-23 >div:first-child {width: 24px; height: 24px; font-size: 24px;}
 .css-23 svg {fill: var(--vscode-foreground);}
 .css-23 {padding: 4px; max-width: 32px;}
 .css-17 {border-radius: 5px;}
-.css-38 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
+.css-35 {display: flex; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 64px; height: 64px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 50%; background-color: var(--vscode-menu-background); color: var(--vscode-foreground);}
 .css-22 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 56px; cursor: pointer;}
 .css-22:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
-.css-33 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #49cc90; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
+.css-28 {font-size: 12px; text-transform: uppercase; font-family: "GilmerBold"; background-color: #49cc90; color: #FFF; padding: 4px 8px; border-radius: 4px; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; min-width: 60px; text-align: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; font-weight: bold;}
 .css-27 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 10px; width: 240px; height: 40px; cursor: pointer; padding: 0 12px; border: 1.5px solid var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background);}
 .css-27:hover {background-color: var(--vscode-sideBar-background); border-radius: 8px;}
 .css-7 {position: absolute; -webkit-touch-callout: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; cursor: move; pointer-events: all;}
 .css-15 {font-size: 14px; max-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground); opacity: 1;}
 .css-13 {height: 16px; width: 14px; cursor: pointer;}
 .css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; gap: 6px; width: 100%; cursor: pointer;}
-.css-36 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
+.css-33 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: end; -ms-flex-pack: end; -webkit-justify-content: flex-end; justify-content: flex-end; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; height: 64px; width: 200px; color: var(--vscode-foreground);}
 .css-0 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; gap: 8px; position: absolute; left: 12px; bottom: 12px; z-index: 1000;}
-.css-28 >div:first-child {width: 16px; height: 16px; font-size: 16px;}
-.css-28 svg {fill: var(--vscode-foreground);}
-.css-28 {display: flex; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;}
-.css-30 {font-size: 12px; margin-left: auto; max-width: 90px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; color: var(--vscode-foreground); opacity: 0.7;}
 .css-10 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 12px; width: 100%; cursor: pointer;}
-.css-31 {height: 16px; width: 14px; cursor: pointer; color: #e535ab;}
+.css-29 {height: 16px; width: 14px; cursor: pointer; color: #e535ab;}
 
 /* DOM */
 <div>
@@ -3253,28 +3216,17 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
               >
                 <div
                   class="css-27"
-                  title="Handles a single conversational turn with the agent"
                 >
                   <div
                     class="css-28"
+                    color="#49cc90"
                   >
-                    <div
-                      class="css-29"
-                    >
-                      <i
-                        class="fw-bi-chat"
-                      />
-                    </div>
+                    post
                   </div>
                   <div
                     class="css-25"
                   >
-                    Agent Chat
-                  </div>
-                  <div
-                    class="css-30"
-                  >
-                    Chat
+                    /chat
                   </div>
                 </div>
                 <div
@@ -3311,7 +3263,7 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                   class="css-23"
                 >
                   <div
-                    class="css-31"
+                    class="css-29"
                   >
                     <i
                       class="fw-bi-graphql"
@@ -3432,7 +3384,7 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                   class="css-27"
                 >
                   <div
-                    class="css-32"
+                    class="css-30"
                     color="#3d7eff"
                   >
                     get
@@ -3455,7 +3407,7 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                   class="css-27"
                 >
                   <div
-                    class="css-33"
+                    class="css-28"
                     color="#49cc90"
                   >
                     post
@@ -3472,10 +3424,10 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 />
               </div>
               <div
-                class="css-34"
+                class="css-31"
               >
                 <div
-                  class="css-35"
+                  class="css-32"
                 >
                   Show More Resources
                 </div>
@@ -3573,20 +3525,20 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
           style="top: 100px; left: 250px;"
         >
           <div
-            class="css-36"
+            class="css-33"
           >
             <div
-              class="css-37"
+              class="css-34"
             >
               <div
-                class="css-38"
+                class="css-35"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-39"
+                  class="css-36"
                 >
                   <svg
                     height="24"
@@ -3611,7 +3563,7 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 />
               </div>
               <div
-                class="css-40 css-18"
+                class="css-37 css-18"
               >
                 <vscode-button>
                   <svg
@@ -3632,10 +3584,10 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 </vscode-button>
               </div>
               <div
-                class="css-41"
+                class="css-38"
               >
                 <div
-                  class="css-42"
+                  class="css-39"
                 />
                 <div
                   class="css-16"
@@ -3652,20 +3604,20 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
           style="top: 244px; left: 250px;"
         >
           <div
-            class="css-36"
+            class="css-33"
           >
             <div
-              class="css-37"
+              class="css-34"
             >
               <div
-                class="css-38"
+                class="css-35"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-39"
+                  class="css-36"
                 >
                   <svg
                     height="24"
@@ -3690,7 +3642,7 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 />
               </div>
               <div
-                class="css-40 css-18"
+                class="css-37 css-18"
               >
                 <vscode-button>
                   <svg
@@ -3711,10 +3663,10 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 </vscode-button>
               </div>
               <div
-                class="css-41"
+                class="css-38"
               >
                 <div
-                  class="css-42"
+                  class="css-39"
                 />
                 <div
                   class="css-16"
@@ -3731,20 +3683,20 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
           style="top: 340px; left: 250px;"
         >
           <div
-            class="css-36"
+            class="css-33"
           >
             <div
-              class="css-37"
+              class="css-34"
             >
               <div
-                class="css-38"
+                class="css-35"
               >
                 <div
                   class="port css-9"
                   data-name="in"
                 />
                 <div
-                  class="css-39"
+                  class="css-36"
                 >
                   <svg
                     height="24"
@@ -3769,7 +3721,7 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 />
               </div>
               <div
-                class="css-40 css-18"
+                class="css-37 css-18"
               >
                 <vscode-button>
                   <svg
@@ -3790,10 +3742,10 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
                 </vscode-button>
               </div>
               <div
-                class="css-41"
+                class="css-38"
               >
                 <div
-                  class="css-42"
+                  class="css-39"
                 />
                 <div
                   class="css-16"
@@ -3814,11 +3766,11 @@ exports[`Component Diagram - Snapshot Tests renders multiple connections complex
           color="var(--vscode-foreground)"
         >
           <div
-            class="css-43"
+            class="css-40"
           >
             <vscode-progress-ring
               aria-live="assertive"
-              class="css-44"
+              class="css-41"
               color="var(--vscode-contrastBorder, var(--vscode-button-background))"
               role="alert"
             />


### PR DESCRIPTION
## Purpose

the `decision` resource for human-in-the-loop chat agents was invisible everywhere in the low-code view — hidden in the project artifact tree, unreachable via click-to-navigate, and uneditable through the Service Designer.

- Stop hard-coding `ai` services to hide their resources / collapse navigation onto `chat`; treat them like any other service so `decision` is listed and clickable
- Show `chat` and `decision` as capability rows on the agent's diagram node; clicking the node opens the Service Designer, matching REST service navigation
- Add a "Human-in-the-Loop" action in the Service Designer that generates a correct `decision` resource, resolving the agent variable from the existing `chat` resource's body
- Fix the Service Designer crash when configuring a chat agent service (agentName is an add-time-only property with no input type)
- Fix resource extraction for `ai` services, previously misread as an object method named "post" instead of a resource
- Give `decision` the same Tracing/Chat title-bar actions as `chat` — the language server already tags both as chat-agent resources; only the frontend was singling out `chat`

Fixes https://github.com/wso2/product-integrator/issues/2271

## Preview

https://github.com/user-attachments/assets/5c3a10d2-8978-4075-b87b-5f62968f24e0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Exposes `chat` and `decision` resources for AI chat-agent services in Service Designer.
- Generates `decision` resources from the existing agent variable for human-in-the-loop workflows.
- Updates diagrams and title-bar actions for both agent resources.
- Improves AI resource extraction, routing, configuration stability, and source-generation error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->