### PR TITLE
Keep chat scroll position stable during streaming, add jump-to-bottom control

### DIFF
--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -58,7 +58,7 @@ import FollowupSuggestions from "../FollowupSuggestions";
 import { Attachment, AttachmentStatus, SkillEnableStage, SkillEntry, TaskApprovalRequest } from "@wso2/ballerina-core";
 import type { ClarifyEvent, ConfigurationCollectionEvent, ConnectorGenerationNotification } from "@wso2/ballerina-core";
 
-import { AIChatView, Header, HeaderButtons, ChatMessage, TurnGroup, AuthProviderChip, UsageBadge, UsageRefreshButton, ApprovalOverlay, OverlayMessage, OverlayCloseButton } from "../../styles";
+import { AIChatView, Header, HeaderButtons, ChatMessage, TurnGroup, AuthProviderChip, UsageBadge, UsageRefreshButton, ApprovalOverlay, OverlayMessage, OverlayCloseButton, JumpToBottomButton } from "../../styles";
 import { SessionHistoryDropdown } from "../SessionHistory";
 import ReferenceDropdown from "../ReferenceDropdown";
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
@@ -112,6 +112,87 @@ const DRIFT_CHECK_ERROR = "Failed to check drift between the code and the docume
 
 const USAGE_EXCEEDED_THRESHOLD_PERCENT = 3;
 const DISCORD_INVITE_URL = "https://discord.com/invite/wso2";
+
+// Distance (px) from the bottom still considered "pinned" — absorbs late layout growth during streaming.
+const BOTTOM_THRESHOLD_PX = 80;
+
+interface ScrollMetrics {
+    scrollHeight: number;
+    scrollTop: number;
+    clientHeight: number;
+}
+
+function isPinnedToBottom(el: ScrollMetrics, threshold: number): boolean {
+    return el.scrollHeight - el.scrollTop - el.clientHeight <= threshold;
+}
+
+// Tracks whether a scroll was caused by our own programmatic scrollIntoView (ignore) or the
+// user (don't). markUserIntent always wins over begin, even mid-guard-window.
+interface AutoScrollGuard {
+    isAutoScrolling(): boolean;
+    markUserIntent(): void;
+    begin(onFallbackSettle: () => void, fallbackMs: number): void;
+    settle(): void;
+    dispose(): void;
+}
+
+function createAutoScrollGuard(): AutoScrollGuard {
+    let autoScrolling = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    function clearPendingTimeout(): void {
+        if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+            timeoutId = undefined;
+        }
+    }
+
+    return {
+        isAutoScrolling: () => autoScrolling,
+        markUserIntent: () => {
+            autoScrolling = false;
+        },
+        begin: (onFallbackSettle, fallbackMs) => {
+            clearPendingTimeout();
+            autoScrolling = true;
+            timeoutId = setTimeout(() => {
+                timeoutId = undefined;
+                autoScrolling = false;
+                onFallbackSettle();
+            }, fallbackMs);
+        },
+        settle: () => {
+            clearPendingTimeout();
+            autoScrolling = false;
+        },
+        dispose: () => {
+            clearPendingTimeout();
+        },
+    };
+}
+
+// Callback ref (not a mount-once effect) so it reattaches whenever the node changes, including a
+// remount after unmount.
+function useResizeObserverRef<T extends Element>(
+    onResize: (rect: DOMRectReadOnly) => void
+): (node: T | null) => void {
+    const observerRef = useRef<ResizeObserver>();
+
+    return useCallback((node: T | null) => {
+        observerRef.current?.disconnect();
+        observerRef.current = undefined;
+        if (!node) {
+            return;
+        }
+        const observer = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                onResize(entry.contentRect);
+            }
+        });
+        observer.observe(node);
+        observerRef.current = observer;
+    }, [onResize]);
+}
 
 //TODO: Add better error handling from backend. stream error type and non 200 status codes
 
@@ -477,6 +558,70 @@ const AIChat: React.FC = () => {
     }
 
     const messagesEndRef = React.useRef<HTMLDivElement>(null);
+    const mainRef = useRef<HTMLElement>(null);
+    const isPinnedToBottomRef = useRef(true);
+    // Last observed scrollTop — distinguishes a scrollbar-thumb drag from our own scroll.
+    const lastScrollTopRef = useRef(0);
+    // Guards against our own programmatic scrollIntoView being misread as a manual user scroll.
+    const autoScrollGuardRef = useRef<AutoScrollGuard>();
+    if (!autoScrollGuardRef.current) {
+        autoScrollGuardRef.current = createAutoScrollGuard();
+    }
+    const [showJumpToBottom, setShowJumpToBottom] = useState(false);
+    // Height of the footer stack, so the "jump to bottom" button can float just above it.
+    const [footerHeight, setFooterHeight] = useState(0);
+    const handleFooterResize = useCallback((rect: DOMRectReadOnly) => setFooterHeight(rect.height), []);
+    const setFooterRef = useResizeObserverRef<HTMLDivElement>(handleFooterResize);
+
+    const checkPinnedState = useCallback(() => {
+        const el = mainRef.current;
+        if (!el) {
+            return;
+        }
+        const atBottom = isPinnedToBottom(el, BOTTOM_THRESHOLD_PX);
+        if (isPinnedToBottomRef.current !== atBottom) {
+            isPinnedToBottomRef.current = atBottom;
+            setShowJumpToBottom(!atBottom);
+        }
+    }, []);
+
+    // A real user interaction always wins, even mid-guard-window — fixes auto-scroll fighting a
+    // user who scrolls up while chunks keep arriving.
+    const handleUserScrollIntent = useCallback(() => {
+        autoScrollGuardRef.current!.markUserIntent();
+    }, []);
+
+    // Real completion signal for our own scroll: fires on "scrollend".
+    const handleProgrammaticScrollSettled = useCallback(() => {
+        autoScrollGuardRef.current!.settle();
+        checkPinnedState();
+    }, [checkPinnedState]);
+
+    // Callback ref, not a mount-once effect: <main> unmounts entirely while Settings/MCP/Skills
+    // is pushed, so a one-shot effect would go stale on every panel round-trip after the first.
+    const setMainRef = useCallback((node: HTMLElement | null) => {
+        const prev = mainRef.current;
+        if (prev) {
+            prev.removeEventListener("wheel", handleUserScrollIntent);
+            prev.removeEventListener("touchmove", handleUserScrollIntent);
+            prev.removeEventListener("keydown", handleUserScrollIntent);
+            prev.removeEventListener("scrollend", handleProgrammaticScrollSettled);
+            autoScrollGuardRef.current!.dispose();
+        }
+        mainRef.current = node;
+        if (node) {
+            node.addEventListener("wheel", handleUserScrollIntent, { passive: true });
+            node.addEventListener("touchmove", handleUserScrollIntent, { passive: true });
+            node.addEventListener("keydown", handleUserScrollIntent);
+            node.addEventListener("scrollend", handleProgrammaticScrollSettled);
+            // A fresh <main> (e.g. returning from Settings) always starts scrolled to top —
+            // resync instead of leaving isPinnedToBottomRef stale.
+            if (isPinnedToBottomRef.current) {
+                node.scrollTop = node.scrollHeight;
+            }
+            checkPinnedState();
+        }
+    }, [handleUserScrollIntent, handleProgrammaticScrollSettled, checkPinnedState]);
 
     /* REFACTORED CODE START [2] */
     // custom hooks: commands + attachments
@@ -1741,25 +1886,63 @@ const AIChat: React.FC = () => {
         generateNaturalProgrammingTemplate(isReqFileExists);
     }, [isReqFileExists]);
 
+    const runProgrammaticScroll = useCallback((behavior: ScrollBehavior) => {
+        messagesEndRef.current?.scrollIntoView({ behavior, block: "end" });
+        // Fallback only matters if the scroll was a no-op; "scrollend" is the real completion signal.
+        autoScrollGuardRef.current!.begin(handleProgrammaticScrollSettled, behavior === "smooth" ? 500 : 100);
+    }, [handleProgrammaticScrollSettled]);
+
     useEffect(() => {
-        const scrollToEnd = (behavior: ScrollBehavior) => {
-            messagesEndRef.current?.scrollIntoView({ behavior, block: "end" });
-        };
-        scrollToEnd("smooth");
-        // Once the turn settles the layout keeps growing (review/restore bar,
-        // markdown + code highlighting), so smooth-scroll lands on a stale
-        // bottom — snap to the true end after that late growth.
+        // User has scrolled up to read earlier content — don't fight them.
+        if (!isPinnedToBottomRef.current) {
+            return;
+        }
+        runProgrammaticScroll("smooth");
+        // The layout keeps growing after a turn settles (review bar, markdown/code highlighting),
+        // so the smooth-scroll above can land short — snap to the true end after that growth.
         if (!isLoading && !isCodeLoading) {
-            const t = setTimeout(() => scrollToEnd("auto"), 120);
+            const t = setTimeout(() => {
+                if (isPinnedToBottomRef.current) {
+                    runProgrammaticScroll("auto");
+                }
+            }, 120);
             return () => clearTimeout(t);
         }
-    }, [messages, isLoading, isCodeLoading, followupSuggestions]);
+    }, [messages, isLoading, isCodeLoading, followupSuggestions, runProgrammaticScroll]);
+
+    const handleScroll = useCallback(() => {
+        const el = mainRef.current;
+        const scrollTop = el?.scrollTop ?? lastScrollTopRef.current;
+        if (autoScrollGuardRef.current!.isAutoScrolling()) {
+            // Our own scroll only moves toward the bottom, so a drop mid-flight is the user.
+            if (scrollTop < lastScrollTopRef.current) {
+                handleUserScrollIntent();
+            } else {
+                lastScrollTopRef.current = scrollTop;
+                return;
+            }
+        }
+        lastScrollTopRef.current = scrollTop;
+        checkPinnedState();
+    }, [checkPinnedState, handleUserScrollIntent]);
+
+    const repinToBottom = useCallback(() => {
+        isPinnedToBottomRef.current = true;
+        setShowJumpToBottom(false);
+    }, []);
+
+    const handleJumpToBottom = useCallback(() => {
+        repinToBottom();
+        runProgrammaticScroll("smooth");
+    }, [repinToBottom, runProgrammaticScroll]);
 
     async function handleSendQuery(content: {
         input: Input[];
         attachments: Attachment[];
         metadata?: Record<string, any>;
     }) {
+        repinToBottom();
+
         // Clear previous generation refs
         currentDiagnosticsRef.current = [];
         functionsRef.current = [];
@@ -2197,6 +2380,7 @@ const AIChat: React.FC = () => {
 
     async function handleClearChat(): Promise<void> {
         setMessages([]);
+        repinToBottom();
         setApprovalRequest(null);
         setContextUsage(null);
         setFollowupSuggestions([]);
@@ -2236,6 +2420,7 @@ const AIChat: React.FC = () => {
         ]);
 
         setMessages(msgs.map(m => ({ role: m.role === "user" ? "User" : "Copilot", content: m.content, type: "text", checkpointId: m.checkpointId, messageId: m.messageId, generationStatus: m.generationStatus })));
+        repinToBottom();
 
         // Rebuild the checkpoint availability set for the switched-to thread.
         // Without this, every checkpointId from the old thread would be absent from the set
@@ -2258,6 +2443,7 @@ const AIChat: React.FC = () => {
             rpcClient.getAiPanelRpcClient().getCheckpoints(),
         ]);
         setMessages(msgs.map(m => ({ role: m.role === "user" ? "User" : "Copilot", content: m.content, type: "text", checkpointId: m.checkpointId, messageId: m.messageId, generationStatus: m.generationStatus })));
+        repinToBottom();
         setAvailableCheckpointIds(new Set(checkpoints.map(cp => cp.id)));
         setRestoringCheckpointId(null);
         setApprovalRequest(null);
@@ -2541,7 +2727,7 @@ const AIChat: React.FC = () => {
                             </Button>
                         </HeaderButtons>
                     </Header>
-                    <main style={{ flex: 1, overflowY: "auto" }}>
+                    <main ref={setMainRef} style={{ flex: 1, overflowY: "auto" }} onScroll={handleScroll}>
                         {migrationSession && (
                             <MigrationContextCard
                                 session={migrationSession}
@@ -2891,6 +3077,18 @@ const AIChat: React.FC = () => {
                         })()}
                         <div ref={messagesEndRef} />
                     </main>
+                    {showJumpToBottom && (
+                        <JumpToBottomButton
+                            type="button"
+                            aria-label="Jump to latest messages"
+                            title="Jump to latest messages"
+                            style={{ bottom: footerHeight + 12 }}
+                            onClick={handleJumpToBottom}
+                        >
+                            <Codicon name="arrow-down" iconSx={{ fontSize: "14px" }} />
+                        </JumpToBottomButton>
+                    )}
+                    <div ref={setFooterRef}>
                     {isUsageExceeded && (
                         <UsageLimitNoticeContainer>
                             <span className="codicon codicon-warning" role="img" aria-hidden="true" />
@@ -3015,6 +3213,7 @@ const AIChat: React.FC = () => {
                         </>
                         );
                     })()}
+                    </div>
                 </AIChatView>
             )}
             {activePanel === "settings" && (

--- a/packages/ballerina-visualizer/src/views/AIPanel/styles.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/styles.tsx
@@ -163,6 +163,35 @@ export const OverlayCloseButton = styled.button`
     }
 `;
 
+// Floating control shown over the chat message list when the user has scrolled away
+// from the bottom during streaming — lets them jump back without fighting auto-scroll.
+export const JumpToBottomButton = styled.button`
+    position: absolute;
+    left: 50%;
+    bottom: 12px;
+    transform: translateX(-50%);
+    z-index: 5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 1px solid var(--vscode-panel-border);
+    background: var(--vscode-editor-background);
+    color: var(--vscode-foreground);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+    opacity: 0.9;
+    &:hover {
+        opacity: 1;
+        background: var(--vscode-toolbar-hoverBackground);
+    }
+    &:focus-visible {
+        outline: 1px solid var(--vscode-focusBorder);
+    }
+`;
+
 // ── AI Panel action buttons ───────────────────────────────────────────────────
 // Shared compact action-button system used across the AI panel surfaces
 // (SettingsPanel, McpManagerPanel, etc). All variants share the same


### PR DESCRIPTION
## Summary
- Auto-scroll previously fired unconditionally on every streamed update, snapping the chat back to the bottom even while the user was scrolled up reading earlier content.
- Auto-scroll now only runs while the user is pinned to the bottom; scrolling up disables it instead of fighting the user.
- Added a floating "Jump to bottom" button (styled like Claude Code's own control) that appears when scrolled up, dynamically tracks the height of the footer/composer stack via a ResizeObserver so it always floats just above it, and re-pins to the bottom on click.

It resolves: https://github.com/wso2/product-integrator/issues/2359

For reference Sample demo:

https://github.com/user-attachments/assets/4c284ea8-1a36-4ec3-8c4a-aa360ca1a9f5

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Preserve manual upward scrolling during streamed chat responses.
- Continue auto-scrolling while the user remains at the bottom.
- Add a floating “Jump to bottom” button with footer-aware positioning.
- Restore bottom positioning and auto-scroll when the button is selected.
- Reset scroll state for new chats, thread changes, deletions, and user turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->