### PR TITLE
Guide Copilot on cloning immutable values

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/immutable-clone-rules.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/immutable-clone-rules.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * System-prompt rule on what `clone()` does to an immutable value.
+ *
+ * Generated code made a request array `readonly` (via `cloneReadOnly()`) so it could enter a lock, then
+ * stored `requested.clone()` as a subscriber's mutable queue list. The language spec (§5.9.2.1) defines
+ * Clone(v) for an immutable v as v itself, so the stored list was still immutable, and the next message's
+ * `push` panicked with `{ballerina/lang.array}InvalidUpdate` — an order-dependent crash that took the whole
+ * server down. Nothing in the prompt said that cloning an immutable value does not produce a mutable copy.
+ *
+ * The remedies were run on Ballerina 2201.13.4: a query expression followed by `.clone()` yields a mutable
+ * array in every position, including direct assignment to an `isolated` variable inside a lock (a bare query
+ * expression there fails BCE3959); `check ro.cloneWithType()` also yields a mutable array but only where the
+ * enclosing function can return `error`.
+ *
+ * Kept in its own module (no imports) so it can be unit-tested without loading the extension host.
+ */
+export const IMMUTABLE_CLONE_RULE =
+    "`clone()` and `cloneReadOnly()` on a value that is ALREADY immutable return the SAME immutable value — they do "
+    + "NOT make a mutable copy (the spec defines Clone(v) for an immutable v as v). So a value you made `readonly` "
+    + "(a `readonly & T` parameter, a `cloneReadOnly()` result, a `readonly` record field) stays immutable after "
+    + "`.clone()`, and storing it into a field or variable whose type is mutable makes a later `push`/member update "
+    + "panic at run time with `{ballerina/lang.array}InvalidUpdate` (\"modification not allowed on readonly value\"). "
+    + "Diagnostics cannot catch this. To obtain genuinely mutable state from a readonly value, REBUILD it: "
+    + "`string[] fresh = (from string q in roQueues select q).clone();` — the trailing `.clone()` is what makes the "
+    + "expression an isolated expression, so this form also works when assigning straight to an `isolated` variable "
+    + "inside a lock (a bare query expression there is a compile error) — or, in a function that can return `error`, "
+    + "`string[] fresh = check roQueues.cloneWithType();`. Never store a readonly-derived value where later code will "
+    + "mutate it.";

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -27,6 +27,7 @@ import { getLanglibInstructions } from "../utils/libs/langlibs";
 import { formatCodebaseStructure, formatCodeContext } from "./utils";
 import { GenerateAgentCodeRequest, OperationType, ProjectSource } from "@wso2/ballerina-core";
 import { formatActiveFileReminder } from "./activeFileReminder";
+import { IMMUTABLE_CLONE_RULE } from "./immutable-clone-rules";
 import { getRequirementAnalysisCodeGenPrefix, getRequirementAnalysisTestGenPrefix } from "./np/prompts";
 import { extractResourceDocumentContent, flattenProjectToFiles } from "../utils/ai-utils";
 import { BALLERINA_RUN_TOOL_NAME } from "./tools/ballerina-run";
@@ -216,6 +217,7 @@ When a connector authenticates via an OAuth2 refresh-token grant that includes a
 - Always use named arguments when providing values to any parameter (e.g., .get(key="value")).
 - Mention types EXPLICITLY in variable declarations and foreach statements. (Avoid var at all costs)
 - To narrow down a union type(or optional type), always declare a separate variable and then use that variable in the if condition.
+- ${IMMUTABLE_CLONE_RULE}
 
 ## File modifications
 - You must apply changes to the existing source code using the provided ${[

--- a/packages/ballerina-extension/src/test-support/immutableCloneRule.test.ts
+++ b/packages/ballerina-extension/src/test-support/immutableCloneRule.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Pins the clone-of-immutable rule. Both remedies it teaches were run on Ballerina 2201.13.4; the
+ * assertions keep the exact forms (query expression with a trailing `.clone()`, `check ... cloneWithType()`)
+ * from drifting into variants that either stay readonly or fail isolation analysis.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { IMMUTABLE_CLONE_RULE } from '../features/ai/agent/immutable-clone-rules';
+
+const promptsSource = fs.readFileSync(path.join(__dirname, '../features/ai/agent/prompts.ts'), 'utf-8');
+
+describe('IMMUTABLE_CLONE_RULE content', () => {
+    it('states that cloning an immutable value returns the same immutable value, with the spec basis', () => {
+        expect(IMMUTABLE_CLONE_RULE).toMatch(/^`clone\(\)` and `cloneReadOnly\(\)` on a value that is ALREADY immutable return the SAME immutable value/);
+        expect(IMMUTABLE_CLONE_RULE).toMatch(/the spec defines Clone\(v\) for an immutable v as v/);
+    });
+
+    it('names the runtime panic and says diagnostics cannot catch it', () => {
+        expect(IMMUTABLE_CLONE_RULE).toMatch(/`\{ballerina\/lang\.array\}InvalidUpdate` \("modification not allowed on readonly value"\)/);
+        expect(IMMUTABLE_CLONE_RULE).toMatch(/Diagnostics cannot catch this/);
+    });
+
+    it('teaches the verified remedies in their exact forms', () => {
+        expect(IMMUTABLE_CLONE_RULE).toContain('`string[] fresh = (from string q in roQueues select q).clone();`');
+        expect(IMMUTABLE_CLONE_RULE).toContain('`string[] fresh = check roQueues.cloneWithType();`');
+        expect(IMMUTABLE_CLONE_RULE).toMatch(/a bare query expression there is a compile error/);
+        expect(IMMUTABLE_CLONE_RULE).toMatch(/in a function that can return `error`/);
+    });
+
+    it('closes with the storage rule', () => {
+        expect(IMMUTABLE_CLONE_RULE).toMatch(/Never store a readonly-derived value where later code will mutate it\.$/);
+    });
+
+    it('contains no unresolved interpolation', () => {
+        expect(IMMUTABLE_CLONE_RULE).not.toMatch(/\$\{/);
+    });
+});
+
+describe('system prompt wiring', () => {
+    it('imports the rule and places it at the end of the Coding Rules', () => {
+        expect(promptsSource).toMatch(/import \{ IMMUTABLE_CLONE_RULE \} from "\.\/immutable-clone-rules";/);
+        const codingRules = promptsSource.indexOf('## Coding Rules');
+        const interpolation = promptsSource.indexOf('${IMMUTABLE_CLONE_RULE}');
+        const fileMods = promptsSource.indexOf('## File modifications');
+        expect(interpolation).toBeGreaterThan(codingRules);
+        expect(interpolation).toBeLessThan(fileMods);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/2376

## Problem
Generated code made a request array readonly with `cloneReadOnly()` so it could cross into a lock, then stored `requested.clone()` as a subscriber's mutable queue list. Clone(v) of an immutable v is v (spec §5.9.2.1), so the stored list stayed immutable and the next message's `push` panicked with `{ballerina/lang.array}InvalidUpdate`, killing the whole server process. The prompt said nothing about `clone()` on immutable values.

## Fix
Add `IMMUTABLE_CLONE_RULE` to the Coding Rules: `clone()`/`cloneReadOnly()` on an immutable value return the same value; storing it in mutable-typed state panics later and diagnostics cannot catch it; rebuild with `(from q in ro select q).clone()` (also valid when assigning to an `isolated` variable inside a lock) or `check ro.cloneWithType()` where the function can return `error`; never store a readonly-derived value that will be mutated. Both remedies were compiled and run on Ballerina 2201.13.4.

## Tests
- `src/test-support/immutableCloneRule.test.ts`: rule text, exact remedy forms, prompt wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
