### PR TITLE
Fix model provider form: quoted placeholder shown as selected Model Type

### DIFF
--- a/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/EnumEditor/EnumEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/EnumEditor/EnumEditor.tsx
@@ -18,6 +18,7 @@
 
 import { Dropdown, OptionProps } from "@wso2/ui-toolkit";
 import React, { ChangeEvent, useMemo } from "react"
+import { unwrapBallerinaString } from "@wso2/ballerina-core";
 import { FormField } from "../../../Form/types";
 
 interface EnumEditorProps {
@@ -33,17 +34,20 @@ export const EnumEditor = (props: EnumEditorProps) => {
     // Ensure value is in items, otherwise use first item's value
     const itemsList = useMemo(() => {
         const baseItems = props.items.length > 0 ? props.items : (props.field.itemOptions ?? []);
+        // A placeholder only describes an empty selection on an optional field (e.g. "(default)").
+        // On a required one it is a sample value, and would read as a selection the form does not have.
+        const noneContent = props.field.optional
+            ? unwrapBallerinaString(props.field.placeholder?.toString()) || "No Selection"
+            : "No Selection";
         return [
             ...baseItems,
             {
                 id: "default-option",
-                // A field-provided placeholder (e.g. "(default)") describes what an empty
-                // selection means; fall back to the generic label otherwise.
-                content: props.field.placeholder?.toString() || "No Selection",
+                content: noneContent,
                 value: DEFAULT_NONE_SELECTED_VALUE
             }
         ];
-    }, [props.items, props.field.itemOptions]);
+    }, [props.items, props.field.itemOptions, props.field.placeholder, props.field.optional]);
 
     const selectedValue = useMemo(() => {
         if (props.value === undefined || props.value === null || props.value === "") {


### PR DESCRIPTION
## Summary
Model Type (and other required-select fields with no default) showed a quoted sample value like `"claude-3-haiku-20240307"` instead of "No Selection", and didn't match any real option — so the required-field check failed and Save stayed disabled until the user manually reselected a value.

`EnumEditor` was treating the field's `placeholder` (a sample value for required fields) the same as an optional field's "no selection" description. Now it only uses the placeholder text for optional fields, and unwraps it.

Fixes https://github.com/wso2/product-integrator/issues/2377

https://github.com/user-attachments/assets/2b4bdf31-bcff-4482-9c62-8887579e66d1

## Test plan
- [ ] Open a Model Provider form (e.g. Anthropic) and confirm Model Type shows "No Selection" until a value is picked
- [ ] Confirm Save is disabled until a real selection is made, and enables correctly once one is picked
- [ ] Confirm optional select fields with a placeholder description (e.g. "(default)") still show that text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated model provider select fields to distinguish sample placeholders from valid selections. Required fields now display “No Selection” until the user selects a valid option, while optional fields retain decoded placeholder descriptions such as “(default)”. This restores correct validation and enables Save after a valid selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->