### PR TITLE
Fix error when switching from boolean to expression

### DIFF
--- a/packages/ballerina-side-panel/src/components/editors/ExpressionField.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/ExpressionField.tsx
@@ -367,7 +367,7 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
             completions={completions}
             onChange={onChange}
             onBlur={onBlur}
-            value={value}
+            value={typeof value === "string" || value == null ? value : String(value)}
             sanitizedExpression={sanitizedExpression}
             rawExpression={rawExpression}
             fileName={fileName}

--- a/packages/ballerina-side-panel/src/components/editors/ExpressionField.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/ExpressionField.tsx
@@ -367,7 +367,7 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
             completions={completions}
             onChange={onChange}
             onBlur={onBlur}
-            value={typeof value === "string" || value == null ? value : String(value)}
+            value={value}
             sanitizedExpression={sanitizedExpression}
             rawExpression={rawExpression}
             fileName={fileName}

--- a/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
@@ -44,7 +44,7 @@ import {
     createTooltipPositioningHandlers,
     AVERAGE_HELPER_PANE_HEIGHT
 } from "../CodeUtils";
-import { correctTokenStreamPositions, normalizeEditorValue } from "../utils";
+import { coerceChipEditorValue, correctTokenStreamPositions, normalizeEditorValue } from "../utils";
 import { history } from "@codemirror/commands";
 import { autocompletion } from "@codemirror/autocomplete";
 import { FloatingButtonContainer, FloatingToggleButton, ChipEditorContainer } from "../styles";
@@ -111,12 +111,13 @@ export type ChipExpressionEditorComponentProps = {
 
 export const ChipExpressionEditorComponent = (props: ChipExpressionEditorComponentProps) => {
     const { configuration = new ChipExpressionEditorConfig() } = props;
+    const normalizedValue = coerceChipEditorValue(props.value);
     const editorRef = useRef<HTMLDivElement>(null);
     const helperPaneRef = useRef<HTMLDivElement>(null);
     const fieldContainerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView | null>(null);
     const [isTokenUpdateScheduled, setIsTokenUpdateScheduled] = useState(true);
-    const [isValueResolving, setIsValueResolving] = useState(() => !!props.value);
+    const [isValueResolving, setIsValueResolving] = useState(() => !!normalizedValue);
 
     useEffect(() => {
         props.onLoadingStateChange?.(isValueResolving);
@@ -294,7 +295,7 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
     useEffect(() => {
         if (!editorRef.current) return;
         const startState = EditorState.create({
-            doc: configuration.serializeValue(props.value ?? ""),
+            doc: configuration.serializeValue(normalizedValue ?? ""),
             extensions: [
                 ...(configuration.getPlugins()),
                 history(),
@@ -360,10 +361,10 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
     }, []);
 
     useEffect(() => {
-        if (props.value == null || !viewRef.current) return;
-        const serializedValue = configuration.serializeValue(props.value);
-        const deserializeValue = configuration.deserializeValue(props.value);
-        if (normalizeEditorValue(deserializeValue) !== normalizeEditorValue(props.value)) {
+        if (normalizedValue == null || !viewRef.current) return;
+        const serializedValue = configuration.serializeValue(normalizedValue);
+        const deserializeValue = configuration.deserializeValue(normalizedValue);
+        if (normalizeEditorValue(deserializeValue) !== normalizeEditorValue(normalizedValue)) {
             if (props.onNormalizeValue) {
                 props.onNormalizeValue(deserializeValue);
             } else {
@@ -417,7 +418,7 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
         };
         updateEditorState();
         return () => { cancelled = true; };
-    }, [props.value, props.fileName, props.targetLineRange?.startLine, isTokenUpdateScheduled]);
+    }, [normalizedValue, props.fileName, props.targetLineRange?.startLine, isTokenUpdateScheduled]);
 
     useEffect(() => {
         completionsRef.current = props.completions;
@@ -487,7 +488,7 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
                             left={helperPaneState.left}
                             isFlipped={helperPaneState.isFlipped}
                             getHelperPane={props.getHelperPane}
-                            value={props.value}
+                            value={normalizedValue}
                             onChange={onHelperItemSelect}
                         />
                     }

--- a/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
+++ b/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
@@ -604,3 +604,6 @@ export const processFunctionWithArguments = async (
 
 export const normalizeEditorValue = (v: unknown) =>
     typeof v === 'string' ? v.trim() : v;
+
+export const coerceChipEditorValue = (value: unknown): string | null | undefined =>
+    typeof value === 'string' || value == null ? (value as string | null | undefined) : String(value);

--- a/packages/ballerina-side-panel/src/test/ExpressionField.test.tsx
+++ b/packages/ballerina-side-panel/src/test/ExpressionField.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// L1 regression test for issue #2307: switching a FLAG (boolean) field to
+// Expression mode crashed because the raw JS boolean form value was handed to
+// the CodeMirror-backed chip editor, whose doc/insert APIs require a string
+// (EditorState.create({ doc: <boolean> }) throws). jsdom cannot instantiate the
+// CodeMirror editor (see docs/TEST_GUIDE "jsdom limits"), so instead of driving
+// the live editor we stub ChipExpressionEditorComponent and assert the
+// normalization invariant at the funnel boundary: ExpressionField must hand the
+// chip editor a string | null | undefined — never a boolean/number. This is the
+// AWS SQS "Auto Delete Messages" flow (type: FLAG, value: false) in EXP mode.
+
+import React from "react";
+import { render } from "@testing-library/react";
+import type { FormField } from "../components/Form/types";
+import { InputMode } from "../components/editors/MultiModeExpressionEditor/ChipExpressionEditor/types";
+
+// Capture whatever value ExpressionField passes to the chip editor.
+const chipValues: unknown[] = [];
+jest.mock(
+    "../components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor",
+    () => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const react = require("react");
+        return {
+            __esModule: true,
+            ChipExpressionEditorComponent: (props: any) => {
+                chipValues.push(props.value);
+                return react.createElement("div", {
+                    "data-testid": "ChipExpressionEditorComponent",
+                    "data-value": String(props.value),
+                });
+            },
+        };
+    }
+);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ExpressionField } = require("../components/editors/ExpressionField");
+
+const autoDeleteMessagesField = (value: any): FormField =>
+    ({
+        key: "autoDeleteMessages",
+        label: "Auto Delete Messages",
+        type: "FLAG",
+        types: [{ fieldType: "FLAG" }, { fieldType: "EXPRESSION" }],
+        value,
+        optional: true,
+        editable: true,
+        enabled: true,
+    } as unknown as FormField);
+
+const renderExpressionField = (value: any) =>
+    render(
+        <ExpressionField
+            field={autoDeleteMessagesField(value)}
+            inputMode={InputMode.EXP}
+            primaryMode={InputMode.BOOLEAN}
+            name="autoDeleteMessages"
+            value={value}
+            completions={[]}
+            onChange={() => {}}
+            isHelperPaneOpen={false}
+            changeHelperPaneState={() => {}}
+            onToggleHelperPane={() => {}}
+            exprRef={React.createRef()}
+            anchorRef={React.createRef()}
+        />
+    );
+
+describe("ExpressionField chip-editor value normalization (issue #2307)", () => {
+    beforeEach(() => {
+        chipValues.length = 0;
+    });
+
+    it.each([
+        ["boolean false", false, "false"],
+        ["boolean true", true, "true"],
+    ])(
+        "INVARIANT: a FLAG %s reaches the chip editor as a string, not a boolean",
+        (_desc, value, expected) => {
+            renderExpressionField(value);
+            const received = chipValues.at(-1);
+            expect(typeof received).toBe("string");
+            expect(received).toBe(expected);
+        }
+    );
+
+    it.each([
+        ["a string expression", "check foo()"],
+        ["an empty string", ""],
+    ])("passes %s through unchanged", (_desc, value) => {
+        renderExpressionField(value);
+        expect(chipValues.at(-1)).toBe(value);
+    });
+
+    it.each([
+        ["null", null],
+        ["undefined", undefined],
+    ])("leaves %s as-is (never coerced to a string)", (_desc, value) => {
+        renderExpressionField(value);
+        expect(chipValues.at(-1)).toBe(value);
+    });
+});

--- a/packages/ballerina-side-panel/src/test/ExpressionField.test.tsx
+++ b/packages/ballerina-side-panel/src/test/ExpressionField.test.tsx
@@ -19,19 +19,15 @@
 // L1 regression test for issue #2307: switching a FLAG (boolean) field to
 // Expression mode crashed because the raw JS boolean form value was handed to
 // the CodeMirror-backed chip editor, whose doc/insert APIs require a string
-// (EditorState.create({ doc: <boolean> }) throws). jsdom cannot instantiate the
-// CodeMirror editor (see docs/TEST_GUIDE "jsdom limits"), so instead of driving
-// the live editor we stub ChipExpressionEditorComponent and assert the
-// normalization invariant at the funnel boundary: ExpressionField must hand the
-// chip editor a string | null | undefined — never a boolean/number. This is the
-// AWS SQS "Auto Delete Messages" flow (type: FLAG, value: false) in EXP mode.
+// (EditorState.create({ doc: <boolean> }) throws).
 
 import React from "react";
 import { render } from "@testing-library/react";
 import type { FormField } from "../components/Form/types";
 import { InputMode } from "../components/editors/MultiModeExpressionEditor/ChipExpressionEditor/types";
+import { coerceChipEditorValue } from "../components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils";
 
-// Capture whatever value ExpressionField passes to the chip editor.
+// Capture whatever value each mount site passes to the chip editor.
 const chipValues: unknown[] = [];
 jest.mock(
     "../components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor",
@@ -53,6 +49,8 @@ jest.mock(
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { ExpressionField } = require("../components/editors/ExpressionField");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ExpressionMode } = require("../components/editors/ExpandedEditor/modes/ExpressionMode");
 
 const autoDeleteMessagesField = (value: any): FormField =>
     ({
@@ -66,7 +64,7 @@ const autoDeleteMessagesField = (value: any): FormField =>
         enabled: true,
     } as unknown as FormField);
 
-const renderExpressionField = (value: any) =>
+const renderInlineEditor = (value: any) =>
     render(
         <ExpressionField
             field={autoDeleteMessagesField(value)}
@@ -84,37 +82,57 @@ const renderExpressionField = (value: any) =>
         />
     );
 
-describe("ExpressionField chip-editor value normalization (issue #2307)", () => {
-    beforeEach(() => {
-        chipValues.length = 0;
-    });
-
-    it.each([
-        ["boolean false", false, "false"],
-        ["boolean true", true, "true"],
-    ])(
-        "INVARIANT: a FLAG %s reaches the chip editor as a string, not a boolean",
-        (_desc, value, expected) => {
-            renderExpressionField(value);
-            const received = chipValues.at(-1);
-            expect(typeof received).toBe("string");
-            expect(received).toBe(expected);
-        }
+const renderExpandedEditor = (value: any) =>
+    render(
+        <ExpressionMode
+            value={value}
+            onChange={() => {}}
+            field={autoDeleteMessagesField(value)}
+            completions={[]}
+        />
     );
+
+describe("coerceChipEditorValue (issue #2307 fix)", () => {
+    it.each([
+        ["boolean true", true, "true"],
+        ["boolean false", false, "false"],
+        ["number", 42, "42"],
+    ])("coerces a non-string %s to a string", (_desc, value, expected) => {
+        const result = coerceChipEditorValue(value);
+        expect(typeof result).toBe("string");
+        expect(result).toBe(expected);
+    });
 
     it.each([
         ["a string expression", "check foo()"],
         ["an empty string", ""],
     ])("passes %s through unchanged", (_desc, value) => {
-        renderExpressionField(value);
-        expect(chipValues.at(-1)).toBe(value);
+        expect(coerceChipEditorValue(value)).toBe(value);
     });
 
     it.each([
         ["null", null],
         ["undefined", undefined],
     ])("leaves %s as-is (never coerced to a string)", (_desc, value) => {
-        renderExpressionField(value);
-        expect(chipValues.at(-1)).toBe(value);
+        expect(coerceChipEditorValue(value)).toBe(value);
+    });
+});
+
+describe("Boolean-to-expression mount sites funnel through ChipExpressionEditorComponent", () => {
+    beforeEach(() => {
+        chipValues.length = 0;
+    });
+
+    // Both mount sites must render without throwing for a raw FLAG boolean, and
+    // both must delegate the value to the single ChipExpressionEditorComponent
+    // that applies coerceChipEditorValue. The earlier inline-only fix left the
+    // expanded site (below) unguarded.
+    it.each([
+        ["inline editor (ExpressionField)", renderInlineEditor],
+        ["expanded editor (ExpressionMode)", renderExpandedEditor],
+    ])("%s hands a raw boolean to the chip editor without crashing", (_desc, renderFn) => {
+        expect(() => renderFn(false)).not.toThrow();
+        expect(chipValues).toHaveLength(1);
+        expect(chipValues.at(-1)).toBe(false);
     });
 });


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-integrator/issues/2307

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Fixed the AWS SQS **Auto Delete Messages** field when switching from boolean input to Expression mode.
- Normalized boolean and numeric values before passing them to the chip expression editor.
- Added regression tests for inline and expanded expression editors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->