### PR TITLE
Fix data loader search hang and missing/wrong icons

### DIFF
--- a/packages/ballerina-visualizer/src/utils/bi.tsx
+++ b/packages/ballerina-visualizer/src/utils/bi.tsx
@@ -82,7 +82,7 @@ import { cloneDeep } from "lodash";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import hljs from "highlight.js";
-import { COMPLETION_ITEM_KIND, CompletionItem, CompletionItemKind, convertCompletionItemKind, FnSignatureDocumentation, getAIModuleIcon, Icon } from "@wso2/ui-toolkit";
+import { COMPLETION_ITEM_KIND, CompletionItem, CompletionItemKind, convertCompletionItemKind, FnSignatureDocumentation, Icon } from "@wso2/ui-toolkit";
 import { FunctionDefinition, STNode } from "@wso2/syntax-tree";
 import { DocSection } from "../components/ExpressionEditor";
 
@@ -93,6 +93,13 @@ import { ConnectionKind, getConnectionKindDisplayName } from "../components/Conn
 import { ConnectionListItem } from "@wso2/wso2-platform-core";
 import { handleRepeatableProperty } from "./node-property-utils";
 export { updateNodeProperties } from "./node-property-utils";
+import {
+    IconFactory,
+    applyGroupedChildIcons,
+    dataLoaderIconFactory,
+    chunkerIconFactory,
+    vectorStoreIconFactory,
+} from "./group-icons";
 hljs.registerLanguage("ballerina", ballerina);
 
 function convertAvailableNodeToPanelNode(
@@ -142,64 +149,6 @@ function convertAvailableNodeToPanelNode(
             />
         ),
     };
-}
-
-
-type IconFactory = (codedata: any, iconUrl?: string) => React.ReactElement;
-
-// Central icon URLs are `…/{org}_{package}_{version}.png`; the middle segment is the package key.
-function getPackageKeyFromIconUrl(iconUrl?: string): string | undefined {
-    const fileName = iconUrl?.split("/").pop();
-    const parts = fileName?.split("_");
-    return parts && parts.length >= 3 ? parts[1] : undefined;
-}
-
-// Prefer the embedded provider SVG so monochrome logos stay visible in dark mode.
-function resolveChildBadgeIcon(codedata: any, iconUrl?: string): React.ReactElement {
-    const embedded =
-        getAIModuleIcon(getPackageKeyFromIconUrl(iconUrl), 14) ?? getAIModuleIcon(codedata?.object, 14);
-    if (embedded) {
-        return embedded;
-    }
-    // Fall back to the node glyph: the URL is synthesised from package coordinates and 404s for unpublished packages.
-    return (
-        <ConnectorIcon
-            url={iconUrl}
-            style={{ width: "14px", height: "14px", fontSize: "14px" }}
-            codedata={codedata}
-            fallbackIcon={<NodeIcon type={codedata?.node} size={14} />}
-        />
-    );
-}
-
-// Keeps the package icon on the group header and gives each child its own @display icon.
-function applyGroupedChildIcons(group: PanelCategory, rawItems: any[], groupIconFactory?: IconFactory): void {
-    const rawGroup = rawItems?.find(
-        (r) => r && !("codedata" in r) && r.metadata?.label === group.title
-    );
-    const packageIconUrl: string | undefined = rawGroup?.metadata?.icon;
-    const firstChild = group.items?.at(0) as PanelNode | undefined;
-
-    if (packageIconUrl) {
-        group.icon = (
-            <ConnectorIcon url={packageIconUrl} style={{ width: "20px", height: "20px", fontSize: "20px" }} />
-        );
-    } else if (groupIconFactory) {
-        // No package icon, so the group falls back to its first child's — which needs the caller's fallback too.
-        group.icon = groupIconFactory(firstChild?.metadata?.codedata, firstChild?.metadata?.metadata?.icon);
-    }
-
-    group.items?.forEach((child) => {
-        const childNode = child as PanelNode;
-        const codedata = childNode.metadata?.codedata;
-        const childIconUrl: string | undefined = childNode.metadata?.metadata?.icon;
-        const hasClassIcon = !groupIconFactory && Boolean(childIconUrl) && childIconUrl !== packageIconUrl;
-        child.icon = hasClassIcon ? (
-            resolveChildBadgeIcon(codedata, childIconUrl)
-        ) : (
-            <NodeIcon type={codedata?.node} size={14} />
-        );
-    });
 }
 
 function convertDiagramCategoryToSidePanelCategory(category: Category, functionType?: FUNCTION_TYPE): PanelCategory {
@@ -332,12 +281,7 @@ export function convertModelProviderCategoriesToSidePanelCategories(categories: 
 }
 
 export function convertVectorStoreCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
-    return convertCategoriesToSidePanelCategoriesWithIcon(categories, (codedata, iconUrl) => {
-        if (codedata?.module === "ai") {
-            return <NodeIcon type="VECTOR_STORE" size={24} />;
-        }
-        return <AIModelIcon type={codedata?.module} codedata={codedata} iconUrl={iconUrl} />;
-    });
+    return convertCategoriesToSidePanelCategoriesWithIcon(categories, vectorStoreIconFactory);
 }
 
 export function convertEmbeddingProviderCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
@@ -376,17 +320,11 @@ export function convertCategoriesToSidePanelCategoriesWithIcon(
 }
 
 export function convertDataLoaderCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
-    return convertCategoriesToSidePanelCategoriesWithIcon(categories, (codedata, iconUrl) => {
-        if (iconUrl && codedata?.module !== "ai" && codedata?.module !== "ai.devant") return <img src={iconUrl} style={{ width: 24, height: 24 }} />;
-        return <NodeIcon type="DATA_LOADER" size={24} />;
-    });
+    return convertCategoriesToSidePanelCategoriesWithIcon(categories, dataLoaderIconFactory);
 }
 
 export function convertChunkerCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
-    return convertCategoriesToSidePanelCategoriesWithIcon(categories, (codedata, iconUrl) => {
-        if (iconUrl && codedata?.module !== "ai" && codedata?.module !== "ai.devant") return <img src={iconUrl} style={{ width: 24, height: 24 }} />;
-        return <NodeIcon type="CHUNKER" size={24} />;
-    });
+    return convertCategoriesToSidePanelCategoriesWithIcon(categories, chunkerIconFactory);
 }
 
 export function convertMemoryStoreCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {

--- a/packages/ballerina-visualizer/src/utils/bi.tsx
+++ b/packages/ballerina-visualizer/src/utils/bi.tsx
@@ -333,6 +333,9 @@ export function convertModelProviderCategoriesToSidePanelCategories(categories: 
 
 export function convertVectorStoreCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
     return convertCategoriesToSidePanelCategoriesWithIcon(categories, (codedata, iconUrl) => {
+        if (codedata?.module === "ai") {
+            return <NodeIcon type="VECTOR_STORE" size={24} />;
+        }
         return <AIModelIcon type={codedata?.module} codedata={codedata} iconUrl={iconUrl} />;
     });
 }

--- a/packages/ballerina-visualizer/src/utils/bi.tsx
+++ b/packages/ballerina-visualizer/src/utils/bi.tsx
@@ -193,7 +193,7 @@ function applyGroupedChildIcons(group: PanelCategory, rawItems: any[], groupIcon
         const childNode = child as PanelNode;
         const codedata = childNode.metadata?.codedata;
         const childIconUrl: string | undefined = childNode.metadata?.metadata?.icon;
-        const hasClassIcon = Boolean(childIconUrl) && childIconUrl !== packageIconUrl;
+        const hasClassIcon = !groupIconFactory && Boolean(childIconUrl) && childIconUrl !== packageIconUrl;
         child.icon = hasClassIcon ? (
             resolveChildBadgeIcon(codedata, childIconUrl)
         ) : (
@@ -375,14 +375,14 @@ export function convertCategoriesToSidePanelCategoriesWithIcon(
 export function convertDataLoaderCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
     return convertCategoriesToSidePanelCategoriesWithIcon(categories, (codedata, iconUrl) => {
         if (iconUrl && codedata?.module !== "ai" && codedata?.module !== "ai.devant") return <img src={iconUrl} style={{ width: 24, height: 24 }} />;
-        return <NodeIcon type={codedata?.node} size={24} />;
+        return <NodeIcon type="DATA_LOADER" size={24} />;
     });
 }
 
 export function convertChunkerCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
     return convertCategoriesToSidePanelCategoriesWithIcon(categories, (codedata, iconUrl) => {
         if (iconUrl && codedata?.module !== "ai" && codedata?.module !== "ai.devant") return <img src={iconUrl} style={{ width: 24, height: 24 }} />;
-        return <NodeIcon type={codedata?.node} size={24} />;
+        return <NodeIcon type="CHUNKER" size={24} />;
     });
 }
 

--- a/packages/ballerina-visualizer/src/utils/bi.tsx
+++ b/packages/ballerina-visualizer/src/utils/bi.tsx
@@ -264,20 +264,9 @@ export function convertAgentCategoriesToSidePanelCategories(categories: Category
 }
 
 export function convertModelProviderCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
-    const panelCategories = categories.map((category) => convertDiagramCategoryToSidePanelCategory(category));
-    panelCategories.forEach((category, index) => {
-        category.items?.forEach((item) => {
-            if ((item as PanelNode).metadata?.codedata) {
-                const codedata = (item as PanelNode).metadata.codedata;
-                const iconUrl = (item as PanelNode)?.metadata?.metadata?.icon;
-                const iconType = codedata?.module == "ai" ? codedata.object : codedata?.module;
-                item.icon = <AIModelIcon type={iconType} codedata={codedata} iconUrl={iconUrl} />;
-            } else if ((item as PanelCategory).items) {
-                applyGroupedChildIcons(item as PanelCategory, categories[index]?.items as any[]);
-            }
-        });
-    });
-    return panelCategories;
+    return convertCategoriesToSidePanelCategoriesWithIcon(categories, (codedata, iconUrl) => (
+        <AIModelIcon type={codedata?.module === "ai" ? codedata.object : codedata?.module} codedata={codedata} iconUrl={iconUrl} />
+    ));
 }
 
 export function convertVectorStoreCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {

--- a/packages/ballerina-visualizer/src/utils/group-icons.test.tsx
+++ b/packages/ballerina-visualizer/src/utils/group-icons.test.tsx
@@ -23,7 +23,7 @@ jest.mock('@wso2/bi-diagram', () => ({
     AIModelIcon: (props: any) => ({ type: 'AIModelIcon', props }),
 }), { virtual: true });
 jest.mock('@wso2/ui-toolkit', () => ({
-    getAIModuleIcon: jest.fn(() => undefined),
+    getAIModuleIcon: jest.fn((): undefined => undefined),
 }), { virtual: true });
 
 import { NodeIcon, ConnectorIcon, AIModelIcon } from "@wso2/bi-diagram";

--- a/packages/ballerina-visualizer/src/utils/group-icons.test.tsx
+++ b/packages/ballerina-visualizer/src/utils/group-icons.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @wso2/bi-diagram and @wso2/ui-toolkit build to ESM, which jest can't parse here; stub with prop-echoing stand-ins.
+jest.mock('@wso2/bi-diagram', () => ({
+    NodeIcon: (props: any) => ({ type: 'NodeIcon', props }),
+    ConnectorIcon: (props: any) => ({ type: 'ConnectorIcon', props }),
+    AIModelIcon: (props: any) => ({ type: 'AIModelIcon', props }),
+}), { virtual: true });
+jest.mock('@wso2/ui-toolkit', () => ({
+    getAIModuleIcon: jest.fn(() => undefined),
+}), { virtual: true });
+
+import { NodeIcon, ConnectorIcon, AIModelIcon } from "@wso2/bi-diagram";
+import {
+    applyGroupedChildIcons,
+    chunkerIconFactory,
+    dataLoaderIconFactory,
+    getPackageKeyFromIconUrl,
+    shouldUseClassIcon,
+    vectorStoreIconFactory,
+} from "./group-icons";
+
+// Assertions inspect the returned element's `type`/`props` directly rather than rendering.
+
+describe("shouldUseClassIcon", () => {
+    it.each([
+        ["group has an icon factory (data loader/chunker/vector store/knowledge base)", true, "https://icons/a.png", "https://icons/pkg.png", false],
+        ["group has no icon factory (model/embedding provider) and child icon differs from package icon", false, "https://icons/a.png", "https://icons/pkg.png", true],
+        ["group has no icon factory but child icon matches the package icon", false, "https://icons/pkg.png", "https://icons/pkg.png", false],
+        ["group has no icon factory and the child has no icon", false, undefined, "https://icons/pkg.png", false],
+    ])("%s", (_name, hasGroupIconFactory, childIconUrl, packageIconUrl, expected) => {
+        expect(shouldUseClassIcon(hasGroupIconFactory, childIconUrl, packageIconUrl)).toBe(expected);
+    });
+});
+
+describe("getPackageKeyFromIconUrl", () => {
+    it.each([
+        ["well-formed central icon URL", "https://cdn/icons/wso2_ai.openai_1.2.0.png", "ai.openai"],
+        ["URL missing the version segment", "https://cdn/icons/wso2_ai.png", undefined],
+        ["undefined URL", undefined, undefined],
+    ])("%s", (_name, iconUrl, expected) => {
+        expect(getPackageKeyFromIconUrl(iconUrl)).toBe(expected);
+    });
+});
+
+describe("dataLoaderIconFactory", () => {
+    it("renders the package icon for a published data loader with an icon URL", () => {
+        const el: any = dataLoaderIconFactory({ module: "wso2/loader" }, "https://icons/loader.png");
+        expect(el.type).toBe("img");
+        expect(el.props.src).toBe("https://icons/loader.png");
+    });
+
+    it("falls back to the DATA_LOADER node icon for the built-in ai module", () => {
+        const el: any = dataLoaderIconFactory({ module: "ai" }, "https://icons/loader.png");
+        expect(el.type).toBe(NodeIcon);
+        expect(el.props.type).toBe("DATA_LOADER");
+    });
+
+    it("falls back to the DATA_LOADER node icon for the built-in ai.devant module", () => {
+        const el: any = dataLoaderIconFactory({ module: "ai.devant" }, "https://icons/loader.png");
+        expect(el.type).toBe(NodeIcon);
+        expect(el.props.type).toBe("DATA_LOADER");
+    });
+
+    it("falls back to the DATA_LOADER node icon when there is no icon URL", () => {
+        const el: any = dataLoaderIconFactory({ module: "wso2/loader" }, undefined);
+        expect(el.type).toBe(NodeIcon);
+        expect(el.props.type).toBe("DATA_LOADER");
+    });
+});
+
+describe("chunkerIconFactory", () => {
+    it("renders the package icon for a published chunker with an icon URL", () => {
+        const el: any = chunkerIconFactory({ module: "wso2/chunker" }, "https://icons/chunker.png");
+        expect(el.type).toBe("img");
+        expect(el.props.src).toBe("https://icons/chunker.png");
+    });
+
+    it("falls back to the CHUNKER node icon for the built-in ai module", () => {
+        const el: any = chunkerIconFactory({ module: "ai" }, "https://icons/chunker.png");
+        expect(el.type).toBe(NodeIcon);
+        expect(el.props.type).toBe("CHUNKER");
+    });
+
+    it("falls back to the CHUNKER node icon for the built-in ai.devant module", () => {
+        const el: any = chunkerIconFactory({ module: "ai.devant" }, "https://icons/chunker.png");
+        expect(el.type).toBe(NodeIcon);
+        expect(el.props.type).toBe("CHUNKER");
+    });
+
+    it("falls back to the CHUNKER node icon when there is no icon URL", () => {
+        const el: any = chunkerIconFactory({ module: "wso2/chunker" }, undefined);
+        expect(el.type).toBe(NodeIcon);
+        expect(el.props.type).toBe("CHUNKER");
+    });
+});
+
+describe("vectorStoreIconFactory", () => {
+    it("uses the VECTOR_STORE node icon for the built-in ai module", () => {
+        const el: any = vectorStoreIconFactory({ module: "ai" }, "https://icons/store.png");
+        expect(el.type).toBe(NodeIcon);
+        expect(el.props.type).toBe("VECTOR_STORE");
+    });
+
+    it("uses the per-class AI model icon for a non-built-in vector store", () => {
+        const el: any = vectorStoreIconFactory({ module: "wso2/pinecone" }, "https://icons/store.png");
+        expect(el.type).toBe(AIModelIcon);
+        expect(el.props.type).toBe("wso2/pinecone");
+    });
+});
+
+describe("applyGroupedChildIcons", () => {
+    const rawItems = [
+        { metadata: { label: "My Group", icon: "https://icons/pkg.png" } },
+    ];
+
+    it("gives the group its package icon when the catalog entry carries one", () => {
+        const group: any = { title: "My Group", items: [] };
+        applyGroupedChildIcons(group, rawItems);
+        expect(group.icon.type).toBe(ConnectorIcon);
+        expect(group.icon.props.url).toBe("https://icons/pkg.png");
+    });
+
+    it("falls back to the group icon factory when the catalog carries no package icon", () => {
+        const group: any = {
+            title: "My Group",
+            items: [{ id: "1", metadata: { codedata: { module: "ai" }, metadata: {} } }],
+        };
+        applyGroupedChildIcons(group, [{ metadata: { label: "My Group" } }], vectorStoreIconFactory);
+        expect(group.icon.type).toBe(NodeIcon);
+        expect(group.icon.props.type).toBe("VECTOR_STORE");
+    });
+
+    it("leaves the group icon unset when there is neither a package icon nor a group icon factory", () => {
+        const group: any = { title: "My Group", items: [] };
+        applyGroupedChildIcons(group, [{ metadata: { label: "My Group" } }]);
+        expect(group.icon).toBeUndefined();
+    });
+
+    it("gives a child its own class badge when the group has no icon factory (model/embedding provider)", () => {
+        const group: any = {
+            title: "My Group",
+            items: [
+                {
+                    id: "1",
+                    metadata: { codedata: { module: "wso2/openai", object: "OpenAiProvider" }, metadata: { icon: "https://icons/openai.png" } },
+                },
+            ],
+        };
+        applyGroupedChildIcons(group, rawItems);
+        const childIcon: any = group.items[0].icon;
+        expect(childIcon.type).toBe(ConnectorIcon);
+        expect(childIcon.props.url).toBe("https://icons/openai.png");
+    });
+
+    it("gives every child the plain node icon when the group has an icon factory (data loader/chunker/vector store/knowledge base)", () => {
+        const group: any = {
+            title: "My Group",
+            items: [
+                {
+                    id: "1",
+                    metadata: { codedata: { module: "wso2/loader", node: "DATA_LOADER_CALL" }, metadata: { icon: "https://icons/loader.png" } },
+                },
+            ],
+        };
+        applyGroupedChildIcons(group, rawItems, dataLoaderIconFactory);
+        const childIcon: any = group.items[0].icon;
+        expect(childIcon.type).toBe(NodeIcon);
+        expect(childIcon.props.type).toBe("DATA_LOADER_CALL");
+    });
+
+    it("gives a child the plain node icon when its icon URL matches the group's package icon", () => {
+        const group: any = {
+            title: "My Group",
+            items: [
+                {
+                    id: "1",
+                    metadata: { codedata: { module: "wso2/openai", node: "CLASS_INIT" }, metadata: { icon: "https://icons/pkg.png" } },
+                },
+            ],
+        };
+        applyGroupedChildIcons(group, rawItems);
+        const childIcon: any = group.items[0].icon;
+        expect(childIcon.type).toBe(NodeIcon);
+        expect(childIcon.props.type).toBe("CLASS_INIT");
+    });
+});

--- a/packages/ballerina-visualizer/src/utils/group-icons.tsx
+++ b/packages/ballerina-visualizer/src/utils/group-icons.tsx
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Icon-selection rules extracted from `bi.tsx` for unit testability; re-exported there.
+
+import * as React from "react";
+import { Category as PanelCategory, Node as PanelNode } from "@wso2/ballerina-side-panel";
+import { NodeIcon, ConnectorIcon, AIModelIcon } from "@wso2/bi-diagram";
+import { getAIModuleIcon } from "@wso2/ui-toolkit";
+
+export type IconFactory = (codedata: any, iconUrl?: string) => React.ReactElement;
+
+// Central icon URLs are `…/{org}_{package}_{version}.png`; the middle segment is the package key.
+export function getPackageKeyFromIconUrl(iconUrl?: string): string | undefined {
+    const fileName = iconUrl?.split("/").pop();
+    const parts = fileName?.split("_");
+    return parts && parts.length >= 3 ? parts[1] : undefined;
+}
+
+// Prefer the embedded provider SVG so monochrome logos stay visible in dark mode.
+export function resolveChildBadgeIcon(codedata: any, iconUrl?: string): React.ReactElement {
+    const embedded =
+        getAIModuleIcon(getPackageKeyFromIconUrl(iconUrl), 14) ?? getAIModuleIcon(codedata?.object, 14);
+    if (embedded) {
+        return embedded;
+    }
+    // Fall back to the node glyph: the URL is synthesised from package coordinates and 404s for unpublished packages.
+    return (
+        <ConnectorIcon
+            url={iconUrl}
+            style={{ width: "14px", height: "14px", fontSize: "14px" }}
+            codedata={codedata}
+            fallbackIcon={<NodeIcon type={codedata?.node} size={14} />}
+        />
+    );
+}
+
+// Class/provider badges are Model/Embedding Provider-only; other grouped lists use the plain node icon.
+export function shouldUseClassIcon(
+    hasGroupIconFactory: boolean,
+    childIconUrl: string | undefined,
+    packageIconUrl: string | undefined
+): boolean {
+    return !hasGroupIconFactory && Boolean(childIconUrl) && childIconUrl !== packageIconUrl;
+}
+
+export function dataLoaderIconFactory(codedata: any, iconUrl?: string): React.ReactElement {
+    if (iconUrl && codedata?.module !== "ai" && codedata?.module !== "ai.devant") {
+        return <img src={iconUrl} style={{ width: 24, height: 24 }} />;
+    }
+    return <NodeIcon type="DATA_LOADER" size={24} />;
+}
+
+export function chunkerIconFactory(codedata: any, iconUrl?: string): React.ReactElement {
+    if (iconUrl && codedata?.module !== "ai" && codedata?.module !== "ai.devant") {
+        return <img src={iconUrl} style={{ width: 24, height: 24 }} />;
+    }
+    return <NodeIcon type="CHUNKER" size={24} />;
+}
+
+export function vectorStoreIconFactory(codedata: any, iconUrl?: string): React.ReactElement {
+    if (codedata?.module === "ai") {
+        return <NodeIcon type="VECTOR_STORE" size={24} />;
+    }
+    return <AIModelIcon type={codedata?.module} codedata={codedata} iconUrl={iconUrl} />;
+}
+
+// Keeps the package icon on the group header and gives each child its own @display icon.
+export function applyGroupedChildIcons(group: PanelCategory, rawItems: any[], groupIconFactory?: IconFactory): void {
+    const rawGroup = rawItems?.find(
+        (r) => r && !("codedata" in r) && r.metadata?.label === group.title
+    );
+    const packageIconUrl: string | undefined = rawGroup?.metadata?.icon;
+    const firstChild = group.items?.at(0) as PanelNode | undefined;
+
+    if (packageIconUrl) {
+        group.icon = (
+            <ConnectorIcon url={packageIconUrl} style={{ width: "20px", height: "20px", fontSize: "20px" }} />
+        );
+    } else if (groupIconFactory) {
+        // No package icon, so the group falls back to its first child's — which needs the caller's fallback too.
+        group.icon = groupIconFactory(firstChild?.metadata?.codedata, firstChild?.metadata?.metadata?.icon);
+    }
+
+    group.items?.forEach((child) => {
+        const childNode = child as PanelNode;
+        const codedata = childNode.metadata?.codedata;
+        const childIconUrl: string | undefined = childNode.metadata?.metadata?.icon;
+        const hasClassIcon = shouldUseClassIcon(Boolean(groupIconFactory), childIconUrl, packageIconUrl);
+        child.icon = hasClassIcon ? (
+            resolveChildBadgeIcon(codedata, childIconUrl)
+        ) : (
+            <NodeIcon type={codedata?.node} size={14} />
+        );
+    });
+}

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
@@ -238,6 +238,7 @@ export function PanelManager(props: PanelManagerProps) {
         expandedGroupId,
         onExpandedGroupChange,
         onSearchAll,
+        onSearchModelProvider,
         onSearchVectorStore,
         onSearchEmbeddingProvider,
         onSearchVectorKnowledgeBase,
@@ -403,6 +404,7 @@ export function PanelManager(props: PanelManagerProps) {
                         onClose={onClose}
                         title={"Model Providers"}
                         searchPlaceholder={"Search model providers"}
+                        onSearchTextChange={(searchText) => onSearchModelProvider?.(searchText, FUNCTION_TYPE.REGULAR)}
                         searchText={searchText}
                         onBack={canGoBack ? onBack : undefined}
                     />

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -74,7 +74,7 @@ import { NodePosition, STNode } from "@wso2/syntax-tree";
 import { View, ProgressIndicator, ThemeColors } from "@wso2/ui-toolkit";
 import { applyModifications, textToModifications } from "../../../utils/utils";
 import { PanelManager, SidePanelView } from "./PanelManager";
-import { transformCategories, getNodeTemplateForConnection, findFunctionByName } from "./utils";
+import { transformCategories, getNodeTemplateForConnection, findFunctionByName, filterCategoriesLocally } from "./utils";
 import { PanelOverlayProvider } from "./context/PanelOverlayContext";
 import { PanelOverlayRenderer } from "./PanelOverlayRenderer";
 import { ExpressionFormField, Category as PanelCategory, S } from "@wso2/ballerina-side-panel";
@@ -1790,45 +1790,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             setShowProgressIndicator(false);
         }
     };
-
-    // Frontend filtering function for cached categories - handles nested structures
-    const filterCategoriesLocally = useCallback((categories: any[], searchText: string): any[] => {
-        if (!searchText.trim()) return categories;
-
-        const lowerSearchText = searchText.toLowerCase();
-
-        const filterItemsRecursively = (items: any[]): any[] => {
-            if (!items) return [];
-
-            return items.map((item: any) => {
-                // Check if this item matches the search
-                const label = item.title || item.label;
-                const itemMatches = label.toLowerCase().includes(lowerSearchText);
-                if (itemMatches) {
-                    return item;
-                }
-                // If this item has nested items (subcategory), recursively filter them
-                if (item.items && Array.isArray(item.items)) {
-                    const filteredSubItems = filterItemsRecursively(item.items);
-
-                    // Include this subcategory if it matches OR has matching nested items
-                    if (filteredSubItems.length > 0) {
-                        return {
-                            ...item,
-                            items: filteredSubItems
-                        };
-                    }
-                    return null; // Filter out this subcategory
-                }
-                return null;
-            }).filter(item => item !== null);
-        };
-
-        return categories.map(category => ({
-            ...category,
-            items: filterItemsRecursively(category.items || [])
-        })).filter(category => category.items && category.items.length > 0);
-    }, []);
 
     // Debounced search following AddConnectionPopupContent pattern
     const debouncedSearch = useMemo(

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -358,6 +358,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     // list) is up: once the toolkit variable is created, it is registered on this agent.
     const pendingDurableMcpAgentRef = useRef<{ agentVar: string | null; insertBefore: any } | null>(null);
     const initialCategoriesRef = useRef<any[]>([]);
+    const instanceListCategoriesRef = useRef<Partial<Record<SearchKind, PanelCategory[]>>>({});
     const showEditForm = useRef<boolean>(false);
     // True while the call form open is step 3 of the create-activity-from-connection wizard.
     const selectedNodeMetadata = useRef<{ nodeId: string; metadata: any; fileName: string }>();
@@ -613,7 +614,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 if (superseded()) {
                     return;
                 }
-                setCategories(convertModelProviderCategoriesToSidePanelCategories(response.categories as Category[]));
+                const modelProviderCategories = convertModelProviderCategoriesToSidePanelCategories(response.categories as Category[]);
+                instanceListCategoriesRef.current["MODEL_PROVIDER"] = modelProviderCategories;
+                setCategories(modelProviderCategories);
                 setSidePanelView(SidePanelView.MODEL_PROVIDER_LIST);
                 setShowSidePanel(true);
             } catch (error) {
@@ -642,9 +645,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 if (superseded()) {
                     return;
                 }
-                setCategories(
-                    convertVectorStoreCategoriesToSidePanelCategories(response.categories as Category[])
-                );
+                const vectorStoreCategories = convertVectorStoreCategoriesToSidePanelCategories(response.categories as Category[]);
+                instanceListCategoriesRef.current["VECTOR_STORE"] = vectorStoreCategories;
+                setCategories(vectorStoreCategories);
                 setSidePanelView(SidePanelView.VECTOR_STORE_LIST);
                 setShowSidePanel(true);
             } catch (error) {
@@ -673,9 +676,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 if (superseded()) {
                     return;
                 }
-                setCategories(
-                    convertEmbeddingProviderCategoriesToSidePanelCategories(response.categories as Category[])
-                );
+                const embeddingProviderCategories = convertEmbeddingProviderCategoriesToSidePanelCategories(response.categories as Category[]);
+                instanceListCategoriesRef.current["EMBEDDING_PROVIDER"] = embeddingProviderCategories;
+                setCategories(embeddingProviderCategories);
                 setSidePanelView(SidePanelView.EMBEDDING_PROVIDER_LIST);
                 setShowSidePanel(true);
             } catch (error) {
@@ -704,9 +707,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 if (superseded()) {
                     return;
                 }
-                setCategories(
-                    convertKnowledgeBaseCategoriesToSidePanelCategories(response.categories as Category[])
-                );
+                const knowledgeBaseCategories = convertKnowledgeBaseCategoriesToSidePanelCategories(response.categories as Category[]);
+                instanceListCategoriesRef.current["KNOWLEDGE_BASE"] = knowledgeBaseCategories;
+                setCategories(knowledgeBaseCategories);
                 setSidePanelView(SidePanelView.KNOWLEDGE_BASE_LIST);
                 setShowSidePanel(true);
             } catch (error) {
@@ -800,7 +803,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 if (superseded()) {
                     return;
                 }
-                setCategories(convertDataLoaderCategoriesToSidePanelCategories(response.categories as Category[]));
+                const dataLoaderCategories = convertDataLoaderCategoriesToSidePanelCategories(response.categories as Category[]);
+                instanceListCategoriesRef.current["DATA_LOADER"] = dataLoaderCategories;
+                setCategories(dataLoaderCategories);
                 setSidePanelView(SidePanelView.DATA_LOADER_LIST);
                 setShowSidePanel(true);
             } catch (error) {
@@ -825,7 +830,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     position: targetRef.current.startLine,
                     filePath: model?.fileName,
                 });
-                setCategories(convertChunkerCategoriesToSidePanelCategories(response.categories as Category[]));
+                const chunkerCategories = convertChunkerCategoriesToSidePanelCategories(response.categories as Category[]);
+                instanceListCategoriesRef.current["CHUNKER"] = chunkerCategories;
+                setCategories(chunkerCategories);
                 setSidePanelView(SidePanelView.CHUNKER_LIST);
                 setShowSidePanel(true);
             } catch (error) {
@@ -1746,28 +1753,32 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         await handleSearch(searchText, functionType, "ACTIVITY_CALL");
     };
 
-    const handleSearchModelProvider = async (_searchText: string, _functionType: FUNCTION_TYPE) => {
-        // await handleSearch(searchText, functionType, "MODEL_PROVIDER");
+    const searchInstanceList = (searchKind: SearchKind, searchText: string) => {
+        setCategories(filterCategoriesLocally(instanceListCategoriesRef.current[searchKind] ?? [], searchText));
     };
 
-    const handleSearchVectorStore = async (_searchText: string, _functionType: FUNCTION_TYPE) => {
-        // await handleSearch(searchText, functionType, "VECTOR_STORE");
+    const handleSearchModelProvider = async (searchText: string, _functionType: FUNCTION_TYPE) => {
+        searchInstanceList("MODEL_PROVIDER", searchText);
     };
 
-    const handleSearchEmbeddingProvider = async (_searchText: string, _functionType: FUNCTION_TYPE) => {
-        // await handleSearch(searchText, functionType, "EMBEDDING_PROVIDER");
+    const handleSearchVectorStore = async (searchText: string, _functionType: FUNCTION_TYPE) => {
+        searchInstanceList("VECTOR_STORE", searchText);
     };
 
-    const handleSearchVectorKnowledgeBase = async (_searchText: string, _functionType: FUNCTION_TYPE) => {
-        // await handleSearch(searchText, functionType, "KNOWLEDGE_BASE");
+    const handleSearchEmbeddingProvider = async (searchText: string, _functionType: FUNCTION_TYPE) => {
+        searchInstanceList("EMBEDDING_PROVIDER", searchText);
     };
 
-    const handleSearchDataLoader = async (_searchText: string, _functionType: FUNCTION_TYPE) => {
-        // await handleSearch(searchText, functionType, "DATA_LOADER");
+    const handleSearchVectorKnowledgeBase = async (searchText: string, _functionType: FUNCTION_TYPE) => {
+        searchInstanceList("KNOWLEDGE_BASE", searchText);
     };
 
-    const handleSearchChunker = async (_searchText: string, _functionType: FUNCTION_TYPE) => {
-        // await handleSearch(searchText, functionType, "CHUNKER");
+    const handleSearchDataLoader = async (searchText: string, _functionType: FUNCTION_TYPE) => {
+        searchInstanceList("DATA_LOADER", searchText);
+    };
+
+    const handleSearchChunker = async (searchText: string, _functionType: FUNCTION_TYPE) => {
+        searchInstanceList("CHUNKER", searchText);
     };
 
     const handleSearchTextChange = (text: string) => {
@@ -2294,12 +2305,12 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        setCategories(
-                            convertFunctionCategoriesToSidePanelCategories(
-                                response.categories as Category[],
-                                FUNCTION_TYPE.REGULAR
-                            )
+                        const modelProviderCategories = convertFunctionCategoriesToSidePanelCategories(
+                            response.categories as Category[],
+                            FUNCTION_TYPE.REGULAR
                         );
+                        instanceListCategoriesRef.current["MODEL_PROVIDER"] = modelProviderCategories;
+                        setCategories(modelProviderCategories);
                         setSidePanelView(SidePanelView.MODEL_PROVIDER_LIST);
                         setShowSidePanel(true);
                     })
@@ -2317,12 +2328,12 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        setCategories(
-                            convertFunctionCategoriesToSidePanelCategories(
-                                response.categories as Category[],
-                                FUNCTION_TYPE.REGULAR
-                            )
+                        const vectorStoreCategories = convertFunctionCategoriesToSidePanelCategories(
+                            response.categories as Category[],
+                            FUNCTION_TYPE.REGULAR
                         );
+                        instanceListCategoriesRef.current["VECTOR_STORE"] = vectorStoreCategories;
+                        setCategories(vectorStoreCategories);
                         setSidePanelView(SidePanelView.VECTOR_STORE_LIST);
                         setShowSidePanel(true);
                     })
@@ -2340,12 +2351,12 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        setCategories(
-                            convertFunctionCategoriesToSidePanelCategories(
-                                response.categories as Category[],
-                                FUNCTION_TYPE.REGULAR
-                            )
+                        const embeddingProviderCategories = convertFunctionCategoriesToSidePanelCategories(
+                            response.categories as Category[],
+                            FUNCTION_TYPE.REGULAR
                         );
+                        instanceListCategoriesRef.current["EMBEDDING_PROVIDER"] = embeddingProviderCategories;
+                        setCategories(embeddingProviderCategories);
                         setSidePanelView(SidePanelView.EMBEDDING_PROVIDER_LIST);
                         setShowSidePanel(true);
                     })
@@ -2363,9 +2374,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        setCategories(
-                            convertKnowledgeBaseCategoriesToSidePanelCategories(response.categories as Category[])
-                        );
+                        const knowledgeBaseCategories = convertKnowledgeBaseCategoriesToSidePanelCategories(response.categories as Category[]);
+                        instanceListCategoriesRef.current["KNOWLEDGE_BASE"] = knowledgeBaseCategories;
+                        setCategories(knowledgeBaseCategories);
                         setSidePanelView(SidePanelView.KNOWLEDGE_BASE_LIST);
                         setShowSidePanel(true);
                     })
@@ -2383,7 +2394,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        setCategories(convertDataLoaderCategoriesToSidePanelCategories(response.categories as Category[]));
+                        const dataLoaderCategories = convertDataLoaderCategoriesToSidePanelCategories(response.categories as Category[]);
+                        instanceListCategoriesRef.current["DATA_LOADER"] = dataLoaderCategories;
+                        setCategories(dataLoaderCategories);
                         setSidePanelView(SidePanelView.DATA_LOADER_LIST);
                         setShowSidePanel(true);
                     })
@@ -2401,7 +2414,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        setCategories(convertChunkerCategoriesToSidePanelCategories(response.categories as Category[]));
+                        const chunkerCategories = convertChunkerCategoriesToSidePanelCategories(response.categories as Category[]);
+                        instanceListCategoriesRef.current["CHUNKER"] = chunkerCategories;
+                        setCategories(chunkerCategories);
                         setSidePanelView(SidePanelView.CHUNKER_LIST);
                         setShowSidePanel(true);
                     })

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -2305,9 +2305,8 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        const modelProviderCategories = convertFunctionCategoriesToSidePanelCategories(
-                            response.categories as Category[],
-                            FUNCTION_TYPE.REGULAR
+                        const modelProviderCategories = convertModelProviderCategoriesToSidePanelCategories(
+                            response.categories as Category[]
                         );
                         instanceListCategoriesRef.current["MODEL_PROVIDER"] = modelProviderCategories;
                         setCategories(modelProviderCategories);
@@ -2328,9 +2327,8 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        const vectorStoreCategories = convertFunctionCategoriesToSidePanelCategories(
-                            response.categories as Category[],
-                            FUNCTION_TYPE.REGULAR
+                        const vectorStoreCategories = convertVectorStoreCategoriesToSidePanelCategories(
+                            response.categories as Category[]
                         );
                         instanceListCategoriesRef.current["VECTOR_STORE"] = vectorStoreCategories;
                         setCategories(vectorStoreCategories);
@@ -2351,9 +2349,8 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        const embeddingProviderCategories = convertFunctionCategoriesToSidePanelCategories(
-                            response.categories as Category[],
-                            FUNCTION_TYPE.REGULAR
+                        const embeddingProviderCategories = convertEmbeddingProviderCategoriesToSidePanelCategories(
+                            response.categories as Category[]
                         );
                         instanceListCategoriesRef.current["EMBEDDING_PROVIDER"] = embeddingProviderCategories;
                         setCategories(embeddingProviderCategories);

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/utils.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/utils.test.ts
@@ -19,7 +19,7 @@
 import { filterCategoriesLocally } from "./utils";
 
 describe("filterCategoriesLocally", () => {
-    const categories = [
+    const categories: any[] = [
         {
             title: "Model Providers",
             items: [

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/utils.test.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/utils.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { filterCategoriesLocally } from "./utils";
+
+describe("filterCategoriesLocally", () => {
+    const categories = [
+        {
+            title: "Model Providers",
+            items: [
+                { title: "OpenAI GPT-4", items: undefined },
+                { title: "Anthropic Claude", items: undefined },
+                {
+                    title: "Azure OpenAI",
+                    items: [
+                        { title: "gpt-35-instance-1", items: undefined },
+                        { title: "gpt-35-instance-2", items: undefined },
+                    ],
+                },
+            ],
+        },
+        {
+            title: "Vector Stores",
+            items: [{ title: "Pinecone Store", items: undefined }],
+        },
+    ];
+
+    it("returns the categories unchanged for an empty query", () => {
+        expect(filterCategoriesLocally(categories, "")).toEqual(categories);
+    });
+
+    it("returns the categories unchanged for a whitespace-only query", () => {
+        expect(filterCategoriesLocally(categories, "   ")).toEqual(categories);
+    });
+
+    it("matches case-insensitively on a top-level item's title", () => {
+        const result = filterCategoriesLocally(categories, "anthropic");
+        expect(result).toHaveLength(1);
+        expect(result[0].title).toBe("Model Providers");
+        expect(result[0].items.map((i: any) => i.title)).toEqual(["Anthropic Claude"]);
+    });
+
+    it("keeps a nested match's parent group with only the matching child", () => {
+        const result = filterCategoriesLocally(categories, "gpt-35-instance-1");
+        expect(result).toHaveLength(1);
+        const azure = result[0].items.find((i: any) => i.title === "Azure OpenAI");
+        expect(azure.items.map((i: any) => i.title)).toEqual(["gpt-35-instance-1"]);
+    });
+
+    it("drops a category with no matches anywhere in its subtree", () => {
+        const result = filterCategoriesLocally(categories, "pinecone");
+        expect(result.map((c: any) => c.title)).toEqual(["Vector Stores"]);
+    });
+
+    it("returns no categories for a query that matches nothing", () => {
+        expect(filterCategoriesLocally(categories, "does-not-exist")).toEqual([]);
+    });
+
+    it("re-filters correctly on a repeated (unchanged) query against the same input", () => {
+        const first = filterCategoriesLocally(categories, "azure");
+        const second = filterCategoriesLocally(categories, "azure");
+        expect(second).toEqual(first);
+    });
+
+    it("does not mutate the input categories", () => {
+        const before = JSON.parse(JSON.stringify(categories));
+        filterCategoriesLocally(categories, "gpt-35-instance-1");
+        expect(categories).toEqual(before);
+    });
+});

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/utils.ts
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/utils.ts
@@ -71,6 +71,45 @@ export const transformCategories = (categories: Category[]): Category[] => {
     return filteredCategories;
 };
 
+// Filters cached categories client-side, recursing into nested items so a matching child keeps its parent group.
+export const filterCategoriesLocally = (categories: any[], searchText: string): any[] => {
+    if (!searchText.trim()) return categories;
+
+    const lowerSearchText = searchText.toLowerCase();
+
+    const filterItemsRecursively = (items: any[]): any[] => {
+        if (!items) return [];
+
+        return items.map((item: any) => {
+            // Check if this item matches the search
+            const label = item.title || item.label;
+            const itemMatches = label.toLowerCase().includes(lowerSearchText);
+            if (itemMatches) {
+                return item;
+            }
+            // If this item has nested items (subcategory), recursively filter them
+            if (item.items && Array.isArray(item.items)) {
+                const filteredSubItems = filterItemsRecursively(item.items);
+
+                // Include this subcategory if it matches OR has matching nested items
+                if (filteredSubItems.length > 0) {
+                    return {
+                        ...item,
+                        items: filteredSubItems
+                    };
+                }
+                return null; // Filter out this subcategory
+            }
+            return null;
+        }).filter(item => item !== null);
+    };
+
+    return categories.map(category => ({
+        ...category,
+        items: filterItemsRecursively(category.items || [])
+    })).filter(category => category.items && category.items.length > 0);
+};
+
 export const findFunctionByName = (components: BallerinaProjectComponents, functionName: string) => {
     for (const pkg of components.packages) {
         for (const module of pkg.modules) {


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/2241

https://github.com/user-attachments/assets/bffdfa3f-e4c8-4236-8e68-4f31b0fd7f14

## Summary
- Searching in the "Data Loaders" instance-list panel (and the same panel for model providers, vector stores, embedding providers, knowledge bases, chunkers) hung on an infinite loading skeleton — the search handler was wired to a stubbed-out no-op with the actual RPC call commented out.
- Wiring it up surfaced a second bug: the shared `search` RPC used there queries the add-new catalog (available types to install), not the project's already-configured instances, so search returned catalog entries instead of the instance being searched for. Search now filters a locally cached copy of the fetched instance list instead of calling that RPC.
- The data loader/chunker group icon fell back to a generic method-call icon for built-in `ballerina/ai` module instances instead of a proper data loader/chunker icon.
- A per-class provider badge icon (intended only for Model/Embedding Provider groups, which can contain multiple provider classes) was being applied to every grouped instance list's action icons, incorrectly replacing the plain action icon on data loaders, chunkers, knowledge bases, and vector stores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Fix instance-list search by filtering cached project instances locally.
- Prevent infinite loading and return configured project instances in search results.
- Correct built-in `ballerina/ai` icons for Data Loader, Chunker, and Vector Store instances.
- Restrict provider badge icons to Model Provider and Embedding Provider groups.
- Use category-specific converters when initializing supported panels.
- Add unit tests for local filtering and icon selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->