### PR TITLE
Document email listeners for Copilot and fetch Ballerina By Example pages from source

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/tools/ballerina-by-example.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/ballerina-by-example.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Resolves a Ballerina By Example page to the source it renders.
+ *
+ * `https://ballerina.io/learn/by-example/<slug>/` is rendered client-side: fetching the page returns the
+ * site's navigation menu and none of the example, so a user who pastes one of these URLs (which is the
+ * documented way to point Copilot at a canonical sample) gets back nothing usable and the model concludes
+ * the API is undocumented. Every example is a directory in the `ballerina-distribution` repository whose
+ * `.bal` file is the page's content, named after the slug with hyphens turned to underscores — so the raw
+ * GitHub file is fetched instead.
+ *
+ * Kept free of `vscode`/`ai` imports so it can be unit tested in isolation.
+ */
+
+export const BALLERINA_BY_EXAMPLE_SOURCE_HOST = "raw.githubusercontent.com";
+
+const BALLERINA_BY_EXAMPLE_URL =
+    /^https?:\/\/(?:www\.)?ballerina\.io\/learn\/by-example\/([a-z0-9][a-z0-9-]*)\/?(?:[?#].*)?$/i;
+
+const BALLERINA_DISTRIBUTION_EXAMPLES =
+    "https://raw.githubusercontent.com/ballerina-platform/ballerina-distribution/master/examples";
+
+export interface BallerinaByExampleSource {
+    /** The example directory name, as it appears in the URL. */
+    slug: string;
+    /** The raw `.bal` file that the page renders. */
+    sourceUrl: string;
+    /** The raw `.md` file with the example's description; fetched only if the source is unavailable. */
+    descriptionUrl: string;
+}
+
+/**
+ * The raw source location for a Ballerina By Example page, or `null` for any other URL — including the
+ * by-example index itself, which has no slug and no single source file.
+ */
+export function resolveBallerinaByExampleSource(url: string): BallerinaByExampleSource | null {
+    const match = BALLERINA_BY_EXAMPLE_URL.exec(url.trim());
+    if (!match) {
+        return null;
+    }
+    const slug = match[1].toLowerCase();
+    const fileStem = slug.replace(/-/g, "_");
+    return {
+        slug,
+        sourceUrl: `${BALLERINA_DISTRIBUTION_EXAMPLES}/${slug}/${fileStem}.bal`,
+        descriptionUrl: `${BALLERINA_DISTRIBUTION_EXAMPLES}/${slug}/${fileStem}.md`,
+    };
+}
+
+/**
+ * The domain allow-list to use for a rewritten fetch. The model typically pins `allowed_domains` to
+ * `ballerina.io` when the user pasted a ballerina.io URL; without adding the raw GitHub host the rewritten
+ * fetch would be silently blocked by the very filter that was meant to keep it on topic.
+ */
+export function withByExampleSourceHost(allowedDomains: string[] | undefined): string[] | undefined {
+    if (!allowedDomains || allowedDomains.length === 0) {
+        return allowedDomains;
+    }
+    return allowedDomains.includes(BALLERINA_BY_EXAMPLE_SOURCE_HOST)
+        ? allowedDomains
+        : [...allowedDomains, BALLERINA_BY_EXAMPLE_SOURCE_HOST];
+}

--- a/packages/ballerina-extension/src/features/ai/agent/tools/web-tools.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/web-tools.ts
@@ -22,6 +22,7 @@ import { CopilotEventHandler } from '../../utils/events';
 import { approvalManager } from '../../state/ApprovalManager';
 import { getAnthropicClient, getProviderModelOptions, ANTHROPIC_SONNET } from '../../utils/ai-client';
 import { sendWebToolToggleNotification } from '../../utils/ai-utils';
+import { resolveBallerinaByExampleSource, withByExampleSourceHost } from './ballerina-by-example';
 
 const WEB_TOOL_NOTIFICATION_TYPE = "webtool";
 
@@ -191,13 +192,53 @@ export function createWebFetchTool(eventHandler: CopilotEventHandler, webSearchE
     });
 }
 
+/** Whether a fetch result is the failure sentinel `extractToolOutput` produces, or nothing at all. */
+function isFailedFetch(content: string | undefined): boolean {
+    return !content || content.trim().length === 0 || content.startsWith('Web fetch failed:');
+}
+
+async function fetchUrlContent(
+    url: string,
+    fetchFactory: (args: Record<string, unknown>) => Tool<unknown, unknown>,
+    allowedDomains: string[] | undefined,
+    blockedDomains: string[] | undefined,
+): Promise<string> {
+    console.log(`[WebTools] fetch | url: ${url}`);
+    const result = await generateText({
+        model: await getAnthropicClient(ANTHROPIC_SONNET),
+        providerOptions: await getProviderModelOptions(),
+        system: 'You are a web fetcher. Your only job is to invoke the web_fetch tool with the given URL. STRICT RULES: (1) Do NOT write any text before the tool call. (2) Do NOT write any text after the tool call. (3) Do NOT summarize, describe, or explain the result. The tool result is consumed programmatically — any text you emit is ignored and wastes tokens.',
+        prompt: `URL: ${url}`,
+        tools: {
+            web_fetch: fetchFactory({
+                maxUses: 3,
+                ...(allowedDomains ? { allowedDomains } : {}),
+                ...(blockedDomains ? { blockedDomains } : {}),
+            }),
+        },
+        toolChoice: { type: 'tool', toolName: 'web_fetch' },
+        stopWhen: hasToolCall('web_fetch'),
+    });
+
+    const content = extractToolOutput(result);
+    console.log(`[WebTools] fetch | done | length: ${content?.length ?? 0}`);
+    return content;
+}
+
 async function executeWebFetch(
     input: WebFetchInput,
     webSearchEnabled: boolean,
     eventHandler: CopilotEventHandler,
     toolCallId: string
 ): Promise<string> {
-    const displayContent = `Fetch content from: ${input.url}`;
+    // A Ballerina By Example page renders client-side, so fetching it yields only the site navigation.
+    // Fetch the example's source from the distribution repository instead; the page URL stays as the
+    // fallback, and the approval prompt shows what is actually about to be fetched.
+    const byExample = resolveBallerinaByExampleSource(input.url);
+    const fetchUrl = byExample?.sourceUrl ?? input.url;
+    const displayContent = byExample
+        ? `Fetch content from: ${input.url} (source: ${fetchUrl})`
+        : `Fetch content from: ${input.url}`;
 
     const approved = await requestApprovalIfNeeded(WEB_FETCH_TOOL_NAME, displayContent, webSearchEnabled, eventHandler);
     if (!approved) {
@@ -220,25 +261,19 @@ async function executeWebFetch(
         const allowedDomains = sanitizeDomainList(input.allowed_domains);
         const blockedDomains = sanitizeDomainList(input.blocked_domains);
 
-        console.log(`[WebTools] fetch | url: ${input.url}`);
-        const result = await generateText({
-            model: await getAnthropicClient(ANTHROPIC_SONNET),
-            providerOptions: await getProviderModelOptions(),
-            system: 'You are a web fetcher. Your only job is to invoke the web_fetch tool with the given URL. STRICT RULES: (1) Do NOT write any text before the tool call. (2) Do NOT write any text after the tool call. (3) Do NOT summarize, describe, or explain the result. The tool result is consumed programmatically — any text you emit is ignored and wastes tokens.',
-            prompt: `URL: ${input.url}`,
-            tools: {
-                web_fetch: fetchFactory({
-                    maxUses: 3,
-                    ...(allowedDomains ? { allowedDomains } : {}),
-                    ...(blockedDomains ? { blockedDomains } : {}),
-                }),
-            },
-            toolChoice: { type: 'tool', toolName: 'web_fetch' },
-            stopWhen: hasToolCall('web_fetch'),
-        });
-
-        const content = extractToolOutput(result);
-        console.log(`[WebTools] fetch | done | length: ${content?.length ?? 0}`);
+        let content: string;
+        if (byExample) {
+            content = await fetchUrlContent(fetchUrl, fetchFactory, withByExampleSourceHost(allowedDomains), blockedDomains);
+            if (isFailedFetch(content)) {
+                // The slug-to-file mapping is a convention, not a guarantee: fall back to the page itself.
+                console.warn(`[WebTools] fetch | by-example source unavailable for ${byExample.slug}, falling back to ${input.url}`);
+                content = await fetchUrlContent(input.url, fetchFactory, allowedDomains, blockedDomains);
+            } else {
+                content = `// Source of ${input.url}\n// (${fetchUrl})\n${content}`;
+            }
+        } else {
+            content = await fetchUrlContent(input.url, fetchFactory, allowedDomains, blockedDomains);
+        }
 
         eventHandler({ type: "tool_result", toolName: WEB_FETCH_TOOL_NAME, toolOutput: { url: input.url }, toolCallId });
         return content || 'Web fetch completed.';

--- a/packages/ballerina-extension/src/test-support/ballerinaByExample.test.ts
+++ b/packages/ballerina-extension/src/test-support/ballerinaByExample.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * A Ballerina By Example page is rendered client-side; fetching it returns the site's navigation and none
+ * of the example. `web_fetch` therefore resolves such a URL to the example's source in the distribution
+ * repository. These tests pin the URL shapes that are (and are not) rewritten and the slug-to-file rule.
+ */
+
+import {
+    BALLERINA_BY_EXAMPLE_SOURCE_HOST,
+    resolveBallerinaByExampleSource,
+    withByExampleSourceHost,
+} from '../features/ai/agent/tools/ballerina-by-example';
+
+const EXAMPLES = 'https://raw.githubusercontent.com/ballerina-platform/ballerina-distribution/master/examples';
+
+describe('resolveBallerinaByExampleSource', () => {
+    it('maps a by-example page to its .bal source, hyphens becoming underscores in the file name', () => {
+        const resolved = resolveBallerinaByExampleSource('https://ballerina.io/learn/by-example/receive-email-using-service/');
+        expect(resolved).toEqual({
+            slug: 'receive-email-using-service',
+            sourceUrl: `${EXAMPLES}/receive-email-using-service/receive_email_using_service.bal`,
+            descriptionUrl: `${EXAMPLES}/receive-email-using-service/receive_email_using_service.md`,
+        });
+    });
+
+    it.each([
+        'https://ballerina.io/learn/by-example/rag-ingestion-with-external-vector-store',
+        'http://ballerina.io/learn/by-example/rag-ingestion-with-external-vector-store/',
+        'https://www.ballerina.io/learn/by-example/rag-ingestion-with-external-vector-store/?x=1',
+        'https://ballerina.io/learn/by-example/rag-ingestion-with-external-vector-store/#section',
+        '  https://ballerina.io/learn/by-example/RAG-Ingestion-With-External-Vector-Store/  ',
+    ])('tolerates scheme, www, trailing slash, query, fragment, case and whitespace: %s', (url) => {
+        expect(resolveBallerinaByExampleSource(url)?.sourceUrl)
+            .toBe(`${EXAMPLES}/rag-ingestion-with-external-vector-store/rag_ingestion_with_external_vector_store.bal`);
+    });
+
+    it.each([
+        'https://ballerina.io/learn/by-example/',
+        'https://ballerina.io/learn/by-example',
+        'https://ballerina.io/learn/get-started/',
+        'https://ballerina.io/learn/by-example/a/b/',
+        'https://central.ballerina.io/ballerina/email/latest',
+        'https://docs.github.com/en/rest/releases/assets',
+        'https://evil.example/https://ballerina.io/learn/by-example/foo/',
+        'not a url',
+    ])('leaves every other URL alone: %s', (url) => {
+        expect(resolveBallerinaByExampleSource(url)).toBeNull();
+    });
+});
+
+describe('withByExampleSourceHost', () => {
+    it('adds the raw GitHub host to a model-supplied allow-list so the rewritten fetch is not blocked', () => {
+        expect(withByExampleSourceHost(['ballerina.io'])).toEqual(['ballerina.io', BALLERINA_BY_EXAMPLE_SOURCE_HOST]);
+    });
+
+    it('does not duplicate the host and leaves an absent allow-list absent', () => {
+        expect(withByExampleSourceHost(['ballerina.io', BALLERINA_BY_EXAMPLE_SOURCE_HOST]))
+            .toEqual(['ballerina.io', BALLERINA_BY_EXAMPLE_SOURCE_HOST]);
+        expect(withByExampleSourceHost(undefined)).toBeUndefined();
+        expect(withByExampleSourceHost([])).toEqual([]);
+    });
+});

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/resources/copilot/generic-services.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/resources/copilot/generic-services.json
@@ -65,6 +65,31 @@
           }
         ]
       }
+    },
+    {
+      "libraryName": "ballerina/email",
+      "type": "generic",
+      "name": "Service",
+      "instructions": "The `ballerina/email` module receives mail through a polling listener, not a client loop. Two listener classes exist and both attach the same `email:Service`:\n- `email:ImapListener` for IMAP4, configured with an `email:ImapListenerConfiguration` record (`host`, `username`, `password`, optional `pollingInterval` in seconds (default 30), `port` (default 993), `security`, `secureSocket`).\n- `email:PopListener` for POP3, configured with an `email:PopListenerConfiguration` record carrying the same fields (`port` default 995).\nThe listener polls the mailbox every `pollingInterval` seconds and dispatches each new mail to `onMessage`. Declare the listener at module level from configurables and attach a named service:\n```ballerina\nimport ballerina/email;\nimport ballerina/log;\n\nlistener email:ImapListener emailListener = check new ({\n    host: imapHost,\n    username: imapUsername,\n    password: imapPassword,\n    pollingInterval: imapPollingIntervalSeconds,\n    port: imapPort\n});\n\nservice \"emailObserver\" on emailListener {\n    // Called once for every newly received email.\n    remote function onMessage(email:Message emailMessage) {\n        log:printInfo(\"Received an email\", subject = emailMessage.subject);\n    }\n\n    // Called when polling the mailbox fails; the listener keeps polling.\n    remote function onError(email:Error emailError) {\n        log:printError(\"Email polling failed\", 'error = emailError);\n    }\n\n    // Called when the listener is closed.\n    remote function onClose(email:Error? closeError) {\n    }\n}\n```\n`onMessage` is required; `onError` and `onClose` are optional. Read `emailMessage.subject`, `emailMessage?.'from`, `emailMessage?.body` and `emailMessage?.htmlBody` from the received `email:Message`. Do not poll with `email:ImapClient`/`email:PopClient` `receiveMessage()` in a loop when the requirement is to react to mail as it arrives — use the listener.",
+      "listener": {
+        "name": "email:ImapListener",
+        "description": "Polls an IMAP mailbox on a fixed interval and dispatches every newly received email to the attached service. Use email:PopListener for POP3 mailboxes.",
+        "parameters": [
+          {
+            "name": "listenerConfig",
+            "description": "IMAP server host, credentials, port, polling interval and security settings",
+            "type": {
+              "name": "ImapListenerConfiguration",
+              "links": [
+                {
+                  "category": "internal",
+                  "recordName": "ImapListenerConfiguration"
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/2364

## Problem
Asked for an `email:ImapListener`, Copilot concluded the API might not exist. `ballerina/email` has no entry in the service index, so no listener or service block was rendered for it, and the module README only shows the PopListener example. When it fetched the "Receive email using a service" Ballerina By Example page for guidance, the page came back as navigation only because it is rendered client-side.

## Fix
- Add a curated `generic-services.json` entry for `ballerina/email` describing `email:ImapListener`/`email:PopListener`, their configuration records and the `email:Service` handlers (`onMessage`, `onError`, `onClose`) with a snippet. The entry is served through the existing generic-services overlay; no Java change.
- `web_fetch` now resolves `https://ballerina.io/learn/by-example/<slug>/` to the example's `.bal` source in the `ballerina-distribution` repository (hyphens become underscores in the file name), adds the raw GitHub host to a model-supplied domain allow-list so the rewritten fetch is not blocked, shows the resolved source in the approval prompt, and falls back to the page when the source is unavailable.

## Tests
- `src/test-support/ballerinaByExample.test.ts`: URL shapes that are and are not rewritten, slug-to-file rule, allow-list handling.
- The generic-services JSON is validated for shape; the LS test suite was not run here (needs Gradle credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
