### PR TITLE
Make Copilot check requirement coverage before finishing

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -27,6 +27,7 @@ import { getLanglibInstructions } from "../utils/libs/langlibs";
 import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
+import { REQUIREMENT_COVERAGE_RULE } from "./requirement-coverage";
 import { getRequirementAnalysisCodeGenPrefix, getRequirementAnalysisTestGenPrefix } from "./np/prompts";
 import { extractResourceDocumentContent, flattenProjectToFiles } from "../utils/ai-utils";
 import { BALLERINA_RUN_TOOL_NAME } from "./tools/ballerina-run";
@@ -129,6 +130,7 @@ This plan will be visible to the user and the execution will be guided on the ta
      - If no skill applies, use ${LIBRARY_SEARCH_TOOL} with relevant keywords to discover available libraries, then use ${LIBRARY_GET_TOOL} to fetch full details for the discovered libraries.
      - If you think user is refering to an ambiguous API, or internal API, call ${CONNECTOR_GENERATOR_TOOL} to request for the API spec from the user and to generate a connector for it.
    - Before marking the task as completed, use ${DIAGNOSTICS_TOOL_NAME} to check for compilation errors and fix them.
+   - ${REQUIREMENT_COVERAGE_RULE} Repeat the check across the whole request before the final response.
    - Mark task as completed using ${TASK_WRITE_TOOL_NAME} (send ALL tasks, no approval flags) — the agent continues automatically. **IMPORTANT: When marking a task as completed in a message with other tool calls, ${TASK_WRITE_TOOL_NAME} MUST always be the LAST tool call in the message.**
    - After completing a logical unit of work (a set of related tasks), set **requestReview: true** on the ${TASK_WRITE_TOOL_NAME} call to let the user review before continuing. Do NOT set this after every single task.
    - Repeat until ALL tasks are done
@@ -155,6 +157,7 @@ Write/modify the Ballerina code to implement the user requirement. Use the ${FIL
 ### Step 4: Validate the code
 Once the code is written, always use ${DIAGNOSTICS_TOOL_NAME} to check for compilation errors and fix them. You may call it multiple times after making changes.
 If errors cannot be resolved after multiple attempts, bring the code to a good state and finish the task.
+${REQUIREMENT_COVERAGE_RULE}
 Once compilation is clean and if the project contains test cases, run the tests.
 
 ### Step 5: Provide a consise summary

--- a/packages/ballerina-extension/src/features/ai/agent/requirement-coverage.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/requirement-coverage.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * System-prompt rule making the agent check that every requested behaviour has a code path before it
+ * declares a task or a turn done.
+ *
+ * The only completion check the prompt asked for was a clean compile. A request for "when a ticket is
+ * created or updated ... push the change to every connected agent" produced a broadcast wired into the PUT
+ * handler only; the TICKET_CREATED enum member was declared and never referenced, the project compiled, and
+ * the omission was found by the user. Diagnostics report errors only, so an unused symbol never reaches the
+ * model either — the check has to be a rule.
+ *
+ * Interpolated at both completion points in ./prompts.ts: the Edit-mode validation step and the Plan-mode
+ * per-task completion bullet. Kept in its own module (no imports) so it can be unit-tested in isolation.
+ */
+export const REQUIREMENT_COVERAGE_RULE =
+    "Compilation is not evidence of completeness. Before you finish, check requirement coverage in your reasoning "
+    + "(do NOT print the list): for every behaviour the user asked for — each endpoint, trigger, event, status and "
+    + "BOTH sides of any \"when X or Y\" phrase — name the code path that implements it. When one behaviour must "
+    + "fire from several operations (create/update/delete, connect/disconnect), wire it into EVERY handler, not "
+    + "just one. A constant, enum member, type or function you declared but never referenced almost always means a "
+    + "path was left unwired. Fix every gap before moving on.";

--- a/packages/ballerina-extension/src/test-support/requirementCoveragePromptRule.test.ts
+++ b/packages/ballerina-extension/src/test-support/requirementCoveragePromptRule.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Pins the requirement-coverage rule and its presence at both completion points of the system prompt.
+ * `prompts.ts` cannot be imported here (extension-host module graph), so wiring is checked in the source.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { REQUIREMENT_COVERAGE_RULE } from '../features/ai/agent/requirement-coverage';
+
+const promptsSource = fs.readFileSync(path.join(__dirname, '../features/ai/agent/prompts.ts'), 'utf-8');
+
+describe('REQUIREMENT_COVERAGE_RULE content', () => {
+    it('defeats the clean-compile-means-done signal', () => {
+        expect(REQUIREMENT_COVERAGE_RULE).toMatch(/^Compilation is not evidence of completeness\./);
+    });
+
+    it('asks for an internal mapping of every behaviour, including both sides of "when X or Y"', () => {
+        expect(REQUIREMENT_COVERAGE_RULE).toMatch(/\(do NOT print the list\)/);
+        expect(REQUIREMENT_COVERAGE_RULE).toMatch(/each endpoint, trigger, event, status and BOTH sides of any "when X or Y" phrase/);
+        expect(REQUIREMENT_COVERAGE_RULE).toMatch(/name the code path that implements it/);
+    });
+
+    it('requires an event fired from several operations to be wired into every handler', () => {
+        expect(REQUIREMENT_COVERAGE_RULE).toMatch(/wire it into EVERY handler, not just one/);
+    });
+
+    it('names the declared-but-unreferenced symbol as the tell', () => {
+        expect(REQUIREMENT_COVERAGE_RULE).toMatch(/constant, enum member, type or function you declared but never referenced/);
+    });
+
+    it('contains no unresolved interpolation', () => {
+        expect(REQUIREMENT_COVERAGE_RULE).not.toMatch(/\$\{/);
+    });
+});
+
+describe('system prompt wiring', () => {
+    it('imports the rule', () => {
+        expect(promptsSource).toMatch(/import \{ REQUIREMENT_COVERAGE_RULE \} from "\.\/requirement-coverage";/);
+    });
+
+    it('interpolates the rule once in the Plan-mode task completion bullet and once in the Edit-mode validation step', () => {
+        const editMode = promptsSource.indexOf('## Edit Mode');
+        const planCompletion = promptsSource.indexOf('Before marking the task as completed');
+        const editStep4 = promptsSource.indexOf('### Step 4: Validate the code');
+        const editStep5 = promptsSource.indexOf('### Step 5');
+        const occurrences = [...promptsSource.matchAll(/\$\{REQUIREMENT_COVERAGE_RULE\}/g)].map((m) => m.index ?? -1);
+        expect(occurrences).toHaveLength(2);
+        expect(occurrences[0]).toBeGreaterThan(planCompletion);
+        expect(occurrences[0]).toBeLessThan(editMode);
+        expect(occurrences[1]).toBeGreaterThan(editStep4);
+        expect(occurrences[1]).toBeLessThan(editStep5);
+    });
+
+    it('asks Plan mode to repeat the check across the whole request before the final response', () => {
+        expect(promptsSource).toMatch(/\$\{REQUIREMENT_COVERAGE_RULE\} Repeat the check across the whole request before the final response\./);
+    });
+});


### PR DESCRIPTION
## Problem
Asked to push ticket changes "when a ticket is created or updated", Copilot wired the broadcast into the PUT handler only. The `TICKET_CREATED` enum member was declared and never referenced, the project compiled, and the user found the gap. The prompt's only completion check was a clean compile, and diagnostics carry errors only, so an unused symbol never reaches the model.

Fixes https://github.com/wso2/product-integrator/issues/2369

## Fix
Add `REQUIREMENT_COVERAGE_RULE` at both completion points, the Plan-mode task-completion bullet and the Edit-mode validation step: compilation is not evidence of completeness; map every requested behaviour (both sides of a "when X or Y") to a code path in reasoning without printing the list; wire multi-operation events into every handler; treat a declared-but-unreferenced symbol as an unwired path; in Plan mode re-check the whole request before the final response.

## Tests
- `src/test-support/requirementCoveragePromptRule.test.ts`: rule text and both interpolation points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
