### PR TITLE
Fix WSO2 Integrator Copilot server-side compaction (context management + UI)

### DIFF
--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -661,11 +661,10 @@ export interface CompactionStartEvent {
     type: 'compaction_start';
 }
 
-/** Fired when server-side compaction completes; carries the extracted summary */
+/** Fired when server-side compaction completes. The model-authored summary is
+ * intentionally NOT carried here — it stays internal and never reaches the webview. */
 export interface CompactionEndEvent {
     type: 'compaction_end';
-    /** Extracted <summary> content from the compaction block */
-    summary?: string;
 }
 
 /** Fired once per session when compaction is disabled because the codebase floor exceeds the trigger */

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -109,12 +109,10 @@ function supportsCompaction(loginMethod: LoginMethod): boolean {
  * Server-side compaction trigger, in input tokens.
  *
  * Unlike MI, BI re-sends the entire project source in every turn's user message, so its
- * per-turn baseline is much larger — MI's 200K trigger would fire almost immediately and
- * leave too little working headroom. Production target: 350_000.
- *
- * NOTE: set to 100_000 for testing / initial rollout so compaction is easy to exercise.
+ * per-turn baseline is much larger — MI's 200K trigger would fire too eagerly. 500K leaves
+ * ample working headroom while staying well within the 1M context window (Claude Sonnet).
  */
-const COMPACT_TRIGGER_TOKENS = 100_000;
+const COMPACT_TRIGGER_TOKENS = 500_000;
 
 /**
  * Builds providerOptions.anthropic.contextManagement, mirroring MI's approach: compaction
@@ -484,6 +482,18 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
             let isCompactionBlock = false;
             let compactionContent = '';
             let cleanedCompactionSummary: string | undefined;
+            // Counts compactions in this turn so each renders as its own card (upsertComponent
+            // keys by id). Mirrors MI: a notice + the extracted summary, rendered in-stream —
+            // never emitted as a raw <compaction> text block (which would render as literal text).
+            let compactionCount = 0;
+            const emitCompactionNotice = (summary?: string) => {
+                this.config.eventHandler({
+                    type: 'chat_component',
+                    componentType: 'compaction',
+                    id: `compaction-${this.config.generationId}-${compactionCount++}`,
+                    data: { summary: summary ?? '' },
+                });
+            };
 
             // Send start event to frontend
             this.config.eventHandler({ type: "start" });

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -106,19 +106,14 @@ function supportsCompaction(loginMethod: LoginMethod): boolean {
 }
 
 /**
- * Server-side compaction trigger, in input tokens.
- *
- * Unlike MI, BI re-sends the entire project source in every turn's user message, so its
- * per-turn baseline is much larger — MI's 200K trigger would fire too eagerly. 500K leaves
- * ample working headroom while staying well within the 1M context window (Claude Sonnet).
+ * Server-side compaction trigger, in input tokens. Higher than MI's 200K because BI re-sends
+ * the whole project source each turn; 500K sits well within Claude Sonnet's 1M window.
  */
 const COMPACT_TRIGGER_TOKENS = 500_000;
 
 /**
- * Builds providerOptions.anthropic.contextManagement, mirroring MI's approach: compaction
- * only, no `clear_tool_uses`. `clear_tool_uses` *deletes* older tool results with no summary
- * to replace them, degrading the agent mid-task; `compact_20260112` *summarizes* instead,
- * preserving the context the agent needs to keep working.
+ * Builds providerOptions.anthropic.contextManagement: compaction only, no `clear_tool_uses`
+ * (which deletes tool results without summarizing). Mirrors MI.
  */
 function buildCompactionProviderOptions(loginMethod: LoginMethod, floorTokens: number) {
     if (!supportsCompaction(loginMethod)) { return undefined; }
@@ -483,15 +478,16 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
             let compactionContent = '';
             let cleanedCompactionSummary: string | undefined;
             // Counts compactions in this turn so each renders as its own card (upsertComponent
-            // keys by id). Mirrors MI: a notice + the extracted summary, rendered in-stream —
-            // never emitted as a raw <compaction> text block (which would render as literal text).
+            // keys by id), instead of a raw <compaction> text block that would show as literal text.
             let compactionCount = 0;
-            const emitCompactionNotice = (summary?: string) => {
+            const emitCompactionNotice = () => {
+                // Notice only — the model-authored summary is kept internal (#2371), never
+                // forwarded to the webview or persisted in the transcript.
                 this.config.eventHandler({
                     type: 'chat_component',
                     componentType: 'compaction',
                     id: `compaction-${this.config.generationId}-${compactionCount++}`,
-                    data: { summary: summary ?? '' },
+                    data: {},
                 });
             };
 
@@ -520,6 +516,25 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                 projectId,
                 toolModelUsage,
                 carriedMessages,
+            };
+
+            // Flush an open compaction block: extract its summary, clear the UI compaction state,
+            // reset the context widget, and emit the in-stream notice card. Called from the block's
+            // own text-end (so the notice lands right after the summary, before any following tool
+            // calls or text), with a stream-end fallback for a block left open at stream end.
+            const flushCompactionBlock = () => {
+                isCompactionBlock = false;
+                const summary = extractCompactionSummary(compactionContent);
+                cleanedCompactionSummary = summary || compactionContent;
+                streamContext.wasCompactionTurn = true;
+                this.config.eventHandler({ type: 'compaction_end', summary: summary ?? undefined });
+                // Reset context widget to near-zero after compaction
+                this.config.eventHandler({
+                    type: 'usage_metrics',
+                    usage: { inputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, outputTokens: 0 },
+                });
+                // Compaction notice, positioned before the continuing response.
+                emitCompactionNotice();
             };
 
             // Process stream events - NATIVE V6 PATTERN
@@ -632,27 +647,20 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                                 compactionContent = '';
                                 this.config.eventHandler({ type: 'compaction_start' });
                             } else {
-                                if (isCompactionBlock) {
-                                    // Compaction block just ended — flush it
-                                    isCompactionBlock = false;
-                                    const summary = extractCompactionSummary(compactionContent);
-                                    cleanedCompactionSummary = summary || compactionContent;
-                                    streamContext.wasCompactionTurn = true;
-                                    this.config.eventHandler({ type: 'compaction_end', summary: summary ?? undefined });
-                                    // Reset context widget to near-zero after compaction
-                                    this.config.eventHandler({
-                                        type: 'usage_metrics',
-                                        usage: { inputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, outputTokens: 0 },
-                                    });
-                                    // Inline notice before the continuing response
-                                    this.config.eventHandler({
-                                        type: 'content_block',
-                                        content: '<compaction>Context compacted — key context preserved, conversation continues below.</compaction>',
-                                    });
-                                }
-                                // Normal text-start: emit paragraph break
+                                // Normal text-start: emit a paragraph break. The compaction block is
+                                // flushed on its own text-end (below), not here, so its notice lands
+                                // before any tool calls that follow it rather than after them, and a
+                                // second compaction can't reset an unflushed first block.
                                 this.config.eventHandler({ type: 'content_block', content: ' \n' });
                             }
+                            continue;
+                        }
+
+                        // Compaction block closed: flush it now so the notice is emitted immediately
+                        // after the summary. Only intercepts the compaction block's own text-end; a
+                        // normal text-end falls through to handleStreamPart as before.
+                        if (part.type === 'text-end' && isCompactionBlock) {
+                            flushCompactionBlock();
                             continue;
                         }
 
@@ -681,20 +689,10 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                         await this.handleStreamPart(part, streamContext);
                     }
 
-                    // Flush compaction block if still open at stream end (e.g. compaction was last block)
+                    // Fallback: flush a compaction block still open at stream end (no text-end arrived,
+                    // e.g. the stream ended on the compaction block itself).
                     if (isCompactionBlock) {
-                        isCompactionBlock = false;
-                        const summary = extractCompactionSummary(compactionContent);
-                        cleanedCompactionSummary = summary || compactionContent;
-                        this.config.eventHandler({ type: 'compaction_end', summary: summary ?? undefined });
-                        this.config.eventHandler({
-                            type: 'usage_metrics',
-                            usage: { inputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, outputTokens: 0 },
-                        });
-                        this.config.eventHandler({
-                            type: 'content_block',
-                            content: '<compaction>Context compacted — key context preserved.</compaction>',
-                        });
+                        flushCompactionBlock();
                     }
 
                     // Check if abort was called after stream completed

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -527,7 +527,9 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                 const summary = extractCompactionSummary(compactionContent);
                 cleanedCompactionSummary = summary || compactionContent;
                 streamContext.wasCompactionTurn = true;
-                this.config.eventHandler({ type: 'compaction_end', summary: summary ?? undefined });
+                // The summary stays internal (kept only in cleanedCompactionSummary for prepareStep);
+                // it is never forwarded to the webview or the persisted transcript.
+                this.config.eventHandler({ type: 'compaction_end' });
                 // Reset context widget to near-zero after compaction
                 this.config.eventHandler({
                     type: 'usage_metrics',

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -53,12 +53,12 @@ import { chatStateStorage } from '../../../views/ai-panel/chatStateStorage';
 import * as path from 'path';
 import { approvalViewManager } from '../state/ApprovalViewManager';
 import {
-    buildContextManagementOptions,
     detectAppliedCompaction,
     estimateFloorTokens,
     extractCompactionSummary,
     stripAnalysisFromCompactionBlocks,
     COMPACTION_BLOCK_PREFIX,
+    SUMMARIZATION_PROMPT,
 } from '@wso2/copilot-utilities/context-management';
 import { sanitizeMessages } from './resilience';
 import { getLoginMethod } from '../../../utils/ai/auth';
@@ -105,10 +105,41 @@ function supportsCompaction(loginMethod: LoginMethod): boolean {
         || loginMethod === LoginMethod.ANTHROPIC_AWS;
 }
 
+/**
+ * Server-side compaction trigger, in input tokens.
+ *
+ * Unlike MI, BI re-sends the entire project source in every turn's user message, so its
+ * per-turn baseline is much larger — MI's 200K trigger would fire almost immediately and
+ * leave too little working headroom. Production target: 350_000.
+ *
+ * NOTE: set to 100_000 for testing / initial rollout so compaction is easy to exercise.
+ */
+const COMPACT_TRIGGER_TOKENS = 100_000;
+
+/**
+ * Builds providerOptions.anthropic.contextManagement, mirroring MI's approach: compaction
+ * only, no `clear_tool_uses`. `clear_tool_uses` *deletes* older tool results with no summary
+ * to replace them, degrading the agent mid-task; `compact_20260112` *summarizes* instead,
+ * preserving the context the agent needs to keep working.
+ */
 function buildCompactionProviderOptions(loginMethod: LoginMethod, floorTokens: number) {
     if (!supportsCompaction(loginMethod)) { return undefined; }
-    const options = buildContextManagementOptions({ estimatedFloorTokens: floorTokens });
-    return options ?? undefined;
+    // Disable when the fixed per-turn floor (system prompt + whole-codebase dump) already
+    // exceeds the trigger — compaction would otherwise fire every turn against empty history.
+    if (floorTokens >= COMPACT_TRIGGER_TOKENS) { return undefined; }
+    return {
+        anthropic: {
+            contextManagement: {
+                edits: [
+                    {
+                        type: 'compact_20260112' as const,
+                        trigger: { type: 'input_tokens' as const, value: COMPACT_TRIGGER_TOKENS },
+                        instructions: SUMMARIZATION_PROMPT,
+                    },
+                ],
+            },
+        },
+    };
 }
 
 function warnCompactionDisabledOnce(projectRootPath: string, eventHandler: (e: any) => void): void {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AgentStreamView/StreamEntry.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AgentStreamView/StreamEntry.tsx
@@ -57,12 +57,14 @@ import {
 
 // ── Item renderer — order-preserving, used by both floating and named entries ─
 
+// Fixed notice for the server-side compaction card. The model-authored summary is kept
+// internal (#2371) — the compaction chat_component carries no summary and none is rendered.
+const COMPACTION_NOTICE_TEXT = "Context compacted — conversation continues below";
+
 /**
- * Renders a text stream item, rendering any embedded `<compaction>…</compaction>`
- * notice as a compaction row rather than raw markdown. New runs emit compaction as a
- * `chat_component`, but a notice can still be folded into a text item by older
- * transcripts (persisted before that change) or a stray raw emission — this keeps
- * those rendering cleanly instead of leaking the literal tag.
+ * Renders a text stream item, folding any embedded `<compaction>…</compaction>` tag (the
+ * compaction-disabled warning, or an old transcript's notice) into a notice row rather than
+ * leaking the literal tag as markdown.
  */
 function renderTextItem(text: string, idx: number): React.ReactNode {
     if (!text.includes("<compaction>")) {
@@ -86,6 +88,8 @@ function renderTextItem(text: string, idx: number): React.ReactNode {
                 </ItemMarkdownWrapper>
             );
         }
+        // The tag's inner text is always a developer-authored notice (the old compaction
+        // notice or the compaction-disabled warning), never the model summary — render it.
         const notice = m[1].trim();
         parts.push(
             <ItemRow key={`${idx}-c${k}`}>
@@ -194,24 +198,12 @@ function renderItem(item: StreamItem, idx: number, streamActive: boolean, rpcCli
                 );
             }
             if (item.componentType === "compaction") {
-                const summary = typeof item.data?.summary === "string" ? item.data.summary.trim() : "";
+                // Notice only — the model-authored summary is kept internal (#2371).
                 return (
-                    <React.Fragment key={idx}>
-                        <ItemRow>
-                            <span className="codicon codicon-fold" aria-hidden="true" />
-                            <ItemLabel loading={false}>Context compacted — conversation continues below</ItemLabel>
-                        </ItemRow>
-                        {summary && (
-                            <ItemDetail>
-                                <details>
-                                    <summary style={{ cursor: "pointer" }}>View summary</summary>
-                                    <ItemMarkdownWrapper>
-                                        <MarkdownRenderer markdownContent={summary} />
-                                    </ItemMarkdownWrapper>
-                                </details>
-                            </ItemDetail>
-                        )}
-                    </React.Fragment>
+                    <ItemRow key={idx}>
+                        <span className="codicon codicon-fold" aria-hidden="true" />
+                        <ItemLabel loading={false}>{COMPACTION_NOTICE_TEXT}</ItemLabel>
+                    </ItemRow>
                 );
             }
             return null;

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AgentStreamView/StreamEntry.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AgentStreamView/StreamEntry.tsx
@@ -57,16 +57,62 @@ import {
 
 // ── Item renderer — order-preserving, used by both floating and named entries ─
 
+/**
+ * Renders a text stream item, rendering any embedded `<compaction>…</compaction>`
+ * notice as a compaction row rather than raw markdown. New runs emit compaction as a
+ * `chat_component`, but a notice can still be folded into a text item by older
+ * transcripts (persisted before that change) or a stray raw emission — this keeps
+ * those rendering cleanly instead of leaking the literal tag.
+ */
+function renderTextItem(text: string, idx: number): React.ReactNode {
+    if (!text.includes("<compaction>")) {
+        return (
+            <ItemMarkdownWrapper key={idx}>
+                <MarkdownRenderer markdownContent={text} />
+            </ItemMarkdownWrapper>
+        );
+    }
+    const re = /<compaction>([\s\S]*?)<\/compaction>/g;
+    const parts: React.ReactNode[] = [];
+    let last = 0;
+    let k = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+        const before = text.slice(last, m.index).trim();
+        if (before) {
+            parts.push(
+                <ItemMarkdownWrapper key={`${idx}-b${k}`}>
+                    <MarkdownRenderer markdownContent={before} />
+                </ItemMarkdownWrapper>
+            );
+        }
+        const notice = m[1].trim();
+        parts.push(
+            <ItemRow key={`${idx}-c${k}`}>
+                <span className="codicon codicon-fold" aria-hidden="true" />
+                <ItemLabel loading={false}>{notice}</ItemLabel>
+            </ItemRow>
+        );
+        last = m.index + m[0].length;
+        k++;
+    }
+    const after = text.slice(last).trim();
+    if (after) {
+        parts.push(
+            <ItemMarkdownWrapper key={`${idx}-a`}>
+                <MarkdownRenderer markdownContent={after} />
+            </ItemMarkdownWrapper>
+        );
+    }
+    return <React.Fragment key={idx}>{parts}</React.Fragment>;
+}
+
 function renderItem(item: StreamItem, idx: number, streamActive: boolean, rpcClient?: any): React.ReactNode {
     switch (item.kind) {
         case "text": {
             const trimmed = item.text.trim();
             if (!trimmed) return null;
-            return (
-                <ItemMarkdownWrapper key={idx}>
-                    <MarkdownRenderer markdownContent={trimmed} />
-                </ItemMarkdownWrapper>
-            );
+            return renderTextItem(trimmed, idx);
         }
         case "tool_call": {
             if (item.toolName === "hurlRunnerTool") {
@@ -145,6 +191,27 @@ function renderItem(item: StreamItem, idx: number, streamActive: boolean, rpcCli
                         </SonarWrapper>
                         <ItemLabel loading={isSpinning}>{item.data.text}</ItemLabel>
                     </ItemRow>
+                );
+            }
+            if (item.componentType === "compaction") {
+                const summary = typeof item.data?.summary === "string" ? item.data.summary.trim() : "";
+                return (
+                    <React.Fragment key={idx}>
+                        <ItemRow>
+                            <span className="codicon codicon-fold" aria-hidden="true" />
+                            <ItemLabel loading={false}>Context compacted — conversation continues below</ItemLabel>
+                        </ItemRow>
+                        {summary && (
+                            <ItemDetail>
+                                <details>
+                                    <summary style={{ cursor: "pointer" }}>View summary</summary>
+                                    <ItemMarkdownWrapper>
+                                        <MarkdownRenderer markdownContent={summary} />
+                                    </ItemMarkdownWrapper>
+                                </details>
+                            </ItemDetail>
+                        )}
+                    </React.Fragment>
                 );
             }
             return null;


### PR DESCRIPTION
## Summary

Fixes how the WSO2 Integrator Copilot handles Anthropic server-side compaction, in two parts.

### 1. Compaction notice leaked into the chat as a raw tag (primary fix)

When compaction fired, the notice was emitted as a plain `content_block`, so it folded
into the agent-stream JSON blob and rendered as the **literal string**
`<compaction>Context compacted — …</compaction>` in the chat. Separately, the summary
extracted from the compaction block was computed and then **discarded** — never used.

- Emit compaction as a `chat_component` (`componentType: "compaction"`), folded through the
  shared `upsertComponent` path so both chat surfaces persist it consistently, and render it
  as a fixed notice row positioned before the continuing response.
- Flush the compaction block on its own `text-end` rather than deferring to the next
  `text-start`. The notice now lands immediately after the summary block ends — before any
  following tool calls — so it is genuinely before the continuing response, and a second
  back-to-back compaction can no longer reset an unflushed first block and drop its notice.
  A stream-end fallback still covers a block left open at the end of the stream.
- Keep the model-authored summary **internal** (see #2371): the `chat_component` carries no
  summary and nothing renders one. The summary is still used server-side to strip
  `<analysis>` blocks from compaction entries. The manually-triggered `compactConversation`
  action is unaffected.
- Defensive fallback: render any `<compaction>` tag folded into an agent-stream text item
  as a notice row rather than raw text, so transcripts persisted before this change (and
  any stray raw emission) no longer leak the literal tag on reload. That path renders the
  tag's inner text, which only ever held a fixed developer notice — never the summary — and
  is also what shows the compaction-disabled warning.

### 2. Context-management config: compaction only

Switch from two context-management edits (`clear_tool_uses_20250919` + `compact_20260112`)
to **compaction only**, triggering at **500K input tokens**.

Rationale: BI re-sends the entire project source in every turn's user message, so its
context is dominated by that non-clearable dump. Compaction (which summarizes the whole
history) is the load-bearing mechanism; `clear_tool_uses` (which only trims tool results)
does comparatively little for BI and adds prompt-cache churn.

The 500K trigger is **higher than the MI Copilot's 200K**, deliberately — BI's per-turn
baseline (system prompt + whole-codebase dump) is much larger, so a 200K trigger would fire
too eagerly. 500K leaves ample working headroom while staying well within Claude Sonnet 5's
1M-token context window (1M is the default for `claude-sonnet-5`; no beta header is needed).
The floor guard still disables compaction when the fixed per-turn overhead already exceeds
the trigger.

Anthropic does recommend using both edits for tool-heavy agents, so `clear_tool_uses` may be
reintroduced as a **measured follow-up** once its cache impact is verified with `appliedEdits`
logging — it is not removed because it caused a bug.

## Scope note

An earlier report of the Copilot emitting a "CRITICAL CONTEXT TO REMEMBER" hand-off and
stopping was investigated and traced to a **stuck-tool session** (the model looping on a
failing `LibraryGetTool`), **not** compaction — the compact edit has always carried our
own summarization instructions, whose output format is different. No change here targets
that behavior; the verified compaction issues are the two above.

## Testing

- Compaction fires and renders as a notice card (no raw tag, no summary shown) on a long
  tool-heavy Ballerina session (Anthropic own-key).
- Transcripts persisted before the change render the notice cleanly on reload.
- `tsc --noEmit` clean for both `ballerina-extension` and `ballerina-visualizer`; host unit
  tests (174) and webview AI unit tests (56) pass.

## Related

Addresses the compaction-notice leak described in wso2/product-integrator#2371.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Configure server-side compaction with `compact_20260112` at 500K input tokens.
- Emit fixed compaction notices before the continuing response.
- Keep model-authored summaries internal.
- Render persisted and streamed `<compaction>` tags as notices.
- Validate long tool sessions, persisted transcripts, and TypeScript compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->