### PR TITLE
Rename SAP JCo trigger to SAP ECC (JCo)

### DIFF
--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
@@ -173,7 +173,7 @@
       "rfc",
       "event"
     ],
-    "triggerName": "SAP JCo",
+    "triggerName": "SAP ECC (JCo)",
     "version": "2.0.1",
     "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_sap.jco_2.0.1.png",
     "kind": "event"

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/ServiceModelAPITests.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/ServiceModelAPITests.java
@@ -193,6 +193,9 @@ public class ServiceModelAPITests {
         TriggerListResponse response = (TriggerListResponse) result.get();
         Assert.assertTrue(Objects.nonNull(response.local()));
         Assert.assertFalse(response.local().isEmpty());
+        Assert.assertTrue(response.local().stream().anyMatch(trigger ->
+                        "sap.jco".equals(trigger.packageName()) && "SAP ECC (JCo)".equals(trigger.name())),
+                "SAP JCo must use the SAP ECC (JCo) picker label");
     }
 
     @Test


### PR DESCRIPTION
Part of https://github.com/wso2-enterprise/integration-engineering/issues/2754

## Summary
- Rename the SAP JCo artifact-picker label to SAP ECC (JCo).
- Add an API-level regression assertion for the sap.jco trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Renamed the SAP JCo artifact-picker label to `SAP ECC (JCo)`.
- Added an API regression assertion for the `sap.jco` trigger and its label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->