### PR TITLE
Guide Copilot to broadcast outside locks with a pattern that compiles

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/lock-io-rules.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/lock-io-rules.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * System-prompt rule against performing I/O inside a lock, with the fan-out pattern that replaces it.
+ *
+ * Generated WebSocket broadcasts held one lock over the subscriber map for the whole loop and wrote to
+ * every connection inside it ("the simplest fix: do the entire broadcast within a single lock block"), so
+ * one slow or dead client blocked delivery to every other subscriber. The obvious repair — snapshot the
+ * callers into an array inside the lock — does NOT compile: a lock over an isolated root may transfer out
+ * only an isolated expression, and while a single `websocket:Caller` is an isolated object, an array of them
+ * is not (BCE3959), and `.clone()` is not applicable to objects. The pattern below is the one that compiles
+ * (verified against Ballerina 2201.13.4): copy the keys, fetch one caller per short lock, write outside.
+ *
+ * Kept in its own module (no imports) so it can be unit-tested without loading the extension host.
+ */
+export const LOCK_IO_RULE = `Never perform network I/O or remote calls (\`->writeMessage\`, HTTP/DB client calls, \`runtime:sleep\`) inside a \`lock\`: one slow or dead peer then blocks every other caller of that lock. A lock over an isolated root (an \`isolated\` variable or \`self\` of an isolated object) may transfer OUT only an isolated expression — a \`readonly\` value or a SINGLE isolated object such as one \`websocket:Caller\`. An ARRAY or MAP of callers is NOT isolated: \`lock { targets = subscribers.toArray(); }\` fails to compile (BCE3959), and \`.clone()\` does not apply to objects. Fan-out pattern — snapshot the KEYS, fetch one connection per short lock, write OUTSIDE the lock, clean up in another short lock:
+\`\`\`ballerina
+isolated map<websocket:Caller> subscribers = {};
+
+isolated function broadcast(readonly & OrderUpdate event) {
+    string[] connectionIds;
+    lock {
+        connectionIds = subscribers.keys().clone(); // string[] is mutable, so .clone() is required
+    }
+    foreach string connectionId in connectionIds {
+        websocket:Caller? caller;
+        lock {
+            caller = subscribers[connectionId]; // a single isolated object leaves the lock as-is
+        }
+        if caller is () {
+            continue;
+        }
+        websocket:Error? result = caller->writeMessage(event); // I/O OUTSIDE the lock
+        if result is websocket:Error {
+            lock {
+                _ = subscribers.removeIfHasKey(connectionId); // cleanup in its own short lock
+            }
+        }
+    }
+}
+\`\`\`
+Build the value being sent (\`event\`) before the loop, outside every lock, and pass it as \`readonly\` so it can enter the locks freely.`;

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -27,6 +27,7 @@ import { getLanglibInstructions } from "../utils/libs/langlibs";
 import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
+import { LOCK_IO_RULE } from "./lock-io-rules";
 import { getRequirementAnalysisCodeGenPrefix, getRequirementAnalysisTestGenPrefix } from "./np/prompts";
 import { extractResourceDocumentContent, flattenProjectToFiles } from "../utils/ai-utils";
 import { BALLERINA_RUN_TOOL_NAME } from "./tools/ballerina-run";
@@ -216,6 +217,7 @@ When a connector authenticates via an OAuth2 refresh-token grant that includes a
 - Always use named arguments when providing values to any parameter (e.g., .get(key="value")).
 - Mention types EXPLICITLY in variable declarations and foreach statements. (Avoid var at all costs)
 - To narrow down a union type(or optional type), always declare a separate variable and then use that variable in the if condition.
+- ${LOCK_IO_RULE}
 
 ## File modifications
 - You must apply changes to the existing source code using the provided ${[

--- a/packages/ballerina-extension/src/test-support/lockIoPromptRule.test.ts
+++ b/packages/ballerina-extension/src/test-support/lockIoPromptRule.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Pins the no-I/O-inside-lock rule and the exact fan-out snippet it teaches. The snippet was compiled
+ * against Ballerina 2201.13.4 before being committed; these assertions keep it from drifting into one of the
+ * variants (`toArray()` snapshot, `.clone()` on callers, bare `keys()`) that fail isolation analysis.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { LOCK_IO_RULE } from '../features/ai/agent/lock-io-rules';
+
+const promptsSource = fs.readFileSync(path.join(__dirname, '../features/ai/agent/prompts.ts'), 'utf-8');
+
+describe('LOCK_IO_RULE content', () => {
+    it('forbids I/O and remote calls inside a lock and says why', () => {
+        expect(LOCK_IO_RULE).toMatch(/^Never perform network I\/O or remote calls/);
+        expect(LOCK_IO_RULE).toMatch(/one slow or dead peer then blocks every other caller/);
+    });
+
+    it('states the transfer-out rule precisely: single isolated object yes, array or map of them no', () => {
+        expect(LOCK_IO_RULE).toMatch(/a `readonly` value or a SINGLE isolated object such as one `websocket:Caller`/);
+        expect(LOCK_IO_RULE).toMatch(/An ARRAY or MAP of callers is NOT isolated/);
+        expect(LOCK_IO_RULE).toMatch(/`lock \{ targets = subscribers\.toArray\(\); \}` fails to compile \(BCE3959\)/);
+        expect(LOCK_IO_RULE).toMatch(/`\.clone\(\)` does not apply to objects/);
+    });
+
+    it('teaches the compiled fan-out pattern verbatim', () => {
+        expect(LOCK_IO_RULE).toContain('connectionIds = subscribers.keys().clone();');
+        expect(LOCK_IO_RULE).toContain('caller = subscribers[connectionId];');
+        expect(LOCK_IO_RULE).toContain('websocket:Error? result = caller->writeMessage(event); // I/O OUTSIDE the lock');
+        expect(LOCK_IO_RULE).toContain('_ = subscribers.removeIfHasKey(connectionId);');
+        expect(LOCK_IO_RULE).toMatch(/isolated function broadcast\(readonly & OrderUpdate event\)/);
+    });
+
+    it('never puts the write inside a lock in the snippet', () => {
+        const snippet = LOCK_IO_RULE.slice(LOCK_IO_RULE.indexOf('```ballerina'), LOCK_IO_RULE.lastIndexOf('```'));
+        // Every lock block in the snippet is a single statement that touches only the map.
+        const lockBodies = [...snippet.matchAll(/lock \{\n([\s\S]*?)\n\s*\}/g)].map((m) => m[1]);
+        expect(lockBodies).toHaveLength(3);
+        for (const body of lockBodies) {
+            expect(body).not.toMatch(/->/);
+            expect(body).toMatch(/subscribers/);
+        }
+    });
+
+    it('contains no unresolved interpolation', () => {
+        expect(LOCK_IO_RULE).not.toMatch(/\$\{/);
+    });
+});
+
+describe('system prompt wiring', () => {
+    it('imports the rule and places it at the end of the Coding Rules', () => {
+        expect(promptsSource).toMatch(/import \{ LOCK_IO_RULE \} from "\.\/lock-io-rules";/);
+        const codingRules = promptsSource.indexOf('## Coding Rules');
+        const interpolation = promptsSource.indexOf('${LOCK_IO_RULE}');
+        const fileMods = promptsSource.indexOf('## File modifications');
+        expect(interpolation).toBeGreaterThan(codingRules);
+        expect(interpolation).toBeLessThan(fileMods);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/2373

## Problem
Generated WebSocket broadcasts wrote to every subscriber inside one lock over the subscriber map, so one slow or dead client blocked delivery to everyone. The prompt had no guidance on I/O inside locks, and the natural repair, snapshotting the callers into an array inside the lock, does not compile: a lock over an isolated root may transfer out only an isolated expression, an array of `websocket:Caller` is not one (BCE3959), and `.clone()` does not apply to objects.

## Fix
Add `LOCK_IO_RULE` to the Coding Rules: never perform I/O or remote calls inside a lock; a single isolated object may leave a lock but an array or map of them may not; fan out by copying the keys, fetching one caller per short lock, writing outside the lock, and cleaning up in another short lock. The snippet in the rule was compiled against Ballerina 2201.13.4 before committing.

## Tests
- `src/test-support/lockIoPromptRule.test.ts`: rule text, the exact snippet, and an invariant that no lock body in the snippet contains a remote call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
