### PR TITLE
Fix optional AutoCompleteEditor fields not being clearable

### DIFF
--- a/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
@@ -76,13 +76,16 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
                 items={field.items}
                 allowItemCreate={field.allowItemCreate ?? true}
                 required={!field.optional}
+                nullable={field.optional}
                 disabled={!field.editable}
                 onValueChange={(val: string) => {
-                    // Preserve existing value when Combobox fires with empty on blur (e.g., click away without selecting)
+                    // For optional fields, `nullable` makes the combobox send us `undefined` as soon as
+                    // the user clears the input. That is a real, intentional clear, so we let it through.
+                    // An empty string means something different: the combobox just fell back to it on
+                    // blur because the field was never touched (e.g. clicked in and out without typing).
+                    // Only that case should restore the old value, otherwise a real clear never sticks.
                     const currentValue = value ?? getValueForDropdown(field) ?? field.value;
-                    const newVal = (val === "" || val === undefined || val === null) && currentValue
-                        ? currentValue
-                        : val;
+                    const newVal = val === "" && currentValue ? currentValue : (val ?? "");
                     setValue(field.key, newVal);
                     field.onValueChange?.(newVal);
                     liveDiagnostics.onValueChange(newVal);


### PR DESCRIPTION
## Summary
- Optional `AUTOCOMPLETE` fields (e.g. the Agent Tool's Approval Function, an HTTP response's Media Type) could not be cleared back to empty once a value was picked or typed. Headless UI's Combobox reselects the previous value on blur unless `nullable` is set, so the field silently restored its old value.
- Pass `nullable` for optional fields so a genuine clear commits immediately, and only fall back to the previous value when Headless UI reports an empty string on a field that was never actually touched (e.g. click away without typing).

Fixes wso2/product-integrator#2270

## Preview

https://github.com/user-attachments/assets/05a4ed4a-826e-4152-afce-3e2236a7e36b

## Remarks
This is a common fix, not specific to the Approval Function field, it applies to every optional `AUTOCOMPLETE` field in the app. See [this issue comment](https://github.com/wso2/product-integrator/issues/2270#issuecomment-5558208023) for more details.

## Test plan
- [x] Agent Tool → Requires Approval → Approval Function: type/select a value, clear it, click away — field stays empty.
- [x] HTTP resource Response → Media Type: same clear/blur check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `AutoCompleteEditor` to support clearing optional fields after a value is entered or selected. Optional fields now pass `nullable`, and intentional clears remain empty while untouched fields retain their previous value on blur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->