### PR TITLE
Guide Copilot to bind external payloads to open records

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/external-payload-records.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/external-payload-records.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * System-prompt rule scoping closed records to schemas the generated code owns.
+ *
+ * The Coding Rules ask for records instead of maps or json, and the langlib guide's conversion examples
+ * used closed records, so an S3 event notification consumed from SQS was bound to `record {| ... |}` types
+ * that declared only the fields the code used. Conversion then failed at run time on the first real event:
+ * "field 'Records[0].eventVersion' cannot be added to the closed record". Nothing distinguished a schema
+ * the code owns from one an external system produces, and the compiler cannot report the mismatch.
+ *
+ * Kept in its own module (no imports) so it can be unit-tested without loading the extension host.
+ */
+export const EXTERNAL_PAYLOAD_RECORD_RULE =
+    "Records that bind data produced by an EXTERNAL system (cloud event notifications such as S3/SQS/SNS "
+    + "events, webhooks, third-party API responses, messages consumed from queues or topics) MUST be OPEN "
+    + "records (`record { ... }` — an open record implicitly accepts extra `anydata` fields): declare only the "
+    + "fields the code uses and mark any field that may be absent optional (`string eventVersion?;`). Use CLOSED "
+    + "records (`record {| ... |}`) only for schemas this code owns: internal models, log entries, and the "
+    + "request/response contracts it defines. Binding a value that carries an undeclared field into a closed "
+    + "record FAILS AT RUNTIME with `{ballerina/lang.value}ConversionError` (\"field 'x' cannot be added to the "
+    + "closed record 'y'\") and is never reported by the compiler, so never bind an external payload into a "
+    + "closed record with `cloneWithType()`, `fromJsonWithType()`, `fromJsonStringWithType()`, `ensureType()` "
+    + "or HTTP/queue payload data binding.";

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -27,6 +27,7 @@ import { getLanglibInstructions } from "../utils/libs/langlibs";
 import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
+import { EXTERNAL_PAYLOAD_RECORD_RULE } from "./external-payload-records";
 import { getRequirementAnalysisCodeGenPrefix, getRequirementAnalysisTestGenPrefix } from "./np/prompts";
 import { extractResourceDocumentContent, flattenProjectToFiles } from "../utils/ai-utils";
 import { BALLERINA_RUN_TOOL_NAME } from "./tools/ballerina-run";
@@ -202,6 +203,7 @@ When a connector authenticates via an OAuth2 refresh-token grant that includes a
 
 ## Coding Rules
 - Use records as canonical representations of data structures. Always define records for data structures instead of using maps or json and navigate using the record fields.
+- ${EXTERNAL_PAYLOAD_RECORD_RULE}
 - Do not invoke methods on json access expressions. Always use separate statements.
 - Use dot notation to access a normal function. Use -> to access a remote function or resource function.
 - Do not use dynamic listener registrations.

--- a/packages/ballerina-extension/src/features/ai/utils/libs/langlibs.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/langlibs.ts
@@ -57,9 +57,10 @@ json data = check jsonText.fromJsonString();
 string jsonArray = "[1, 2, 3]";
 int[] numbers = check jsonArray.fromJsonStringWithType();
 
-// Converting JSON to a record type
-string configText = "{\"port\":8080,\"timeout\":60}";
-type Config record {| int port; int timeout; |};
+// Converting JSON to a record type. The record is OPEN (record { ... }), so a payload
+// carrying fields it does not declare still converts; a closed record {| ... |} would fail.
+string configText = "{\"port\":8080,\"timeout\":60,\"region\":\"eu\"}";
+type Config record { int port; int timeout; };
 Config config = check configText.fromJsonStringWithType(Config);
 \`\`\`
 
@@ -86,12 +87,28 @@ copy.push(4);  // original stays [1, 2, 3]
 To convert between types while preserving data, use cloneWithType():
 \`\`\`ballerina
 json cfg = {port: 8080};
-type Config record {| int port; int timeout = 60; |};
+type Config record { int port; int timeout = 60; };
 Config config = check cfg.cloneWithType();
 
 // Converting arrays
 json[] arr = [1, 2, 3];
 int[] numbers = check arr.cloneWithType();
+\`\`\`
+
+Open versus closed records in conversions: \`record {| ... |}\` is a CLOSED record. cloneWithType(), fromJsonWithType(), fromJsonStringWithType() and ensureType() fail at runtime with \`{ballerina/lang.value}ConversionError\` ("field 'x' cannot be added to the closed record") when the input carries ANY field the record does not declare, and the compiler cannot warn about it. Use an open \`record { ... }\` for data that comes from an external system (cloud events, webhooks, third-party API responses, queue messages); use a closed record only for a schema this code fully controls:
+\`\`\`ballerina
+// External payload: open, only the fields we use, optional where the producer may omit them.
+type S3EventRecord record {
+    string eventName;
+    string eventTime;
+    string awsRegion?;
+};
+
+// Owned schema: closed, because this code defines every field.
+type S3EventLogEntry record {|
+    string eventType;
+    string bucketName;
+|};
 \`\`\`
 
 To validate that a value matches a specific type, use ensureType():

--- a/packages/ballerina-extension/src/test-support/externalPayloadRecordRules.test.ts
+++ b/packages/ballerina-extension/src/test-support/externalPayloadRecordRules.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Guards the open-versus-closed record guidance. The regression that motivated it was silent: closed
+ * records for an S3 event payload compiled cleanly and failed on the first real event, so the rule text
+ * and the langlib examples are pinned here. `prompts.ts` cannot be imported (extension-host graph), so its
+ * wiring is checked against the source text.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { EXTERNAL_PAYLOAD_RECORD_RULE } from '../features/ai/agent/external-payload-records';
+import { LANGLIB_USAGE_INSTRUCTIONS } from '../features/ai/utils/libs/langlibs';
+
+const promptsSource = fs.readFileSync(path.join(__dirname, '../features/ai/agent/prompts.ts'), 'utf-8');
+
+describe('EXTERNAL_PAYLOAD_RECORD_RULE content', () => {
+    it('scopes open records to external payloads and closed records to owned schemas', () => {
+        expect(EXTERNAL_PAYLOAD_RECORD_RULE).toMatch(/EXTERNAL system/);
+        expect(EXTERNAL_PAYLOAD_RECORD_RULE).toMatch(/MUST be OPEN records \(`record \{ \.\.\. \}`/);
+        expect(EXTERNAL_PAYLOAD_RECORD_RULE).toMatch(/Use CLOSED records \(`record \{\| \.\.\. \|\}`\) only for schemas this code owns/);
+    });
+
+    it('names the runtime failure and every conversion path that triggers it', () => {
+        expect(EXTERNAL_PAYLOAD_RECORD_RULE).toMatch(/FAILS AT RUNTIME/);
+        expect(EXTERNAL_PAYLOAD_RECORD_RULE).toMatch(/\{ballerina\/lang\.value\}ConversionError/);
+        expect(EXTERNAL_PAYLOAD_RECORD_RULE).toMatch(/never reported by the compiler/);
+        for (const fn of ['cloneWithType()', 'fromJsonWithType()', 'fromJsonStringWithType()', 'ensureType()']) {
+            expect(EXTERNAL_PAYLOAD_RECORD_RULE).toContain(fn);
+        }
+    });
+
+    it('tells the model to mark possibly-absent fields optional', () => {
+        expect(EXTERNAL_PAYLOAD_RECORD_RULE).toMatch(/mark any field that may be absent optional/);
+    });
+
+    it('contains no unresolved interpolation', () => {
+        expect(EXTERNAL_PAYLOAD_RECORD_RULE).not.toMatch(/\$\{/);
+    });
+});
+
+describe('system prompt wiring', () => {
+    it('imports the rule and places it directly under the records-first coding rule', () => {
+        expect(promptsSource).toMatch(/import \{ EXTERNAL_PAYLOAD_RECORD_RULE \} from "\.\/external-payload-records";/);
+        const codingRules = promptsSource.indexOf('## Coding Rules');
+        const recordsRule = promptsSource.indexOf('Use records as canonical representations', codingRules);
+        const scopingRule = promptsSource.indexOf('${EXTERNAL_PAYLOAD_RECORD_RULE}', recordsRule);
+        const fileMods = promptsSource.indexOf('## File modifications');
+        expect(codingRules).toBeGreaterThan(-1);
+        expect(scopingRule).toBeGreaterThan(recordsRule);
+        expect(scopingRule).toBeLessThan(fileMods);
+    });
+});
+
+describe('langlib conversion examples', () => {
+    it('convert into OPEN records, never into a closed record', () => {
+        // Every `check ... WithType(...)` target record declared in the guide must be open.
+        const conversions = [...LANGLIB_USAGE_INSTRUCTIONS.matchAll(/type (\w+) record \{\|[^}]*\|\};\n(\w+) \w+ = check [^\n]*WithType/g)];
+        expect(conversions).toHaveLength(0);
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toContain('type Config record { int port; int timeout; };');
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toContain('type Config record { int port; int timeout = 60; };');
+    });
+
+    it('explain the open-versus-closed distinction with a labelled example of each', () => {
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toMatch(/Open versus closed records in conversions/);
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toMatch(/\{ballerina\/lang\.value\}ConversionError/);
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toMatch(/External payload: open/);
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toMatch(/Owned schema: closed/);
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toMatch(/type S3EventRecord record \{\n/);
+        expect(LANGLIB_USAGE_INSTRUCTIONS).toMatch(/type S3EventLogEntry record \{\|/);
+    });
+
+    it('keep the only remaining closed record in the guide as the labelled owned-schema example', () => {
+        const closed = [...LANGLIB_USAGE_INSTRUCTIONS.matchAll(/type (\w+) record \{\|/g)].map((m) => m[1]);
+        expect(closed).toEqual(['S3EventLogEntry']);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/2320

## Problem
Copilot bound an AWS S3 event notification consumed from SQS to closed records (`record {| ... |}`) that declared only the fields the code used. The first real event failed at run time: `field 'Records[0].eventVersion' cannot be added to the closed record`. The coding rules ask for records instead of json without distinguishing schemas the code owns from schemas an external system produces, the langlib guide's conversion examples all used closed records, and the compiler cannot report the mismatch.

## Fix
- Add `EXTERNAL_PAYLOAD_RECORD_RULE` directly under the records-first coding rule: data from an external system binds to OPEN records with optional fields; closed records only for schemas this code owns; names the runtime `ConversionError` and every conversion path that triggers it (`cloneWithType`, `fromJsonWithType`, `fromJsonStringWithType`, `ensureType`, payload data binding).
- Switch the langlib `fromJsonStringWithType`/`cloneWithType` examples to open records and add a labelled open-versus-closed example.

## Tests
- `src/test-support/externalPayloadRecordRules.test.ts`: rule text, prompt wiring, and langlib invariants (no conversion into a closed record; exactly one labelled closed example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
