### PR TITLE
Show class APIs (ai:Agent, knowledge bases, listeners) to Copilot library selection

### DIFF
--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
@@ -21,16 +21,18 @@ import {
     GetFunctionsRequest,
     GetFunctionsResponse,
     getFunctionsResponseSchema,
-    MinifiedClient,
-    MinifiedRemoteFunction,
-    MinifiedResourceFunction,
-    PathParameter,
 } from "./function-types";
 import { Client, GetTypeResponse, GetTypesRequest, GetTypesResponse, getTypesResponseSchema, Library, MiniType, RemoteFunction, ResourceFunction, Service, FixedService, Annotation } from "./library-types";
 import { TypeDefinition, AbstractFunction, Type, RecordTypeDefinition, UnionTypeDefinition } from "./library-types";
 import {
+    collectClassFunctions,
+    getClassFunctionCount,
     getClientFunctionCount,
+    getCompleteFuncForMiniFunc,
+    getConstructor,
     hasNothingToSelect,
+    mergeClassTypeDefs,
+    selectClasses,
     selectServices,
     toSelectionRequest,
     withRestoredServiceLibraries,
@@ -185,7 +187,7 @@ async function getRequiredFunctions(
     const selectableLibs = libraryList.filter((lib) => !passthroughLibs.includes(lib));
     const passthroughResp: GetFunctionResponse[] = passthroughLibs.map((lib) => ({ name: lib.name }));
 
-    const largeLibs = selectableLibs.filter((lib) => getClientFunctionCount(lib.clients) >= 100);
+    const largeLibs = selectableLibs.filter((lib) => getClientFunctionCount(lib.clients) + getClassFunctionCount(lib.classes) >= 100);
     const smallLibs = selectableLibs.filter((lib) => !largeLibs.includes(lib));
 
     console.log(
@@ -254,7 +256,7 @@ async function getSuggestedFunctions(
     const startTime = Date.now();
     const libraryNames = libraryList.map((lib) => lib.name).join(", ");
     const functionCount = libraryList.reduce(
-        (total, lib) => total + getClientFunctionCount(lib.clients) + (lib.functions?.length || 0),
+        (total, lib) => total + getClientFunctionCount(lib.clients) + getClassFunctionCount(lib.classes) + (lib.functions?.length || 0),
         0
     );
 
@@ -268,7 +270,8 @@ CRITICAL RULES:
 3. Copy all field values EXACTLY as provided - preserve every character including backslashes and special characters.
 4. For resource functions: "accessor" and "paths" are SEPARATE fields - NEVER combine them.
 5. A library is relevant if ANY of its clients, functions, or services match the query. A service matches when its "doc" (what the service is for), its "listenerDoc" (how it is triggered), its name, or ANY ONE of its handlers under "methods", is what the query needs. List each matching service under the library's "services" field, copying its "listener" and "name" verbatim; omit the services that do not match. If a library matches ONLY via its services, still include the library in the output with empty/omitted clients and functions.
-6. "doc", "listenerDoc" and a handler's "doc" are evidence to reason over, never fields to copy: the response carries only "listener" and "name" for a service.`;
+6. "doc", "listenerDoc" and a handler's "doc" are evidence to reason over, never fields to copy: the response carries only "listener" and "name" for a service.
+7. A library may list "classes": object types the code constructs with \`new\` and drives through their own methods (an agent, a knowledge base, a listener, a request/response object). A class is relevant when the query needs ANY of its methods. List each matching class under the library's "classes" field, copying its "name" and only the matching "functions" verbatim, exactly as you would for a client. A library that matches ONLY via a class is still relevant.`;
 
     const getLibUserPrompt = `You will be provided with a list of libraries, clients, and their functions, and a user query.
 
@@ -283,9 +286,9 @@ ${JSON.stringify(libraryList)}
 To process the user query and filter the libraries, clients, services and functions, follow these steps:
 
 1. Analyze the user query to understand the specific requirements or needs.
-2. Review the provided libraries, clients, services and functions in Library_Context_JSON.
-3. Select only the libraries, clients, services and functions that directly match the query's needs.
-4. Exclude any irrelevant libraries, clients, services or functions.
+2. Review the provided libraries, clients, classes, services and functions in Library_Context_JSON.
+3. Select only the libraries, clients, classes, services and functions that directly match the query's needs.
+4. Exclude any irrelevant libraries, clients, classes, services or functions.
 5. If no relevant functions and services are found, return an empty array for libraries.
 6. Organize the remaining relevant information.
 
@@ -389,6 +392,9 @@ export async function toMaximizedLibrariesFromLibJson(
         const filteredClients = selectClients(originalLib.clients, funcResponse);
         const filteredFunctions = selectFunctions(originalLib.functions, funcResponse);
         const filteredServices = selectServices(originalLib.services, funcResponse);
+        // The classes the model kept. They are rendered with only the methods it kept, and their method
+        // signatures take part in the type closure below so the records they name are defined too.
+        const selectedClasses = selectClasses(originalLib.typeDefs, funcResponse);
 
         const maximizedLib: Library = {
             name: funcResponse.name,
@@ -399,7 +405,9 @@ export async function toMaximizedLibrariesFromLibJson(
             // The SELECTED services, not the library's whole set: the closure is what pulls a service's
             // parameter, return, annotation and binding types into `typeDefs`, so walking dropped services
             // would keep paying the larger half of their cost after dropping the services themselves.
-            typeDefs: getOwnTypeDefsForLib(filteredClients, filteredFunctions, originalLib.typeDefs, filteredServices ? filteredServices : undefined, originalLib.annotations),
+            typeDefs: mergeClassTypeDefs(
+                getOwnTypeDefsForLib(filteredClients, filteredFunctions, originalLib.typeDefs, filteredServices ? filteredServices : undefined, originalLib.annotations, selectedClasses),
+                selectedClasses),
             services: filteredServices,
             annotations: originalLib.annotations ? originalLib.annotations : null,
             instructions: originalLib.instructions ? originalLib.instructions : null,
@@ -502,48 +510,16 @@ function selectFunctions(
     return output.length > 0 ? output : undefined;
 }
 
-function getConstructor(functions: (RemoteFunction | ResourceFunction)[]): RemoteFunction | null {
-    for (const func of functions) {
-        if ('type' in func && func.type === TYPE_CONSTRUCTOR) {
-            return func as RemoteFunction;
-        }
-    }
-    return null;
-}
 
-function normalizePaths(paths: (PathParameter | string)[]): string[] {
-    return paths.map((path) => {
-        const pathStr = typeof path === "string" ? path : path.name;
-        return pathStr.replace(/\\./g, ".");
-    });
-}
 
-function getCompleteFuncForMiniFunc(
-    minFunc: MinifiedRemoteFunction | MinifiedResourceFunction,
-    fullFunctions: (RemoteFunction | ResourceFunction)[]
-): (RemoteFunction | ResourceFunction) | null {
-    if ("name" in minFunc) {
-        // MinifiedRemoteFunction
-        return fullFunctions.find((f) => "name" in f && f.name === minFunc.name) || null;
-    } else {
-        // MinifiedResourceFunction
-        return (
-            fullFunctions.find(
-                (f) =>
-                    "accessor" in f &&
-                    f.accessor === minFunc.accessor &&
-                    JSON.stringify(normalizePaths(f.paths)) === JSON.stringify(normalizePaths(minFunc.paths))
-            ) || null
-        );
-    }
-}
 
 function getOwnTypeDefsForLib(
     clients: Client[],
     functions: RemoteFunction[] | undefined,
     allTypeDefs: TypeDefinition[],
     services?: Service[],
-    annotations?: Annotation[]
+    annotations?: Annotation[],
+    selectedClasses?: TypeDefinition[]
 ): TypeDefinition[] {
     const allFunctions: AbstractFunction[] = [];
 
@@ -556,6 +532,11 @@ function getOwnTypeDefsForLib(
     if (functions) {
         allFunctions.push(...functions);
     }
+
+    // Add the methods of the selected classes: `Agent.run(string|Prompt|Resume ...)` is the only place the
+    // human-in-the-loop records are named, so without this the class would render against types the
+    // prompt never defines.
+    allFunctions.push(...collectClassFunctions(selectedClasses));
 
     return getOwnRecordRefs(allFunctions, allTypeDefs, services, annotations);
 }
@@ -833,6 +814,10 @@ function getExternalTypeDefsRefs(libraries: Library[]): Map<string, string[]> {
         if (lib.functions) {
             allFunctions.push(...lib.functions);
         }
+
+        // Add the methods of every rendered class, selected or reference-pulled: a method signature can
+        // name a foreign type just as a client's can, and the renderer writes it either way.
+        allFunctions.push(...collectClassFunctions(lib.typeDefs));
 
         getExternalTypeDefRefs(externalRecords, allFunctions, lib.typeDefs, lib.services, lib.annotations);
     }

--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-types.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-types.ts
@@ -22,6 +22,17 @@ export interface GetFunctionsRequest {
     clients: MinifiedClient[];
     functions?: MinifiedRemoteFunction[];
     services?: MinifiedService[];
+    /**
+     * The library's non-client classes and object types that declare methods (`ai:Agent`,
+     * `ai:VectorKnowledgeBase`, `email:ImapListener`, `http:Request`), minified exactly like a client.
+     *
+     * Before this, a class reached the generating model only when some selected function, client, service
+     * or annotation *named* it in a signature. `ai:Agent` is named by nothing — it is constructed with
+     * `new` and driven through its own methods — so `Agent.run`, `KnowledgeBase.ingest/retrieve` and the
+     * human-in-the-loop types their signatures pull in were never rendered, and the model worked from
+     * README prose alone. Sending the classes lets the selection model keep the ones the query needs.
+     */
+    classes?: MinifiedClient[];
 }
 
 export interface MinifiedClient {
@@ -125,6 +136,8 @@ export interface GetFunctionResponse {
     clients?: MinifiedClient[];
     functions?: MinifiedRemoteFunction[];
     services?: SelectedService[];
+    /** The classes the model kept, each with only the methods it kept — see {@link GetFunctionsRequest.classes}. */
+    classes?: MinifiedClient[];
 }
 
 export interface PathParameter {
@@ -173,6 +186,7 @@ const libraryResponseSchema = z.object({
     clients: z.array(clientSchema).optional(),
     functions: z.array(remoteFunctionSchema).optional(),
     services: z.array(selectedServiceSchema).optional(),
+    classes: z.array(clientSchema).optional(),
 });
 
 export const getFunctionsResponseSchema = z.object({

--- a/packages/ballerina-extension/src/features/ai/utils/libs/library-selection.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/library-selection.ts
@@ -33,10 +33,22 @@ import {
     MinifiedResourceFunction,
     MinifiedService,
 } from "./function-types";
-import { Client, FixedService, Library, RemoteFunction, ResourceFunction, Service } from "./library-types";
+import {
+    Client,
+    ClassTypeDefinition,
+    FixedService,
+    Library,
+    PathParameter,
+    RemoteFunction,
+    ResourceFunction,
+    Service,
+    TypeDefinition,
+} from "./library-types";
 
 /** The `type` a client's constructor carries; it is re-attached by `selectClients`, never selected. */
 const TYPE_CONSTRUCTOR = "Constructor";
+/** The `type` of a class or object type definition — the only kind of type definition that has methods to select. */
+const TYPE_CLASS = "Class";
 
 /**
  * A library with fewer services than this never has them filtered.
@@ -49,6 +61,15 @@ export const MIN_SERVICES_TO_FILTER = 3;
 
 export function getClientFunctionCount(clients: MinifiedClient[]): number {
     return clients.reduce((count, client) => count + client.functions.length, 0);
+}
+
+/**
+ * How many class methods a request asks the model to judge. A class entry is shaped like a client entry, so
+ * the count is the same shape too; it is kept separate so a class-only library reads as a decision in
+ * {@link hasNothingToSelect} and weighs in the large/small split alongside the client functions.
+ */
+export function getClassFunctionCount(classes?: MinifiedClient[]): number {
+    return classes ? getClientFunctionCount(classes) : 0;
 }
 
 /**
@@ -71,6 +92,7 @@ export function getClientFunctionCount(clients: MinifiedClient[]): number {
  */
 export function hasNothingToSelect(lib: GetFunctionsRequest): boolean {
     return getClientFunctionCount(lib.clients) === 0
+        && getClassFunctionCount(lib.classes) === 0
         && (lib.functions?.length ?? 0) === 0
         && (lib.services?.length ?? 0) < MIN_SERVICES_TO_FILTER;
 }
@@ -291,13 +313,162 @@ export function selectServices(
  *                                    here would give this module the VS Code dependency it exists without
  */
 export function toSelectionRequest(lib: Library, includeFunctionDescriptions: boolean): GetFunctionsRequest {
+    const classes = toRequestClasses(lib.typeDefs);
     return {
         name: lib.name,
         description: lib.description,
         clients: toRequestClients(lib.clients),
         functions: toRequestFunctions(lib.functions, includeFunctionDescriptions),
         services: toServiceRequestEntries(lib.services),
+        ...(classes ? { classes } : {}),
     };
+}
+
+/**
+ * Whether a type definition is a class or object type that declares at least one method other than its
+ * constructor — the only kind of type definition the selection model has a decision to make about.
+ */
+export function isSelectableClass(typeDef: TypeDefinition): typeDef is ClassTypeDefinition {
+    if (typeDef.type !== TYPE_CLASS) {
+        return false;
+    }
+    const functions = (typeDef as ClassTypeDefinition).functions ?? [];
+    return functions.some((func) => !isConstructor(func));
+}
+
+/**
+ * The library's selectable classes, each minified exactly like a client: its name, its doc, and its
+ * methods reduced to identity, parameter names and return type name. The constructor is omitted here for
+ * the same reason it is omitted for clients — it is not a choice — and `selectClasses` re-attaches it.
+ *
+ * `undefined` rather than `[]` when there is nothing to send, so a library without classes serialises
+ * exactly as it did before this field existed.
+ */
+export function toRequestClasses(typeDefs: TypeDefinition[] | undefined): MinifiedClient[] | undefined {
+    const classes = (typeDefs ?? []).filter(isSelectableClass).map((typeDef) => ({
+        name: typeDef.name,
+        description: typeDef.description,
+        functions: toRequestClientFunctions(typeDef.functions ?? []),
+    }));
+    return classes.length > 0 ? classes : undefined;
+}
+
+/**
+ * Re-inflates the classes the model kept from the library's own type definitions: the constructor (if the
+ * class has one) followed by the kept methods, resolved back to their complete declarations. A class the
+ * model named that the library does not declare, or a method it named that the class does not have, is
+ * dropped rather than invented — the response is only ever a selection over what was sent.
+ */
+export function selectClasses(
+    originalTypeDefs: TypeDefinition[] | undefined,
+    funcResponse: GetFunctionResponse
+): ClassTypeDefinition[] {
+    const selected = funcResponse.classes ?? [];
+    if (selected.length === 0 || !originalTypeDefs) {
+        return [];
+    }
+
+    const result: ClassTypeDefinition[] = [];
+    for (const minClass of selected) {
+        const original = originalTypeDefs.find(
+            (typeDef): typeDef is ClassTypeDefinition => typeDef.type === TYPE_CLASS && typeDef.name === minClass.name
+        );
+        if (!original) {
+            continue;
+        }
+        const originalFunctions: (RemoteFunction | ResourceFunction)[] = original.functions ?? [];
+        const functions: (RemoteFunction | ResourceFunction)[] = [];
+        for (const minFunc of minClass.functions ?? []) {
+            const complete = getCompleteFuncForMiniFunc(minFunc, originalFunctions);
+            if (complete && !functions.includes(complete)) {
+                functions.push(complete);
+            }
+        }
+        if (functions.length === 0) {
+            continue;
+        }
+        const constructor = getConstructor(originalFunctions);
+        result.push({
+            ...original,
+            functions: constructor ? [constructor, ...functions] : functions,
+        });
+    }
+    return result;
+}
+
+/**
+ * The type definitions to render for a library: the ones its selected functions, clients and services
+ * reference, plus the classes the model kept. A class that is both referenced and kept is rendered once,
+ * from the referenced copy — that copy carries every method, and a signature that names the class is a
+ * stronger reason to show all of it than the model's per-method pick.
+ */
+export function mergeClassTypeDefs(
+    referenced: TypeDefinition[],
+    selectedClasses: ClassTypeDefinition[]
+): TypeDefinition[] {
+    const known = new Set(referenced.map((typeDef) => typeDef.name));
+    const merged = [...referenced];
+    for (const selected of selectedClasses) {
+        if (!known.has(selected.name)) {
+            known.add(selected.name);
+            merged.push(selected);
+        }
+    }
+    return merged;
+}
+
+/** Every method of every class type definition in the list — what the type-reference scanners walk. */
+export function collectClassFunctions(typeDefs: TypeDefinition[] | undefined): (RemoteFunction | ResourceFunction)[] {
+    const functions: (RemoteFunction | ResourceFunction)[] = [];
+    for (const typeDef of typeDefs ?? []) {
+        if (typeDef.type === TYPE_CLASS) {
+            functions.push(...((typeDef as ClassTypeDefinition).functions ?? []));
+        }
+    }
+    return functions;
+}
+
+function isConstructor(func: RemoteFunction | ResourceFunction): boolean {
+    return "type" in func && func.type === TYPE_CONSTRUCTOR;
+}
+
+/** The class's or client's constructor, if it declares one. */
+export function getConstructor(functions: (RemoteFunction | ResourceFunction)[]): RemoteFunction | null {
+    for (const func of functions) {
+        if (isConstructor(func)) {
+            return func as RemoteFunction;
+        }
+    }
+    return null;
+}
+
+function normalizePaths(paths: (PathParameter | string)[]): string[] {
+    return paths.map((path) => {
+        const pathStr = typeof path === "string" ? path : path.name;
+        return pathStr.replace(/\\./g, ".");
+    });
+}
+
+/**
+ * Resolves a minified function from the response back to its complete declaration: a remote/plain method
+ * by name, a resource method by accessor plus path (dots un-escaped on both sides so the comparison does not
+ * depend on how either side quoted them).
+ */
+export function getCompleteFuncForMiniFunc(
+    minFunc: MinifiedRemoteFunction | MinifiedResourceFunction,
+    fullFunctions: (RemoteFunction | ResourceFunction)[]
+): (RemoteFunction | ResourceFunction) | null {
+    if ("name" in minFunc) {
+        return fullFunctions.find((f) => "name" in f && f.name === minFunc.name) || null;
+    }
+    return (
+        fullFunctions.find(
+            (f) =>
+                "accessor" in f &&
+                f.accessor === minFunc.accessor &&
+                JSON.stringify(normalizePaths(f.paths)) === JSON.stringify(normalizePaths(minFunc.paths))
+        ) || null
+    );
 }
 
 /** Each client as the request states it: its name, its doc, and its functions minified. */

--- a/packages/ballerina-extension/src/test-support/librarySelectionClasses.test.ts
+++ b/packages/ballerina-extension/src/test-support/librarySelectionClasses.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Classes reach the generating model only through selection. `ai:Agent`, `ai:VectorKnowledgeBase` and
+ * `email:ImapListener` are constructed with `new` and driven through their own methods, so no function
+ * signature names them and the type-reference closure never pulled them in — the model never saw
+ * `Agent.run(string|Prompt|Resume ...)`, `KnowledgeBase.ingest`/`retrieve`, or the human-in-the-loop
+ * records those signatures name. These tests pin the request side (classes are sent), the response side
+ * (kept classes are re-inflated with their constructor and only the kept methods), and the merge with the
+ * reference-pulled type definitions.
+ */
+
+import {
+    collectClassFunctions,
+    getClassFunctionCount,
+    hasNothingToSelect,
+    isSelectableClass,
+    mergeClassTypeDefs,
+    selectClasses,
+    toRequestClasses,
+    toSelectionRequest,
+} from '../features/ai/utils/libs/library-selection';
+import { getFunctionsResponseSchema } from '../features/ai/utils/libs/function-types';
+import {
+    ClassTypeDefinition,
+    Library,
+    RecordTypeDefinition,
+    RemoteFunction,
+    ResourceFunction,
+    TypeDefinition,
+} from '../features/ai/utils/libs/library-types';
+import { toSyntaxString } from '../features/ai/utils/libs/to-syntax-string';
+
+function method(name: string, type: string, params: string[], returnType: string, links?: string[]): RemoteFunction {
+    return {
+        type,
+        name,
+        description: `${name} doc`,
+        parameters: params.map((p) => ({ name: p, description: '', type: { name: 'string' } })),
+        return: { type: { name: returnType, ...(links ? { links: links.map((l) => ({ category: 'internal' as const, recordName: l })) } : {}) } },
+    };
+}
+
+function resource(accessor: string, paths: string[]): ResourceFunction {
+    return {
+        type: 'Resource Function',
+        accessor,
+        paths,
+        description: '',
+        parameters: [],
+        return: { type: { name: 'error?' } },
+    };
+}
+
+const runMethod: RemoteFunction = {
+    type: 'Normal Function',
+    name: 'run',
+    description: 'Runs the agent',
+    parameters: [
+        {
+            name: 'query',
+            description: '',
+            type: {
+                name: 'string|Prompt|Resume',
+                links: [
+                    { category: 'internal', recordName: 'Prompt' },
+                    { category: 'internal', recordName: 'Resume' },
+                ],
+            },
+        },
+        { name: 'sessionId', description: '', type: { name: 'string' }, default: '"default"' },
+    ],
+    return: { type: { name: 'string|Error' } },
+};
+
+const agentClass: ClassTypeDefinition = {
+    name: 'Agent',
+    description: 'An AI agent',
+    type: 'Class',
+    functions: [
+        { ...method('init', 'Constructor', ['systemPrompt', 'model'], 'Error?'), name: 'init' },
+        runMethod,
+        method('getTools', 'Normal Function', [], 'ToolConfig[]'),
+    ],
+};
+
+const listenerClass: ClassTypeDefinition = {
+    name: 'ImapListener',
+    description: 'Polls an IMAP mailbox',
+    type: 'Class',
+    functions: [
+        method('init', 'Constructor', ['listenerConfig'], 'Error?'),
+        method('attach', 'Normal Function', ['s', 'name'], 'error?'),
+        method('start', 'Normal Function', [], 'error?'),
+    ],
+};
+
+const markerClass: ClassTypeDefinition = {
+    name: 'Service',
+    description: 'Marker service type',
+    type: 'Class',
+    functions: [],
+};
+
+const constructorOnlyClass: ClassTypeDefinition = {
+    name: 'Chunker',
+    description: 'Only constructible',
+    type: 'Class',
+    functions: [method('init', 'Constructor', ['maxChunkSize'], '')],
+};
+
+const resumeRecord: RecordTypeDefinition = {
+    name: 'Resume',
+    description: 'Resumes a paused run',
+    type: 'Record',
+    fields: [{ name: 'decisions', description: '', type: { name: 'map<HumanResponse>' } }],
+};
+
+const promptRecord: RecordTypeDefinition = {
+    name: 'Prompt',
+    description: 'A prompt',
+    type: 'Record',
+    fields: [],
+};
+
+const typeDefs: TypeDefinition[] = [agentClass, listenerClass, markerClass, constructorOnlyClass, resumeRecord, promptRecord];
+
+function library(): Library {
+    return {
+        name: 'ballerina/ai',
+        description: 'AI',
+        typeDefs,
+        clients: [],
+        functions: [],
+        services: [],
+    };
+}
+
+describe('isSelectableClass', () => {
+    it('is true only for a class that declares a method other than its constructor', () => {
+        expect(isSelectableClass(agentClass)).toBe(true);
+        expect(isSelectableClass(listenerClass)).toBe(true);
+    });
+
+    it('is false for marker classes, constructor-only classes and non-class definitions', () => {
+        expect(isSelectableClass(markerClass)).toBe(false);
+        expect(isSelectableClass(constructorOnlyClass)).toBe(false);
+        expect(isSelectableClass(resumeRecord)).toBe(false);
+    });
+});
+
+describe('toRequestClasses', () => {
+    it('minifies every selectable class like a client and omits the constructor', () => {
+        const classes = toRequestClasses(typeDefs)!;
+        expect(classes.map((c) => c.name)).toEqual(['Agent', 'ImapListener']);
+        const agent = classes[0];
+        expect(agent.description).toBe('An AI agent');
+        expect(agent.functions).toEqual([
+            { name: 'run', parameters: ['query', 'sessionId'], returnType: 'string|Error' },
+            { name: 'getTools', parameters: [], returnType: 'ToolConfig[]' },
+        ]);
+    });
+
+    it('is undefined when the library has no selectable class, so the request shape is unchanged', () => {
+        expect(toRequestClasses([markerClass, resumeRecord])).toBeUndefined();
+        expect(toRequestClasses(undefined)).toBeUndefined();
+        expect(toSelectionRequest({ ...library(), typeDefs: [resumeRecord] }, false)).not.toHaveProperty('classes');
+    });
+
+    it('toSelectionRequest carries the classes alongside clients, functions and services', () => {
+        const request = toSelectionRequest(library(), false);
+        expect(request.classes?.map((c) => c.name)).toEqual(['Agent', 'ImapListener']);
+        expect(getClassFunctionCount(request.classes)).toBe(4);
+    });
+
+    it('a class-only library is a selection decision, not a passthrough', () => {
+        const request = toSelectionRequest(library(), false);
+        expect(hasNothingToSelect(request)).toBe(false);
+        expect(hasNothingToSelect({ ...request, classes: undefined })).toBe(true);
+    });
+});
+
+describe('selectClasses', () => {
+    it('re-inflates a kept class with its constructor and only the kept methods, in order', () => {
+        const [agent] = selectClasses(typeDefs, {
+            name: 'ballerina/ai',
+            classes: [{ name: 'Agent', functions: [{ name: 'run' }] }],
+        });
+        expect(agent.name).toBe('Agent');
+        expect(agent.type).toBe('Class');
+        expect(agent.functions.map((f: RemoteFunction) => f.name)).toEqual(['init', 'run']);
+        // The complete declaration, not the minified one: parameter types and links survive.
+        expect(agent.functions[1]).toBe(runMethod);
+    });
+
+    it('resolves resource methods by accessor and path', () => {
+        const withResource: ClassTypeDefinition = {
+            name: 'Req',
+            description: '',
+            type: 'Class',
+            functions: [resource('get', ['items', 'all']), resource('post', ['items'])],
+        };
+        const [req] = selectClasses([withResource], {
+            name: 'lib',
+            classes: [{ name: 'Req', functions: [{ accessor: 'post', paths: ['items'] }] }],
+        });
+        expect(req.functions).toEqual([withResource.functions[1]]);
+    });
+
+    it('drops classes and methods the library does not declare rather than inventing them', () => {
+        const kept = selectClasses(typeDefs, {
+            name: 'ballerina/ai',
+            classes: [
+                { name: 'Nope', functions: [{ name: 'run' }] },
+                { name: 'Agent', functions: [{ name: 'fly' }] },
+            ],
+        });
+        expect(kept).toEqual([]);
+    });
+
+    it('returns nothing when the response names no classes', () => {
+        expect(selectClasses(typeDefs, { name: 'ballerina/ai' })).toEqual([]);
+        expect(selectClasses(undefined, { name: 'ballerina/ai', classes: [{ name: 'Agent', functions: [{ name: 'run' }] }] })).toEqual([]);
+    });
+});
+
+describe('mergeClassTypeDefs', () => {
+    it('appends selected classes that the reference closure did not already pull in', () => {
+        const [agent] = selectClasses(typeDefs, { name: 'ballerina/ai', classes: [{ name: 'Agent', functions: [{ name: 'run' }] }] });
+        const merged = mergeClassTypeDefs([resumeRecord], [agent]);
+        expect(merged.map((t) => t.name)).toEqual(['Resume', 'Agent']);
+    });
+
+    it('keeps the referenced copy when a class is both referenced and selected', () => {
+        const [partial] = selectClasses(typeDefs, { name: 'ballerina/ai', classes: [{ name: 'Agent', functions: [{ name: 'run' }] }] });
+        const merged = mergeClassTypeDefs([agentClass], [partial]);
+        expect(merged).toEqual([agentClass]);
+    });
+});
+
+describe('collectClassFunctions', () => {
+    it('yields every method of every class definition so the type scanners can walk their signatures', () => {
+        const functions = collectClassFunctions(typeDefs);
+        expect(functions).toContain(runMethod);
+        expect(functions.length).toBe(agentClass.functions.length + listenerClass.functions.length + constructorOnlyClass.functions.length);
+        expect(collectClassFunctions(undefined)).toEqual([]);
+    });
+});
+
+describe('response schema', () => {
+    it('accepts a classes field shaped like clients', () => {
+        const parsed = getFunctionsResponseSchema.safeParse({
+            libraries: [{ name: 'ballerina/ai', classes: [{ name: 'Agent', functions: [{ name: 'run' }] }] }],
+        });
+        expect(parsed.success).toBe(true);
+    });
+});
+
+describe('end to end: a selected class renders with its members', () => {
+    it('renders the kept Agent methods and the Resume record the run signature names', () => {
+        const [agent] = selectClasses(typeDefs, { name: 'ballerina/ai', classes: [{ name: 'Agent', functions: [{ name: 'run' }] }] });
+        const rendered = toSyntaxString([{ ...library(), typeDefs: mergeClassTypeDefs([resumeRecord], [agent]) }]);
+        expect(rendered).toContain('class Agent {');
+        expect(rendered).toContain('function init(string systemPrompt, string model) returns Error?;');
+        expect(rendered).toContain('function run(string|Prompt|Resume query, string sessionId = "default") returns string|Error;');
+        expect(rendered).not.toContain('getTools');
+        expect(rendered).toContain('type Resume record {');
+    });
+});


### PR DESCRIPTION
## Problem
Copilot could not use class-based APIs such as `ai:Agent.run(...)`, `ai:VectorKnowledgeBase.ingest/retrieve` or `email:ImapListener`. A class was rendered into the library documentation only when some selected function, client, service or annotation named it in a signature. Types that are created with `new` and driven through their own methods are named by nothing, so their methods, and the records those methods reference (`ai:Resume`, `ai:PendingApproval`, ...), never reached the model. It then worked from README prose and produced RAG and human-in-the-loop code that had to be corrected from the ballerina.io examples.

## Fix
- Send the library's selectable classes (classes declaring a method other than `init`) to the Haiku selection call under a new `classes` field, minified exactly like clients, and accept the same field back.
- Re-inflate the kept classes with their constructor and only the kept methods, and merge them with the reference-pulled type definitions (the referenced, complete copy wins on a name clash).
- Walk class method signatures in both the internal and external type-reference scanners so the records they name are defined in the prompt.
- Count class methods in the large/small split and in the passthrough check.

## Tests
- `src/test-support/librarySelectionClasses.test.ts`: request shape, response re-inflation (remote and resource methods), merge rules, schema, and an end-to-end render of a selected class with the record its signature names.
- Full `test:unit` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added selectable class support for `ai:Agent`, `ai:VectorKnowledgeBase`, and `email:ImapListener`.
- Added class data to Haiku selection requests and responses.
- Restored selected classes with constructors, methods, and referenced type definitions.
- Included class methods in type scanning, library sizing, and passthrough decisions.
- Added coverage for selection, merging, schema validation, and end-to-end rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->