### PR TITLE
Allow clearing value for optional fields in AutoCompleteEditor

### DIFF
--- a/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
@@ -71,7 +71,7 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
                 errorMsg={errorMsg || undefined}
                 {...register(field.key, {
                     required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
-                    value: getValueForDropdown(field),
+                    value: field.optional ? (field.value ?? "") : getValueForDropdown(field),
                     validate: buildValidate(field)
                 })}
                 label={capitalize(field.label)}
@@ -89,7 +89,7 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
                         : field.optional
                             ? ""
                             : currentValue ?? "";
-                    setValue(field.key, newVal);
+                    setValue(field.key, newVal, { shouldDirty: true });
                     field.onValueChange?.(newVal);
                     liveDiagnostics.onValueChange(newVal);
                 }}

--- a/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
@@ -41,6 +41,8 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
 
     const value = watch(field.key);
 
+    const comboboxValue = (field.optional ? ((value as string) || null) : value) as string;
+
     // Live diagnostics: client rules (e.g. the identifier check on a free-typed value) run on
     // every change, same as TextEditor — react-hook-form's default `onSubmit` mode otherwise
     // leaves `errors` empty until submit is attempted, so a `validations[]` failure would go
@@ -65,7 +67,7 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
             <AutoComplete
                 id={field.key}
                 description={field.documentation}
-                value={value as string}
+                value={comboboxValue}
                 errorMsg={errorMsg || undefined}
                 {...register(field.key, {
                     required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
@@ -76,13 +78,17 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
                 items={field.items}
                 allowItemCreate={field.allowItemCreate ?? true}
                 required={!field.optional}
+                nullable={field.optional}
                 disabled={!field.editable}
                 onValueChange={(val: string) => {
-                    // Preserve existing value when Combobox fires with empty on blur (e.g., click away without selecting)
-                    const currentValue = value ?? getValueForDropdown(field) ?? field.value;
-                    const newVal = (val === "" || val === undefined || val === null) && currentValue
-                        ? currentValue
-                        : val;
+                    // A nullable Combobox reports the cleared state as null/undefined on blur.
+                    const isEmpty = val === "" || val === undefined || val === null;
+                    const currentValue = ((value as string) || undefined) ?? getValueForDropdown(field) ?? field.value;
+                    const newVal = !isEmpty
+                        ? val
+                        : field.optional
+                            ? ""
+                            : currentValue ?? "";
                     setValue(field.key, newVal);
                     field.onValueChange?.(newVal);
                     liveDiagnostics.onValueChange(newVal);

--- a/packages/ballerina-side-panel/src/test/AutoCompleteEditor.test.tsx
+++ b/packages/ballerina-side-panel/src/test/AutoCompleteEditor.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+
+jest.mock("@wso2/ballerina-rpc-client", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const h = require("./rpcHarness");
+    return { __esModule: true, useRpcContext: h.useRpcContext, Context: h.TestRpcContext };
+});
+
+// Stub the ui-toolkit AutoComplete: record the props the editor passes and expose its onValueChange so a test can emit the
+// clear signal a nullable Combobox sends on blur, without depending on Headless UI internals.
+const mockAutoComplete: { props?: any } = {};
+jest.mock("@wso2/ui-toolkit", () => {
+    const actual = jest.requireActual("@wso2/ui-toolkit");
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const react = require("react");
+    return {
+        __esModule: true,
+        ...actual,
+        // forwardRef because the real AutoComplete is one and register() passes a ref.
+        AutoComplete: react.forwardRef((props: any, ref: any) => {
+            mockAutoComplete.props = props;
+            return react.createElement("input", {
+                ref,
+                "data-testid": "autocomplete-input",
+                value: props.value ?? "",
+                readOnly: true,
+            });
+        }),
+    };
+});
+
+import { act } from "@testing-library/react";
+import type { FormField } from "../components/Form/types";
+import { renderWithForm } from "./formHarness";
+import { AutoCompleteEditor } from "../components/editors/AutoCompleteEditor";
+
+const KEY = "approvalFunction";
+
+const autoCompleteField = (optional: boolean): FormField =>
+    ({
+        key: KEY,
+        label: "Approval Function",
+        type: "AUTOCOMPLETE",
+        items: ["approveFn", "rejectFn"],
+        value: "approveFn",
+        optional,
+        editable: true,
+        enabled: true,
+        documentation: "",
+    } as unknown as FormField);
+
+/** The value a nullable Headless UI Combobox reports when cleared and blurred: getItemKey(null). */
+const CLEARED = undefined;
+
+beforeEach(() => {
+    mockAutoComplete.props = undefined;
+});
+
+describe("AutoCompleteEditor clear-on-blur (#2270)", () => {
+    it("INVARIANT: makes the Combobox nullable for an optional field", () => {
+        renderWithForm(<AutoCompleteEditor field={autoCompleteField(true)} />, {
+            defaultValues: { [KEY]: "approveFn" },
+        });
+        expect(mockAutoComplete.props.nullable).toBe(true);
+    });
+
+    it("INVARIANT: keeps the Combobox non-nullable for a required field", () => {
+        renderWithForm(<AutoCompleteEditor field={autoCompleteField(false)} />, {
+            defaultValues: { [KEY]: "approveFn" },
+        });
+        expect(mockAutoComplete.props.nullable).toBe(false);
+    });
+
+    it("INVARIANT: an optional field commits empty when cleared", () => {
+        const { getForm } = renderWithForm(<AutoCompleteEditor field={autoCompleteField(true)} />, {
+            defaultValues: { [KEY]: "approveFn" },
+        });
+
+        // Clear the input and blur without selecting a suggestion -> nullable Combobox reports empty.
+        act(() => mockAutoComplete.props.onValueChange(CLEARED));
+
+        expect(getForm().getValues(KEY)).toBe("");
+    });
+
+    it("INVARIANT: a cleared optional field passes strict null to the Combobox (#2270 saved-form)", () => {
+        // Headless UI restores the value on blur unless the Combobox value is strictly null;
+        // an empty string is not enough. The editor must translate the cleared "" to null so a
+        // previously-saved value can actually be removed.
+        renderWithForm(<AutoCompleteEditor field={autoCompleteField(true)} />, {
+            defaultValues: { [KEY]: "approveFn" },
+        });
+
+        expect(mockAutoComplete.props.value).toBe("approveFn");
+        act(() => mockAutoComplete.props.onValueChange(CLEARED));
+        expect(mockAutoComplete.props.value).toBeNull();
+    });
+
+    it("INVARIANT: a required field restores its prior value on empty blur", () => {
+        const { getForm } = renderWithForm(<AutoCompleteEditor field={autoCompleteField(false)} />, {
+            defaultValues: { [KEY]: "approveFn" },
+        });
+
+        act(() => mockAutoComplete.props.onValueChange(CLEARED));
+
+        expect(getForm().getValues(KEY)).toBe("approveFn");
+    });
+
+    it("INVARIANT: a required field with an initially empty value restores its configured fallback on empty blur", () => {
+        // An empty form value must be treated as absent, not preserved: blur should restore the
+        // field's configured default (getValueForDropdown -> field.value "approveFn").
+        const { getForm } = renderWithForm(<AutoCompleteEditor field={autoCompleteField(false)} />, {
+            defaultValues: { [KEY]: "" },
+        });
+
+        act(() => mockAutoComplete.props.onValueChange(CLEARED));
+
+        expect(getForm().getValues(KEY)).toBe("approveFn");
+    });
+});

--- a/packages/ballerina-side-panel/src/test/fixtures/fields/issue-2270.json
+++ b/packages/ballerina-side-panel/src/test/fixtures/fields/issue-2270.json
@@ -1,0 +1,17 @@
+{
+    "description": "#2270: optional AUTOCOMPLETE (Approval Function ref) still selects AutoCompleteEditor",
+    "expectedEditor": "AutoCompleteEditor",
+    "fieldInputType": { "fieldType": "AUTOCOMPLETE" },
+    "field": {
+        "key": "f_AUTOCOMPLETE",
+        "label": "Approval Function",
+        "type": "AUTOCOMPLETE",
+        "optional": true,
+        "editable": true,
+        "documentation": "",
+        "value": "approveFn",
+        "items": ["approveFn", "rejectFn"],
+        "types": [{ "fieldType": "AUTOCOMPLETE", "selected": false }],
+        "enabled": true
+    }
+}


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-integrator/issues/2270

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `AutoCompleteEditor` so users can clear optional autocomplete fields.
- Preserved existing values for required fields when users clear the input.
- Added tests and a fixture for the Agent tool’s optional “Approval Function” field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->