### PR TITLE
Add a WebSocket probe tool and stop Hurl from verifying WebSocket services

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -31,6 +31,9 @@ import { getRequirementAnalysisCodeGenPrefix, getRequirementAnalysisTestGenPrefi
 import { extractResourceDocumentContent, flattenProjectToFiles } from "../utils/ai-utils";
 import { BALLERINA_RUN_TOOL_NAME } from "./tools/ballerina-run";
 import { BALLERINA_STOP_TOOL_NAME } from "./tools/ballerina-stop";
+import { BALLERINA_GET_LOGS_TOOL_NAME } from "./tools/ballerina-get-logs";
+import { HURL_TOOL_NAME } from "./tools/hurl-tool";
+import { WEBSOCKET_PROBE_TOOL_NAME } from "./tools/websocket-probe";
 import { getBuiltInSkillsSection, getProjectSkillsSection, getUserSkillsSection, getDisabledSkillsSection, ProjectSkillMeta } from "./skills";
 import { WEB_SEARCH_TOOL_NAME, WEB_FETCH_TOOL_NAME } from "./tools/web-tools";
 // TODO(auto-memory): temporarily disabled for this release — restore once the memory feature is refined.
@@ -258,6 +261,11 @@ In WSO2 Integrator, a Ballerina workspace is called a **project** and a Ballerin
 - You do NOT decide which (library, shape) combinations are actually managed — the tool verifies each against the managed registry and silently downgrades unsupported ones to manual entry. So emit a group for ANY connector credential that fits one of the two shapes; grouping a candidate that turns out to be unsupported is harmless. That tolerance covers the library and shape only — every mapped name must be a configurable that already exists in source, spelled exactly as declared. Only leave TRULY non-connector secrets (e.g. a database password, or a standalone API key not tied to any connector) in \`variables\`.
 - Use one managedConnections entry per connector instance (repeat the same library for two clients of it), and put each configurable in EXACTLY ONE place — never list the same name in both a group and \`variables\`.
 - You can call ${BALLERINA_STOP_TOOL_NAME} when you need to restart a service (e.g. after code changes) or when the user explicitly asks to stop it.
+
+## Trying out endpoints
+- Use ${HURL_TOOL_NAME} for HTTP endpoints ONLY. Hurl cannot open WebSocket connections: a script against ws:// or wss://, or one sending an Upgrade: websocket header, is rejected, and a request that times out or errors has FAILED — never read a timeout or a missing HTTP 101 as a successful upgrade.
+- Use ${WEBSOCKET_PROBE_TOOL_NAME} to verify a WebSocket service running on this machine. It performs the upgrade, reports the HTTP status when the upgrade is refused (400 = returned websocket:UpgradeError, 401/403 = auth, 500 = a panic in the upgrade resource or an incompatible http:Listener), sends the given messages in order and returns the frames the server pushed. \`upgraded: false\`, an \`error\`, or zero received frames from a service that is expected to push data means the service is NOT working: read its output with ${BALLERINA_GET_LOGS_TOOL_NAME} and fix the code.
+- When the user has asked you to run or try out the integration, exercise EACH requested trigger at least once (e.g. both the create and the update path of an event) and report every trigger you could not exercise as unverified.
 
 ## Test Runner
 When running tests:

--- a/packages/ballerina-extension/src/features/ai/agent/tool-registry.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tool-registry.ts
@@ -53,6 +53,7 @@ import { createBallerinaGetLogsTool, BALLERINA_GET_LOGS_TOOL_NAME } from './tool
 import { createBallerinaStopTool, BALLERINA_STOP_TOOL_NAME } from './tools/ballerina-stop';
 import { RunningServicesManager } from './tools/running-service-manager';
 import { createHurlTool, HURL_TOOL_NAME } from './tools/hurl-tool';
+import { createWebSocketProbeTool, WEBSOCKET_PROBE_TOOL_NAME } from './tools/websocket-probe';
 import { createWebSearchTool, WEB_SEARCH_TOOL_NAME, createWebFetchTool, WEB_FETCH_TOOL_NAME } from './tools/web-tools';
 import { createClarifyTool, CLARIFY_TOOL } from './tools/clarify';
 import { createSkillTool, SKILL_TOOL_NAME } from './tools/skill-tool';
@@ -141,6 +142,7 @@ export function createToolRegistry(opts: ToolRegistryOptions) {
             [MIGRATION_SOURCE_READ_TOOL]: createMigrationSourceReadTool(eventHandler, migrationSourcePath),
         } : {}),
         [HURL_TOOL_NAME]: createHurlTool(eventHandler),
+        [WEBSOCKET_PROBE_TOOL_NAME]: createWebSocketProbeTool(eventHandler),
         [BALLERINA_RUN_TOOL_NAME]: createBallerinaRunTool(tempProjectPath, opts.runningServices, eventHandler),
         [BALLERINA_GET_LOGS_TOOL_NAME]: createBallerinaGetLogsTool(opts.runningServices, eventHandler),
         [BALLERINA_STOP_TOOL_NAME]: createBallerinaStopTool(opts.runningServices, eventHandler),

--- a/packages/ballerina-extension/src/features/ai/agent/tools/hurl-tool.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/hurl-tool.ts
@@ -20,10 +20,12 @@ import * as vscode from 'vscode';
 import { CopilotEventHandler } from '../../utils/events';
 import { runningServicesManager } from './running-service-manager';
 import { solveRelativeTempPath } from '../utils';
+import { detectWebSocketUsage, websocketRejectionMessage } from './hurl-websocket-guard';
+import { WEBSOCKET_PROBE_TOOL_NAME } from './websocket-probe';
 
 export const HURL_TOOL_NAME = "hurlRunnerTool";
 const HURL_LM_TOOL_NAME = "run-hurl-test";
-const TOOL_DESCRIPTION = `The hurl script to execute. Hurl is a command-line tool for running HTTP requests written in a simple text format. A script can contain one or more requests.
+const TOOL_DESCRIPTION = `The hurl script to execute. Hurl is a command-line tool for running HTTP requests written in a simple text format. A script can contain one or more requests. HTTP only: a script targeting ws:// or wss://, or sending an Upgrade: websocket header, is rejected without running — use ${WEBSOCKET_PROBE_TOOL_NAME} for WebSocket endpoints.
 Example Script:
 GET http://example.com/api/resource
 Accept: application/json
@@ -121,7 +123,7 @@ function removeSummaryFromHurlOutput(response: RawHurlToolOutput): HurlToolOutpu
 
 export function createHurlTool(eventHandler: CopilotEventHandler) {
     return tool({
-        description: `A tool to execute Hurl scripts. The input is a Hurl script as a string. The output includes the execution results, including response details. Use this tool to try out HTTP endpoints. Prefer requests without assertions for simple try-it scenarios ( without including status code assertions such as HTTP 200 or other types of assertions)`,
+        description: `A tool to execute Hurl scripts. The input is a Hurl script as a string. The output includes the execution results, including response details. Use this tool to try out HTTP endpoints ONLY — Hurl cannot open WebSocket connections; use ${WEBSOCKET_PROBE_TOOL_NAME} for ws:// and wss:// endpoints. A request that times out or reports an error has FAILED; never read it as success. Prefer requests without assertions for simple try-it scenarios ( without including status code assertions such as HTTP 200 or other types of assertions)`,
         inputSchema: HURLInputSchema,
         execute: async (input): Promise<HurlToolOutput> => await executeHurlRequest(input, eventHandler)
     });
@@ -137,6 +139,28 @@ export const executeHurlRequest = async (input: HURLInput, eventHandler: Copilot
             toolInput: { hurlScript, scenario: input.tryItScenario },
             toolCallId
         });
+        const webSocketUsage = detectWebSocketUsage(hurlScript);
+        if (webSocketUsage) {
+            // Hurl drives curl, which cannot complete a WebSocket session; the run would only produce timeouts
+            // that have been misread as a working upgrade. Refuse up front and point at the right tool.
+            const rejection: HurlToolOutput = {
+                input: { requests: [] },
+                output: {
+                    status: "error",
+                    durationMs: 0,
+                    entries: [],
+                    warnings: [websocketRejectionMessage(webSocketUsage, WEBSOCKET_PROBE_TOOL_NAME)],
+                },
+            };
+            eventHandler({
+                type: "tool_result",
+                toolName: HURL_TOOL_NAME,
+                toolOutput: { hurlScript: input.hurlScript, scenario: input.tryItScenario, runResult: rejection },
+                toolCallId,
+                failed: true,
+            });
+            return rejection;
+        }
         const runningServices = runningServicesManager.getAll().filter(service => !service.exited);
         const runningServiceTargets = runningServices.flatMap(service => {
             const target = solveRelativeTempPath(service.packagePath);

--- a/packages/ballerina-extension/src/features/ai/agent/tools/hurl-websocket-guard.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/hurl-websocket-guard.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Detects a Hurl script that tries to talk to a WebSocket endpoint.
+ *
+ * Hurl drives curl, which cannot complete a WebSocket session: such a request either errors or sits until
+ * the 30-second timeout, and both come back as an entry with `status: "error"`. In testing, the agent read
+ * those timeouts as a successful upgrade and declared a WebSocket service verified without a single frame
+ * having been received. Rejecting the script up front, with a message that names the failure and the right
+ * tool, removes the ambiguity.
+ *
+ * Only the two places a WebSocket intent can be expressed are inspected — the request line's URL scheme
+ * and the request's header block — so a `ws://` inside a JSON body, a raw triple-backtick body, or an
+ * assertion such as `header "Upgrade" == "websocket"` does not trip it.
+ *
+ * Kept free of `vscode` imports so it can be unit tested in isolation.
+ */
+
+const HURL_METHODS = new Set([
+    "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH",
+    "LINK", "UNLINK", "PURGE", "LOCK", "UNLOCK", "PROPFIND", "VIEW",
+]);
+
+const SECTION_HEADER = /^\[[A-Za-z]+\]$/;
+
+export interface WebSocketUsage {
+    /** 1-based line of the script where the WebSocket intent was found. */
+    line: number;
+    /** What was matched: a `ws://`/`wss://` request URL or a WebSocket upgrade header. */
+    reason: string;
+}
+
+/**
+ * The first WebSocket intent in the script, or `null` when the script is plain HTTP.
+ */
+export function detectWebSocketUsage(hurlScript: string): WebSocketUsage | null {
+    const lines = hurlScript.split(/\r?\n/);
+    let inRawBody = false;
+    let inHeaders = false;
+
+    for (let i = 0; i < lines.length; i++) {
+        const raw = lines[i];
+        const line = raw.trim();
+
+        if (line.startsWith("```")) {
+            inRawBody = !inRawBody;
+            inHeaders = false;
+            continue;
+        }
+        if (inRawBody) {
+            continue;
+        }
+
+        const tokens = line.split(/\s+/);
+        if (tokens.length >= 2 && HURL_METHODS.has(tokens[0])) {
+            inHeaders = true;
+            if (/^wss?:\/\//i.test(tokens[1])) {
+                return { line: i + 1, reason: `request URL '${tokens[1]}' uses the ${tokens[1].slice(0, tokens[1].indexOf(":")).toLowerCase()} scheme` };
+            }
+            continue;
+        }
+
+        // A blank line ends the header block (a body or the next request follows); so does a section such as
+        // [Asserts] or [Options], and so does the response spec `HTTP 200`.
+        if (line.length === 0 || SECTION_HEADER.test(line) || /^HTTP(\/[0-9.]+)?\s+\d{3}/.test(line)) {
+            inHeaders = false;
+            continue;
+        }
+
+        if (inHeaders) {
+            if (/^upgrade\s*:\s*websocket\b/i.test(line)) {
+                return { line: i + 1, reason: "the request carries an 'Upgrade: websocket' header" };
+            }
+            if (/^sec-websocket-key\s*:/i.test(line)) {
+                return { line: i + 1, reason: "the request carries a 'Sec-WebSocket-Key' header" };
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * The warning shown to the model and the user when a WebSocket script is rejected. Names the tool to use
+ * instead and states explicitly how a Hurl timeout must NOT be read.
+ */
+export function websocketRejectionMessage(usage: WebSocketUsage, probeToolName: string): string {
+    return `Hurl is HTTP-only and cannot open WebSocket connections (line ${usage.line}: ${usage.reason}). `
+        + `The script was not executed. A Hurl timeout or a missing HTTP 101 against a WebSocket endpoint is a failure, `
+        + `never evidence that the upgrade worked. Use the ${probeToolName} tool to verify a WebSocket service: it performs `
+        + `the upgrade, reports the HTTP status when the upgrade is refused, sends messages and returns the frames the server pushes.`;
+}

--- a/packages/ballerina-extension/src/features/ai/agent/tools/websocket-frames.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/websocket-frames.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * The small part of RFC 6455 a verification probe needs: the opening-handshake key exchange and the data
+ * framing (text, binary, close, ping, pong; 7/16/64-bit payload lengths; client-side masking).
+ *
+ * Written against the RFC rather than pulled in as a dependency: the extension host's Node runtime has no
+ * usable WebSocket client (the global exists only behind an experimental flag and reports no HTTP status
+ * on a refused upgrade), and a probe whose whole purpose is to report *why* an upgrade failed needs the
+ * raw `http` response anyway. Pure functions over Buffers, so the codec is unit tested in isolation.
+ */
+
+import * as crypto from "crypto";
+
+/** The GUID RFC 6455 §4.2.2 appends to the client key before hashing. */
+const WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+export const OPCODE_CONTINUATION = 0x0;
+export const OPCODE_TEXT = 0x1;
+export const OPCODE_BINARY = 0x2;
+export const OPCODE_CLOSE = 0x8;
+export const OPCODE_PING = 0x9;
+export const OPCODE_PONG = 0xa;
+
+export interface WebSocketFrame {
+    fin: boolean;
+    opcode: number;
+    payload: Buffer;
+}
+
+/** A fresh `Sec-WebSocket-Key`: 16 random bytes, base64-encoded (RFC 6455 §4.1). */
+export function createHandshakeKey(): string {
+    return crypto.randomBytes(16).toString("base64");
+}
+
+/** The `Sec-WebSocket-Accept` value a compliant server must answer the given key with (RFC 6455 §4.2.2). */
+export function computeAcceptKey(handshakeKey: string): string {
+    return crypto.createHash("sha1").update(handshakeKey + WEBSOCKET_GUID).digest("base64");
+}
+
+/**
+ * Encodes one frame. Client-to-server frames MUST be masked (RFC 6455 §5.1); `mask` defaults to true so
+ * the probe cannot forget, and a test server passes `false` for its own frames.
+ */
+export function encodeFrame(opcode: number, payload: Buffer, mask: boolean = true): Buffer {
+    const length = payload.length;
+    let header: Buffer;
+    if (length < 126) {
+        header = Buffer.alloc(2);
+        header[1] = length;
+    } else if (length <= 0xffff) {
+        header = Buffer.alloc(4);
+        header[1] = 126;
+        header.writeUInt16BE(length, 2);
+    } else {
+        header = Buffer.alloc(10);
+        header[1] = 127;
+        header.writeBigUInt64BE(BigInt(length), 2);
+    }
+    header[0] = 0x80 | (opcode & 0x0f); // FIN set, RSV clear
+
+    if (!mask) {
+        return Buffer.concat([header, payload]);
+    }
+    header[1] |= 0x80;
+    const maskingKey = crypto.randomBytes(4);
+    const masked = Buffer.alloc(length);
+    for (let i = 0; i < length; i++) {
+        masked[i] = payload[i] ^ maskingKey[i % 4];
+    }
+    return Buffer.concat([header, maskingKey, masked]);
+}
+
+export function encodeTextFrame(text: string, mask: boolean = true): Buffer {
+    return encodeFrame(OPCODE_TEXT, Buffer.from(text, "utf8"), mask);
+}
+
+/** A close frame carrying a status code and an optional UTF-8 reason (RFC 6455 §5.5.1). */
+export function encodeCloseFrame(code: number = 1000, reason: string = "", mask: boolean = true): Buffer {
+    const reasonBytes = Buffer.from(reason, "utf8");
+    const payload = Buffer.alloc(2 + reasonBytes.length);
+    payload.writeUInt16BE(code, 0);
+    reasonBytes.copy(payload, 2);
+    return encodeFrame(OPCODE_CLOSE, payload, mask);
+}
+
+/** The status code and reason inside a close frame's payload; a payload with no code reads as 1005. */
+export function decodeClosePayload(payload: Buffer): { code: number; reason: string } {
+    if (payload.length < 2) {
+        return { code: 1005, reason: "" };
+    }
+    return { code: payload.readUInt16BE(0), reason: payload.subarray(2).toString("utf8") };
+}
+
+/**
+ * Decodes every complete frame at the start of `buffer` and returns the bytes that did not yet form a
+ * complete frame, so a stream can be fed chunk by chunk. Masked frames (from a client) are unmasked.
+ */
+export function decodeFrames(buffer: Buffer): { frames: WebSocketFrame[]; rest: Buffer } {
+    const frames: WebSocketFrame[] = [];
+    let offset = 0;
+
+    while (buffer.length - offset >= 2) {
+        const byte0 = buffer[offset];
+        const byte1 = buffer[offset + 1];
+        const fin = (byte0 & 0x80) !== 0;
+        const opcode = byte0 & 0x0f;
+        const masked = (byte1 & 0x80) !== 0;
+        let length = byte1 & 0x7f;
+        let cursor = offset + 2;
+
+        if (length === 126) {
+            if (buffer.length - cursor < 2) {
+                break;
+            }
+            length = buffer.readUInt16BE(cursor);
+            cursor += 2;
+        } else if (length === 127) {
+            if (buffer.length - cursor < 8) {
+                break;
+            }
+            const big = buffer.readBigUInt64BE(cursor);
+            if (big > BigInt(Number.MAX_SAFE_INTEGER)) {
+                throw new Error("WebSocket frame payload length exceeds the supported size");
+            }
+            length = Number(big);
+            cursor += 8;
+        }
+
+        let maskingKey: Buffer | undefined;
+        if (masked) {
+            if (buffer.length - cursor < 4) {
+                break;
+            }
+            maskingKey = buffer.subarray(cursor, cursor + 4);
+            cursor += 4;
+        }
+
+        if (buffer.length - cursor < length) {
+            break;
+        }
+        const payload = Buffer.from(buffer.subarray(cursor, cursor + length));
+        if (maskingKey) {
+            for (let i = 0; i < payload.length; i++) {
+                payload[i] ^= maskingKey[i % 4];
+            }
+        }
+        frames.push({ fin, opcode, payload });
+        offset = cursor + length;
+    }
+
+    return { frames, rest: Buffer.from(buffer.subarray(offset)) };
+}

--- a/packages/ballerina-extension/src/features/ai/agent/tools/websocket-probe-core.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/websocket-probe-core.ts
@@ -1,0 +1,386 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * A WebSocket probe for verifying a locally running service: performs the opening handshake over `http`
+ * or `https`, reports the HTTP status and body when the upgrade is refused, sends the given text messages
+ * in order, and collects every frame the server pushes until the wait window closes or the server closes.
+ *
+ * Built on the raw `http` module deliberately. What the agent needs from a failed upgrade is the status
+ * (400 for a returned `websocket:UpgradeError`, 401/403 from auth, 500 from a panic in the upgrade
+ * resource) — Node's own WebSocket client reports only "non-101 status code" and is behind an experimental
+ * flag in the extension host's runtime. Every path resolves: a probe never rejects, so the tool can always
+ * hand the model a structured result.
+ *
+ * Restricted to loopback hosts: the probe exists to exercise a service the agent just started, and an
+ * unrestricted outbound socket from the extension host would be a new egress path.
+ */
+
+import * as http from "http";
+import * as https from "https";
+import * as net from "net";
+import {
+    computeAcceptKey,
+    createHandshakeKey,
+    decodeClosePayload,
+    decodeFrames,
+    encodeCloseFrame,
+    encodeFrame,
+    encodeTextFrame,
+    OPCODE_BINARY,
+    OPCODE_CLOSE,
+    OPCODE_CONTINUATION,
+    OPCODE_PING,
+    OPCODE_PONG,
+    OPCODE_TEXT,
+} from "./websocket-frames";
+
+export const DEFAULT_WAIT_SECONDS = 5;
+export const MAX_WAIT_SECONDS = 30;
+/** Time allowed for the TCP connect plus the handshake response before the probe gives up. */
+export const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+/** How much of a refused upgrade's body is kept — enough for an error payload, not a whole page. */
+const MAX_RESPONSE_BODY_BYTES = 4096;
+/** How many frames are kept; a chatty service is still reported, just not verbatim. */
+const MAX_FRAMES = 200;
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]", "0.0.0.0"]);
+
+export interface WebSocketProbeOptions {
+    /** `ws://` or `wss://` URL of the endpoint, including any query parameters. */
+    url: string;
+    /** Extra request headers for the upgrade request, e.g. an `Authorization` header. */
+    headers?: Record<string, string>;
+    /** Text messages to send, in order, once the connection is open. */
+    messages?: string[];
+    /** How long to keep the connection open collecting frames after the last message. */
+    waitSeconds?: number;
+    /** Overridable for tests; production callers use the default. */
+    connectTimeoutMs?: number;
+}
+
+export interface ReceivedFrame {
+    type: "text" | "binary";
+    /** UTF-8 text for text frames; base64 for binary frames. */
+    data: string;
+}
+
+export interface WebSocketProbeResult {
+    url: string;
+    /** True only when the server answered the handshake with HTTP 101 and a valid accept key. */
+    upgraded: boolean;
+    /** The HTTP status of the handshake response — 101 on success, the refusal status otherwise. */
+    statusCode?: number;
+    statusMessage?: string;
+    /** Present when the upgrade was refused: what the server answered instead. */
+    responseHeaders?: Record<string, string>;
+    responseBody?: string;
+    framesSent: number;
+    framesReceived: ReceivedFrame[];
+    /** Set when the server closed the connection; absent when the probe closed it after the wait window. */
+    closeCode?: number;
+    closeReason?: string;
+    /** A transport or protocol error: connection refused, timeout, bad accept key, ... */
+    error?: string;
+    timedOut: boolean;
+    durationMs: number;
+}
+
+/** Whether the URL points at a loopback address — the only hosts the probe will talk to. */
+export function isLoopbackUrl(url: string): boolean {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+    const host = parsed.hostname.toLowerCase();
+    if (LOOPBACK_HOSTS.has(host)) {
+        return true;
+    }
+    // 127.0.0.0/8, and IPv6 loopback written without brackets after URL parsing.
+    if (net.isIPv4(host)) {
+        return host.startsWith("127.");
+    }
+    return host === "::1";
+}
+
+function toHttpUrl(url: string): URL {
+    const parsed = new URL(url);
+    if (parsed.protocol === "ws:") {
+        parsed.protocol = "http:";
+    } else if (parsed.protocol === "wss:") {
+        parsed.protocol = "https:";
+    } else if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new Error(`Unsupported URL scheme '${parsed.protocol}' — use ws:// or wss://`);
+    }
+    return parsed;
+}
+
+function headersToRecord(headers: http.IncomingHttpHeaders): Record<string, string> {
+    const record: Record<string, string> = {};
+    for (const [name, value] of Object.entries(headers)) {
+        if (value === undefined) {
+            continue;
+        }
+        record[name] = Array.isArray(value) ? value.join(", ") : value;
+    }
+    return record;
+}
+
+/**
+ * Runs the probe. Never rejects: every failure mode is reported in the result.
+ */
+export function probeWebSocket(options: WebSocketProbeOptions): Promise<WebSocketProbeResult> {
+    const startedAt = Date.now();
+    const waitSeconds = Math.min(Math.max(options.waitSeconds ?? DEFAULT_WAIT_SECONDS, 0), MAX_WAIT_SECONDS);
+    const connectTimeoutMs = options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+    const messages = options.messages ?? [];
+
+    const result: WebSocketProbeResult = {
+        url: options.url,
+        upgraded: false,
+        framesSent: 0,
+        framesReceived: [],
+        timedOut: false,
+        durationMs: 0,
+    };
+
+    return new Promise<WebSocketProbeResult>((resolve) => {
+        let settled = false;
+        let socket: net.Socket | undefined;
+        let connectTimer: NodeJS.Timeout | undefined;
+        let waitTimer: NodeJS.Timeout | undefined;
+
+        const finish = (): void => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            if (connectTimer) {
+                clearTimeout(connectTimer);
+            }
+            if (waitTimer) {
+                clearTimeout(waitTimer);
+            }
+            if (socket && !socket.destroyed) {
+                socket.destroy();
+            }
+            result.durationMs = Date.now() - startedAt;
+            resolve(result);
+        };
+
+        const fail = (message: string): void => {
+            if (!settled && !result.error) {
+                result.error = message;
+            }
+            finish();
+        };
+
+        if (!isLoopbackUrl(options.url)) {
+            fail("The WebSocket probe only connects to services on this machine (localhost / 127.0.0.1 / ::1).");
+            return;
+        }
+
+        let target: URL;
+        try {
+            target = toHttpUrl(options.url);
+        } catch (e) {
+            fail(e instanceof Error ? e.message : String(e));
+            return;
+        }
+
+        const handshakeKey = createHandshakeKey();
+        const expectedAccept = computeAcceptKey(handshakeKey);
+        const requestHeaders: Record<string, string> = {
+            ...(options.headers ?? {}),
+            Connection: "Upgrade",
+            Upgrade: "websocket",
+            "Sec-WebSocket-Version": "13",
+            "Sec-WebSocket-Key": handshakeKey,
+        };
+
+        const isTls = target.protocol === "https:";
+        const requestOptions: https.RequestOptions = {
+            method: "GET",
+            host: target.hostname.replace(/^\[|\]$/g, ""),
+            port: target.port ? Number(target.port) : (isTls ? 443 : 80),
+            path: `${target.pathname}${target.search}`,
+            headers: requestHeaders,
+            // Local services under test routinely run on self-signed certificates; the probe only ever
+            // talks to loopback, so skipping verification cannot expose it to a third party.
+            ...(isTls ? { rejectUnauthorized: false } : {}),
+        };
+
+        const req = (isTls ? https : http).request(requestOptions);
+
+        connectTimer = setTimeout(() => {
+            result.timedOut = true;
+            req.destroy();
+            fail(`No handshake response within ${connectTimeoutMs} ms — the service is not listening, or it never answered the upgrade request.`);
+        }, connectTimeoutMs);
+
+        req.on("error", (err: NodeJS.ErrnoException) => {
+            if (err.code === "ECONNREFUSED") {
+                fail(`Connection refused at ${target.host} — nothing is listening on that port.`);
+                return;
+            }
+            fail(`${err.code ? err.code + ": " : ""}${err.message}`);
+        });
+
+        // A non-101 answer: the upgrade was refused. Report exactly what the server said.
+        req.on("response", (res) => {
+            if (connectTimer) {
+                clearTimeout(connectTimer);
+            }
+            result.statusCode = res.statusCode;
+            result.statusMessage = res.statusMessage;
+            result.responseHeaders = headersToRecord(res.headers);
+            const chunks: Buffer[] = [];
+            let received = 0;
+            res.on("data", (chunk: Buffer) => {
+                if (received < MAX_RESPONSE_BODY_BYTES) {
+                    chunks.push(chunk.subarray(0, MAX_RESPONSE_BODY_BYTES - received));
+                    received += chunk.length;
+                }
+            });
+            const done = (): void => {
+                result.responseBody = Buffer.concat(chunks).toString("utf8");
+                result.error = `The server refused the WebSocket upgrade with HTTP ${res.statusCode}${res.statusMessage ? " " + res.statusMessage : ""}.`;
+                finish();
+            };
+            res.on("end", done);
+            res.on("error", done);
+        });
+
+        req.on("upgrade", (res, upgradedSocket, head) => {
+            if (connectTimer) {
+                clearTimeout(connectTimer);
+            }
+            socket = upgradedSocket;
+            result.statusCode = res.statusCode;
+            result.statusMessage = res.statusMessage;
+            result.responseHeaders = headersToRecord(res.headers);
+
+            const accept = res.headers["sec-websocket-accept"];
+            if (accept !== expectedAccept) {
+                fail(`The server answered HTTP 101 but its Sec-WebSocket-Accept header does not match the key sent (got '${accept ?? "none"}').`);
+                return;
+            }
+            result.upgraded = true;
+
+            let pending: Buffer = Buffer.from(head);
+            let fragments: { opcode: number; parts: Buffer[] } | undefined;
+
+            const recordFrame = (opcode: number, payload: Buffer): void => {
+                if (result.framesReceived.length >= MAX_FRAMES) {
+                    return;
+                }
+                if (opcode === OPCODE_TEXT) {
+                    result.framesReceived.push({ type: "text", data: payload.toString("utf8") });
+                } else {
+                    result.framesReceived.push({ type: "binary", data: payload.toString("base64") });
+                }
+            };
+
+            const consume = (chunk: Buffer): void => {
+                pending = Buffer.concat([pending, chunk]);
+                let decoded;
+                try {
+                    decoded = decodeFrames(pending);
+                } catch (e) {
+                    fail(e instanceof Error ? e.message : String(e));
+                    return;
+                }
+                pending = decoded.rest;
+                for (const frame of decoded.frames) {
+                    switch (frame.opcode) {
+                        case OPCODE_TEXT:
+                        case OPCODE_BINARY:
+                            if (frame.fin) {
+                                recordFrame(frame.opcode, frame.payload);
+                            } else {
+                                fragments = { opcode: frame.opcode, parts: [frame.payload] };
+                            }
+                            break;
+                        case OPCODE_CONTINUATION:
+                            if (fragments) {
+                                fragments.parts.push(frame.payload);
+                                if (frame.fin) {
+                                    recordFrame(fragments.opcode, Buffer.concat(fragments.parts));
+                                    fragments = undefined;
+                                }
+                            }
+                            break;
+                        case OPCODE_PING:
+                            if (!socket?.destroyed) {
+                                socket?.write(encodeFrame(OPCODE_PONG, frame.payload));
+                            }
+                            break;
+                        case OPCODE_PONG:
+                            break;
+                        case OPCODE_CLOSE: {
+                            const close = decodeClosePayload(frame.payload);
+                            result.closeCode = close.code;
+                            result.closeReason = close.reason;
+                            if (!socket?.destroyed) {
+                                socket?.write(encodeCloseFrame(close.code === 1005 ? 1000 : close.code));
+                            }
+                            finish();
+                            return;
+                        }
+                        default:
+                            break;
+                    }
+                }
+            };
+
+            upgradedSocket.on("data", consume);
+            upgradedSocket.on("error", (err: Error) => fail(err.message));
+            upgradedSocket.on("close", () => {
+                // Closed without a close frame (e.g. the process died): report it as an abnormal closure.
+                if (!settled && result.closeCode === undefined) {
+                    result.closeCode = 1006;
+                    result.closeReason = "connection closed without a close frame";
+                }
+                finish();
+            });
+
+            if (head.length > 0) {
+                pending = Buffer.alloc(0);
+                consume(Buffer.from(head));
+            }
+
+            for (const message of messages) {
+                if (settled) {
+                    break;
+                }
+                upgradedSocket.write(encodeTextFrame(message));
+                result.framesSent++;
+            }
+
+            waitTimer = setTimeout(() => {
+                if (!settled && !upgradedSocket.destroyed) {
+                    upgradedSocket.write(encodeCloseFrame(1000, "probe complete"));
+                }
+                // Give the peer a moment to answer the close frame, then finish regardless.
+                setTimeout(finish, 250);
+            }, waitSeconds * 1000);
+        });
+
+        req.end();
+    });
+}

--- a/packages/ballerina-extension/src/features/ai/agent/tools/websocket-probe.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/websocket-probe.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { tool } from 'ai';
+import { z } from 'zod';
+import { CopilotEventHandler } from '../../utils/events';
+import { BALLERINA_GET_LOGS_TOOL_NAME } from './ballerina-get-logs';
+import { BALLERINA_RUN_TOOL_NAME } from './ballerina-run';
+import { DEFAULT_WAIT_SECONDS, MAX_WAIT_SECONDS, probeWebSocket, WebSocketProbeResult } from './websocket-probe-core';
+
+export const WEBSOCKET_PROBE_TOOL_NAME = "websocketProbeTool";
+
+const WebSocketProbeInputSchema = z.object({
+    url: z.string().describe("The ws:// or wss:// URL of the WebSocket endpoint on this machine, including any query parameters (e.g. ws://localhost:9090/orders/track?orderId=ORD-1001)."),
+    headers: z.record(z.string(), z.string()).optional().describe("Extra headers for the upgrade request, e.g. {\"Authorization\": \"Bearer <token>\"}."),
+    messages: z.array(z.string()).optional().describe("Text messages to send, in order, after the connection is open. Send JSON as a string."),
+    waitSeconds: z.number().min(0).max(MAX_WAIT_SECONDS).optional().describe(`Seconds to keep the connection open collecting frames pushed by the server after the last message. Default ${DEFAULT_WAIT_SECONDS}, max ${MAX_WAIT_SECONDS}. Use a value longer than the service's push interval when it pushes on a timer.`),
+    scenario: z.string().max(60).optional().describe("A short description of what this probe verifies, shown to the user."),
+});
+
+export type WebSocketProbeInput = z.infer<typeof WebSocketProbeInputSchema>;
+
+export function createWebSocketProbeTool(eventHandler: CopilotEventHandler) {
+    return tool({
+        description: `Verifies a WebSocket service running on this machine. Performs the HTTP upgrade to the given ws:// or wss:// URL, sends the given text messages in order, and collects every frame the server pushes for waitSeconds.
+
+**Use this — never ${'hurlRunnerTool'} — for anything WebSocket.** Hurl is HTTP-only and cannot open a WebSocket connection.
+
+**Reading the result:**
+- \`upgraded: true\` with \`statusCode: 101\` means the handshake succeeded. \`framesReceived\` lists what the server pushed; if the service is expected to push data and this is empty, the service is NOT working as required.
+- \`upgraded: false\` means the server refused the upgrade: \`statusCode\` and \`responseBody\` say why (400 = a returned websocket:UpgradeError, 401/403 = authentication, 500 = a panic in the upgrade resource or an incompatible http:Listener). This is a failure to fix, not a pass.
+- \`closeCode: 1006\` or \`1011\` means the connection dropped abnormally — check the service logs with ${BALLERINA_GET_LOGS_TOOL_NAME}.
+- \`error\` set means the probe could not complete (connection refused, timeout, protocol error). A timeout is never evidence that the service works.
+
+The service must already be running (start it with ${BALLERINA_RUN_TOOL_NAME}). Self-signed certificates on wss:// are accepted because only loopback hosts can be probed.`,
+        inputSchema: WebSocketProbeInputSchema,
+        execute: async (input: WebSocketProbeInput, context?: { toolCallId?: string }): Promise<WebSocketProbeResult> => {
+            const toolCallId = context?.toolCallId || `fallback-${Date.now()}`;
+            eventHandler({
+                type: "tool_call",
+                toolName: WEBSOCKET_PROBE_TOOL_NAME,
+                toolInput: { url: input.url, messages: input.messages ?? [], scenario: input.scenario },
+                toolCallId,
+            });
+
+            const result = await probeWebSocket({
+                url: input.url,
+                headers: input.headers,
+                messages: input.messages,
+                waitSeconds: input.waitSeconds,
+            });
+
+            console.log(`[WebSocketProbe] ${input.url} → upgraded=${result.upgraded} status=${result.statusCode ?? "-"} `
+                + `sent=${result.framesSent} received=${result.framesReceived.length} close=${result.closeCode ?? "-"} error=${result.error ?? "-"}`);
+
+            const failed = !result.upgraded || result.error !== undefined;
+            eventHandler({
+                type: "tool_result",
+                toolName: WEBSOCKET_PROBE_TOOL_NAME,
+                toolOutput: { ...result, scenario: input.scenario },
+                toolCallId,
+                ...(failed ? { failed: true } : {}),
+            });
+            return result;
+        },
+    });
+}

--- a/packages/ballerina-extension/src/features/ai/state/toolLabels.ts
+++ b/packages/ballerina-extension/src/features/ai/state/toolLabels.ts
@@ -62,6 +62,8 @@ export function describeToolCall(toolName: string, toolInput?: any): string {
             return 'Stopping a service';
         case 'hurlRunnerTool':
             return 'Testing HTTP endpoints';
+        case 'websocketProbeTool':
+            return 'Testing a WebSocket endpoint';
         case 'LibrarySearchTool':
         case 'LibraryGetTool':
             return 'Looking up libraries';

--- a/packages/ballerina-extension/src/test-support/agentStatusLabels.test.ts
+++ b/packages/ballerina-extension/src/test-support/agentStatusLabels.test.ts
@@ -74,6 +74,8 @@ describe('describeToolCall', () => {
     it('labels non-file tools without touching the path logic', () => {
         expect(describeToolCall('getCompilationErrors')).toBe('Checking for errors');
         expect(describeToolCall('runTests')).toBe('Running tests');
+        expect(describeToolCall('hurlRunnerTool')).toBe('Testing HTTP endpoints');
+        expect(describeToolCall('websocketProbeTool')).toBe('Testing a WebSocket endpoint');
     });
 
     it('names the tool behind an MCP call, and falls back for unknown tools', () => {

--- a/packages/ballerina-extension/src/test-support/hurlWebSocketGuard.test.ts
+++ b/packages/ballerina-extension/src/test-support/hurlWebSocketGuard.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * The Hurl tool must refuse WebSocket scripts (Hurl cannot complete a WebSocket session, and its timeouts
+ * were being read as a working upgrade), while leaving every plain-HTTP script alone — including scripts
+ * whose bodies or assertions merely mention WebSockets.
+ */
+
+import { detectWebSocketUsage, websocketRejectionMessage } from '../features/ai/agent/tools/hurl-websocket-guard';
+
+describe('detectWebSocketUsage', () => {
+    it('flags a ws:// or wss:// request URL', () => {
+        expect(detectWebSocketUsage('GET ws://localhost:9090/orders/track?orderId=ORD-1')).toEqual({
+            line: 1,
+            reason: "request URL 'ws://localhost:9090/orders/track?orderId=ORD-1' uses the ws scheme",
+        });
+        expect(detectWebSocketUsage('POST http://localhost:8080/api\n\n{"a":1}\n\nGET WSS://localhost:9090/feed')?.line).toBe(5);
+    });
+
+    it('flags an Upgrade: websocket or Sec-WebSocket-Key header in a request header block', () => {
+        expect(detectWebSocketUsage('GET http://localhost:9090/chat\nConnection: Upgrade\nUpgrade: websocket\n')).toEqual({
+            line: 3,
+            reason: "the request carries an 'Upgrade: websocket' header",
+        });
+        expect(detectWebSocketUsage('GET http://localhost:9090/chat\nsec-websocket-key: dGhlIHNhbXBsZSBub25jZQ==\n')?.reason)
+            .toBe("the request carries a 'Sec-WebSocket-Key' header");
+    });
+
+    it.each([
+        ['a plain GET', 'GET http://localhost:9090/api/v1/tickets\nAccept: application/json'],
+        ['a JSON body that mentions a ws:// URL', 'POST http://localhost:8080/api/config\nContent-Type: application/json\n\n{"endpoint": "ws://localhost:9090/feed", "upgrade": "websocket"}'],
+        ['a raw triple-backtick body carrying upgrade headers', 'POST http://localhost:8080/upload\n\n```\nGET ws://x/y\nUpgrade: websocket\n```'],
+        ['an assertion on the Upgrade header', 'GET http://localhost:9090/health\nHTTP 200\n[Asserts]\nheader "Upgrade" == "websocket"'],
+        ['a header block that ended at a section', 'GET http://localhost:9090/health\n[Options]\nUpgrade: websocket'],
+        ['an empty script', ''],
+    ])('leaves %s alone', (_name, script) => {
+        expect(detectWebSocketUsage(script)).toBeNull();
+    });
+
+    it('resets the header block between requests so a later header is attributed to its own request', () => {
+        const script = 'GET http://localhost:9090/a\nAccept: */*\n\nGET http://localhost:9090/b\nUpgrade: websocket';
+        expect(detectWebSocketUsage(script)?.line).toBe(5);
+    });
+});
+
+describe('websocketRejectionMessage', () => {
+    it('names the failure, says the script did not run, forbids the timeout-as-success reading and names the probe tool', () => {
+        const message = websocketRejectionMessage({ line: 3, reason: 'the request carries an \'Upgrade: websocket\' header' }, 'websocketProbeTool');
+        expect(message).toMatch(/Hurl is HTTP-only/);
+        expect(message).toMatch(/line 3/);
+        expect(message).toMatch(/was not executed/);
+        expect(message).toMatch(/never evidence that the upgrade worked/);
+        expect(message).toMatch(/Use the websocketProbeTool tool/);
+    });
+});

--- a/packages/ballerina-extension/src/test-support/verificationPromptRules.test.ts
+++ b/packages/ballerina-extension/src/test-support/verificationPromptRules.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * The system prompt had no guidance on trying endpoints out at all, which is how a WebSocket service came to
+ * be "verified" with an HTTP client and its timeouts read as success. `prompts.ts` cannot be imported here
+ * (extension-host module graph), so the block and its tool-name interpolations are checked in the source.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const promptsSource = fs.readFileSync(path.join(__dirname, '../features/ai/agent/prompts.ts'), 'utf-8');
+
+describe('endpoint verification guidance in the system prompt', () => {
+    const block = promptsSource.slice(promptsSource.indexOf('## Trying out endpoints'), promptsSource.indexOf('## Test Runner'));
+
+    it('exists inside the "Running, invoking and tests" section', () => {
+        const section = promptsSource.indexOf('# Running, invoking and tests');
+        const heading = promptsSource.indexOf('## Trying out endpoints');
+        const testRunner = promptsSource.indexOf('## Test Runner');
+        expect(section).toBeGreaterThan(-1);
+        expect(heading).toBeGreaterThan(section);
+        expect(heading).toBeLessThan(testRunner);
+    });
+
+    it('scopes Hurl to HTTP and forbids reading a timeout as a successful upgrade', () => {
+        expect(block).toMatch(/\$\{HURL_TOOL_NAME\} for HTTP endpoints ONLY/);
+        expect(block).toMatch(/Hurl cannot open WebSocket connections/);
+        expect(block).toMatch(/never read a timeout or a missing HTTP 101 as a successful upgrade/);
+    });
+
+    it('points at the probe tool and states what a failed probe means', () => {
+        expect(block).toMatch(/\$\{WEBSOCKET_PROBE_TOOL_NAME\} to verify a WebSocket service/);
+        expect(block).toMatch(/400 = returned websocket:UpgradeError, 401\/403 = auth, 500 = a panic in the upgrade resource or an incompatible http:Listener/);
+        expect(block).toMatch(/zero received frames from a service that is expected to push data means the service is NOT working/);
+        expect(block).toMatch(/\$\{BALLERINA_GET_LOGS_TOOL_NAME\}/);
+    });
+
+    it('requires every requested trigger to be exercised when the user asked to run or try out', () => {
+        expect(block).toMatch(/exercise EACH requested trigger at least once/);
+        expect(block).toMatch(/report every trigger you could not exercise as unverified/);
+    });
+
+    it('imports every tool name it interpolates', () => {
+        expect(promptsSource).toMatch(/import \{ HURL_TOOL_NAME \} from "\.\/tools\/hurl-tool";/);
+        expect(promptsSource).toMatch(/import \{ WEBSOCKET_PROBE_TOOL_NAME \} from "\.\/tools\/websocket-probe";/);
+        expect(promptsSource).toMatch(/import \{ BALLERINA_GET_LOGS_TOOL_NAME \} from "\.\/tools\/ballerina-get-logs";/);
+    });
+});

--- a/packages/ballerina-extension/src/test-support/websocketProbe.test.ts
+++ b/packages/ballerina-extension/src/test-support/websocketProbe.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * The frame codec is checked against RFC 6455 byte layouts, and the probe is run against in-process
+ * servers: one that upgrades and echoes, one that refuses the upgrade with a 500 (the shape a panic in a
+ * Ballerina upgrade resource produces), one that never answers, and one that is not listening at all.
+ */
+
+import * as http from 'http';
+import * as net from 'net';
+import {
+    computeAcceptKey,
+    decodeClosePayload,
+    decodeFrames,
+    encodeCloseFrame,
+    encodeFrame,
+    encodeTextFrame,
+    OPCODE_BINARY,
+    OPCODE_CLOSE,
+    OPCODE_PING,
+    OPCODE_TEXT,
+} from '../features/ai/agent/tools/websocket-frames';
+import { isLoopbackUrl, probeWebSocket } from '../features/ai/agent/tools/websocket-probe-core';
+
+describe('WebSocket frame codec', () => {
+    it('computes the RFC 6455 §4.2.2 accept key for the RFC example', () => {
+        expect(computeAcceptKey('dGhlIHNhbXBsZSBub25jZQ==')).toBe('s3pPLMBiTxaQ9kYGzzhZRbK+xOo=');
+    });
+
+    it('encodes an unmasked text frame with the RFC single-frame layout', () => {
+        // RFC 6455 §5.7: "Hello" as a single unmasked text frame is 0x81 0x05 followed by the bytes.
+        expect([...encodeTextFrame('Hello', false)]).toEqual([0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f]);
+    });
+
+    it('masks client frames and the decoder unmasks them', () => {
+        const encoded = encodeTextFrame('Hello');
+        expect(encoded[0]).toBe(0x81);
+        expect(encoded[1]).toBe(0x85); // MASK bit + length 5
+        expect(encoded.length).toBe(2 + 4 + 5);
+        const { frames, rest } = decodeFrames(encoded);
+        expect(frames).toHaveLength(1);
+        expect(frames[0].fin).toBe(true);
+        expect(frames[0].opcode).toBe(OPCODE_TEXT);
+        expect(frames[0].payload.toString('utf8')).toBe('Hello');
+        expect(rest.length).toBe(0);
+    });
+
+    it('uses the 16-bit and 64-bit extended payload lengths', () => {
+        const medium = Buffer.alloc(300, 0x41);
+        const mediumFrame = encodeFrame(OPCODE_BINARY, medium, false);
+        expect(mediumFrame[1]).toBe(126);
+        expect(mediumFrame.readUInt16BE(2)).toBe(300);
+        expect(decodeFrames(mediumFrame).frames[0].payload.equals(medium)).toBe(true);
+
+        const large = Buffer.alloc(70_000, 0x42);
+        const largeFrame = encodeFrame(OPCODE_BINARY, large, true);
+        expect(largeFrame[1] & 0x7f).toBe(127);
+        expect(Number(largeFrame.readBigUInt64BE(2))).toBe(70_000);
+        expect(decodeFrames(largeFrame).frames[0].payload.equals(large)).toBe(true);
+    });
+
+    it('decodes several frames from one buffer and keeps a trailing partial frame as rest', () => {
+        const a = encodeTextFrame('one', false);
+        const b = encodeFrame(OPCODE_PING, Buffer.from('p'), false);
+        const c = encodeTextFrame('three', false);
+        const stream = Buffer.concat([a, b, c.subarray(0, 3)]);
+        const { frames, rest } = decodeFrames(stream);
+        expect(frames.map((f) => f.opcode)).toEqual([OPCODE_TEXT, OPCODE_PING]);
+        expect(rest.equals(c.subarray(0, 3))).toBe(true);
+        const { frames: tail } = decodeFrames(Buffer.concat([rest, c.subarray(3)]));
+        expect(tail[0].payload.toString()).toBe('three');
+    });
+
+    it('round-trips close frames with code and reason', () => {
+        const frame = encodeCloseFrame(1011, 'boom', false);
+        const decoded = decodeFrames(frame).frames[0];
+        expect(decoded.opcode).toBe(OPCODE_CLOSE);
+        expect(decodeClosePayload(decoded.payload)).toEqual({ code: 1011, reason: 'boom' });
+        expect(decodeClosePayload(Buffer.alloc(0))).toEqual({ code: 1005, reason: '' });
+    });
+});
+
+describe('isLoopbackUrl', () => {
+    it.each([
+        'ws://localhost:9090/x', 'wss://127.0.0.1:9443/x', 'ws://127.5.5.5/x', 'ws://[::1]:9090/x', 'ws://0.0.0.0:9090/x',
+    ])('accepts %s', (url) => {
+        expect(isLoopbackUrl(url)).toBe(true);
+    });
+
+    it.each(['ws://example.com/x', 'ws://10.0.0.5:9090/x', 'wss://api.github.com/', 'nonsense'])('rejects %s', (url) => {
+        expect(isLoopbackUrl(url)).toBe(false);
+    });
+});
+
+/**
+ * Closes a server even when a peer left a socket half-open: an HTTP server's sockets allow half-open and
+ * a silent `net` server never reads, so `server.close()` alone would wait forever on either.
+ */
+function closeServer(server: net.Server, sockets: Set<net.Socket>): Promise<void> {
+    for (const socket of sockets) {
+        socket.destroy();
+    }
+    return new Promise<void>((done) => server.close(() => done()));
+}
+
+function trackSockets(server: net.Server): Set<net.Socket> {
+    const sockets = new Set<net.Socket>();
+    server.on('connection', (socket: net.Socket) => {
+        sockets.add(socket);
+        socket.on('close', () => sockets.delete(socket));
+    });
+    return sockets;
+}
+
+async function listen(server: net.Server): Promise<number> {
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()));
+    return (server.address() as net.AddressInfo).port;
+}
+
+/** An in-process server that completes the handshake and echoes text frames, prefixed, until closed. */
+function startEchoServer(): Promise<{ port: number; close: () => Promise<void>; received: string[] }> {
+    const received: string[] = [];
+    const server = http.createServer((_req, res) => {
+        res.writeHead(426, { Upgrade: 'websocket' });
+        res.end('upgrade required');
+    });
+    const sockets = trackSockets(server);
+    server.on('upgrade', (req, socket: net.Socket) => {
+        const key = req.headers['sec-websocket-key'] as string;
+        socket.write(
+            'HTTP/1.1 101 Switching Protocols\r\n'
+            + 'Upgrade: websocket\r\n'
+            + 'Connection: Upgrade\r\n'
+            + `Sec-WebSocket-Accept: ${computeAcceptKey(key)}\r\n\r\n`,
+        );
+        // Push one frame unprompted, the way a service pushing status updates does.
+        socket.write(encodeTextFrame('welcome', false));
+        let pending = Buffer.alloc(0);
+        socket.on('data', (chunk: Buffer) => {
+            pending = Buffer.concat([pending, chunk]);
+            const { frames, rest } = decodeFrames(pending);
+            pending = rest;
+            for (const frame of frames) {
+                if (frame.opcode === OPCODE_TEXT) {
+                    const text = frame.payload.toString('utf8');
+                    received.push(text);
+                    socket.write(encodeTextFrame(`echo:${text}`, false));
+                } else if (frame.opcode === OPCODE_CLOSE) {
+                    socket.write(encodeCloseFrame(1000, 'bye', false));
+                    socket.end();
+                }
+            }
+        });
+        socket.on('error', () => undefined);
+    });
+    return listen(server).then((port) => ({ port, received, close: () => closeServer(server, sockets) }));
+}
+
+describe('probeWebSocket', () => {
+    it('upgrades, sends the messages in order and collects the frames the server pushes', async () => {
+        const server = await startEchoServer();
+        try {
+            const result = await probeWebSocket({
+                url: `ws://127.0.0.1:${server.port}/tickets/live?queue=hana`,
+                messages: ['{"action":"REPLACE","queues":["hana"]}', '{"action":"SUBSCRIBE","queues":["nora"]}'],
+                waitSeconds: 0.3,
+            });
+            expect(result.upgraded).toBe(true);
+            expect(result.statusCode).toBe(101);
+            expect(result.error).toBeUndefined();
+            expect(result.framesSent).toBe(2);
+            expect(result.framesReceived.map((f) => f.data)).toEqual([
+                'welcome',
+                'echo:{"action":"REPLACE","queues":["hana"]}',
+                'echo:{"action":"SUBSCRIBE","queues":["nora"]}',
+            ]);
+            expect(server.received).toEqual(['{"action":"REPLACE","queues":["hana"]}', '{"action":"SUBSCRIBE","queues":["nora"]}']);
+            // The probe closed the connection with a close frame and the server answered it.
+            expect(result.closeCode).toBe(1000);
+            expect(result.closeReason).toBe('bye');
+            expect(result.timedOut).toBe(false);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('reports a refused upgrade with the HTTP status and body instead of treating it as a pass', async () => {
+        const server = http.createServer((_req, res) => {
+            res.writeHead(500, { 'content-type': 'text/plain' });
+            res.end("{ballerina}TypeCastError {\"message\":\"incompatible types: 'jwt:Payload' cannot be cast to 'map<json>'\"}");
+        });
+        const sockets = trackSockets(server);
+        const port = await listen(server);
+        try {
+            const result = await probeWebSocket({ url: `ws://localhost:${port}/orders/track?orderId=ORD-1`, waitSeconds: 1 });
+            expect(result.upgraded).toBe(false);
+            expect(result.statusCode).toBe(500);
+            expect(result.responseBody).toContain('TypeCastError');
+            expect(result.error).toMatch(/refused the WebSocket upgrade with HTTP 500/);
+            expect(result.framesReceived).toEqual([]);
+        } finally {
+            await closeServer(server, sockets);
+        }
+    });
+
+    it('times out when the server never answers the handshake, and says so', async () => {
+        const server = net.createServer(() => { /* accept and stay silent */ });
+        const sockets = trackSockets(server);
+        const port = await listen(server);
+        try {
+            const result = await probeWebSocket({ url: `ws://127.0.0.1:${port}/`, waitSeconds: 1, connectTimeoutMs: 300 });
+            expect(result.upgraded).toBe(false);
+            expect(result.timedOut).toBe(true);
+            expect(result.error).toMatch(/No handshake response within 300 ms/);
+        } finally {
+            await closeServer(server, sockets);
+        }
+    });
+
+    it('reports a refused connection when nothing is listening', async () => {
+        const probe = net.createServer();
+        const port = await listen(probe);
+        await closeServer(probe, new Set());
+
+        const result = await probeWebSocket({ url: `ws://127.0.0.1:${port}/`, waitSeconds: 1 });
+        expect(result.upgraded).toBe(false);
+        expect(result.error).toMatch(/Connection refused/);
+    });
+
+    it('refuses to probe anything but loopback hosts', async () => {
+        const result = await probeWebSocket({ url: 'wss://echo.websocket.events/', waitSeconds: 1 });
+        expect(result.upgraded).toBe(false);
+        expect(result.error).toMatch(/only connects to services on this machine/);
+    });
+
+    it('rejects a server whose accept key does not match', async () => {
+        const server = http.createServer();
+        server.on('upgrade', (_req, socket: net.Socket) => {
+            socket.write('HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: bogus=\r\n\r\n');
+        });
+        const sockets = trackSockets(server);
+        const port = await listen(server);
+        try {
+            const result = await probeWebSocket({ url: `ws://127.0.0.1:${port}/`, waitSeconds: 1 });
+            expect(result.upgraded).toBe(false);
+            expect(result.statusCode).toBe(101);
+            expect(result.error).toMatch(/Sec-WebSocket-Accept header does not match/);
+        } finally {
+            await closeServer(server, sockets);
+        }
+    });
+});

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AgentStreamView/toolDisplay.test.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AgentStreamView/toolDisplay.test.ts
@@ -118,6 +118,12 @@ describe("getToolCallDisplay", () => {
         expect(() => getToolCallDisplay("file_read", null)).not.toThrow();
         expect(getToolCallDisplay("file_read", null).detail).toBe("file...");
     });
+
+    it("shows the probed WebSocket URL", () => {
+        expect(getToolCallDisplay("websocketProbeTool", { url: "ws://localhost:9090/orders/track" }))
+            .toEqual({ label: "Probing WebSocket:", detail: "ws://localhost:9090/orders/track" });
+        expect(getToolCallDisplay("websocketProbeTool", {}).label).toBe("Probing WebSocket...");
+    });
 });
 
 describe("getToolResultDisplay", () => {
@@ -129,6 +135,17 @@ describe("getToolResultDisplay", () => {
     it("summarises diagnostics by count", () => {
         expect(getToolResultDisplay("getCompilationErrors", { diagnostics: [1, 2] }).label).toBe("Found 2 error(s)");
         expect(getToolResultDisplay("getCompilationErrors", { diagnostics: [] }).label).toBe("No issues found");
+    });
+
+    it("distinguishes a WebSocket upgrade from a refusal and a transport failure", () => {
+        expect(getToolResultDisplay("websocketProbeTool", { upgraded: true, framesReceived: [{}, {}] }).label)
+            .toBe("WebSocket connected, 2 frames received");
+        expect(getToolResultDisplay("websocketProbeTool", { upgraded: true, framesReceived: [{}] }).label)
+            .toBe("WebSocket connected, 1 frame received");
+        expect(getToolResultDisplay("websocketProbeTool", { upgraded: false, statusCode: 500 }).label)
+            .toBe("WebSocket upgrade refused (HTTP 500)");
+        expect(getToolResultDisplay("websocketProbeTool", { upgraded: false, error: "Connection refused at localhost:9090" }))
+            .toEqual({ label: "WebSocket probe failed", detail: "Connection refused at localhost:9090" });
     });
 
     it("degrades to the generic label for an unknown tool", () => {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AgentStreamView/toolDisplay.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AgentStreamView/toolDisplay.ts
@@ -126,6 +126,7 @@ export function getToolCallDisplay(toolName: string | undefined, toolInput: any)
         case "ConnectorGeneratorTool": return { label: "Generating connector..." };
         case "runTests": return { label: "Running tests..." };
         case "hurlRunnerTool": return { label: "Sending HTTP request..." };
+        case "websocketProbeTool": return { label: toolInput?.url ? "Probing WebSocket:" : "Probing WebSocket...", detail: toolInput?.url };
         case "runBallerinaPackage": return { label: `Running ${toolInput?.runType === "service" ? "service" : "program"}...` };
         case "getServiceLogs": return { label: "Fetching logs..." };
         case "stopBallerinaService": return { label: "Stopping service..." };
@@ -174,6 +175,16 @@ export function getToolResultDisplay(toolName: string | undefined, toolOutput: a
         case "ConnectorGeneratorTool": return { label: "Connector ready" };
         case "runTests": return { label: toolOutput?.summary ?? "Tests completed" };
         case "hurlRunnerTool": return { label: "HTTP request completed" };
+        case "websocketProbeTool": {
+            if (toolOutput?.upgraded) {
+                const count = Array.isArray(toolOutput?.framesReceived) ? toolOutput.framesReceived.length : 0;
+                return { label: `WebSocket connected, ${count} frame${count === 1 ? "" : "s"} received` };
+            }
+            if (typeof toolOutput?.statusCode === "number") {
+                return { label: `WebSocket upgrade refused (HTTP ${toolOutput.statusCode})` };
+            }
+            return { label: "WebSocket probe failed", detail: toolOutput?.error };
+        }
         case "runBallerinaPackage": {
             const status = toolOutput?.status ?? "completed";
             return { label: status === "started" ? "Service started" : status === "completed" ? "Program completed" : status === "timeout" ? "Program timed out" : "Run failed" };


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/2368

## Problem
Copilot "verified" WebSocket services with the Hurl tool, which is an HTTP client. Hurl cannot complete a WebSocket session, so every request ended in a timeout or error, and the agent read those as successful upgrades without a single frame having been received. There was no WebSocket tool and no prompt guidance on trying endpoints out.

## Fix
- `hurlRunnerTool` refuses a script whose request URL is `ws://`/`wss://` or whose request headers carry `Upgrade: websocket` / `Sec-WebSocket-Key`, with a warning that names the failure, says the script did not run, and points at the probe tool. Bodies and assertions that merely mention WebSockets are not affected.
- New `websocketProbeTool`: performs the RFC 6455 handshake over `http`/`https` with a small in-tree codec (the extension host's Node has no usable WebSocket client, and it would not report the refusal status anyway), reports the HTTP status and body when the upgrade is refused (400/401/500), sends the given messages in order, collects pushed frames for `waitSeconds`, answers pings, reports close codes (1006 for a dropped connection) and never rejects. Loopback hosts only; self-signed `wss` accepted.
- Registered in the tool registry, ambient status labels and the AI panel tool display.
- New "Trying out endpoints" prompt block: Hurl is HTTP-only, a timeout is a failure, what each probe outcome means, exercise every requested trigger when asked to run.

## Tests
- `hurlWebSocketGuard.test.ts`: detector and message.
- `websocketProbe.test.ts`: codec against RFC byte layouts (incl. the RFC accept-key example), probe against in-process echo, 500, silent, closed and bad-accept-key servers.
- `verificationPromptRules.test.ts`, `agentStatusLabels.test.ts`, visualizer `toolDisplay.test.ts` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
