### PR TITLE
Add concurrency rules and isolation diagnostic hints to the Copilot prompt

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/concurrency-rules.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/concurrency-rules.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * System-prompt rules for writing code that satisfies the compiler's isolation analysis up front:
+ * which module-level variables an `isolated` function or a service method may read, when a variable
+ * must be `isolated` and guarded by `lock`, and how isolated objects fit in.
+ *
+ * The rule that matters most is the one the language spec states in §7.3.5 (Isolated functions): a
+ * module-level variable may be read from an isolated context without a lock when it is `final` (or
+ * `configurable`, or a listener/service) AND its static type is a subtype of `readonly` OR of
+ * `isolated object {}`. Guidance that mentioned only the `readonly` half made the agent conclude that a
+ * `final` instance of an `isolated class` (a store, an `ai:Agent`, a connector client) could not be used
+ * from a service, and it then wrapped the object in an `isolated` variable plus a `lock`, or added
+ * `& readonly` to a type that cannot be immutable.
+ *
+ * Kept in its own module (no imports) so it can be unit-tested without loading the extension host.
+ * Interpolated into the system prompt by getSystemPrompt() in ./prompts.ts.
+ */
+export const CONCURRENCY_CODING_RULES = `## Concurrency Safety and Shared State
+Ballerina checks isolation at compile time so services can handle requests concurrently. Follow these rules whenever the code has module-level state, service fields, or workers:
+- \`configurable\` variables are implicitly final and readable from any isolated context — NEVER write \`final configurable\` (it is a compile error).
+- For other module-level variables: if the variable is never reassigned, declare it \`final\`. A \`final\` module-level variable can be read from an \`isolated\` function or a service method WITHOUT a lock when its static type is immutable (\`readonly\`, e.g. \`final int[] & readonly defaults = [1, 2];\`) OR an isolated object — that covers most connector clients and listeners (e.g. \`final http:Client httpClient = check new (url);\`), \`ai:Agent\`, and instances of a class you declared \`isolated class\`. Do NOT declare such a variable \`isolated\`, do NOT wrap its use in \`lock { }\`, and do NOT add \`& readonly\` to it. \`final\` alone is not sufficient for any OTHER type: a \`final map<string>\` or \`final int[]\` is still non-isolated mutable state. If the state is shared and MUTABLE, declare the variable \`isolated\` (e.g. \`isolated int[] requests = [];\`) and access it ONLY inside \`lock { }\` blocks; an \`isolated\` variable must be initialized at its declaration.
+- When you write your own class that will be held in a module-level \`final\` variable and used from services, declare it \`isolated class\`, declare every mutable field \`private\`, initialize each field with a fresh literal or constructor, and access \`self\` fields only inside \`lock { }\` blocks within its methods.
+- In a service holding mutable state, apply the same rules to its fields (\`private\`, fresh initializer, \`self\` only inside \`lock { }\`). For requests to be dispatched concurrently, each resource/remote method must ALSO satisfy isolated-function rules: it may only call \`isolated\` functions and must not touch non-final module-level mutable state. The compiler then infers both the service and its methods as \`isolated\`.
+- One \`lock\` block may protect only ONE isolated root: never access two \`isolated\` variables (or an \`isolated\` variable plus \`self\`) in the same lock. Use separate lock statements and pass values between them via local variables. If two pieces of state must change together atomically, store them in ONE protected value (a single record or map behind one isolated variable).
+- A value that leaves a lock protecting an isolated root (returned or assigned to an outer variable) must not alias the protected state: copy it with \`.clone()\` (or \`.cloneReadOnly()\` when an immutable result is acceptable). Immutable (\`readonly\`) values and single isolated objects (a client, a caller) may leave without cloning. An ordinary lock over non-isolated state has no transfer restrictions — do not add gratuitous clones there.
+- Never use \`start\`, named \`worker\` declarations, or worker send/receive actions (\`->\`/\`<-\`) inside a \`lock\` block. Read the needed values into locals inside the lock, then do the async work after it.
+- Functions called from an \`isolated\` function, or from inside a lock protecting isolated state, must themselves be \`isolated\`. Write helper functions as \`isolated\` when they only work on their parameters and local state.
+- Keep lock blocks minimal: only the shared-state read/write belongs inside; perform I/O and remote calls outside the lock.`;

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -27,6 +27,7 @@ import { getLanglibInstructions } from "../utils/libs/langlibs";
 import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
+import { CONCURRENCY_CODING_RULES } from "./concurrency-rules";
 import { getRequirementAnalysisCodeGenPrefix, getRequirementAnalysisTestGenPrefix } from "./np/prompts";
 import { extractResourceDocumentContent, flattenProjectToFiles } from "../utils/ai-utils";
 import { BALLERINA_RUN_TOOL_NAME } from "./tools/ballerina-run";
@@ -216,6 +217,8 @@ When a connector authenticates via an OAuth2 refresh-token grant that includes a
 - Always use named arguments when providing values to any parameter (e.g., .get(key="value")).
 - Mention types EXPLICITLY in variable declarations and foreach statements. (Avoid var at all costs)
 - To narrow down a union type(or optional type), always declare a separate variable and then use that variable in the if condition.
+
+${CONCURRENCY_CODING_RULES}
 
 ## File modifications
 - You must apply changes to the existing source code using the provided ${[

--- a/packages/ballerina-extension/src/features/ai/agent/tools/diagnostic-hints.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/diagnostic-hints.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Map of Ballerina diagnostic codes to resolving hints.
+ *
+ * Each entry maps a diagnostic code (e.g., "BCE3943") to a directive hint on how to resolve it. Hints ride
+ * along with the diagnostics returned by the getCompilationErrors tool so the agent can apply the canonical
+ * fix instead of guessing at the compiler's isolation terminology. The isolation entries follow the language
+ * spec §7.3.5 / §7.23 and the compiler's IsolationAnalyzer messages (quoted above each entry).
+ *
+ * Kept in its own module (no imports) so it can be unit-tested without loading the extension host.
+ */
+export const DIAGNOSTIC_HINTS: Readonly<Record<string, string>> = {
+    "BCE2000": "This usually indicates a missing import statement. Please ensure that all necessary modules are imported in each file where they are used.",
+
+    // "invalid access of mutable storage in an 'isolated' function"
+    "BCE3943": "An `isolated` function may only read module-level state that is (a) `final` (or `configurable`) with a type "
+        + "that is immutable (`readonly`) OR an isolated object (a connector client, a listener, `ai:Agent`, an instance of an "
+        + "`isolated class`), or (b) declared `isolated` and accessed only inside `lock { }`. If the reported variable is already "
+        + "`final` and its type is an isolated object, the access is legal — the error comes from a DIFFERENT variable in the same "
+        + "function. Fix: if the variable is never reassigned, declare it `final` (and give it an immutable type if it is a "
+        + "map/array/record); if it is shared mutable state, declare it `isolated` (e.g. `isolated int[] stack = [];`) and wrap "
+        + "every access in `lock { }`. Do NOT simply drop the `isolated` qualifier from a resource/remote method — that disables "
+        + "concurrent dispatch.",
+
+    // "invalid non-private mutable field in an isolated object"
+    "BCE3956": "Every mutable field of an isolated object/class must be `private`. Add the `private` qualifier, or make the "
+        + "field `final` with an immutable (`readonly`) or isolated-object type if it is never reassigned.",
+
+    // "invalid access of a mutable field of an 'isolated' object outside a 'lock' statement"
+    "BCE3957": "Access to a mutable `self` field of an isolated object must be inside a `lock` statement. Wrap the statement(s) "
+        + "in `lock { ... }` (group nearby accesses of the field into one lock; mutable values leaving the lock must be cloned).",
+
+    // "invalid attempt to transfer out a value from a 'lock' statement with restricted variable usage: expected an isolated expression"
+    "BCE3959": "A value leaving a lock that protects an isolated variable or `self` (via `return` or assignment to an outer "
+        + "variable) must not alias the protected state. Return/assign a copy: `return m[k].clone();` (or `.cloneReadOnly()` "
+        + "when an immutable result is acceptable). A single isolated object (a client, a caller) may leave as-is; an ARRAY or "
+        + "MAP of them may not — copy the keys (`m.keys().clone()`) and fetch one element per lock instead.",
+
+    // "invalid attempt to transfer a value into a 'lock' statement with restricted variable usage"
+    "BCE3960": "A mutable value defined outside this lock must not be stored into protected state directly. Store a copy "
+        + "instead: `m[k] = v.clone();`, or declare the incoming parameter/variable as `readonly & T` so it is immutable.",
+
+    // "invalid invocation of a non-isolated function in a 'lock' statement with restricted variable usage"
+    "BCE3961": "Only `isolated` functions may be called inside a lock that accesses an isolated variable or `self` of an "
+        + "isolated object. Add the `isolated` qualifier to the called function, or move the call outside the lock.",
+
+    // "invalid access of an 'isolated' variable outside a 'lock' statement"
+    "BCE3962": "An `isolated` module variable may only be accessed inside a `lock` statement. Wrap the access in `lock { ... }`. "
+        + "Remember: one lock may access only ONE isolated variable, and mutable values crossing the lock boundary must be cloned.",
+
+    // "cannot access more than one variable for which usage is restricted in a single 'lock' statement"
+    "BCE3964": "A single `lock` statement may access only ONE isolated variable (or `self` of an isolated object). Split the "
+        + "logic into separate lock statements, copying needed values into locals in between (e.g. `int bv; lock { bv = b; } "
+        + "lock { a += bv; }`). If two pieces of state must change atomically together, merge them into one protected value.",
+
+    // "an uninitialized module variable declaration cannot be marked as 'isolated'"
+    "BCE3965": "An `isolated` module variable must be initialized at the declaration. Add an initializer that is an isolated "
+        + "expression (e.g. `isolated int[] data = [];`).",
+};

--- a/packages/ballerina-extension/src/features/ai/agent/tools/diagnostics-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/diagnostics-utils.ts
@@ -3,6 +3,7 @@ import { checkProjectDiagnostics, isModuleNotFoundDiagsExist as resolveModuleNot
 import { StateMachine } from '../../../../stateMachine';
 import * as path from 'path';
 import { Uri } from 'vscode';
+import { DIAGNOSTIC_HINTS } from './diagnostic-hints';
 
 export const DIAGNOSTICS_TOOL_NAME = "getCompilationErrors";
 
@@ -21,24 +22,6 @@ export interface DiagnosticsCheckResult {
     message: string;
 }
 
-/**
- * Map of Ballerina diagnostic codes to resolving hints
- *
- * Each entry maps a diagnostic code (e.g., "BCE2000") to a helpful hint on how to resolve it.
- * These hints are shown alongside the diagnostic message to help developers fix issues quickly.
- *
- * TODO: Populate this map with actual Ballerina diagnostic codes and their corresponding hints.
- * Example structure:
- * {
- *   "BCE2000": "Add missing import statement for the module",
- *   "BCE2001": "Check variable type compatibility",
- *   "BCE2002": "Ensure function return type matches declaration",
- * }
- */
-const DIAGNOSTIC_HINTS: Record<string, string> = {
-    // Diagnostic code mappings to be populated
-    "BCE2000": "This usually indicates a missing import statement. Please ensure that all necessary modules are imported in each file where they are used.",
-};
 
 /**
  * Converts language server Diagnostics to EnrichedDiagnostic entries with hints

--- a/packages/ballerina-extension/src/test-support/concurrencyPromptRules.test.ts
+++ b/packages/ballerina-extension/src/test-support/concurrencyPromptRules.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Pins the concurrency rules the system prompt teaches, in particular the spec §7.3.5 rule about
+ * module-level `final` variables: readable from isolated code without a lock when the type is `readonly`
+ * OR an isolated object. A rule that mentioned only the `readonly` half made the agent treat a `final`
+ * instance of an `isolated class` as unusable from a service. `prompts.ts` cannot be imported here (it
+ * pulls the extension-host module graph), so its wiring is checked against the source text.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { CONCURRENCY_CODING_RULES } from '../features/ai/agent/concurrency-rules';
+import { DIAGNOSTIC_HINTS } from '../features/ai/agent/tools/diagnostic-hints';
+
+const promptsSource = fs.readFileSync(path.join(__dirname, '../features/ai/agent/prompts.ts'), 'utf-8');
+
+describe('CONCURRENCY_CODING_RULES content', () => {
+    it('is a markdown section with the expected heading', () => {
+        expect(CONCURRENCY_CODING_RULES.startsWith('## Concurrency Safety and Shared State')).toBe(true);
+    });
+
+    it('never suggests final on configurable variables (compile error)', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/NEVER write `final configurable`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/implicitly final/);
+    });
+
+    it('teaches that a final variable is readable from isolated code when its type is readonly OR an isolated object', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/never reassigned, declare it `final`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/WITHOUT a lock when its static type is immutable \(`readonly`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/OR an isolated object/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/most connector clients and listeners/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/`ai:Agent`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/instances of a class you declared `isolated class`/);
+    });
+
+    it('forbids the wrong repairs for a final isolated object', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/Do NOT declare such a variable `isolated`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/do NOT wrap its use in `lock \{ \}`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/do NOT add `& readonly` to it/);
+    });
+
+    it('still scopes "final alone is not sufficient" to non-isolated mutable types', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/`final` alone is not sufficient for any OTHER type/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/`final map<string>` or `final int\[\]` is still non-isolated mutable state/);
+    });
+
+    it('teaches the isolated-variable + lock pattern for shared mutable state', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/declare the variable `isolated`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/ONLY inside `lock \{ \}` blocks/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/must be initialized at its declaration/);
+    });
+
+    it('tells the model to declare its own module-level object classes as isolated class', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/declare it `isolated class`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/declare every mutable field `private`/);
+    });
+
+    it('teaches the one-root-per-lock rule and the transfer rule scoped to restricted locks', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/only ONE isolated root/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/copy it with `\.clone\(\)`/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/single isolated objects \(a client, a caller\) may leave without cloning/);
+        expect(CONCURRENCY_CODING_RULES).toMatch(/ordinary lock over non-isolated state has no transfer restrictions/);
+    });
+
+    it('forbids strand creation and worker message passing inside locks', () => {
+        expect(CONCURRENCY_CODING_RULES).toMatch(/Never use `start`, named `worker` declarations, or worker send\/receive/);
+    });
+
+    it('contains no unresolved interpolations or stray backtick escapes', () => {
+        expect(CONCURRENCY_CODING_RULES).not.toMatch(/\$\{/);
+        expect(CONCURRENCY_CODING_RULES).not.toMatch(/\\`/);
+    });
+});
+
+describe('system prompt wiring', () => {
+    it('imports the rules constant', () => {
+        expect(promptsSource).toMatch(/import \{ CONCURRENCY_CODING_RULES \} from "\.\/concurrency-rules";/);
+    });
+
+    it('interpolates the rules between Coding Rules and File modifications', () => {
+        const codingRules = promptsSource.indexOf('## Coding Rules');
+        const interpolation = promptsSource.indexOf('${CONCURRENCY_CODING_RULES}');
+        const fileMods = promptsSource.indexOf('## File modifications');
+        expect(codingRules).toBeGreaterThan(-1);
+        expect(interpolation).toBeGreaterThan(codingRules);
+        expect(interpolation).toBeLessThan(fileMods);
+    });
+});
+
+describe('isolation diagnostic hints', () => {
+    it('keeps the pre-existing missing-import hint', () => {
+        expect(DIAGNOSTIC_HINTS.BCE2000).toMatch(/missing import/);
+    });
+
+    it('BCE3943 states both legal final types and the different-variable case, and forbids dropping isolated', () => {
+        const hint = DIAGNOSTIC_HINTS.BCE3943;
+        expect(hint).toMatch(/immutable \(`readonly`\) OR an isolated object/);
+        expect(hint).toMatch(/instance of an `isolated class`/);
+        expect(hint).toMatch(/the error comes from a DIFFERENT variable/);
+        expect(hint).toMatch(/Do NOT simply drop the `isolated` qualifier/);
+    });
+
+    it('covers the lock rules the agent hits most and agrees with the prompt on the array-of-objects case', () => {
+        for (const code of ['BCE3956', 'BCE3957', 'BCE3959', 'BCE3960', 'BCE3961', 'BCE3962', 'BCE3964', 'BCE3965']) {
+            expect(typeof DIAGNOSTIC_HINTS[code]).toBe('string');
+            expect(DIAGNOSTIC_HINTS[code].length).toBeGreaterThan(40);
+        }
+        expect(DIAGNOSTIC_HINTS.BCE3959).toMatch(/an ARRAY or MAP of them may not/);
+        expect(DIAGNOSTIC_HINTS.BCE3964).toMatch(/only ONE isolated variable/);
+    });
+});


### PR DESCRIPTION
## Problem
Copilot treated a module-level `final` variable holding an instance of an `isolated class` (or an `ai:Agent`, or a connector client) as unusable from a service, and either wrapped it in an `isolated` variable plus a `lock` or added `& readonly` to a type that cannot be immutable. The language spec (§7.3.5) allows an isolated function to read a final module-level variable whose static type is a subtype of `readonly` **or** of `isolated object {}`. The prompt had no concurrency guidance, and the only diagnostic hint was for missing imports.

## Fix
- Add `CONCURRENCY_CODING_RULES` to the system prompt between Coding Rules and File modifications: `configurable` is implicitly final; a `final` variable is readable without a lock when its type is readonly or an isolated object (clients, listeners, `ai:Agent`, `isolated class` instances); never wrap those in `isolated`/`lock` or add `& readonly`; `final` alone is not sufficient for other mutable types; isolated variable plus lock for shared mutable state; declare own module-level object classes as `isolated class`; one root per lock; transfer rules; no `start`/workers inside locks.
- Move `DIAGNOSTIC_HINTS` into its own module and add hints for the isolation diagnostics BCE3943, BCE3956, BCE3957, BCE3959 to BCE3962, BCE3964 and BCE3965. Codes were verified against the 2201.13.4 compiler. BCE3943 states the isolated-object case and the "error comes from a different variable" case explicitly.

## Tests
- `src/test-support/concurrencyPromptRules.test.ts`: rule text, prompt wiring, hint coverage and content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
