### PR TITLE
Fix ParameterBranch test broken by optionality helpers moving to core

### DIFF
--- a/packages/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/ParameterBranch.test.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/ParameterBranch.test.tsx
@@ -29,9 +29,15 @@ import { act } from "react-dom/test-utils";
 import { TypeField } from "@wso2/ballerina-core";
 import { loadFixture } from "@wso2/test-config/fixtures";
 
-// The core barrel pulls in ESM-only LS transport modules that jest cannot load. `keywords` (read
-// by utils/getFieldName to escape reserved field names) is all this tree needs from it.
-jest.mock("@wso2/ballerina-core", () => ({ __esModule: true, keywords: [] as string[] }));
+// The core barrel pulls in ESM-only LS transport modules that jest cannot load, so only what this
+// tree reads from it is stubbed: `keywords` (utils/getFieldName escapes reserved field names) and
+// the optionality helpers, taken from their real leaf module so the required/optional split under
+// test is the shipped one.
+jest.mock("@wso2/ballerina-core", () => ({
+    __esModule: true,
+    keywords: [] as string[],
+    ...jest.requireActual("@wso2/ballerina-core/lib/utils/optionality-utils"),
+}));
 
 // Stubbed so the assertions read the rendered labels, not a toolkit abstraction over them.
 jest.mock("@wso2/ui-toolkit", () => ({


### PR DESCRIPTION
`ParameterBranch.test.tsx` fails on `staging/5.14.0` with `TypeError: (0 , utils_1.isOptionalParam) is not a function`, taking down the Fast tests job for every PR that touches this package's dependency graph (seen on #1047, which is unrelated to this code).

## Cause

A semantic conflict between two independently-green PRs:

- **Sep 1, `2e4e31c232` (#976)** added `ParameterBranch.test.tsx`, which mocks the core barrel as `{ __esModule: true, keywords: [] }`.
- **Sep 2, `e7d26e18b4`** moved `isOptionalParam`/`getOptionalityLabel` into `@wso2/ballerina-core`, leaving `RecordConstructView/utils/index.tsx:24` a bare re-export.

`ParameterBranch.tsx` imports `isOptionalParam` from `./utils`, which now just re-exports it from the mocked package. The mock doesn't provide it, so the binding is `undefined`.

Neither PR's CI could catch it: the test passed before the move, and the move touched no file the test mocked.

## Fix

Pull the real helpers into the mock from their leaf module, which is free of the ESM-only LS transport imports that forced the barrel mock in the first place. Using the real implementation rather than a stub keeps the required/optional split the test asserts on tied to the shipped behaviour. Depending on core's built `lib/` is what `jest.config.js` already documents for this package.

## Testing

`npx jest` in `ballerina-visualizer`: 38 suites / 555 tests pass, was 3 failed / 552 passed.

Note: `npm run test:typecheck` reports 11 pre-existing `Type 'Timeout' is not assignable to type 'number'` errors in unrelated files. Untouched here — the CI type-check step is skipped when jest fails, so it is unverified whether those also fail on the runner.

## Follow-up

`HelperView/ConfigurePanel/utils/index.tsx` and `statement-editor/.../ParameterTree/utils/index.tsx` have the same re-export shape; neither has a test mocking the core barrel today, so neither is broken, but both would hit the identical trap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed `ParameterBranch.test.tsx` by using the real optionality helpers from `@wso2/ballerina-core/lib/utils/optionality-utils`.
- Preserved required and optional field behavior in the test mock.
- Confirmed that 38 Jest suites and 555 tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->