### PR TITLE
Fix file edit tools silently corrupting or skipping edits

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/tools/text-editor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/text-editor.ts
@@ -33,13 +33,17 @@ import { seedNewPackageBaseline } from "../../utils/project/ls-schema-notificati
  */
 const fileEditLocks = new Map<string, Promise<void>>();
 
-/** Runs before path validation, so it must not throw on whatever the model sent. */
+/**
+ * Runs before path validation, so it must not throw on whatever the model sent. Uses
+ * path.join, not path.resolve: validateFilePath allows "/main.bal", which resolve would key
+ * outside the project, giving the same file two locks.
+ */
 function fileLockKey(tempProjectPath: string, filePath: unknown): string {
   if (typeof filePath !== 'string' || filePath.length === 0) {
     return `${tempProjectPath}|<invalid>`;
   }
   try {
-    return path.resolve(tempProjectPath, filePath);
+    return path.join(tempProjectPath, filePath);
   } catch {
     return `${tempProjectPath}|${filePath}`;
   }
@@ -64,17 +68,26 @@ function withFileLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
  * Confirms the computed content reached disk. Only "the file is unchanged" is treated as a
  * failure; a mismatch against the exact expected content is warned about instead, since
  * format-on-save legitimately reshapes the file after we hand it over.
+ *
+ * Skipped when the two paths differ: the migration flow (runStagesForPackage, no
+ * existingTempPath) reads from a temp copy while the write goes to the real package root.
  */
 function verifyPersisted(
-  fullPath: string,
+  writtenPath: string | undefined,
+  readPath: string,
   preEditRaw: string,
   expected: string,
   logPrefix: string,
   file_path: string
 ): ValidationResult {
+  if (!writtenPath || path.resolve(writtenPath) !== path.resolve(readPath)) {
+    console.warn(`${logPrefix} Skipping write verification for ${file_path}: read from ${readPath}, wrote to ${writtenPath}.`);
+    return { valid: true };
+  }
+
   let actual: string;
   try {
-    actual = fs.readFileSync(fullPath, 'utf-8');
+    actual = fs.readFileSync(readPath, 'utf-8');
   } catch (error) {
     console.error(`${logPrefix} Could not re-read ${file_path} to verify the edit:`, error);
     return {
@@ -83,7 +96,9 @@ function verifyPersisted(
     };
   }
 
-  if (contentsEquivalent(actual, preEditRaw) && !contentsEquivalent(expected, preEditRaw)) {
+  // Exact comparison: an edit that only touches trailing whitespace still has to register as
+  // applied, and contentsEquivalent would call it unchanged.
+  if (actual === preEditRaw && expected !== preEditRaw) {
     console.error(`${logPrefix} Edit did not reach disk for ${file_path} — content is unchanged after write.`);
     return {
       valid: false,
@@ -113,7 +128,7 @@ async function persistLiveEdit(
   allModifiedFiles: Set<string> | undefined,
   ctx: ExecutionContext | undefined,
   tempProjectPath: string
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<{ ok: boolean; error?: string; writtenPath?: string }> {
   if (modifiedFiles) {
     insertIntoUpdateFileNames(modifiedFiles, file_path);
   }
@@ -125,7 +140,7 @@ async function persistLiveEdit(
       fs.mkdirSync(path.dirname(directPath), { recursive: true });
       fs.writeFileSync(directPath, content, 'utf8');
       allModifiedFiles?.add(file_path);
-      return { ok: true };
+      return { ok: true, writtenPath: directPath };
     } catch (error) {
       console.error("[TextEditorTool] Direct persist failed:", error);
       return { ok: false, error: error instanceof Error ? error.message : String(error) };
@@ -153,7 +168,7 @@ async function persistLiveEdit(
         .map(abs => path.relative(packageRoot, abs));
       await seedNewPackageBaseline(packageRoot, content, preexistingBalFiles);
     }
-    return { ok: true };
+    return { ok: true, writtenPath: absolutePath };
   } catch (error) {
     console.error("[TextEditorTool] Live persist failed:", error);
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
@@ -428,7 +443,7 @@ export function createWriteExecute(
       return result;
     }
 
-    const verification = verifyPersisted(fullPath, preEditRaw, contentToWrite, '[FileWriteTool]', file_path);
+    const verification = verifyPersisted(persisted.writtenPath, fullPath, preEditRaw, contentToWrite, '[FileWriteTool]', file_path);
     if (!verification.valid) {
       const result = {
         success: false,
@@ -586,7 +601,7 @@ export function createEditExecute(
       return result;
     }
 
-    const verification = verifyPersisted(fullPath, rawContent, contentToWrite, '[FileEditTool]', file_path);
+    const verification = verifyPersisted(persisted.writtenPath, fullPath, rawContent, contentToWrite, '[FileEditTool]', file_path);
     if (!verification.valid) {
       const result = {
         success: false,
@@ -762,7 +777,7 @@ export function createMultiEditExecute(
       return result;
     }
 
-    const verification = verifyPersisted(fullPath, rawContent, contentToWrite, '[FileMultiEditTool]', file_path);
+    const verification = verifyPersisted(persisted.writtenPath, fullPath, rawContent, contentToWrite, '[FileMultiEditTool]', file_path);
     if (!verification.valid) {
       const result = {
         success: false,

--- a/packages/ballerina-extension/src/features/ai/agent/tools/text-editor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/text-editor.ts
@@ -21,29 +21,115 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { CopilotEventHandler } from "../../utils/events";
 import { normalizeInvisibleChars } from "../../utils/string-utils";
-import { normalizeToLf, readAndNormalize, restoreEol } from "../../utils/eol-utils";
+import { detectEol, normalizeToLf, readAndNormalize, restoreEol } from "../../utils/eol-utils";
+import { applyEdit, contentsEquivalent } from "../../utils/edit-replacement";
 import { addToIntegration } from "../../../../rpc-managers/ai-panel/utils";
 import { recordAiTouchedFile } from "../../../../rpc-managers/diagram-validity";
 import { seedNewPackageBaseline } from "../../utils/project/ls-schema-notifications";
+
+/**
+ * Serializes the read-modify-write cycle per file. Each tool reads from disk and writes back
+ * a whole-document replace, so parallel tool calls on one file would clobber each other.
+ */
+const fileEditLocks = new Map<string, Promise<void>>();
+
+/** Runs before path validation, so it must not throw on whatever the model sent. */
+function fileLockKey(tempProjectPath: string, filePath: unknown): string {
+  if (typeof filePath !== 'string' || filePath.length === 0) {
+    return `${tempProjectPath}|<invalid>`;
+  }
+  try {
+    return path.resolve(tempProjectPath, filePath);
+  } catch {
+    return `${tempProjectPath}|${filePath}`;
+  }
+}
+
+function withFileLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const previous = fileEditLocks.get(key) ?? Promise.resolve();
+  // Run regardless of whether the previous holder resolved or rejected.
+  const result = previous.then(fn, fn);
+  const tail = result.then(() => undefined, () => undefined);
+  fileEditLocks.set(key, tail);
+  void tail.then(() => {
+    // Drop the entry once nothing is queued behind us, so the map stays bounded.
+    if (fileEditLocks.get(key) === tail) {
+      fileEditLocks.delete(key);
+    }
+  });
+  return result;
+}
+
+/**
+ * Confirms the computed content reached disk. Only "the file is unchanged" is treated as a
+ * failure; a mismatch against the exact expected content is warned about instead, since
+ * format-on-save legitimately reshapes the file after we hand it over.
+ */
+function verifyPersisted(
+  fullPath: string,
+  preEditRaw: string,
+  expected: string,
+  logPrefix: string,
+  file_path: string
+): ValidationResult {
+  let actual: string;
+  try {
+    actual = fs.readFileSync(fullPath, 'utf-8');
+  } catch (error) {
+    console.error(`${logPrefix} Could not re-read ${file_path} to verify the edit:`, error);
+    return {
+      valid: false,
+      error: `The edit for '${file_path}' could not be verified — the file could not be read back after writing. The file may be unchanged; re-read it before retrying.`
+    };
+  }
+
+  if (contentsEquivalent(actual, preEditRaw) && !contentsEquivalent(expected, preEditRaw)) {
+    console.error(`${logPrefix} Edit did not reach disk for ${file_path} — content is unchanged after write.`);
+    return {
+      valid: false,
+      error: `The edit for '${file_path}' was not applied — the file is unchanged on disk. Re-read the file and retry the edit.`
+    };
+  }
+
+  if (!contentsEquivalent(actual, expected)) {
+    console.warn(`${logPrefix} ${file_path} differs from the computed content after saving (likely an on-save formatter).`);
+  }
+
+  return { valid: true };
+}
 
 /**
  * Persists a tool's computed content directly into the real workspace file via VS Code's
  * document model (workspace.applyEdit + saveAll), so open editors and diagrams see it
  * immediately. No intermediate temp-directory write: tempProjectPath is the real project
  * root, so this is the only place a live edit is actually written.
+ *
+ * Callers must not report success when this returns ok: false.
  */
 async function persistLiveEdit(
   file_path: string,
   content: string,
   modifiedFiles: string[] | undefined,
   allModifiedFiles: Set<string> | undefined,
-  ctx: ExecutionContext | undefined
-): Promise<void> {
+  ctx: ExecutionContext | undefined,
+  tempProjectPath: string
+): Promise<{ ok: boolean; error?: string }> {
   if (modifiedFiles) {
     insertIntoUpdateFileNames(modifiedFiles, file_path);
   }
   if (!ctx) {
-    return;
+    // No execution context (the memory tools are rooted at a plain directory outside the
+    // workspace), so there is no document model to go through. Write straight to disk.
+    try {
+      const directPath = path.join(tempProjectPath, file_path);
+      fs.mkdirSync(path.dirname(directPath), { recursive: true });
+      fs.writeFileSync(directPath, content, 'utf8');
+      allModifiedFiles?.add(file_path);
+      return { ok: true };
+    } catch (error) {
+      console.error("[TextEditorTool] Direct persist failed:", error);
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
   }
   const workspaceRoot = ctx.workspacePath || ctx.projectPath;
   const absolutePath = path.join(workspaceRoot, file_path);
@@ -67,8 +153,10 @@ async function persistLiveEdit(
         .map(abs => path.relative(packageRoot, abs));
       await seedNewPackageBaseline(packageRoot, content, preexistingBalFiles);
     }
+    return { ok: true };
   } catch (error) {
     console.error("[TextEditorTool] Live persist failed:", error);
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
   }
 }
 
@@ -157,6 +245,8 @@ const ErrorMessages = {
   EDIT_FAILED: 'Edit operation failed',
   NO_EDITS: 'No edits provided',
   FILE_READ_NOT_PERMITTED: 'File read not permitted',
+  WRITE_FAILED: 'Write operation failed',
+  WRITE_NOT_PERSISTED: 'Change was not persisted to disk',
 };
 
 // ============================================================================
@@ -260,8 +350,9 @@ export function createWriteExecute(
   return async (args: {
     file_path: string;
     content: string;
-  }): Promise<TextEditorResult> => {
-    const { file_path, content } = args;
+    overwrite?: boolean;
+  }): Promise<TextEditorResult> => withFileLock(fileLockKey(tempProjectPath, args.file_path), async () => {
+    const { file_path, content, overwrite = false } = args;
 
     // Emit tool_call event
     emitFileToolCall(eventHandler, FILE_WRITE_TOOL_NAME, file_path);
@@ -298,14 +389,15 @@ export function createWriteExecute(
     // Check if file exists (track for message generation)
     const fileExists = fs.existsSync(fullPath);
 
-    // Check if file exists with non-empty content
-    if (fileExists) {
-      const existingContent = fs.readFileSync(fullPath, 'utf-8');
-      if (existingContent.trim().length > 0) {
+    // Check if file exists with non-empty content. `overwrite` is the escape hatch for a
+    // file no old_string can uniquely address; without it there is no way to rewrite one.
+    const preEditRaw = fileExists ? fs.readFileSync(fullPath, 'utf-8') : '';
+    if (fileExists && !overwrite) {
+      if (preEditRaw.trim().length > 0) {
         console.error(`[FileWriteTool] File already exists with content: ${file_path}`);
         const result = {
           success: false,
-          message: `File '${file_path}' already exists with content. Use ${FILE_SINGLE_EDIT_TOOL_NAME} or ${FILE_BATCH_EDIT_TOOL_NAME} to modify it instead.`,
+          message: `File '${file_path}' already exists with content. Use ${FILE_SINGLE_EDIT_TOOL_NAME} or ${FILE_BATCH_EDIT_TOOL_NAME} to modify it instead. If the file is corrupted or must be rewritten wholesale, call this tool again with overwrite set to true.`,
           error: `Error: ${ErrorMessages.FILE_ALREADY_EXISTS}`
         };
         emitFileToolResult(eventHandler, FILE_WRITE_TOOL_NAME, result, file_path);
@@ -316,10 +408,36 @@ export function createWriteExecute(
     const lineCount = content.split('\n').length;
     const action: 'created' | 'updated' = fileExists ? 'updated' : 'created';
 
+    // Preserve the file's existing EOL style so a rewrite doesn't churn every line on Windows.
+    const contentToWrite = fileExists
+      ? restoreEol(normalizeToLf(content), detectEol(preEditRaw))
+      : content;
+
     // Neither case notifies the ai:// baseline: a brand-new file has to stay absent from it
     // to read as an addition, and an existing one is already frozen there from generation
     // start. See the notes in utils/project/ls-schema-notifications.ts.
-    await persistLiveEdit(file_path, content, modifiedFiles, allModifiedFiles, ctx);
+    const persisted = await persistLiveEdit(file_path, contentToWrite, modifiedFiles, allModifiedFiles, ctx, tempProjectPath);
+    if (!persisted.ok) {
+      console.error(`[FileWriteTool] Failed to persist ${file_path}: ${persisted.error}`);
+      const result = {
+        success: false,
+        message: `Failed to write '${file_path}': ${persisted.error ?? 'the write could not be applied'}. The file was not modified.`,
+        error: `Error: ${ErrorMessages.WRITE_FAILED}`
+      };
+      emitFileToolResult(eventHandler, FILE_WRITE_TOOL_NAME, result, file_path);
+      return result;
+    }
+
+    const verification = verifyPersisted(fullPath, preEditRaw, contentToWrite, '[FileWriteTool]', file_path);
+    if (!verification.valid) {
+      const result = {
+        success: false,
+        message: verification.error!,
+        error: `Error: ${ErrorMessages.WRITE_NOT_PERSISTED}`
+      };
+      emitFileToolResult(eventHandler, FILE_WRITE_TOOL_NAME, result, file_path);
+      return result;
+    }
 
     console.log(`[FileWriteTool] Successfully ${action} file: ${file_path} with ${lineCount} lines.`);
     const result = {
@@ -332,7 +450,7 @@ export function createWriteExecute(
     emitFileToolResult(eventHandler, FILE_WRITE_TOOL_NAME, result, file_path);
 
     return result;
-  };
+  });
 }
 
 // ============================================================================
@@ -351,7 +469,7 @@ export function createEditExecute(
     old_string: string;
     new_string: string;
     replace_all?: boolean;
-  }): Promise<TextEditorResult> => {
+  }): Promise<TextEditorResult> => withFileLock(fileLockKey(tempProjectPath, args.file_path), async () => {
     const { file_path, old_string, new_string, replace_all = false } = args;
 
     // Emit tool_call event
@@ -452,19 +570,32 @@ export function createEditExecute(
       return result;
     }
 
-    // Perform replacement
-    let newContent: string;
-    if (workingContent.trim() === "" && workingOldString.trim() === "") {
-        newContent = workingNewString;
-    } else {
-      if (replace_all) {
-        newContent = workingContent.replaceAll(workingOldString, workingNewString);
-      } else {
-        newContent = workingContent.replace(workingOldString, workingNewString);
-      }
+    // Perform replacement (applyEdit keeps `$` sequences in new_string literal).
+    const newContent = applyEdit(workingContent, workingOldString, workingNewString, replace_all);
+
+    const contentToWrite = restoreEol(newContent, originalEol);
+    const persisted = await persistLiveEdit(file_path, contentToWrite, modifiedFiles, allModifiedFiles, ctx, tempProjectPath);
+    if (!persisted.ok) {
+      console.error(`[FileEditTool] Failed to persist ${file_path}: ${persisted.error}`);
+      const result = {
+        success: false,
+        message: `Failed to apply the edit to '${file_path}': ${persisted.error ?? 'the write could not be applied'}. The file was not modified.`,
+        error: `Error: ${ErrorMessages.WRITE_FAILED}`
+      };
+      emitFileToolResult(eventHandler, FILE_SINGLE_EDIT_TOOL_NAME, result, file_path);
+      return result;
     }
 
-    await persistLiveEdit(file_path, restoreEol(newContent, originalEol), modifiedFiles, allModifiedFiles, ctx);
+    const verification = verifyPersisted(fullPath, rawContent, contentToWrite, '[FileEditTool]', file_path);
+    if (!verification.valid) {
+      const result = {
+        success: false,
+        message: verification.error!,
+        error: `Error: ${ErrorMessages.WRITE_NOT_PERSISTED}`
+      };
+      emitFileToolResult(eventHandler, FILE_SINGLE_EDIT_TOOL_NAME, result, file_path);
+      return result;
+    }
 
     const replacedCount = replace_all ? occurrenceCount : 1;
     console.log(`[FileEditTool] Successfully replaced ${replacedCount} occurrence(s) in file: ${file_path}`);
@@ -477,7 +608,7 @@ export function createEditExecute(
     emitFileToolResult(eventHandler, FILE_SINGLE_EDIT_TOOL_NAME, result, file_path);
 
     return result;
-  };
+  });
 }
 
 // ============================================================================
@@ -498,7 +629,7 @@ export function createMultiEditExecute(
       new_string: string;
       replace_all?: boolean;
     }>;
-  }): Promise<TextEditorResult> => {
+  }): Promise<TextEditorResult> => withFileLock(fileLockKey(tempProjectPath, args.file_path), async () => {
     const { file_path, edits } = args;
 
     // Emit tool_call event
@@ -560,12 +691,9 @@ export function createMultiEditExecute(
         useNormalizedMatching = true;
         break;
       }
-      // Simulate the edit for subsequent checks
-      if (edit.replace_all) {
-        testContent = testContent.replaceAll(edit.old_string, edit.new_string);
-      } else {
-        testContent = testContent.replace(edit.old_string, edit.new_string);
-      }
+      // Simulate the edit for subsequent checks. Must match the apply pass below, or later
+      // edits get validated against content that never gets written.
+      testContent = applyEdit(testContent, edit.old_string, edit.new_string, edit.replace_all ?? false);
     }
 
     if (useNormalizedMatching) {
@@ -605,15 +733,7 @@ export function createMultiEditExecute(
       }
 
       // Apply the edit to simulate the sequence
-      if (content.trim() === "" && workingOldString.trim() === "") {
-        content = workingNewString;
-      } else {
-        if (edit.replace_all) {
-          content = content.replaceAll(workingOldString, workingNewString);
-        } else {
-          content = content.replace(workingOldString, workingNewString);
-        }
-      }
+      content = applyEdit(content, workingOldString, workingNewString, edit.replace_all ?? false);
     }
 
     // If there were validation errors, return them without applying any edits
@@ -629,7 +749,29 @@ export function createMultiEditExecute(
     }
 
     // All validations passed, content already has all edits applied
-    await persistLiveEdit(file_path, restoreEol(content, originalEol), modifiedFiles, allModifiedFiles, ctx);
+    const contentToWrite = restoreEol(content, originalEol);
+    const persisted = await persistLiveEdit(file_path, contentToWrite, modifiedFiles, allModifiedFiles, ctx, tempProjectPath);
+    if (!persisted.ok) {
+      console.error(`[FileMultiEditTool] Failed to persist ${file_path}: ${persisted.error}`);
+      const result = {
+        success: false,
+        message: `Failed to apply the edits to '${file_path}': ${persisted.error ?? 'the write could not be applied'}. The file was not modified.`,
+        error: `Error: ${ErrorMessages.WRITE_FAILED}`
+      };
+      emitFileToolResult(eventHandler, FILE_BATCH_EDIT_TOOL_NAME, result, file_path);
+      return result;
+    }
+
+    const verification = verifyPersisted(fullPath, rawContent, contentToWrite, '[FileMultiEditTool]', file_path);
+    if (!verification.valid) {
+      const result = {
+        success: false,
+        message: verification.error!,
+        error: `Error: ${ErrorMessages.WRITE_NOT_PERSISTED}`
+      };
+      emitFileToolResult(eventHandler, FILE_BATCH_EDIT_TOOL_NAME, result, file_path);
+      return result;
+    }
 
     console.log(`[FileMultiEditTool] Successfully applied ${edits.length} edits to file: ${file_path}`);
     const result = {
@@ -641,7 +783,7 @@ export function createMultiEditExecute(
     emitFileToolResult(eventHandler, FILE_BATCH_EDIT_TOOL_NAME, result, file_path);
 
     return result;
-  };
+  });
 }
 
 // ============================================================================
@@ -765,6 +907,7 @@ const getFilePathDescription = (op: string) => `The relative path to the file to
 type WriteExecute = (args: {
   file_path: string;
   content: string;
+  overwrite?: boolean;
 }) => Promise<any>;
 
 type EditExecute = (args: {
@@ -794,14 +937,16 @@ export function createWriteTool(execute: WriteExecute) {
   return tool({
     description: `Writes a file to the local filesystem.
     Usage:
-    - This tool will return an error if there is a file with non-empty content at the provided path.
+    - This tool will return an error if there is a file with non-empty content at the provided path, unless **overwrite** is set to true.
     - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
     - If this is an existing file, Use ${FILE_BATCH_EDIT_TOOL_NAME} or ${FILE_SINGLE_EDIT_TOOL_NAME} to modify it instead.
+    - Use **overwrite** only as a last resort, to rewrite a file whose existing content is corrupted or otherwise cannot be repaired with ${FILE_SINGLE_EDIT_TOOL_NAME} (for example when the text you need to replace is duplicated throughout the file, so no old_string can be made unique). Read the file first and supply the complete intended content, since everything currently in the file is discarded.
     - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
     - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.`,
     inputSchema: z.object({
       file_path: z.string().describe(getFilePathDescription("write")),
-      content: z.string().describe("The content to write to the file, This cannot be empty")
+      content: z.string().describe("The content to write to the file, This cannot be empty"),
+      overwrite: z.boolean().default(false).describe("Replace the file's existing content (default false). Only set this to true to recover a file that cannot be repaired with an edit tool; the current content is discarded entirely.")
     }),
     execute
   });

--- a/packages/ballerina-extension/src/features/ai/agent/tools/text-editor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/text-editor.ts
@@ -114,12 +114,11 @@ function verifyPersisted(
 }
 
 /**
- * Persists a tool's computed content directly into the real workspace file via VS Code's
- * document model (workspace.applyEdit + saveAll), so open editors and diagrams see it
- * immediately. No intermediate temp-directory write: tempProjectPath is the real project
- * root, so this is the only place a live edit is actually written.
- *
- * Callers must not report success when this returns ok: false.
+ * Persists a tool's computed content. Workspace-backed edits go through VS Code's document
+ * model (workspace.applyEdit + saveAll) so open editors and diagrams see them immediately;
+ * without an ExecutionContext there is no document model and the write goes straight to disk.
+ * Either way this is the only place an edit is written, and callers must not report success
+ * when it returns ok: false.
  */
 async function persistLiveEdit(
   file_path: string,
@@ -154,6 +153,15 @@ async function persistLiveEdit(
   const isNewPackageToml = path.basename(file_path) === 'Ballerina.toml' && !fs.existsSync(absolutePath);
   try {
     await addToIntegration(workspaceRoot, [{ filePath: file_path, content }]);
+  } catch (error) {
+    console.error("[TextEditorTool] Live persist failed:", error);
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+
+  // The write landed; everything below is bookkeeping. A failure here must not be reported as
+  // a failed edit: the model would retry, and for a new package's Ballerina.toml the
+  // isNewPackageToml check no longer holds on the retry, so the baseline would never be seeded.
+  try {
     recordAiTouchedFile(absolutePath);
     allModifiedFiles?.add(file_path);
     if (isNewPackageToml) {
@@ -168,11 +176,10 @@ async function persistLiveEdit(
         .map(abs => path.relative(packageRoot, abs));
       await seedNewPackageBaseline(packageRoot, content, preexistingBalFiles);
     }
-    return { ok: true, writtenPath: absolutePath };
   } catch (error) {
-    console.error("[TextEditorTool] Live persist failed:", error);
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    console.error(`[TextEditorTool] Post-write bookkeeping failed for ${file_path}:`, error);
   }
+  return { ok: true, writtenPath: absolutePath };
 }
 
 // ============================================================================

--- a/packages/ballerina-extension/src/features/ai/utils/edit-replacement.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/edit-replacement.ts
@@ -1,18 +1,20 @@
-// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
-
-// WSO2 LLC. licenses this file to you under the Apache License,
-// Version 2.0 (the "License"); you may not use this file except
-// in compliance with the License.
-// You may obtain a copy of the License at
-
-// http://www.apache.org/licenses/LICENSE-2.0
-
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations
-// under the License.
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 /**
  * Pure find/replace core for the file edit tools. Kept free of `vscode` and `fs` imports so

--- a/packages/ballerina-extension/src/features/ai/utils/edit-replacement.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/edit-replacement.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Pure find/replace core for the file edit tools. Kept free of `vscode` and `fs` imports so
+ * it can be unit tested; the tools module it serves is not importable under jest.
+ */
+
+import { normalizeToLf } from './eol-utils';
+
+/**
+ * Replaces `searchString` in `content`, inserting `replacement` verbatim.
+ *
+ * `replace`/`replaceAll` expand `$` sequences in a *string* replacement even when the search
+ * pattern is a plain string: `` $` `` splices in everything before the match, `$'` everything
+ * after, `$&` the match, and `$$` collapses to `$`. Ballerina payloads hit this because
+ * backticks delimit regex and string templates, so an end-anchored regex (``re `^\d{6}$` ``)
+ * duplicates the file at the match point. A function replacer disables the expansion.
+ */
+export function replaceLiteral(
+    content: string,
+    searchString: string,
+    replacement: string,
+    replaceAll: boolean
+): string {
+    return replaceAll
+        ? content.replaceAll(searchString, () => replacement)
+        : content.replace(searchString, () => replacement);
+}
+
+/** Applies one find/replace. An empty edit on an empty file writes the whole file. */
+export function applyEdit(
+    content: string,
+    oldString: string,
+    newString: string,
+    replaceAll: boolean
+): string {
+    if (content.trim() === "" && oldString.trim() === "") {
+        return newString;
+    }
+    return replaceLiteral(content, oldString, newString, replaceAll);
+}
+
+/**
+ * Compares contents ignoring EOL style and the trailing/final whitespace that on-save
+ * settings (trimTrailingWhitespace, insertFinalNewline, trimFinalNewlines) rewrite for us.
+ */
+export function contentsEquivalent(a: string, b: string): boolean {
+    const canonical = (s: string) => normalizeToLf(s).replace(/[ \t]+$/gm, '').replace(/\n+$/, '');
+    return canonical(a) === canonical(b);
+}

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/utils.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/utils.ts
@@ -67,8 +67,9 @@ export async function addToIntegration(workspaceFolderPath: string, fileChanges:
         );
     }
 
-    // Apply all formatted changes at once. applyEdit signals failure by returning false
-    // rather than throwing, usually because the document version changed underneath it.
+    // applyEdit signals failure by returning false rather than throwing, usually because the
+    // document version changed underneath it. Gated on isBalFileAdded so an empty
+    // WorkspaceEdit isn't applied; saveAll stays ungated to keep the old flush behaviour.
     if (isBalFileAdded) {
         const applied = await workspace.applyEdit(formattedWorkspaceEdit);
         if (!applied) {
@@ -76,14 +77,14 @@ export async function addToIntegration(workspaceFolderPath: string, fileChanges:
                 `Failed to apply workspace edit for: ${fileChanges.map(f => f.filePath).join(', ')}`
             );
         }
-        // saveAll also flushes unrelated dirty editors, so a false return is not proof that
-        // our file failed. Callers verify their own file against disk.
-        const saved = await workspace.saveAll();
-        if (!saved) {
-            console.warn(
-                `[addToIntegration] workspace.saveAll() reported a failure while saving: ${fileChanges.map(f => f.filePath).join(', ')}`
-            );
-        }
+    }
+    // saveAll also flushes unrelated dirty editors, so a false return is not proof that our
+    // file failed. Callers verify their own file against disk.
+    const saved = await workspace.saveAll();
+    if (!saved) {
+        console.warn(
+            `[addToIntegration] workspace.saveAll() reported a failure while saving: ${fileChanges.map(f => f.filePath).join(', ')}`
+        );
     }
 
     // Write non ballerina files separately as ls doesn't need to be notified of those changes

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/utils.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/utils.ts
@@ -67,9 +67,24 @@ export async function addToIntegration(workspaceFolderPath: string, fileChanges:
         );
     }
 
-    // Apply all formatted changes at once
-    await workspace.applyEdit(formattedWorkspaceEdit);
-    await workspace.saveAll();
+    // Apply all formatted changes at once. applyEdit signals failure by returning false
+    // rather than throwing, usually because the document version changed underneath it.
+    if (isBalFileAdded) {
+        const applied = await workspace.applyEdit(formattedWorkspaceEdit);
+        if (!applied) {
+            throw new Error(
+                `Failed to apply workspace edit for: ${fileChanges.map(f => f.filePath).join(', ')}`
+            );
+        }
+        // saveAll also flushes unrelated dirty editors, so a false return is not proof that
+        // our file failed. Callers verify their own file against disk.
+        const saved = await workspace.saveAll();
+        if (!saved) {
+            console.warn(
+                `[addToIntegration] workspace.saveAll() reported a failure while saving: ${fileChanges.map(f => f.filePath).join(', ')}`
+            );
+        }
+    }
 
     // Write non ballerina files separately as ls doesn't need to be notified of those changes
     for (const fileChange of nonBalFiles) {
@@ -88,7 +103,9 @@ export async function addToIntegration(workspaceFolderPath: string, fileChanges:
 
     return new Promise((resolve, reject) => {
         if (!isBalFileAdded) {
+            // No LS notification is coming, so don't leave a subscription and timer behind.
             resolve([]);
+            return;
         }
         // Get the artifact notification handler instance
         const notificationHandler = ArtifactNotificationHandler.getInstance();

--- a/packages/ballerina-extension/src/test-support/editReplacement.test.ts
+++ b/packages/ballerina-extension/src/test-support/editReplacement.test.ts
@@ -22,6 +22,7 @@
 // JS expanded `$` patterns in it. An end-anchored Ballerina regex (re `...$`) yielded
 // `` $` `` and spliced the head of the file in at the match point, multiplying the file.
 
+import * as path from 'path';
 import { applyEdit, contentsEquivalent, replaceLiteral } from '../features/ai/utils/edit-replacement';
 
 describe('replaceLiteral / applyEdit — $ substitution patterns are inserted literally', () => {
@@ -72,8 +73,7 @@ describe('replaceLiteral / applyEdit — $ substitution patterns are inserted li
 
         // Growth must be bounded by the payload delta, not by the file size.
         expect(result.length).toBe(source.length + 6 * (payload.length - '    return "x";'.length));
-        // Every function must still appear exactly once — a duplicated, self-similar file
-        // is what left the agent with no way to recover.
+        // Every function must still appear exactly once; a self-similar dup is unrecoverable.
         for (let i = 1; i <= 6; i++) {
             expect(result.split(`function f${i}()`)).toHaveLength(2);
         }
@@ -104,5 +104,22 @@ describe('contentsEquivalent', () => {
         expect(contentsEquivalent('a\nb', 'a\nc')).toBe(false);
         // Leading indentation is significant in Ballerina and must not be normalised away.
         expect(contentsEquivalent('    a', 'a')).toBe(false);
+    });
+});
+
+// The per-file lock must key off the same path the tools operate on: path.resolve drops the
+// project root for an absolute-looking file_path that validateFilePath still accepts.
+describe('lock key path normalization', () => {
+    const root = path.join(path.sep, 'tmp', 'proj');
+
+    it.each(['main.bal', 'sub/main.bal'])('agrees with path.join for the relative path %s', (p) => {
+        expect(path.join(root, p)).toBe(path.resolve(root, p));
+    });
+
+    it('keeps an absolute-looking file_path inside the project root', () => {
+        const abs = `${path.sep}main.bal`;
+        expect(path.join(root, abs)).toBe(path.join(root, 'main.bal'));
+        // The bug: resolve escapes the root, so it would not collide with the plain spelling.
+        expect(path.resolve(root, abs)).not.toBe(path.join(root, abs));
     });
 });

--- a/packages/ballerina-extension/src/test-support/editReplacement.test.ts
+++ b/packages/ballerina-extension/src/test-support/editReplacement.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Regression coverage for the file edit tools' replacement core.
+//
+// The tools used to pass `new_string` as the replacement argument of replace/replaceAll, so
+// JS expanded `$` patterns in it. An end-anchored Ballerina regex (re `...$`) yielded
+// `` $` `` and spliced the head of the file in at the match point, multiplying the file.
+
+import { applyEdit, contentsEquivalent, replaceLiteral } from '../features/ai/utils/edit-replacement';
+
+describe('replaceLiteral / applyEdit — $ substitution patterns are inserted literally', () => {
+    const file = [
+        'import ballerina/http;',
+        '',
+        'function validate(string id) returns boolean {',
+        '    return true;',
+        '}',
+        '',
+    ].join('\n');
+    const target = '    return true;';
+
+    it('keeps a backtick regex literal anchored with $ intact', () => {
+        const payload = '    return id.matches(re `^ORD-[0-9]{6}$`);';
+        const result = applyEdit(file, target, payload, false);
+
+        expect(result).toBe(file.replace(target, () => payload));
+        expect(result).toContain('re `^ORD-[0-9]{6}$`');
+        // The head of the file must not be spliced in at the match point.
+        expect(result.split('import ballerina/http;')).toHaveLength(2);
+        expect(result.length).toBeLessThan(file.length + payload.length);
+    });
+
+    it('does not collapse $$ in a string template', () => {
+        const payload = '    return string `Price: $${amount}`;';
+        expect(applyEdit(file, target, payload, false)).toContain('string `Price: $${amount}`');
+    });
+
+    it.each([
+        ['$&  (whole match)', 'a$&b'],
+        ["$'  (suffix)", "a$'b"],
+        ['$`  (prefix)', 'a$`b'],
+        ['$1  (capture group)', 'a$1b'],
+        ['$$  (escaped dollar)', 'a$$b'],
+    ])('inserts %s verbatim', (_label, payload) => {
+        expect(replaceLiteral('X', 'X', payload, false)).toBe(payload);
+        expect(replaceLiteral('X', 'X', payload, true)).toBe(payload);
+    });
+
+    it('does not multiply the file when replace_all hits many matches', () => {
+        let source = '';
+        for (let i = 1; i <= 6; i++) {
+            source += `function f${i}() returns string {\n    return "x";\n}\n`;
+        }
+        const payload = '    return string `amt: $`;';
+        const result = applyEdit(source, '    return "x";', payload, true);
+
+        // Growth must be bounded by the payload delta, not by the file size.
+        expect(result.length).toBe(source.length + 6 * (payload.length - '    return "x";'.length));
+        // Every function must still appear exactly once — a duplicated, self-similar file
+        // is what left the agent with no way to recover.
+        for (let i = 1; i <= 6; i++) {
+            expect(result.split(`function f${i}()`)).toHaveLength(2);
+        }
+    });
+
+    it('replaces only the first match when replaceAll is false', () => {
+        expect(applyEdit('a a a', 'a', 'b', false)).toBe('b a a');
+        expect(applyEdit('a a a', 'a', 'b', true)).toBe('b b b');
+    });
+
+    it('writes the replacement as the whole file for an empty edit on an empty file', () => {
+        expect(applyEdit('', '', 'hello', false)).toBe('hello');
+        expect(applyEdit('   \n', '', 'hello', false)).toBe('hello');
+    });
+});
+
+describe('contentsEquivalent', () => {
+    it('ignores EOL style', () => {
+        expect(contentsEquivalent('a\r\nb\r\n', 'a\nb\n')).toBe(true);
+    });
+
+    it('ignores trailing whitespace and final-newline fixups applied on save', () => {
+        expect(contentsEquivalent('a   \nb\t\n', 'a\nb')).toBe(true);
+        expect(contentsEquivalent('a\nb\n\n\n', 'a\nb')).toBe(true);
+    });
+
+    it('still reports real content differences', () => {
+        expect(contentsEquivalent('a\nb', 'a\nc')).toBe(false);
+        // Leading indentation is significant in Ballerina and must not be normalised away.
+        expect(contentsEquivalent('    a', 'a')).toBe(false);
+    });
+});


### PR DESCRIPTION
Fixes: 
https://github.com/wso2/product-integrator/issues/2266 
https://github.com/wso2/product-integrator/issues/2332

## Problem

Copilot's file edit tools reported success while leaving the file untouched (7+ sightings across `main.bal`/`connections.bal`, caught only by re-reading), and payloads containing backtick templates corrupted files — in one case duplicating a file 6× with no way to recover it.

## Root causes

1. **`$` substitution patterns.** The tools passed the model's `new_string` as the *replacement* argument of `String.prototype.replace`/`replaceAll`, which expands `$` sequences even when the search pattern is a plain string. `` $` `` splices in everything before the match, so an end-anchored Ballerina regex (``re `^ORD-\d{6}$` ``) or a string template ending in `$` duplicated the file at the match point; `$$` silently collapsed to `$`. The batch tool's dry-run pass had the same defect, so it validated later edits against content that would never be written.

2. **Unconditional success.** The persistence helper swallowed every failure and returned `void`; callers always reported success. The underlying `workspace.applyEdit`/`saveAll` signal failure by *returning false*, not throwing, and neither return value was checked.

3. **No write serialization.** Each tool read from disk and wrote back a whole-document replace with no lock, so parallel tool calls on one file discarded each other's edits while both reported success.

4. **No recovery path.** Once a file was duplicated, the copies were self-similar so no `old_string` could be made unique, `file_write` refused non-empty files, and no delete tool existed.

## Fixes

- Route every replacement through a function replacer so `new_string` is inserted verbatim. Extracted into a `vscode`-free module (`edit-replacement.ts`) so it is unit-testable, and shared between the batch tool's dry-run and apply passes.
- Propagate persistence failures, check `applyEdit`'s return value, and re-read the file after each write to confirm the change landed. Only "the file is unchanged" fails; a mismatch against the exact expected content is warned about, since format-on-save legitimately reshapes files. `saveAll` returning false is a warning, as it also flushes unrelated editors.
- Serialize the read-modify-write cycle per resolved path across all three tools.
- Add an `overwrite` flag to `file_write`, scoped in the tool description to last-resort recovery.

Also fixed a leaked subscription and 10s timer on every non-`.bal` write, and a silent no-op that made the memory tools' write/edit do nothing when no execution context was present.

## Testing

13 regression tests covering each `$` pattern, the 6× duplication case, and the on-save-tolerant comparison. Typecheck clean; unit suite green apart from `iconCodepoints`, which fails identically on a clean `staging/5.14.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved file edit reliability by validating persisted changes, reporting failures, and serializing operations per file.
- Centralized replacement logic to preserve literal replacement text and align dry-run and apply behavior.
- Added `overwrite` support to `file_write` for recovery scenarios.
- Fixed execution-context handling for memory-tool writes and edits.
- Prevented undisposed listeners and timers for non-`.bal` writes.
- Added 13 regression tests. Typechecking passes, and the unit suite passes except for the existing `iconCodepoints` failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->