### PR TITLE
Fix: Align HITL approval badge angle with workflow feature (45° → 135°)

### DIFF
--- a/packages/bi-diagram/src/components/nodes/AgentWidget/ApprovalBadge.tsx
+++ b/packages/bi-diagram/src/components/nodes/AgentWidget/ApprovalBadge.tsx
@@ -25,15 +25,15 @@ interface ApprovalBadgeProps {
 }
 
 /**
- * A shield badge on the tool's top-right corner shown when the tool's
+ * A shield badge on the tool's bottom-right corner shown when the tool's
  * @ai:AgentTool annotation gates it for human-in-the-loop approval.
  */
 export function ApprovalBadge({ background }: ApprovalBadgeProps) {
     return (
-        // Positioned on the 45° point of the tool circle (cx=80 cy=24 r=22, shared by
-        // AgentNodeWidget and AgentCallNodeWidget). If that circle's geometry changes in
-        // either widget, these coordinates need to move with it.
-        <foreignObject x="88.5" y="-0.5" width="17" height="17" style={{ overflow: "visible" }}>
+        // Positioned on the 135° point of the tool circle (cx=80 cy=24 r=22, shared by
+        // AgentNodeWidget and AgentCallNodeWidget), to match the workflow feature's HITL badge.
+        // If that circle's geometry changes in either widget, these coordinates need to move with it.
+        <foreignObject x="88.5" y="31.5" width="17" height="17" style={{ overflow: "visible" }}>
             <Tooltip content="Requires Approval" containerSx={{ display: "flex" }}>
                 <div
                     css={css`


### PR DESCRIPTION
## Description
Moves the human in the loop approval badge on tool icons from the 45 degree point to the 135 degree point, so it lines up with the equivalent badge in the workflow (durable agent) feature.

Fixes wso2/product-integrator#2354

<img width="522" height="441" alt="Screenshot 2026-09-07 at 10 56 04" src="https://github.com/user-attachments/assets/f5856d20-9afa-4e1b-92cd-5e7713aee69d" />

## Test plan
- [x] Add an AI Agent node with a tool marked "Requires Approval" and confirm the badge now sits at the bottom right of the tool icon.
- [x] Confirm it visually matches the workflow feature's badge placement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Repositioned the `ApprovalBadge` from the tool icon’s top-right to its bottom-right.
- Updated related documentation and positioning comments to match the new placement.
- Aligned the badge position with the workflow feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->