### PR TITLE
Surface runtime panics from service output in the run and logs tools

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -31,6 +31,7 @@ import { getRequirementAnalysisCodeGenPrefix, getRequirementAnalysisTestGenPrefi
 import { extractResourceDocumentContent, flattenProjectToFiles } from "../utils/ai-utils";
 import { BALLERINA_RUN_TOOL_NAME } from "./tools/ballerina-run";
 import { BALLERINA_STOP_TOOL_NAME } from "./tools/ballerina-stop";
+import { BALLERINA_GET_LOGS_TOOL_NAME } from "./tools/ballerina-get-logs";
 import { getBuiltInSkillsSection, getProjectSkillsSection, getUserSkillsSection, getDisabledSkillsSection, ProjectSkillMeta } from "./skills";
 import { WEB_SEARCH_TOOL_NAME, WEB_FETCH_TOOL_NAME } from "./tools/web-tools";
 // TODO(auto-memory): temporarily disabled for this release — restore once the memory feature is refined.
@@ -258,6 +259,7 @@ In WSO2 Integrator, a Ballerina workspace is called a **project** and a Ballerin
 - You do NOT decide which (library, shape) combinations are actually managed — the tool verifies each against the managed registry and silently downgrades unsupported ones to manual entry. So emit a group for ANY connector credential that fits one of the two shapes; grouping a candidate that turns out to be unsupported is harmless. That tolerance covers the library and shape only — every mapped name must be a configurable that already exists in source, spelled exactly as declared. Only leave TRULY non-connector secrets (e.g. a database password, or a standalone API key not tied to any connector) in \`variables\`.
 - Use one managedConnections entry per connector instance (repeat the same library for two clients of it), and put each configurable in EXACTLY ONE place — never list the same name in both a group and \`variables\`.
 - You can call ${BALLERINA_STOP_TOOL_NAME} when you need to restart a service (e.g. after code changes) or when the user explicitly asks to stop it.
+- When a client receives HTTP 500 or a dropped connection from a running service, read the service output with ${BALLERINA_GET_LOGS_TOOL_NAME} before changing anything: a \`runtimePanics\` entry (an \`error: {ballerina}...\` trace with a \`file.bal:line\` location) names the statement that failed. A panic in a resource or remote method is the cause of the 500 — fix that statement; never treat the service as working while its output shows a panic.
 
 ## Test Runner
 When running tests:

--- a/packages/ballerina-extension/src/features/ai/agent/tools/ballerina-get-logs.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/ballerina-get-logs.ts
@@ -19,6 +19,7 @@ import { z } from 'zod';
 import { CopilotEventHandler } from '../../utils/events';
 import { RunningServicesManager } from './running-service-manager';
 import { BALLERINA_RUN_TOOL_NAME } from './ballerina-run';
+import { buildRuntimePanicNote, detectRuntimePanics } from './runtime-panics';
 
 export const BALLERINA_GET_LOGS_TOOL_NAME = "getServiceLogs";
 
@@ -77,13 +78,19 @@ async function getLogs(
 
     const newLogs = service.logs.slice(service.logCursor).join('');
     service.logCursor = service.logs.length;
+    // A panic trace in the output is the reason clients saw a 500 or a dropped connection; surface it so the
+    // model reads the failing location instead of passing over a page of logs.
+    const runtimePanics = detectRuntimePanics(newLogs);
+    const panicFields = runtimePanics.length > 0 ? { runtimePanics } : {};
+    const panicNote = buildRuntimePanicNote(runtimePanics);
 
     if (service.exited) {
         return {
             status: "exited",
             exitCode: service.exitCode,
             logs: newLogs,
-            message: `Service has exited with code ${service.exitCode}.`,
+            ...panicFields,
+            message: `Service has exited with code ${service.exitCode}.${panicNote}`,
         };
     }
 
@@ -98,6 +105,7 @@ async function getLogs(
     return {
         status: "running",
         logs: newLogs,
-        message: `${newLogs.split('\n').length} new log lines.`,
+        ...panicFields,
+        message: `${newLogs.split('\n').length} new log lines.${panicNote}`,
     };
 }

--- a/packages/ballerina-extension/src/features/ai/agent/tools/ballerina-run.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/ballerina-run.ts
@@ -26,6 +26,7 @@ import { BALLERINA_GET_LOGS_TOOL_NAME } from './ballerina-get-logs';
 import { BALLERINA_STOP_TOOL_NAME } from './ballerina-stop';
 import { resolvePackageBasePath } from './path-utils';
 import { getRunCommand } from '../../../project/cmds/cmd-runner';
+import { buildRuntimePanicNote, detectRuntimePanics } from './runtime-panics';
 
 export const BALLERINA_RUN_TOOL_NAME = "runBallerinaPackage";
 
@@ -168,13 +169,15 @@ export async function executeRun(
     }
 
     runningServices.remove(taskId);
+    const runtimePanics = detectRuntimePanics(completionResult.logs);
     return {
         status: service.exitCode === 0 ? "completed" : "error",
         exitCode: service.exitCode,
         output: completionResult.logs,
-        message: service.exitCode === 0
+        ...(runtimePanics.length > 0 ? { runtimePanics } : {}),
+        message: (service.exitCode === 0
             ? "Program completed successfully."
-            : "Build or runtime error. Check output for details.",
+            : "Build or runtime error. Check output for details.") + buildRuntimePanicNote(runtimePanics),
     };
 }
 

--- a/packages/ballerina-extension/src/features/ai/agent/tools/runtime-panics.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/runtime-panics.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Detects Ballerina runtime panics in the output of a running program.
+ *
+ * A panic prints as an `error:` line naming the error type and its detail, followed by tab-indented
+ * `at` frames, the first of which is where the panic happened:
+ *
+ *     error: {ballerina}TypeCastError {"message":"incompatible types: 'jwt:Payload' cannot be cast to 'map<json>'"}
+ *         at damsith.order_tracker.0:authorizeOrderAccess(main.bal:65)
+ *            damsith.order_tracker.0.$anonType$_0:$get$.(main.bal:30)
+ *
+ * The clients of such a service see only an HTTP 500 (or a dropped connection), and the model reading a
+ * page of service output easily passes over the trace. Surfacing the panics as structured data on the
+ * run/logs tool results — type, message, and the exact `file.bal:line` — lets the model go straight to
+ * the failing statement instead of guessing from the status code.
+ *
+ * Kept free of `vscode` imports so it can be unit tested in isolation.
+ */
+
+export interface RuntimePanic {
+    /** The error type as printed, e.g. `{ballerina}TypeCastError` or `{ballerina/lang.array}InvalidUpdate`. */
+    errorType: string;
+    /** The `message` from the error detail when present, otherwise the raw detail text. */
+    message: string;
+    /** The innermost frame's `file.bal:line`, e.g. `main.bal:65`, when the trace carries one. */
+    location?: string;
+    /** The innermost frame's function, e.g. `authorizeOrderAccess`, when the trace carries one. */
+    function?: string;
+    /** The stack frames as printed, innermost first, without the leading `at`. */
+    frames: string[];
+}
+
+const PANIC_LINE = /^error:\s+(\{[^}]*\}[A-Za-z_][\w$]*)\s*(.*)$/;
+const FRAME_LINE = /^\s+(?:at\s+)?(\S.*)$/;
+const FRAME_LOCATION = /([A-Za-z_][\w$.]*)\(([^()]+\.bal:\d+)\)\s*$/;
+
+function extractMessage(detail: string): string {
+    const trimmed = detail.trim();
+    if (!trimmed) {
+        return "";
+    }
+    try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed && typeof parsed === "object" && typeof parsed.message === "string") {
+            return parsed.message;
+        }
+    } catch {
+        // Not JSON — keep the raw detail.
+    }
+    return trimmed;
+}
+
+/**
+ * Every panic trace in the given output, in order of appearance.
+ */
+export function detectRuntimePanics(output: string): RuntimePanic[] {
+    const lines = output.split(/\r?\n/);
+    const panics: RuntimePanic[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+        const match = PANIC_LINE.exec(lines[i]);
+        if (!match) {
+            continue;
+        }
+        const panic: RuntimePanic = { errorType: match[1], message: extractMessage(match[2]), frames: [] };
+        let j = i + 1;
+        while (j < lines.length) {
+            const frame = FRAME_LINE.exec(lines[j]);
+            // Frames are indented; the first un-indented line ends the trace.
+            if (!frame || !/^\s/.test(lines[j])) {
+                break;
+            }
+            panic.frames.push(frame[1].trim());
+            j++;
+        }
+        const innermost = panic.frames.find((f) => FRAME_LOCATION.test(f));
+        if (innermost) {
+            const loc = FRAME_LOCATION.exec(innermost)!;
+            const qualified = loc[1];
+            panic.function = qualified.substring(qualified.lastIndexOf(":") + 1) || qualified;
+            panic.location = loc[2];
+        }
+        panics.push(panic);
+        i = j - 1;
+    }
+    return panics;
+}
+
+/**
+ * The note appended to a run/logs tool message when panics were detected. States the consequence the model
+ * must not miss: a panic in a resource or remote method is why clients saw a 500 or lost their connection,
+ * and where in the source it happened.
+ */
+export function buildRuntimePanicNote(panics: RuntimePanic[]): string {
+    if (panics.length === 0) {
+        return "";
+    }
+    const summary = panics
+        .slice(0, 3)
+        .map((p) => `${p.errorType}${p.location ? ` at ${p.function ? p.function + " " : ""}(${p.location})` : ""}${p.message ? `: ${p.message}` : ""}`)
+        .join("; ");
+    return ` ${panics.length} runtime panic(s) detected in the output (see runtimePanics): ${summary}. `
+        + `A panic in a resource or remote method is what makes clients receive HTTP 500 or lose their connection `
+        + `— fix the statement at the reported location; do not treat the service as working.`;
+}

--- a/packages/ballerina-extension/src/test-support/runtimePanics.test.ts
+++ b/packages/ballerina-extension/src/test-support/runtimePanics.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Runtime panics in service output are the reason clients saw HTTP 500 or a dropped connection. The traces
+ * below are the ones observed in testing (a TypeCastError in a WebSocket upgrade resource; an InvalidUpdate
+ * in onMessage) as the Ballerina runtime prints them.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { buildRuntimePanicNote, detectRuntimePanics } from '../features/ai/agent/tools/runtime-panics';
+
+const promptsSource = fs.readFileSync(path.join(__dirname, '../features/ai/agent/prompts.ts'), 'utf-8');
+
+const TYPE_CAST_TRACE = [
+    'Compiling source',
+    '\tdamsith/order_tracker:0.1.0',
+    'Running executable',
+    '',
+    "error: {ballerina}TypeCastError {\"message\":\"incompatible types: 'jwt:Payload' cannot be cast to 'map<json>'\"}",
+    '\tat damsith.order_tracker.0:authorizeOrderAccess(main.bal:65)',
+    '\t   damsith.order_tracker.0.$anonType$_0:$get$.(main.bal:30)',
+    '',
+].join('\n');
+
+const INVALID_UPDATE_TRACE = [
+    'error: {ballerina/lang.array}InvalidUpdate {"message":"modification not allowed on readonly value"}',
+    '\tat ballerina.lang.array.0:push(array.bal:419)',
+    '\t   damsith.support_desk.0:updateTicketSubscription(ticket_events.bal:76)',
+    '\t   damsith.support_desk.0.TicketLiveService:onMessage(main.bal:132)',
+].join('\n');
+
+describe('detectRuntimePanics', () => {
+    it('extracts the error type, message, innermost user frame and location from a TypeCastError trace', () => {
+        const [panic] = detectRuntimePanics(TYPE_CAST_TRACE);
+        expect(panic.errorType).toBe('{ballerina}TypeCastError');
+        expect(panic.message).toBe("incompatible types: 'jwt:Payload' cannot be cast to 'map<json>'");
+        expect(panic.function).toBe('authorizeOrderAccess');
+        expect(panic.location).toBe('main.bal:65');
+        expect(panic.frames).toEqual([
+            'damsith.order_tracker.0:authorizeOrderAccess(main.bal:65)',
+            'damsith.order_tracker.0.$anonType$_0:$get$.(main.bal:30)',
+        ]);
+    });
+
+    it('takes the innermost frame even when it is a langlib frame', () => {
+        const [panic] = detectRuntimePanics(INVALID_UPDATE_TRACE);
+        expect(panic.errorType).toBe('{ballerina/lang.array}InvalidUpdate');
+        expect(panic.message).toBe('modification not allowed on readonly value');
+        expect(panic.function).toBe('push');
+        expect(panic.location).toBe('array.bal:419');
+        expect(panic.frames).toHaveLength(3);
+    });
+
+    it('finds every panic in a page of output and ignores ordinary log lines', () => {
+        const output = `time=2026-09-04 level=INFO module=x message="ticket created"\n${TYPE_CAST_TRACE}\nerror: something unrelated without a type\n${INVALID_UPDATE_TRACE}\n`;
+        const panics = detectRuntimePanics(output);
+        expect(panics.map((p) => p.errorType)).toEqual(['{ballerina}TypeCastError', '{ballerina/lang.array}InvalidUpdate']);
+    });
+
+    it('keeps a non-JSON detail verbatim and copes with a trace that has no frames', () => {
+        const [panic] = detectRuntimePanics('error: {ballerina}DivisionByZero / by zero');
+        expect(panic.message).toBe('/ by zero');
+        expect(panic.location).toBeUndefined();
+        expect(panic.frames).toEqual([]);
+    });
+
+    it('returns nothing for clean output', () => {
+        expect(detectRuntimePanics('Running executable\n\ntime=... level=INFO message="started"\n')).toEqual([]);
+        expect(detectRuntimePanics('')).toEqual([]);
+    });
+});
+
+describe('buildRuntimePanicNote', () => {
+    it('is empty when there are no panics', () => {
+        expect(buildRuntimePanicNote([])).toBe('');
+    });
+
+    it('names the type, function, location and message, and states the consequence', () => {
+        const note = buildRuntimePanicNote(detectRuntimePanics(TYPE_CAST_TRACE));
+        expect(note).toMatch(/1 runtime panic\(s\) detected/);
+        expect(note).toMatch(/\{ballerina\}TypeCastError at authorizeOrderAccess \(main\.bal:65\): incompatible types/);
+        expect(note).toMatch(/clients receive HTTP 500 or lose their connection/);
+        expect(note).toMatch(/do not treat the service as working/);
+    });
+});
+
+describe('system prompt wiring', () => {
+    it('tells the model to read runtimePanics from the logs tool when clients see a 500', () => {
+        expect(promptsSource).toMatch(/When a client receives HTTP 500 or a dropped connection from a running service, read the service output with \$\{BALLERINA_GET_LOGS_TOOL_NAME\}/);
+        expect(promptsSource).toMatch(/never treat the service as working while its output shows a panic/);
+        expect(promptsSource).toMatch(/import \{ BALLERINA_GET_LOGS_TOOL_NAME \} from "\.\/tools\/ballerina-get-logs";/);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/2375


## Problem
Every valid WebSocket connection returned HTTP 500 because a cast panicked inside the upgrade resource. The runtime printed the trace with the exact location (`{ballerina}TypeCastError ... at authorizeOrderAccess(main.bal:65)`) to the service's output, but the client saw only a 500 and the model never connected the two. The run and logs tools returned raw output with no signal that a panic had occurred.

## Fix
- Add `detectRuntimePanics()`, which parses Ballerina panic traces into error type, detail message, innermost frame function and `file.bal:line`, and all frames.
- `getServiceLogs` and `runBallerinaPackage` (main mode) return a `runtimePanics` field and append a note naming the type, location and message, stating that a panic in a resource or remote method is why clients get 500s or dropped connections.
- Prompt: when clients see a 500 or a dropped connection, read the service output first and fix the statement at the reported location; never treat a service as working while its output shows a panic.

## Tests
- `src/test-support/runtimePanics.test.ts`: parser against the traces observed in testing (TypeCastError in an upgrade resource, InvalidUpdate in onMessage), multiple panics in one page, non-JSON details, note text, prompt wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
