### PR TITLE
Animate the trailing ellipsis on AI panel status labels

### DIFF
--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/Footer/index.tsx
@@ -126,6 +126,41 @@ const LoadingLabel = styled.span`
     }
 `;
 
+/** Cycles the trailing dots so the label reads as actively working, not stalled. */
+const dotsCycle = keyframes`
+    0%, 20% { content: ""; }
+    40% { content: "."; }
+    60% { content: ".."; }
+    80%, 100% { content: "..."; }
+`;
+
+/**
+ * Rendered as a sibling of LoadingLabel rather than nested inside it: LoadingLabel's
+ * -webkit-text-fill-color: transparent is inherited by children, which would make
+ * dots nested inside it invisible.
+ */
+const AnimatedEllipsis = styled.span`
+    flex: none;
+
+    &::after {
+        content: "";
+        animation: ${dotsCycle} 1.5s steps(1, end) infinite;
+    }
+
+    @media (prefers-reduced-motion: reduce), (forced-colors: active) {
+        &::after {
+            content: "...";
+            animation: none;
+        }
+    }
+`;
+
+const LoadingLabelRow = styled.span`
+    display: inline-flex;
+    align-items: baseline;
+    min-width: 0;
+`;
+
 /**
  * Holds each label on screen for a minimum time before showing the next one.
  * Some tool calls (a small file read, a cached lookup) resolve fast enough that
@@ -167,6 +202,9 @@ function useStickyLabel(value: string, minVisibleMs = MIN_LABEL_VISIBLE_MS): str
  */
 const LoadingIndicator: React.FC<{ label: string }> = React.memo(({ label }) => {
     const shownLabel = useStickyLabel(label);
+    // Callers may already end their label in a literal "..." (e.g. tool-call
+    // labels); strip it so the animated ellipsis below is never doubled up.
+    const baseLabel = shownLabel.replace(/\.+$/, "");
     const runningColors = useOrbColors("running");
     return (
         // aria-live sits on the stable container: the label itself remounts on
@@ -176,8 +214,11 @@ const LoadingIndicator: React.FC<{ label: string }> = React.memo(({ label }) => 
                 <Sphere colors={runningColors} energy={ORB_ENERGY.running} />
                 <Gloss />
             </LoadingOrb>
-            {/* Keyed so a changed label remounts and replays the enter animation. */}
-            <LoadingLabel key={shownLabel}>{shownLabel}</LoadingLabel>
+            <LoadingLabelRow>
+                {/* Keyed so a changed label remounts and replays the enter animation. */}
+                <LoadingLabel key={shownLabel}>{baseLabel}</LoadingLabel>
+                <AnimatedEllipsis aria-hidden="true" />
+            </LoadingLabelRow>
         </LoadingIndicatorContainer>
     );
 });


### PR DESCRIPTION
## Description
- The "Generating" status label (shown while Copilot streams a plain-text reply with no active tool call) was missing its trailing ellipsis, inconsistent with other status labels like "Reading main.bal..." and "Planning...".
- Instead of hardcoding a static "..." back onto just that one fallback, `LoadingIndicator` now strips any literal trailing dots from whatever label it receives and renders a single CSS-animated ellipsis after it — so "Generating" and every tool-call label (which already ended in a static "...") all get the same live, animated dots, and stay consistent going forward regardless of what a caller's label string ends with.
- Respects `prefers-reduced-motion` / forced-colors, matching the existing guard on the label's shimmer animation.

It resolves: https://github.com/wso2/product-integrator/issues/2362

Reference:

https://github.com/user-attachments/assets/37ed89f2-93c3-4a2d-bdcb-9639739d0cb6

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Update the composer loading indicator to display “Generating...” when no tool call is active. This keeps status labels visually consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->