### PR TITLE
Guide Copilot to contain panics in service callbacks

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/panic-containment-rules.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/panic-containment-rules.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * System-prompt rules for keeping a panic in one request or message from taking down the whole program.
+ *
+ * A generated WebSocket `onMessage` let a panic escape; the runtime terminated the process, dropping every
+ * other connection (close code 1006) and the HTTP API sharing it. Containment was added only after the user
+ * asked for it. The behaviour was reproduced on Ballerina 2201.13.4: a panic escaping a WebSocket remote
+ * method or an HTTP resource ends the process (the HTTP caller may still be sent a 500 first), a panic in a
+ * WebSocket upgrade `get` resource is answered with HTTP 500 and the process survives, and a returned `error`
+ * is logged and the connection stays open. The prompt said nothing about `trap` or panics.
+ *
+ * Kept in its own module (no imports) so it can be unit-tested without loading the extension host.
+ */
+export const PANIC_CONTAINMENT_RULES = `## Panic containment in services
+- A panic that escapes a service resource or remote method — an HTTP resource, \`onMessage\`/\`onOpen\`/\`onClose\`, or any other listener callback — is NOT contained by the listener: the runtime prints the panic and the WHOLE PROCESS EXITS, taking down every other service, listener and connection in the program. The failing caller may still receive a 500 first, so a contained-looking response is not evidence the server survived. Returning an \`error\` is safe: it is logged and only that request or message fails. Exception: in a WebSocket upgrade \`get\` resource a panic does not kill the process — the listener answers the handshake with HTTP 500 and prints the panic only to stderr, so clients see "Unexpected server response: 500" with nothing in the application log; never let a panic reach the upgrade resource either.
+- In any code reachable from a listener callback, prefer error-returning constructs over panicking ones: \`check\` (never \`checkpanic\`); \`x is T\`, \`x.ensureType(T)\` or \`cloneWithType\` instead of the cast \`<T>x\`; a length check before indexing \`a[i]\`; a zero check before \`/\` or \`%\`. This — not \`trap\` — is the primary defence.
+- Where a panic is still possible (mutating shared state, helpers you wrote that may panic, e.g. \`push\` on a value that may be \`readonly\`), add ONE \`trap\` at the callback boundary as a last-resort net: \`T|error r = trap doWork(...); if r is error { log:printError("...", 'error = r); return r; }\`. One trap per callback around the risky call — do not scatter \`trap\` over individual statements or wrap calls that already return \`T|error\`.`;

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -27,6 +27,7 @@ import { getLanglibInstructions } from "../utils/libs/langlibs";
 import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
+import { PANIC_CONTAINMENT_RULES } from "./panic-containment-rules";
 import { getRequirementAnalysisCodeGenPrefix, getRequirementAnalysisTestGenPrefix } from "./np/prompts";
 import { extractResourceDocumentContent, flattenProjectToFiles } from "../utils/ai-utils";
 import { BALLERINA_RUN_TOOL_NAME } from "./tools/ballerina-run";
@@ -216,6 +217,8 @@ When a connector authenticates via an OAuth2 refresh-token grant that includes a
 - Always use named arguments when providing values to any parameter (e.g., .get(key="value")).
 - Mention types EXPLICITLY in variable declarations and foreach statements. (Avoid var at all costs)
 - To narrow down a union type(or optional type), always declare a separate variable and then use that variable in the if condition.
+
+${PANIC_CONTAINMENT_RULES}
 
 ## File modifications
 - You must apply changes to the existing source code using the provided ${[

--- a/packages/ballerina-extension/src/test-support/panicContainmentRules.test.ts
+++ b/packages/ballerina-extension/src/test-support/panicContainmentRules.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Pins the panic-containment rules: the process-level consequence, the upgrade-resource exception, the
+ * error-returning constructs preferred over trap, and the single boundary trap. `prompts.ts` cannot be
+ * imported here (extension-host module graph), so wiring is checked in the source.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { PANIC_CONTAINMENT_RULES } from '../features/ai/agent/panic-containment-rules';
+
+const promptsSource = fs.readFileSync(path.join(__dirname, '../features/ai/agent/prompts.ts'), 'utf-8');
+
+describe('PANIC_CONTAINMENT_RULES content', () => {
+    it('states that an escaped panic exits the whole process and that a 500 is not evidence of survival', () => {
+        expect(PANIC_CONTAINMENT_RULES.startsWith('## Panic containment in services')).toBe(true);
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/the WHOLE PROCESS EXITS/);
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/a contained-looking response is not evidence the server survived/);
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/Returning an `error` is safe/);
+    });
+
+    it('states the upgrade-resource exception with the unlogged-500 symptom', () => {
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/in a WebSocket upgrade `get` resource a panic does not kill the process/);
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/answers the handshake with HTTP 500 and prints the panic only to stderr/);
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/never let a panic reach the upgrade resource either/);
+    });
+
+    it('prefers error-returning constructs, names checkpanic and the cast, and does not call cloneWithType a hazard', () => {
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/`check` \(never `checkpanic`\)/);
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/`x is T`, `x\.ensureType\(T\)` or `cloneWithType` instead of the cast `<T>x`/);
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/This — not `trap` — is the primary defence/);
+    });
+
+    it('asks for exactly one trap at the callback boundary, not blanket trapping', () => {
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/add ONE `trap` at the callback boundary/);
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/`T\|error r = trap doWork\(\.\.\.\); if r is error \{ log:printError\("\.\.\.", 'error = r\); return r; \}`/);
+        expect(PANIC_CONTAINMENT_RULES).toMatch(/do not scatter `trap` over individual statements/);
+    });
+
+    it('contains no unresolved interpolations or stray backtick escapes', () => {
+        expect(PANIC_CONTAINMENT_RULES).not.toMatch(/\$\{/);
+        expect(PANIC_CONTAINMENT_RULES).not.toMatch(/\\`/);
+    });
+});
+
+describe('system prompt wiring', () => {
+    it('imports the rules and places them between Coding Rules and File modifications', () => {
+        expect(promptsSource).toMatch(/import \{ PANIC_CONTAINMENT_RULES \} from "\.\/panic-containment-rules";/);
+        const codingRules = promptsSource.indexOf('## Coding Rules');
+        const interpolation = promptsSource.indexOf('${PANIC_CONTAINMENT_RULES}');
+        const fileMods = promptsSource.indexOf('## File modifications');
+        expect(interpolation).toBeGreaterThan(codingRules);
+        expect(interpolation).toBeLessThan(fileMods);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/2374

## Problem
A generated WebSocket `onMessage` let a panic escape; the runtime terminated the process, dropping every other connection (close code 1006) and the HTTP API sharing it. Containment was added only after the user asked. The prompt said nothing about `trap` or panics. Verified on 2201.13.4: a panic escaping a WebSocket remote method or an HTTP resource ends the process (the HTTP caller may still get a 500 first); a panic in the upgrade `get` resource is answered with HTTP 500 and the process survives; a returned `error` keeps the connection open.

## Fix
Add `PANIC_CONTAINMENT_RULES` to the Coding Rules: the process-level consequence and the upgrade-resource exception; prefer error-returning constructs (`check` not `checkpanic`, `is`/`ensureType`/`cloneWithType` over casts, bounds and zero checks); one `trap` at the callback boundary as a last-resort net rather than blanket trapping.

## Tests
- `src/test-support/panicContainmentRules.test.ts`: rule text and prompt wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
