### PR TITLE
Fix HITL config section blending into Advanced Configurations

### DIFF
--- a/packages/ballerina-side-panel/src/components/Form/index.tsx
+++ b/packages/ballerina-side-panel/src/components/Form/index.tsx
@@ -32,6 +32,7 @@ import {
     ProgressRing
 } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
+import { indentedFieldStyles } from "./styles";
 
 import { ExpressionFormField, FieldDerivation, FieldGroup, FormExpressionEditorProps, FormField, FormImports, FormValues } from "./types";
 import { FieldFactory } from "../editors/FieldFactory";
@@ -123,11 +124,7 @@ namespace S {
     // A field rendered indented under the field above it, so the two read as grouped (e.g. a
     // fixed-value input that belongs to the checkbox above it).
     export const IndentedRow = styled(Row)`
-        width: calc(100% - 14px);
-        margin-left: 14px;
-        padding-left: 10px;
-        border-left: 2px solid ${ThemeColors.OUTLINE_VARIANT};
-        box-sizing: border-box;
+        ${indentedFieldStyles}
     `;
 
     export const CategoryRow = styled.div<{ bottomBorder?: boolean; topBorder?: boolean }>`
@@ -1403,6 +1400,7 @@ export const Form = forwardRef((props: FormProps, _ref) => {
 
                     return renderedComponents;
                 })()}
+                {hasAdvanceFields && <S.GroupDivider />}
                 {hasAdvanceFields && (
                     <S.Row>
                         {optionalFieldsTitle}

--- a/packages/ballerina-side-panel/src/components/Form/styles.ts
+++ b/packages/ballerina-side-panel/src/components/Form/styles.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { css } from "@emotion/react";
+import { ThemeColors } from "@wso2/ui-toolkit";
+
+// A left border and indent that marks a field as belonging to the one above it. Used by both
+// Form's IndentedRow and CheckBoxConditionalEditor's revealed sub-field, so they stay visually
+// identical from one definition instead of two copies that could drift apart over time. This
+// file does not import from Form/index.tsx or the editors folder, so both of those files can
+// import from here without creating a circular import.
+export const indentedFieldStyles = css`
+    width: calc(100% - 14px);
+    margin-left: 14px;
+    padding-left: 10px;
+    border-left: 2px solid ${ThemeColors.OUTLINE_VARIANT};
+    box-sizing: border-box;
+`;

--- a/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/CheckBoxConditionalEditor.tsx
@@ -18,6 +18,7 @@
 
 import React, { useEffect, useState } from "react";
 import { FormField } from "../Form/types";
+import { indentedFieldStyles } from "../Form/styles";
 import { CheckBoxGroup, FormCheckBox } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
 import { FieldFactory } from "./FieldFactory";
@@ -35,11 +36,15 @@ const Form = styled.div`
     align-items: start;
 `;
 
+// Indents the revealed sub-fields under the checkbox that reveals them, so they read as
+// belonging to it. This is the same treatment Form/index.tsx's IndentedRow uses for a
+// fixed-value input that belongs to the checkbox above it.
 const FormSection = styled.div`
     display: grid;
     gap: 20px;
     width: 100%;
     align-items: start;
+    ${indentedFieldStyles}
 `;
 
 const Label = styled.div`


### PR DESCRIPTION
## Summary
- Add a divider before the "Advanced Configurations" toggle so it no longer visually blends into whatever field sits above it.
- Indent the "Approval Function" sub-field under the "Requires Approval" checkbox, reusing the same left-border/indent style as the form's existing `IndentedRow` (extracted into a small shared module so both use one definition instead of duplicated CSS).

Fixes wso2/product-integrator#2336

## Preview
https://github.com/user-attachments/assets/6cebf671-60e2-4f9f-bfbb-323e1c37d0c8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a divider before **Advanced Configurations** to clearly separate it from HITL settings.
- Indented the **Approval Function** field under **Requires Approval**.
- Shared indentation and left-border styles across related form components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->