### PR TITLE
Let user navigation through the generation remount guard

### DIFF
--- a/packages/ballerina-extension/src/RPCLayer.ts
+++ b/packages/ballerina-extension/src/RPCLayer.ts
@@ -54,9 +54,7 @@ import { registerPlatformExtRpcHandlers } from './rpc-managers/platform-ext/rpc-
 import { MigrationPanelWebview } from './views/migration-panel/webview';
 import { isRecording, recordRpc } from './test-support/fixtureRecorder';
 import { chatStateStorage } from './views/ai-panel/chatStateStorage';
-
-// Event types that trigger MainPanel's remount/re-fetch regardless of state value.
-const DISRUPTIVE_TRANSITION_EVENTS = new Set(['VIEW_UPDATE', 'UPDATE_PROJECT_STRUCTURE']);
+import { shouldSuppressDisruptiveTransition } from './utils/state-machine-utils';
 
 export class RPCLayer {
     static _messenger: Messenger = new Messenger({ ignoreHiddenViews: false });
@@ -65,7 +63,7 @@ export class RPCLayer {
         if (isWebviewPanel(webViewPanel)) {
             RPCLayer._messenger.registerWebviewPanel(webViewPanel as WebviewPanel);
             StateMachine.service().onTransition((state, event) => {
-                if (DISRUPTIVE_TRANSITION_EVENTS.has(event?.type) && chatStateStorage.hasAnyActiveExecution()) {
+                if (shouldSuppressDisruptiveTransition(event, chatStateStorage.hasAnyActiveExecution())) {
                     return;
                 }
                 RPCLayer._messenger.sendNotification(stateChanged, { type: 'webview', webviewType: VisualizerWebview.viewType }, state.value);

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -617,7 +617,7 @@ export class ApprovalViewManager {
         }
         console.log('[ApprovalViewManager] Closing ReviewMode — a new generation is starting');
         history.pop();
-        updateView(false);
+        updateView(false, undefined, { userInitiated: true });
         this.notifyReviewModeClosed();
     }
 

--- a/packages/ballerina-extension/src/rpc-managers/visualizer/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/visualizer/rpc-manager.ts
@@ -78,7 +78,7 @@ export class VisualizerRpcManager implements VisualizerAPI {
     goBack(params: GoBackRequest): void {
         const wasReviewMode = StateMachine.context().view === MACHINE_VIEW.ReviewMode;
         history.pop();
-        updateView(false, params?.identifier);
+        updateView(false, params?.identifier, { userInitiated: true });
         if (wasReviewMode) {
             approvalViewManager.notifyReviewModeClosed();
         }
@@ -111,12 +111,12 @@ export class VisualizerRpcManager implements VisualizerAPI {
 
     goSelected(index: number): void {
         history.select(index);
-        updateView();
+        updateView(false, undefined, { userInitiated: true });
     }
 
     addToHistory(entry: HistoryEntry): void {
         history.push(entry);
-        updateView();
+        updateView(false, undefined, { userInitiated: true });
     }
 
     private async refreshDataMapperView(): Promise<void> {

--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -428,6 +428,15 @@ const stateMachine = createMachine<MachineContext>(
                                     evalsetData: (context, event) => event.data.evalsetData,
                                     isViewUpdateTransition: false
                                 })
+                            },
+                            // Without this, a throw here (e.g. a project-structure lookup racing a
+                            // Copilot generation's edits) leaves the machine stuck in this state
+                            // forever — falling back to the still-current view beats a wedged panel.
+                            onError: {
+                                target: "viewReady",
+                                actions: (context, event) => {
+                                    console.error('Failed to resolve the view to show', event.data);
+                                }
                             }
                         }
                     },
@@ -726,68 +735,83 @@ const stateMachine = createMachine<MachineContext>(
                 }
             });
         },
-        showView(context, event): Promise<VisualizerLocation> {
-            return new Promise(async (resolve, reject) => {
-                StateMachinePopup.resetState();
-                const selectedEntry = getLastHistory();
-                if (!context.langClient) {
-                    if (!selectedEntry) {
-                        return resolve(
-                            context.workspacePath
-                                ? { view: MACHINE_VIEW.WorkspaceOverview }
-                                : { view: MACHINE_VIEW.PackageOverview, documentUri: context.documentUri }
-                        );
+        async showView(context, event): Promise<VisualizerLocation> {
+            StateMachinePopup.resetState();
+            const selectedEntry = getLastHistory();
+            if (!context.langClient) {
+                if (!selectedEntry) {
+                    return context.workspacePath
+                        ? { view: MACHINE_VIEW.WorkspaceOverview }
+                        : { view: MACHINE_VIEW.PackageOverview, documentUri: context.documentUri };
+                }
+                return { ...selectedEntry.location, view: selectedEntry.location.view ? selectedEntry.location.view : MACHINE_VIEW.PackageOverview };
+            }
+
+            if (selectedEntry?.location.view === MACHINE_VIEW.AgentDefinitionDesigner) {
+                return selectedEntry.location;
+            }
+
+            if (selectedEntry && (selectedEntry.location.view === MACHINE_VIEW.ERDiagram || selectedEntry.location.view === MACHINE_VIEW.ServiceDesigner || selectedEntry.location.view === MACHINE_VIEW.BIDiagram || selectedEntry.location.view === MACHINE_VIEW.ReviewMode)) {
+                // Get updated location and identifier if transition was from VIEW_UPDATE event
+                if (context.isViewUpdateTransition && selectedEntry.location.view !== MACHINE_VIEW.ReviewMode) {
+                    const updatedView = await getView(selectedEntry.location.documentUri, selectedEntry.location.position, context?.projectPath);
+                    return updatedView.location;
+                }
+                return selectedEntry.location;
+            }
+
+            const defaultLocation = {
+                documentUri: context.documentUri,
+                position: undefined
+            };
+            const {
+                location = defaultLocation,
+                uid
+            } = selectedEntry ?? {};
+
+            const { documentUri, position } = location;
+
+            // TODO: Refactor this to remove the full ST request
+            const node = documentUri && await StateMachine.langClient().getSyntaxTree({
+                documentIdentifier: {
+                    uri: Uri.file(documentUri).toString()
+                }
+            }) as SyntaxTree;
+
+            if (!selectedEntry?.location.view) {
+                return context.workspacePath
+                    ? { view: MACHINE_VIEW.WorkspaceOverview }
+                    : { view: MACHINE_VIEW.PackageOverview, documentUri: context.documentUri };
+            }
+
+            let selectedST;
+
+            if (node?.parseSuccess) {
+                const fullST = node.syntaxTree;
+                if (!uid && position) {
+                    const generatedUid = generateUid(position, fullST);
+                    selectedST = getNodeByUid(generatedUid, fullST);
+                    if (generatedUid && selectedST) {
+                        history.updateCurrentEntry({
+                            ...selectedEntry,
+                            location: {
+                                ...selectedEntry.location,
+                                position: selectedST.position,
+                                syntaxTree: selectedST
+                            },
+                            uid: generatedUid
+                        });
                     }
-                    return resolve({ ...selectedEntry.location, view: selectedEntry.location.view ? selectedEntry.location.view : MACHINE_VIEW.PackageOverview });
                 }
 
-                if (selectedEntry?.location.view === MACHINE_VIEW.AgentDefinitionDesigner) {
-                    return resolve(selectedEntry.location);
-                }
+                if (uid && position) {
+                    selectedST = getNodeByUid(uid, fullST);
 
-                if (selectedEntry && (selectedEntry.location.view === MACHINE_VIEW.ERDiagram || selectedEntry.location.view === MACHINE_VIEW.ServiceDesigner || selectedEntry.location.view === MACHINE_VIEW.BIDiagram || selectedEntry.location.view === MACHINE_VIEW.ReviewMode)) {
-                    // Get updated location and identifier if transition was from VIEW_UPDATE event
-                    if (context.isViewUpdateTransition && selectedEntry.location.view !== MACHINE_VIEW.ReviewMode) {
-                        const updatedView = await getView(selectedEntry.location.documentUri, selectedEntry.location.position, context?.projectPath);
-                        return resolve(updatedView.location);
-                    }
-                    return resolve(selectedEntry.location);
-                }
+                    if (!selectedST) {
+                        const nodeWithUpdatedUid = getNodeByName(uid, fullST);
+                        selectedST = nodeWithUpdatedUid[0];
 
-                const defaultLocation = {
-                    documentUri: context.documentUri,
-                    position: undefined
-                };
-                const {
-                    location = defaultLocation,
-                    uid
-                } = selectedEntry ?? {};
-
-                const { documentUri, position } = location;
-
-                // TODO: Refactor this to remove the full ST request
-                const node = documentUri && await StateMachine.langClient().getSyntaxTree({
-                    documentIdentifier: {
-                        uri: Uri.file(documentUri).toString()
-                    }
-                }) as SyntaxTree;
-
-                if (!selectedEntry?.location.view) {
-                    return resolve(
-                        context.workspacePath
-                            ? { view: MACHINE_VIEW.WorkspaceOverview }
-                            : { view: MACHINE_VIEW.PackageOverview, documentUri: context.documentUri }
-                    );
-                }
-
-                let selectedST;
-
-                if (node?.parseSuccess) {
-                    const fullST = node.syntaxTree;
-                    if (!uid && position) {
-                        const generatedUid = generateUid(position, fullST);
-                        selectedST = getNodeByUid(generatedUid, fullST);
-                        if (generatedUid && selectedST) {
+                        if (selectedST) {
                             history.updateCurrentEntry({
                                 ...selectedEntry,
                                 location: {
@@ -795,16 +819,10 @@ const stateMachine = createMachine<MachineContext>(
                                     position: selectedST.position,
                                     syntaxTree: selectedST
                                 },
-                                uid: generatedUid
+                                uid: nodeWithUpdatedUid[1]
                             });
-                        }
-                    }
-
-                    if (uid && position) {
-                        selectedST = getNodeByUid(uid, fullST);
-
-                        if (!selectedST) {
-                            const nodeWithUpdatedUid = getNodeByName(uid, fullST);
+                        } else {
+                            const nodeWithUpdatedUid = getNodeByIndex(uid, fullST);
                             selectedST = nodeWithUpdatedUid[0];
 
                             if (selectedST) {
@@ -812,45 +830,30 @@ const stateMachine = createMachine<MachineContext>(
                                     ...selectedEntry,
                                     location: {
                                         ...selectedEntry.location,
+                                        identifier: getComponentIdentifier(selectedST),
                                         position: selectedST.position,
                                         syntaxTree: selectedST
                                     },
                                     uid: nodeWithUpdatedUid[1]
                                 });
                             } else {
-                                const nodeWithUpdatedUid = getNodeByIndex(uid, fullST);
-                                selectedST = nodeWithUpdatedUid[0];
-
-                                if (selectedST) {
-                                    history.updateCurrentEntry({
-                                        ...selectedEntry,
-                                        location: {
-                                            ...selectedEntry.location,
-                                            identifier: getComponentIdentifier(selectedST),
-                                            position: selectedST.position,
-                                            syntaxTree: selectedST
-                                        },
-                                        uid: nodeWithUpdatedUid[1]
-                                    });
-                                } else {
-                                    // show identification failure message
-                                }
+                                // show identification failure message
                             }
-                        } else {
-                            history.updateCurrentEntry({
-                                ...selectedEntry,
-                                location: {
-                                    ...selectedEntry.location,
-                                    position: selectedST.position,
-                                    syntaxTree: selectedST
-                                }
-                            });
                         }
+                    } else {
+                        history.updateCurrentEntry({
+                            ...selectedEntry,
+                            location: {
+                                ...selectedEntry.location,
+                                position: selectedST.position,
+                                syntaxTree: selectedST
+                            }
+                        });
                     }
                 }
-                const lastView = getLastHistory().location;
-                return resolve(lastView);
-            });
+            }
+            const lastView = getLastHistory().location;
+            return lastView;
         }
     }
 });

--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -38,7 +38,8 @@ import {
     getView,
     releaseCreateLanding,
     resolveCreateLandingOverride,
-    resolveSingleIntegrationOverride
+    resolveSingleIntegrationOverride,
+    shouldSuppressDisruptiveTransition
 } from './utils/state-machine-utils';
 import * as path from 'path';
 import { extension } from './BalExtensionContext';
@@ -1069,7 +1070,7 @@ export function openView(
     stateService.send({ type: type, viewLocation: location });
 }
 
-export function updateView(refreshTreeView?: boolean, updatedIdentifier?: string) {
+export function updateView(refreshTreeView?: boolean, updatedIdentifier?: string, options?: { userInitiated?: boolean }) {
     if (StateMachinePopup.isActive()) {
         return;
     }
@@ -1154,10 +1155,10 @@ export function updateView(refreshTreeView?: boolean, updatedIdentifier?: string
     }
 
 
-    // Skip the disruptive remount while a Copilot generation is active; notifyCurrentWebview()
-    // below still fires so the diagram's own content refresh keeps flowing.
-    if (!chatStateStorage.hasAnyActiveExecution()) {
-        stateService.send({ type: "VIEW_UPDATE", viewLocation: lastView ? newLocation : { view: "Overview" } });
+    // Only navigation the user asked for may remount mid-generation; the agent's edits replay this on every write.
+    const viewUpdate = { type: "VIEW_UPDATE", viewLocation: lastView ? newLocation : { view: "Overview" }, userInitiated: options?.userInitiated };
+    if (!shouldSuppressDisruptiveTransition(viewUpdate, chatStateStorage.hasAnyActiveExecution())) {
+        stateService.send(viewUpdate);
     }
     if (refreshTreeView) {
         buildProjectsStructure(StateMachine.context().projectInfo, StateMachine.langClient(), true);

--- a/packages/ballerina-extension/src/test-support/generationRemountSuppression.test.ts
+++ b/packages/ballerina-extension/src/test-support/generationRemountSuppression.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// state-machine-utils.ts imports the real barrel (WebSocket LS client, unloadable under jest)
+// and ../stateMachine (needs WorkspaceEdit/Range/createWebviewPanel the shared vscode mock lacks).
+jest.mock("@wso2/ballerina-core", () => ({
+    MACHINE_VIEW: {},
+    DIRECTORY_MAP: {},
+    EVENT_TYPE: {},
+    FOCUS_FLOW_DIAGRAM_VIEW: {},
+    isSamePath: (a: string, b: string) => a === b,
+}));
+
+jest.mock("../stateMachine", () => ({
+    StateMachine: { context: jest.fn() },
+    openView: jest.fn(),
+}));
+
+import { shouldSuppressDisruptiveTransition } from "../utils/state-machine-utils";
+
+describe("shouldSuppressDisruptiveTransition", () => {
+    // The two `true` rows are the remount storm the guard exists for; the flagged VIEW_UPDATE
+    // row is the Back button mid-generation, and done.invoke.showView must never be gated.
+    it.each<[string, boolean | undefined, boolean, boolean]>([
+        ["VIEW_UPDATE", undefined, true, true],
+        ["VIEW_UPDATE", false, true, true],
+        ["VIEW_UPDATE", true, true, false],
+        ["VIEW_UPDATE", undefined, false, false],
+        ["VIEW_UPDATE", true, false, false],
+        ["UPDATE_PROJECT_STRUCTURE", undefined, true, true],
+        ["UPDATE_PROJECT_STRUCTURE", true, true, false],
+        ["UPDATE_PROJECT_STRUCTURE", undefined, false, false],
+        ["OPEN_VIEW", undefined, true, false],
+        ["OPEN_VIEW", true, true, false],
+        ["done.invoke.showView", undefined, true, false],
+    ])("%s, userInitiated=%s, generationActive=%s -> suppressed=%s", (type, userInitiated, generationActive, expected) => {
+        expect(shouldSuppressDisruptiveTransition({ type, userInitiated }, generationActive)).toBe(expected);
+    });
+});

--- a/packages/ballerina-extension/src/utils/state-machine-utils.ts
+++ b/packages/ballerina-extension/src/utils/state-machine-utils.ts
@@ -152,6 +152,16 @@ export function resolveSingleIntegrationOverride(
         : undefined;
 }
 
+const DISRUPTIVE_TRANSITION_EVENTS = new Set(["VIEW_UPDATE", "UPDATE_PROJECT_STRUCTURE"]);
+
+// The agent's live edits replay VIEW_UPDATE on every write; navigation the user asked for is never withheld.
+export function shouldSuppressDisruptiveTransition(
+    event: { type: string; userInitiated?: boolean },
+    generationActive: boolean
+): boolean {
+    return generationActive && DISRUPTIVE_TRANSITION_EVENTS.has(event.type) && !event.userInitiated;
+}
+
 export async function getView(documentUri: string, position: NodePosition, projectPath: string): Promise<HistoryEntry> {
     const haveTreeData = !!StateMachine.context().projectStructure;
     const classMemberArtifactType = await getClassMemberArtifactType(documentUri, position, projectPath);

--- a/packages/ballerina-extension/src/utils/state-machine-utils.ts
+++ b/packages/ballerina-extension/src/utils/state-machine-utils.ts
@@ -413,6 +413,11 @@ function getViewByArtifacts(documentUri: string, position: NodePosition, project
     if (currentProjectArtifacts) {
         // Iterate through each category in the directory map
         const project = currentProjectArtifacts.projects.find(project => isSamePath(project.projectPath, projectPath));
+        if (!project) {
+            // The project structure can be mid-rebuild (e.g. a live Copilot generation editing
+            // files) when this runs; fall back to the overview rather than dereference undefined.
+            return { location: { view: MACHINE_VIEW.PackageOverview, documentUri: documentUri } };
+        }
         for (const [key, directory] of Object.entries(project.directoryMap)) {
             // Check each artifact in the category
             for (const dir of directory) {


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2370

- Add a shared `shouldSuppressDisruptiveTransition` predicate so both suppression guards use the same rule instead of two separately-maintained checks
- Let `updateView` carry a `userInitiated` flag on the `VIEW_UPDATE` event, so real navigation bypasses the guard while the agent's own per-edit remount stream stays suppressed
- Flag `goBack`, `goSelected`, `addToHistory`, and `closeReviewModeIfOpen` as user-initiated
- Add a test for the suppression predicate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Centralized generation-time transition suppression logic.
- Added `userInitiated` metadata to view updates.
- Allowed user navigation during generation while suppressing agent-driven remounts.
- Marked history navigation and review-mode closure as user initiated.
- Added recovery when view lookup fails during generation.
- Added tests for suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->