### PR TITLE
Fix array-typed and unsupported-type configurable handling in Config.toml

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -191,7 +191,7 @@ ${getLanglibInstructions()}
 
 ## Code Structure
 - In WSO2 Integrator, Automation is simply an app with a main method unless user specifically mentions a service. Cron Job kind of requirements are handled in the deployment level for Kubernetes or Integration platform level.
-- Define required configurables for the query. Use only string, int, decimal, boolean types in configurable variables. Never assign hardcoded default values to configurables.
+- Define required configurables for the query. Use only string, int, byte, float, decimal, boolean types (or arrays of them) in configurable variables — never a langlib-qualified numeric subtype, even if a connector's client method parameter uses one; those are not supported as configurable types and fail at runtime. Widen to the base type and cast when calling the client. Never assign hardcoded default values to configurables.
 - Initialize any necessary clients with the correct configuration based on the retrieved libraries at the module level (before any function or service declarations).
 - Implement the main function OR service to address the query requirements.
 

--- a/packages/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -33,6 +33,9 @@ import {
     renameConfigKeys,
     isPlaceholderValue,
     computeCollectStatus,
+    stripTypeDecorations,
+    isArrayType,
+    arrayElementType,
 } from "../../../../utils/toml-utils";
 import { ManagedConnectionGroup } from "@wso2/ballerina-core/lib/state-machine-types";
 import { RecoverableAgentError, resolveContained, resolvePackageBasePath } from "./path-utils";
@@ -688,8 +691,48 @@ async function handleCollectMode(
         );
     }
 
+    // int:Signed8/16/32/64 and int:Unsigned8/16/32 compile but fail as configurables at runtime.
+    const UNSUPPORTED_INT_SUBTYPE = /^int:(Un)?signed(8|16|32|64)$/i;
+    const unsupportedTypeVars = variables.filter(v => {
+        const type = stripTypeDecorations(sourceTypes[v.name]);
+        return UNSUPPORTED_INT_SUBTYPE.test(isArrayType(type) ? arrayElementType(type) : type);
+    });
+    if (unsupportedTypeVars.length > 0) {
+        return createErrorResult(
+            "UNSUPPORTED_CONFIGURABLE_TYPE",
+            `${unsupportedTypeVars.map(v => `'${v.name}' (${sourceTypes[v.name]})`).join(", ")} ` +
+            `${unsupportedTypeVars.length > 1 ? "declare" : "declares"} a langlib-qualified int subtype, which Ballerina does not support for ` +
+            `configurable variables. Widen the declaration to 'int' (casting when calling the client), save, then retry.`
+        );
+    }
+
+    // Arrays are only collected as a flat, comma-separated list of scalars — an array of any other
+    // element type (record, map, json, ...) would silently be written as an array of strings instead
+    // of the shape Ballerina's config loader actually expects, and fail later with no clear cause.
+    const SUPPORTED_ARRAY_ELEMENT_TYPES = new Set(["string", "int", "byte", "decimal", "float", "boolean"]);
+    const unsupportedArrayVars = variables.filter(v => {
+        const type = stripTypeDecorations(sourceTypes[v.name]);
+        return isArrayType(type) && !SUPPORTED_ARRAY_ELEMENT_TYPES.has(arrayElementType(type));
+    });
+    if (unsupportedArrayVars.length > 0) {
+        return createErrorResult(
+            "UNSUPPORTED_CONFIGURABLE_TYPE",
+            `${unsupportedArrayVars.map(v => `'${v.name}' (${sourceTypes[v.name]})`).join(", ")} ` +
+            `${unsupportedArrayVars.length > 1 ? "declare" : "declares"} an array of a type this tool cannot collect as a scalar list ` +
+            `(only string[], int[], byte[], decimal[]/float[], and boolean[] are supported). Widen or restructure the configurable, save, then retry.`
+        );
+    }
+
     // Enrich variables with LS-derived types so the writer uses the correct type.
     const enrichedVariables: ConfigVariable[] = variables.map(v => ({ ...v, type: sourceTypes[v.name] }));
+
+    // All configurables in source, so the writer's repair pass knows the type of a key already on
+    // disk that this round didn't resubmit.
+    const allSourceVariables: ConfigVariable[] = Object.entries(sourceTypes).map(([name, type]) => ({
+        name,
+        description: "",
+        type,
+    }));
 
     // Determine paths based on isTestConfig flag
     const configPath = getConfigPath(packageBasePath, isTestConfig);
@@ -772,7 +815,7 @@ async function handleCollectMode(
     const preservedCount = notProvided.length - skippedNew.length;
     console.log(`[ConfigCollector] collect saved=${providedCount} skippedNew=${skippedNew.length} preserved=${preservedCount} requested=${enrichedVariables.length} file=${configFileName}`);
 
-    writeConfigValuesToConfig(configPath, provided, enrichedVariables, orgName, packageName);
+    writeConfigValuesToConfig(configPath, provided, [...enrichedVariables, ...allSourceVariables], orgName, packageName);
 
     // Track modified file for syncing to workspace.
     // Path is relative to tempProjectPath, so prefix with packagePath for workspace projects.

--- a/packages/ballerina-extension/src/test-support/tomlUtils.test.ts
+++ b/packages/ballerina-extension/src/test-support/tomlUtils.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { parse } from "@iarna/toml";
+
+import {
+    ConfigVariable,
+    getAllConfigStatus,
+    readExistingConfigValues,
+    writeConfigValuesToConfig,
+} from "../utils/toml-utils";
+
+const ORG = "myorg";
+const PKG = "mypkg";
+
+let configPath: string;
+
+beforeEach(() => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "toml-utils-"));
+    configPath = path.join(dir, "Config.toml");
+});
+
+afterEach(() => {
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+});
+
+function readSection(): Record<string, unknown> {
+    const parsed = parse(fs.readFileSync(configPath, "utf-8")) as Record<string, any>;
+    return parsed[ORG][PKG];
+}
+
+describe("writeConfigValuesToConfig — numeric repair covers the whole section", () => {
+    const variables: ConfigVariable[] = [
+        { name: "tiny", description: "", type: "float" },
+        { name: "port", description: "", type: "int" },
+        { name: "other", description: "", type: "string" },
+    ];
+
+    it("REGRESSION: a numeric key already on disk survives a write that doesn't resubmit it", () => {
+        writeConfigValuesToConfig(configPath, { tiny: "1e-7", port: "8080" }, variables, ORG, PKG);
+
+        // Second write only resubmits an unrelated key — tiny/port are not in `configValues`.
+        writeConfigValuesToConfig(configPath, { other: "5" }, variables, ORG, PKG);
+
+        const raw = fs.readFileSync(configPath, "utf-8");
+        // Must still be parseable — a corrupted token like "1e-7.0" is invalid TOML.
+        expect(() => parse(raw)).not.toThrow();
+
+        const section = readSection();
+        expect(section.tiny).toBe(1e-7);
+        expect(section.port).toBe(8080);
+        expect(section.other).toBe("5");
+        // No underscore digit-grouping in the written text — Ballerina rejects it.
+        expect(raw).not.toMatch(/\d_\d/);
+    });
+
+    it("keeps a numeric array already on disk intact across an unrelated write", () => {
+        const arrVars: ConfigVariable[] = [
+            { name: "ports", description: "", type: "int[]" },
+            { name: "other", description: "", type: "string" },
+        ];
+        writeConfigValuesToConfig(configPath, { ports: "8080, 9090" }, arrVars, ORG, PKG);
+        writeConfigValuesToConfig(configPath, { other: "5" }, arrVars, ORG, PKG);
+
+        const section = readSection();
+        expect(section.ports).toEqual([8080, 9090]);
+    });
+});
+
+describe("writeConfigValuesToConfig — integral float/decimal values", () => {
+    it("keeps a decimal point on a whole-number float scalar", () => {
+        const variables: ConfigVariable[] = [{ name: "rate", description: "", type: "float" }];
+        writeConfigValuesToConfig(configPath, { rate: "1.0" }, variables, ORG, PKG);
+
+        const raw = fs.readFileSync(configPath, "utf-8");
+        expect(raw).toMatch(/rate\s*=\s*1\.0/);
+        expect(parse(raw) as any).toBeDefined();
+    });
+
+    it("keeps a decimal point on whole-number decimal array elements", () => {
+        const variables: ConfigVariable[] = [{ name: "rates", description: "", type: "decimal[]" }];
+        writeConfigValuesToConfig(configPath, { rates: "1.0, 2.5, 3.0" }, variables, ORG, PKG);
+
+        const raw = fs.readFileSync(configPath, "utf-8");
+        expect(raw).toMatch(/rates\s*=\s*\[\s*1\.0,\s*2\.5,\s*3\.0\s*\]/);
+    });
+
+    it("does not add a decimal point to plain int values", () => {
+        const variables: ConfigVariable[] = [{ name: "port", description: "", type: "int" }];
+        writeConfigValuesToConfig(configPath, { port: "8080" }, variables, ORG, PKG);
+
+        const raw = fs.readFileSync(configPath, "utf-8");
+        expect(raw).toMatch(/port\s*=\s*8080\s*$/m);
+    });
+});
+
+describe("writeConfigValuesToConfig — byte range", () => {
+    it("accepts a byte value within 0-255", () => {
+        const variables: ConfigVariable[] = [{ name: "flags", description: "", type: "byte" }];
+        writeConfigValuesToConfig(configPath, { flags: "255" }, variables, ORG, PKG);
+
+        expect(readSection().flags).toBe(255);
+    });
+
+    it("rejects a byte scalar value outside 0-255", () => {
+        const variables: ConfigVariable[] = [{ name: "flags", description: "", type: "byte" }];
+        expect(() =>
+            writeConfigValuesToConfig(configPath, { flags: "256" }, variables, ORG, PKG)
+        ).toThrow(/byte value/i);
+    });
+
+    it("rejects a byte array element outside 0-255", () => {
+        const variables: ConfigVariable[] = [{ name: "flags", description: "", type: "byte[]" }];
+        expect(() =>
+            writeConfigValuesToConfig(configPath, { flags: "10, 300" }, variables, ORG, PKG)
+        ).toThrow(/byte value/i);
+    });
+
+    it("does not restrict plain int values to the byte range", () => {
+        const variables: ConfigVariable[] = [{ name: "port", description: "", type: "int" }];
+        writeConfigValuesToConfig(configPath, { port: "8080" }, variables, ORG, PKG);
+
+        expect(readSection().port).toBe(8080);
+    });
+});
+
+describe("writeConfigValuesToConfig — malformed decimal tokens", () => {
+    it("rejects a numeric-prefixed non-numeric scalar (parseFloat would silently truncate it)", () => {
+        const variables: ConfigVariable[] = [{ name: "timeout", description: "", type: "float" }];
+        expect(() =>
+            writeConfigValuesToConfig(configPath, { timeout: "12ms" }, variables, ORG, PKG)
+        ).toThrow(/invalid decimal value/i);
+    });
+
+    it("rejects a numeric-prefixed non-numeric array element", () => {
+        const variables: ConfigVariable[] = [{ name: "timeouts", description: "", type: "decimal[]" }];
+        expect(() =>
+            writeConfigValuesToConfig(configPath, { timeouts: "1.5, 12ms" }, variables, ORG, PKG)
+        ).toThrow(/invalid decimal value/i);
+    });
+
+    it("still accepts valid exponent-notation decimals", () => {
+        const variables: ConfigVariable[] = [{ name: "tiny", description: "", type: "float" }];
+        writeConfigValuesToConfig(configPath, { tiny: "1e-7" }, variables, ORG, PKG);
+
+        expect(readSection().tiny).toBe(1e-7);
+    });
+});
+
+describe("readExistingConfigValues — boolean values", () => {
+    it("returns 'false' for a configurable boolean explicitly set to false", () => {
+        const variables: ConfigVariable[] = [{ name: "flag", description: "", type: "boolean" }];
+        writeConfigValuesToConfig(configPath, { flag: "false" }, variables, ORG, PKG);
+
+        const existing = readExistingConfigValues(configPath, ["flag"], ORG, PKG);
+        expect(existing.flag).toBe("false");
+    });
+
+    it("returns 'true' for a configurable boolean set to true", () => {
+        const variables: ConfigVariable[] = [{ name: "flag", description: "", type: "boolean" }];
+        writeConfigValuesToConfig(configPath, { flag: "true" }, variables, ORG, PKG);
+
+        const existing = readExistingConfigValues(configPath, ["flag"], ORG, PKG);
+        expect(existing.flag).toBe("true");
+    });
+});
+
+describe("getAllConfigStatus — agrees with readExistingConfigValues for booleans", () => {
+    it("reports a false boolean as filled, not missing", () => {
+        const variables: ConfigVariable[] = [{ name: "flag", description: "", type: "boolean" }];
+        writeConfigValuesToConfig(configPath, { flag: "false" }, variables, ORG, PKG);
+
+        const status = getAllConfigStatus(configPath, ORG, PKG);
+        expect(status.flag).toBe("filled");
+    });
+});

--- a/packages/ballerina-extension/src/utils/toml-utils.ts
+++ b/packages/ballerina-extension/src/utils/toml-utils.ts
@@ -29,6 +29,241 @@ export function isPlaceholderValue(value: string | undefined | null): boolean {
     return typeof value === "string" && /^\$\{[^}]+\}$/.test(value);
 }
 
+// Strips '& readonly' and a trailing '?' so e.g. "string[] & readonly" reduces to "string[]".
+export function stripTypeDecorations(type: string): string {
+    return type.replace(/&\s*readonly/g, "").replace(/\?\s*$/, "").trim();
+}
+
+// Matches an array type suffix, fixed-length or not: "[]", "[2]", "[10]", ... (Ballerina supports
+// fixed-length array configurables, e.g. `configurable string[2] items = ?;`).
+const ARRAY_TYPE_SUFFIX = /\[\d*\]\s*$/;
+
+export function isArrayType(type: string): boolean {
+    return ARRAY_TYPE_SUFFIX.test(type);
+}
+
+// Declared size of a fixed-length array type (e.g. "string[2]" -> 2); undefined for "string[]".
+export function fixedArrayLength(type: string): number | undefined {
+    const match = type.match(/\[(\d+)\]\s*$/);
+    return match ? parseInt(match[1], 10) : undefined;
+}
+
+export function arrayElementType(type: string): string {
+    return type.replace(ARRAY_TYPE_SUFFIX, "").trim();
+}
+
+// True if a comma exists at the top level (outside quotes, outside nested brackets/braces). A
+// quote only opens at an element boundary, so a mid-word apostrophe (e.g. "Bob's") can't swallow
+// the rest of the string; depth is clamped at 0 so an unbalanced closing bracket can't either.
+function hasTopLevelComma(value: string): boolean {
+    let depth = 0;
+    let quote: string | null = null;
+    let isEscaped = false;
+    let atBoundary = true;
+    for (const char of value) {
+        if (quote) {
+            if (isEscaped) {
+                isEscaped = false;
+            } else if (char === "\\") {
+                isEscaped = true;
+            } else if (char === quote) {
+                quote = null;
+            }
+            continue;
+        }
+        if ((char === "\"" || char === "'") && atBoundary) {
+            quote = char;
+            continue;
+        }
+        if (char === "[" || char === "{") {
+            depth++;
+        } else if (char === "]" || char === "}") {
+            depth = Math.max(0, depth - 1);
+        } else if (depth === 0 && char === ",") {
+            return true;
+        }
+        atBoundary = /\s/.test(char);
+    }
+    return false;
+}
+
+// Splits on top-level occurrences of a separator character, never inside a quoted element or a
+// nested array/inline-table. Same boundary-gated quoting and depth clamp as hasTopLevelComma.
+function tokenizeTopLevel(value: string, isSeparator: (char: string) => boolean): string[] {
+    const values: string[] = [];
+    let current = "";
+    let depth = 0;
+    let quote: string | null = null;
+    let isEscaped = false;
+    let atBoundary = true;
+
+    const pushCurrent = () => {
+        const trimmed = current.trim();
+        if (trimmed.length > 0) {
+            values.push(trimmed);
+        }
+        current = "";
+        atBoundary = true;
+    };
+
+    for (const char of value) {
+        if (quote) {
+            current += char;
+            if (isEscaped) {
+                isEscaped = false;
+            } else if (char === "\\") {
+                isEscaped = true;
+            } else if (char === quote) {
+                quote = null;
+            }
+            continue;
+        }
+        if ((char === "\"" || char === "'") && atBoundary) {
+            quote = char;
+            current += char;
+            continue;
+        }
+        if (char === "[" || char === "{") {
+            depth++;
+        } else if (char === "]" || char === "}") {
+            depth = Math.max(0, depth - 1);
+        }
+        if (depth === 0 && isSeparator(char)) {
+            pushCurrent();
+        } else {
+            current += char;
+            if (!/\s/.test(char)) {
+                atBoundary = false;
+            }
+        }
+    }
+    pushCurrent();
+    return values;
+}
+
+// Splits an array literal's elements: on commas if any exist at the top level, else on
+// whitespace. Either way, a quoted element (e.g. "New York") is never split on its own internal
+// characters — quote an element to protect an internal space from being treated as a separator.
+function splitArrayElements(value: string): string[] {
+    const isSeparator = hasTopLevelComma(value) ? (c: string) => c === "," : (c: string) => /\s/.test(c);
+    return tokenizeTopLevel(value, isSeparator);
+}
+
+// Decodes TOML basic-string escapes (\" \\ \n \t \r \b \f). Only meaningful for a value that was
+// actually double-quote-delimited — a bare token or a single-quoted TOML literal string has no
+// escape syntax to decode.
+function decodeTomlEscapes(value: string): string {
+    return value.replace(/\\(["\\bfnrt])/g, (_match, escaped: string) => {
+        switch (escaped) {
+            case "n": return "\n";
+            case "t": return "\t";
+            case "r": return "\r";
+            case "b": return "\b";
+            case "f": return "\f";
+            default: return escaped; // \" or \\
+        }
+    });
+}
+
+// Strips a single matching pair of surrounding quotes, decoding TOML escapes for a double-quoted
+// (but not single-quoted, which TOML treats as a literal string) element.
+function unquote(value: string): string {
+    const trimmed = value.trim();
+    if (trimmed.length >= 2) {
+        const first = trimmed[0];
+        const last = trimmed[trimmed.length - 1];
+        if ((first === "\"" || first === "'") && first === last) {
+            const inner = trimmed.slice(1, -1);
+            return first === "\"" ? decodeTomlEscapes(inner) : inner;
+        }
+    }
+    return trimmed;
+}
+
+const STRICT_INT_PATTERN = /^[+-]?\d+$/;
+// Whole-token match only — parseFloat accepts a numeric prefix of a longer string (e.g. "12ms" -> 12),
+// which would silently write a different value than what was typed.
+const STRICT_DECIMAL_PATTERN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+const BYTE_MIN = 0;
+const BYTE_MAX = 255;
+
+// float/decimal needs a decimal point or exponent to stay a float in TOML — @iarna/toml drops it
+// for an integral value (e.g. 1.0 -> 1), which Ballerina's config provider then rejects.
+function formatNumericValue(value: number, isFloatLike: boolean): string {
+    const str = String(value);
+    if (!isFloatLike || str.includes(".") || /e/i.test(str)) {
+        return str;
+    }
+    return `${str}.0`;
+}
+
+// `context` distinguishes an array-element error ("in array") from a scalar one ("").
+function parseIntegerToken(variableName: string, value: string, isByte: boolean, context: string): number {
+    if (!STRICT_INT_PATTERN.test(value)) {
+        throw new Error(`Invalid integer value${context} for ${variableName}`);
+    }
+    const n = parseInt(value, 10);
+    if (isByte && (n < BYTE_MIN || n > BYTE_MAX)) {
+        throw new Error(`Byte value${context} for ${variableName} must be between ${BYTE_MIN} and ${BYTE_MAX}`);
+    }
+    return n;
+}
+
+function parseDecimalToken(variableName: string, value: string, context: string): number {
+    if (!STRICT_DECIMAL_PATTERN.test(value)) {
+        throw new Error(`Invalid decimal value${context} for ${variableName}`);
+    }
+    return parseFloat(value);
+}
+
+function coerceArrayElement(variableName: string, raw: string, elementType: string): unknown {
+    const value = unquote(raw);
+    switch (elementType) {
+        case "int":
+        case "byte":
+            return parseIntegerToken(variableName, value, elementType === "byte", " in array");
+        case "decimal":
+        case "float":
+            return parseDecimalToken(variableName, value, " in array");
+        case "boolean":
+            if (value !== "true" && value !== "false") {
+                throw new Error(`Invalid boolean value in array for ${variableName}`);
+            }
+            return value === "true";
+        default:
+            return value;
+    }
+}
+
+// Parses a submitted array value (a bracket literal or a bare comma/whitespace-separated list)
+// into a real JS array so @iarna/toml emits a TOML array instead of a quoted string.
+function parseArrayConfigValue(variableName: string, value: string, varType: string): unknown[] {
+    const trimmed = value.trim();
+    const elementType = arrayElementType(stripTypeDecorations(varType));
+
+    const inner = trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1).trim() : trimmed;
+    const elements = inner ? splitArrayElements(inner) : [];
+
+    const expectedLength = fixedArrayLength(varType);
+    if (expectedLength !== undefined && elements.length !== expectedLength) {
+        throw new Error(`Expected ${expectedLength} value(s) for ${variableName}, got ${elements.length}`);
+    }
+
+    return elements.map(el => coerceArrayElement(variableName, el, elementType));
+}
+
+// Renders a JS array back into a bracket-literal string for display/pre-fill in the UI.
+function stringifyArrayConfigValue(value: unknown[]): string {
+    const renderElement = (v: unknown) => {
+        if (typeof v !== "string") {
+            return String(v);
+        }
+        const escaped = v.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+        return `"${escaped}"`;
+    };
+    return `[${value.map(renderElement).join(", ")}]`;
+}
+
 function readTomlSection(
     configPath: string,
     orgName: string,
@@ -58,7 +293,10 @@ export function getAllConfigStatus(
         return status;
     }
     for (const [key, value] of Object.entries(section)) {
-        if (value !== null && typeof value !== "object") {
+        // An explicitly-submitted empty array is a deliberate, meaningful value, not "unset" —
+        // treated as filled here to agree with computeCollectStatus/classifySubmission, which
+        // already treat the pre-filled "[]" display string as provided.
+        if (value !== null && (typeof value !== "object" || Array.isArray(value))) {
             status[key] = "filled";
         }
     }
@@ -94,24 +332,18 @@ export function writeConfigValuesToConfig(
         }
     }
 
-    const numericKeys = new Set<string>();
     for (const [variableName, value] of Object.entries(configValues)) {
-        const varType = typeMap.get(variableName) || "string";
-        if (varType === "int" || varType === "byte") {
-            const intValue = parseInt(value, 10);
-            if (isNaN(intValue)) {
-                throw new Error(`Invalid integer value for ${variableName}`);
-            }
-            section[variableName] = intValue;
-            numericKeys.add(variableName);
+        const varType = stripTypeDecorations(typeMap.get(variableName) || "string");
+        if (isArrayType(varType)) {
+            section[variableName] = parseArrayConfigValue(variableName, value, varType);
+        } else if (varType === "int" || varType === "byte") {
+            section[variableName] = parseIntegerToken(variableName, value, varType === "byte", "");
         } else if (varType === "decimal" || varType === "float") {
-            const decimalValue = parseFloat(value);
-            if (isNaN(decimalValue)) {
-                throw new Error(`Invalid decimal value for ${variableName}`);
-            }
-            section[variableName] = decimalValue;
-            numericKeys.add(variableName);
+            section[variableName] = parseDecimalToken(variableName, value, "");
         } else if (varType === "boolean") {
+            if (value !== "true" && value !== "false") {
+                throw new Error(`Invalid boolean value for ${variableName}`);
+            }
             section[variableName] = value === "true";
         } else {
             section[variableName] = value;
@@ -126,28 +358,49 @@ export function writeConfigValuesToConfig(
 
         let tomlContent = stringify(config);
 
-        // @iarna/toml formats large numbers with underscores (e.g. 8_080); Ballerina requires plain digits.
-        // Scope replacements to the [org.name] section only to avoid touching identically-named keys
-        // in other sections of the same file.
-        if (numericKeys.size > 0) {
-            const sectionHeader = `[${orgName}.${packageName}]`;
-            const sectionStart = tomlContent.indexOf(sectionHeader);
-            if (sectionStart !== -1) {
-                const afterHeader = sectionStart + sectionHeader.length;
-                const nextSection = tomlContent.indexOf("\n[", afterHeader);
-                const sectionEnd = nextSection !== -1 ? nextSection : tomlContent.length;
+        // @iarna/toml round-trips numbers with quirks Ballerina rejects (underscore grouping,
+        // a spurious ".0" on some exponent floats, dropping the point off an integral float).
+        // Repaired from `section` (every key in the file, not just this call's submission) so a
+        // key already on disk and not resubmitted still gets fixed up, scoped to this org.package
+        // section so identically-named keys elsewhere in the file are untouched.
+        const sectionHeader = `[${orgName}.${packageName}]`;
+        const sectionStart = tomlContent.indexOf(sectionHeader);
+        if (sectionStart !== -1) {
+            const afterHeader = sectionStart + sectionHeader.length;
+            const nextSection = tomlContent.indexOf("\n[", afterHeader);
+            const sectionEnd = nextSection !== -1 ? nextSection : tomlContent.length;
 
-                let sectionSlice = tomlContent.slice(sectionStart, sectionEnd);
-                for (const key of numericKeys) {
-                    const numValue = section[key];
-                    if (typeof numValue === "number") {
-                        const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-                        const pattern = new RegExp(`^(\\s*${escapedKey}\\s*=\\s*)[0-9][0-9_]*(?:\\.[0-9]+)?`, "gm");
-                        sectionSlice = sectionSlice.replace(pattern, `$1${numValue}`);
-                    }
+            let sectionSlice = tomlContent.slice(sectionStart, sectionEnd);
+            for (const [key, numValue] of Object.entries(section)) {
+                if (typeof numValue !== "number") {
+                    continue;
                 }
-                tomlContent = tomlContent.slice(0, sectionStart) + sectionSlice + tomlContent.slice(sectionEnd);
+                const declaredType = stripTypeDecorations(typeMap.get(key) || "");
+                const isFloatLike = declaredType === "decimal" || declaredType === "float";
+                const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                const pattern = new RegExp(
+                    `^(\\s*${escapedKey}\\s*=\\s*)[+-]?[0-9][0-9_]*(?:\\.[0-9_]+)?(?:[eE][+-]?[0-9]+)?(?:\\.0)?`,
+                    "gm"
+                );
+                sectionSlice = sectionSlice.replace(pattern, `$1${formatNumericValue(numValue, isFloatLike)}`);
             }
+            // Same idea for a numeric array: rebuild its '[ ... ]' span from the real values.
+            for (const [key, arrValue] of Object.entries(section)) {
+                if (!Array.isArray(arrValue) || arrValue.length === 0 || !arrValue.every(e => typeof e === "number")) {
+                    continue;
+                }
+                const declaredType = stripTypeDecorations(typeMap.get(key) || "");
+                const elementType = isArrayType(declaredType) ? arrayElementType(declaredType) : declaredType;
+                // A fractional element forces every element to render as a float — TOML arrays are
+                // single-type, so an integral sibling left as "1" would be a mixed-type array.
+                const hasFractionalValue = arrValue.some(v => !Number.isInteger(v));
+                const isFloatLike = hasFractionalValue || elementType === "decimal" || elementType === "float";
+                const formatted = `[ ${arrValue.map(v => formatNumericValue(v, isFloatLike)).join(", ")} ]`;
+                const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                const pattern = new RegExp(`(^\\s*${escapedKey}\\s*=\\s*)\\[[^\\]]*\\]`, "m");
+                sectionSlice = sectionSlice.replace(pattern, `$1${formatted}`);
+            }
+            tomlContent = tomlContent.slice(0, sectionStart) + sectionSlice + tomlContent.slice(sectionEnd);
         }
 
         fs.writeFileSync(configPath, tomlContent, "utf-8");
@@ -180,6 +433,10 @@ export function readExistingConfigValues(
                 existingValues[name] = value;
             } else if (typeof value === "number") {
                 existingValues[name] = value.toString();
+            } else if (typeof value === "boolean") {
+                existingValues[name] = value ? "true" : "false";
+            } else if (Array.isArray(value)) {
+                existingValues[name] = stringifyArrayConfigValue(value);
             }
         }
     }

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
@@ -266,15 +266,48 @@ interface FieldConfig {
 
 const NUMERIC_INT_TYPES = new Set(["int", "byte"]);
 const NUMERIC_FLOAT_TYPES = new Set(["decimal", "float"]);
+// Matches what parseInt(value, 10) can safely/unambiguously read — no exponent notation or
+// underscore grouping, both of which parseInt silently truncates at (e.g. "1e3" -> 1, "8_080" -> 8).
+const STRICT_INT_PATTERN = /^[+-]?\d+$/;
+// Whole-token match — parseFloat accepts a numeric prefix of a longer string (e.g. "12ms" -> 12).
+const STRICT_DECIMAL_PATTERN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+const BYTE_MIN = 0;
+const BYTE_MAX = 255;
+
+function isValidByteToken(value: string): boolean {
+    const n = Number(value);
+    return n >= BYTE_MIN && n <= BYTE_MAX;
+}
+// Matches an array type suffix, fixed-length or not: "[]", "[2]", "[10]", ...
+const ARRAY_TYPE_SUFFIX = /\[\d*\]\s*$/;
+
+// Strips '& readonly' and a trailing '?' — the LS reports array configurables this way.
+function stripTypeDecorations(type: string): string {
+    return type.replace(/&\s*readonly/g, "").replace(/\?\s*$/, "").trim();
+}
+
+// Rough (non-quote-aware) split used only to validate individual elements of a numeric array before
+// submit; the authoritative, quote-aware parse happens server-side in toml-utils.ts.
+function splitArrayElementsForValidation(value: string): string[] {
+    const trimmed = value.trim();
+    const inner = trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1).trim() : trimmed;
+    if (!inner) return [];
+    return (inner.includes(",") ? inner.split(",") : inner.split(/\s+/))
+        .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+        .filter((s) => s.length > 0);
+}
 
 function getFieldConfig(type: string | undefined): FieldConfig {
     if (NUMERIC_INT_TYPES.has(type ?? "")) {
+        const isByte = type === "byte";
         return {
             inputKind: "number",
             placeholder: "Enter integer",
             validate: (v) => {
-                if (!v.trim()) return null;
-                if (isNaN(parseInt(v, 10)) || !Number.isInteger(parseFloat(v))) return "Enter a valid integer";
+                const trimmed = v.trim();
+                if (!trimmed) return null;
+                if (!STRICT_INT_PATTERN.test(trimmed)) return "Enter a valid integer";
+                if (isByte && !isValidByteToken(trimmed)) return "Enter a byte value between 0 and 255";
                 return null;
             },
         };
@@ -284,9 +317,9 @@ function getFieldConfig(type: string | undefined): FieldConfig {
             inputKind: "number",
             placeholder: "Enter number",
             validate: (v) => {
-                if (!v.trim()) return null;
-                if (isNaN(parseFloat(v))) return "Enter a valid number";
-                return null;
+                const trimmed = v.trim();
+                if (!trimmed) return null;
+                return STRICT_DECIMAL_PATTERN.test(trimmed) ? null : "Enter a valid number";
             },
         };
     }
@@ -301,7 +334,40 @@ function getFieldConfig(type: string | undefined): FieldConfig {
             validate: () => null, // select always holds a valid option
         };
     }
-    // Default: string, records, arrays, maps, or any unknown LS type
+    const strippedType = type ? stripTypeDecorations(type) : type;
+    if (strippedType && ARRAY_TYPE_SUFFIX.test(strippedType)) {
+        // Per-element validation for a numeric/boolean array, matching its scalar field's validation.
+        const elementType = strippedType.replace(ARRAY_TYPE_SUFFIX, "").trim();
+        const isNumericInt = NUMERIC_INT_TYPES.has(elementType);
+        const isNumericFloat = NUMERIC_FLOAT_TYPES.has(elementType);
+        const isByte = elementType === "byte";
+        const isBoolean = elementType === "boolean";
+        return {
+            inputKind: "text",
+            placeholder: "Enter values separated by commas, e.g. read, write",
+            validate: (v) => {
+                if (!v.trim() || (!isNumericInt && !isNumericFloat && !isBoolean)) return null;
+                for (const el of splitArrayElementsForValidation(v)) {
+                    if (isNumericInt) {
+                        if (!STRICT_INT_PATTERN.test(el)) {
+                            return "Enter valid integers separated by commas";
+                        }
+                        if (isByte && !isValidByteToken(el)) {
+                            return "Enter byte values between 0 and 255, separated by commas";
+                        }
+                    }
+                    if (isNumericFloat && !STRICT_DECIMAL_PATTERN.test(el)) {
+                        return "Enter valid numbers separated by commas";
+                    }
+                    if (isBoolean && el !== "true" && el !== "false") {
+                        return "Enter 'true' or 'false' values separated by commas";
+                    }
+                }
+                return null;
+            },
+        };
+    }
+    // Default: string, records, maps, or any unknown LS type
     return {
         inputKind: "text",
         placeholder: "Enter value",


### PR DESCRIPTION
## Description
- Array-typed configurables (e.g. `string[] & readonly` OAuth scopes) were serialized as a quoted TOML string instead of a real array — `writeConfigValuesToConfig` never branched on array types, so `@iarna/toml` faithfully quoted whatever raw string it was given. Added array-aware parsing (bracket literal or bare comma/whitespace-separated input), per-element type coercion, and a fix for `@iarna/toml`'s numeric underscore-grouping inside arrays.
- Added a guard rejecting langlib-qualified int subtypes (`int:Signed8/16/32/64`, `int:Unsigned8/16/32`, scalar or array) at config-collection time — these compile but fail at runtime with "configurable variable '...' is not supported" (confirmed empirically against Ballerina 2201.13.4; the array form actually crashes with a raw Java stack trace rather than a clean error). Strengthened the agent's own prompt guidance to avoid generating these types in the first place.
- Added a second guard rejecting arrays of any other unsupported element type (record/map/json/etc.) before they're silently mis-written.
- Fixed `getAllConfigStatus` incorrectly treating any array (including `[]`) as "filled", and `readExistingConfigValues` dropping array values entirely instead of pre-filling them.
- Added client-side validation for numeric array fields in the Configuration Collector UI, so invalid input (e.g. `"8080, abc"` for an `int[]`) is caught before submit instead of

It resolves: https://github.com/wso2/product-integrator/issues/2322

**For reference:**

https://github.com/user-attachments/assets/03b9f884-214b-4fd1-8a92-34704ced5f11

**Config.toml**

<img width="1511" height="852" alt="Screenshot 2026-09-14 at 09 52 10" src="https://github.com/user-attachments/assets/8c414885-3b4b-4674-aaf7-e29f1e35bc1d" />


## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Add end-to-end support for array-typed configurables in `Config.toml`.
- Parse and serialize array values with per-element type conversion.
- Preserve populated arrays during status checks and value pre-fill.
- Reject unsupported array element types and langlib-qualified integer subtypes.
- Add array input validation to the Configuration Collector UI.
- Update agent guidance to support primitive arrays and avoid unsupported integer subtypes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->