### PR TITLE
Update HITL types for the `ballerina/ai` renaming

### DIFF
--- a/packages/ballerina-core/src/rpc-types/agent-chat/index.ts
+++ b/packages/ballerina-core/src/rpc-types/agent-chat/index.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse, SubmitDecisionRequest, ApprovalDecision, ApprovalRequest, HumanResponse, DecisionMessage, PendingApprovalInfo } from "./interfaces";
+import { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse, SubmitDecisionRequest, ApprovalOutcome, ApprovalRequest, HumanDecision, DecisionMessage, PendingApprovalInfo } from "./interfaces";
 
 export interface AgentChatAPI {
     getChatMessage: (params: ChatReqMessage) => Promise<ChatRespMessage>;
@@ -33,4 +33,4 @@ export interface AgentChatAPI {
     switchChatAgent: (params: SwitchAgentRequest) => Promise<SwitchAgentResponse>;
 }
 
-export type { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse, SubmitDecisionRequest, ApprovalDecision, ApprovalRequest, HumanResponse, DecisionMessage, PendingApprovalInfo };
+export type { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse, SubmitDecisionRequest, ApprovalOutcome, ApprovalRequest, HumanDecision, DecisionMessage, PendingApprovalInfo };

--- a/packages/ballerina-core/src/rpc-types/agent-chat/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/agent-chat/interfaces.ts
@@ -20,7 +20,8 @@ export interface ChatReqMessage {
     message: string;
 }
 
-export type ApprovalDecision = 'APPROVE' | 'REJECT';
+// Mirrors `ai:ApprovalOutcome` (renamed from `ApprovalDecision` in module-ballerina-ai#169).
+export type ApprovalOutcome = 'APPROVE' | 'REJECT';
 
 export interface ApprovalRequest {
     id: string;
@@ -32,21 +33,23 @@ export interface ApprovalRequest {
     batchIndex: number;
 }
 
-export interface HumanResponse {
-    decision: ApprovalDecision;
+// Mirrors `ai:HumanDecision` (renamed from `HumanResponse`, field `decision` renamed to `outcome`,
+// in module-ballerina-ai#169).
+export interface HumanDecision {
+    outcome: ApprovalOutcome;
     reason?: string;
 }
 
 // Sent from the webview to the extension; the extension fills in `sessionId`
 // from the active agent-chat context before posting to the service's `decision` resource.
 export interface SubmitDecisionRequest {
-    decisions: Record<string, HumanResponse>;
+    decisions: Record<string, HumanDecision>;
 }
 
 // Mirrors `ai:DecisionMessage`, the wire payload posted to a chat service's `decision` resource.
 export interface DecisionMessage {
     sessionId: string;
-    decisions: Record<string, HumanResponse>;
+    decisions: Record<string, HumanDecision>;
 }
 
 export interface PendingApprovalInfo {
@@ -96,7 +99,7 @@ export interface ChatHistoryMessage {
     // Present when type is 'approval': the requests the agent paused on.
     pendingApproval?: PendingApprovalInfo;
     // Present once the pending approval above has been resolved by the user.
-    decisions?: Record<string, HumanResponse>;
+    decisions?: Record<string, HumanDecision>;
     // Set when the user gives up on this batch via the card's Dismiss action (typically after
     // repeated failed submissions), so the card is terminal even though some requests may
     // still lack a decision. This is a client-side choice, not something the service reports.

--- a/packages/ballerina-extension/src/rpc-managers/agent-chat/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/agent-chat/rpc-manager.ts
@@ -35,7 +35,7 @@ import {
     SwitchAgentResponse,
     SubmitDecisionRequest,
     DecisionMessage,
-    HumanResponse,
+    HumanDecision,
     PendingApprovalInfo
 } from "@wso2/ballerina-core";
 import * as vscode from 'vscode';
@@ -171,7 +171,7 @@ export class AgentChatRpcManager implements AgentChatAPI {
     // to (a batch may be resolved across several submitDecision calls, one request at a time),
     // so a later getChatHistory()/switchChatAgent() replay renders resolved requests collapsed
     // rather than as if still pending.
-    private resolvePendingApprovalInHistory(sessionId: string, decisions: Record<string, HumanResponse>): void {
+    private resolvePendingApprovalInHistory(sessionId: string, decisions: Record<string, HumanDecision>): void {
         const decidedIds = Object.keys(decisions);
         const history = AgentChatRpcManager.chatHistoryMap.get(sessionId);
         if (!history) {

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ApprovalCard.tsx
@@ -19,15 +19,15 @@
 import React, { useState } from "react";
 import styled from "@emotion/styled";
 import { Icon, Button } from "@wso2/ui-toolkit";
-import { ApprovalRequest, HumanResponse } from "@wso2/ballerina-core";
+import { ApprovalRequest, HumanDecision } from "@wso2/ballerina-core";
 
 interface ApprovalCardProps {
     requests: ApprovalRequest[];
-    decisions?: Record<string, HumanResponse>;
+    decisions?: Record<string, HumanDecision>;
     // Set once the user has dismissed this batch; renders as terminal even if some requests
     // still lack a decision.
     unresolvable?: boolean;
-    onSubmit: (decisions: Record<string, HumanResponse>) => Promise<void>;
+    onSubmit: (decisions: Record<string, HumanDecision>) => Promise<void>;
     // Lets the user give up on a batch that keeps failing instead of being stuck with a
     // disabled chat input. Optional since a fully/terminally rendered card has no use for it.
     onDismiss?: () => void;
@@ -241,14 +241,14 @@ const TextLinkButton = styled.button`
     }
 `;
 
-const DecidedBadge = styled.span<{ decision: "APPROVE" | "REJECT" }>`
+const DecidedBadge = styled.span<{ outcome: "APPROVE" | "REJECT" }>`
     display: inline-flex;
     align-items: center;
     gap: 4px;
     font-size: 12px;
     font-weight: 600;
-    color: ${({ decision }: { decision: "APPROVE" | "REJECT" }) =>
-        decision === "APPROVE" ? "var(--vscode-terminal-ansiGreen)" : "var(--vscode-errorForeground)"};
+    color: ${({ outcome }: { outcome: "APPROVE" | "REJECT" }) =>
+        outcome === "APPROVE" ? "var(--vscode-terminal-ansiGreen)" : "var(--vscode-errorForeground)"};
 `;
 
 const BatchActions = styled.div`
@@ -268,12 +268,12 @@ const CollapsedSummary = styled.div`
     font-size: 12px;
 `;
 
-const SummaryItem = styled.span<{ decision: "APPROVE" | "REJECT" }>`
+const SummaryItem = styled.span<{ outcome: "APPROVE" | "REJECT" }>`
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    color: ${({ decision }: { decision: "APPROVE" | "REJECT" }) =>
-        decision === "APPROVE" ? "var(--vscode-terminal-ansiGreen)" : "var(--vscode-errorForeground)"};
+    color: ${({ outcome }: { outcome: "APPROVE" | "REJECT" }) =>
+        outcome === "APPROVE" ? "var(--vscode-terminal-ansiGreen)" : "var(--vscode-errorForeground)"};
 `;
 
 function isPlainObject(value: unknown): value is Record<string, any> {
@@ -348,7 +348,7 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
 
     const toggleArgs = (id: string) => setExpandedArgs(prev => ({ ...prev, [id]: !prev[id] }));
 
-    const submit = async (partial: Record<string, HumanResponse>) => {
+    const submit = async (partial: Record<string, HumanDecision>) => {
         setSubmitting(true);
         try {
             await onSubmit(partial);
@@ -363,7 +363,7 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
         }
     };
 
-    const handleApprove = (id: string) => submit({ [id]: { decision: "APPROVE" } });
+    const handleApprove = (id: string) => submit({ [id]: { outcome: "APPROVE" } });
 
     const handleStartReject = (id: string) => {
         setRejectingId(id);
@@ -372,18 +372,18 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
 
     const handleConfirmReject = (id: string) => {
         const reason = reasonText.trim();
-        submit({ [id]: { decision: "REJECT", ...(reason ? { reason } : {}) } });
+        submit({ [id]: { outcome: "REJECT", ...(reason ? { reason } : {}) } });
     };
 
     const handleApproveAll = () => {
-        const decisionsMap: Record<string, HumanResponse> = {};
-        pendingRequests.forEach(r => { decisionsMap[r.id] = { decision: "APPROVE" }; });
+        const decisionsMap: Record<string, HumanDecision> = {};
+        pendingRequests.forEach(r => { decisionsMap[r.id] = { outcome: "APPROVE" }; });
         submit(decisionsMap);
     };
 
     const handleRejectAll = () => {
-        const decisionsMap: Record<string, HumanResponse> = {};
-        pendingRequests.forEach(r => { decisionsMap[r.id] = { decision: "REJECT" }; });
+        const decisionsMap: Record<string, HumanDecision> = {};
+        pendingRequests.forEach(r => { decisionsMap[r.id] = { outcome: "REJECT" }; });
         submit(decisionsMap);
     };
 
@@ -395,19 +395,19 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
                         const decided = decisions?.[req.id];
                         if (decided) {
                             return (
-                                <SummaryItem key={req.id} decision={decided.decision}>
+                                <SummaryItem key={req.id} outcome={decided.outcome}>
                                     <Icon
-                                        name={decided.decision === "APPROVE" ? "bi-check" : "bi-close"}
+                                        name={decided.outcome === "APPROVE" ? "bi-check" : "bi-close"}
                                         sx={{ width: 14, height: 14 }}
                                         iconSx={{ fontSize: "14px" }}
                                     />
-                                    {req.toolName} {decided.decision === "APPROVE" ? "approved" : "rejected"}
+                                    {req.toolName} {decided.outcome === "APPROVE" ? "approved" : "rejected"}
                                     {decided.reason ? ` — "${decided.reason}"` : ""}
                                 </SummaryItem>
                             );
                         }
                         return (
-                            <SummaryItem key={req.id} decision="REJECT">
+                            <SummaryItem key={req.id} outcome="REJECT">
                                 <Icon name="bi-warning" sx={{ width: 14, height: 14 }} iconSx={{ fontSize: "14px" }} />
                                 {req.toolName} could not be resumed
                             </SummaryItem>
@@ -425,13 +425,13 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
                     {requests.map(req => {
                         const decided = decisions![req.id];
                         return (
-                            <SummaryItem key={req.id} decision={decided.decision}>
+                            <SummaryItem key={req.id} outcome={decided.outcome}>
                                 <Icon
-                                    name={decided.decision === "APPROVE" ? "bi-check" : "bi-close"}
+                                    name={decided.outcome === "APPROVE" ? "bi-check" : "bi-close"}
                                     sx={{ width: 14, height: 14 }}
                                     iconSx={{ fontSize: "14px" }}
                                 />
-                                {req.toolName} {decided.decision === "APPROVE" ? "approved" : "rejected"}
+                                {req.toolName} {decided.outcome === "APPROVE" ? "approved" : "rejected"}
                                 {decided.reason ? ` — "${decided.reason}"` : ""}
                             </SummaryItem>
                         );
@@ -474,13 +474,13 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({ requests, decisions,
                             <ArgumentsContainer>{renderArguments(req.arguments)}</ArgumentsContainer>
                         )}
                         {decided ? (
-                            <DecidedBadge decision={decided.decision}>
+                            <DecidedBadge outcome={decided.outcome}>
                                 <Icon
-                                    name={decided.decision === "APPROVE" ? "bi-check" : "bi-close"}
+                                    name={decided.outcome === "APPROVE" ? "bi-check" : "bi-close"}
                                     sx={{ width: 14, height: 14 }}
                                     iconSx={{ fontSize: "14px" }}
                                 />
-                                {decided.decision === "APPROVE" ? "Approved" : "Rejected"}
+                                {decided.outcome === "APPROVE" ? "Approved" : "Rejected"}
                                 {decided.reason ? ` — "${decided.reason}"` : ""}
                             </DecidedBadge>
                         ) : rejectingId === req.id ? (

--- a/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
+++ b/packages/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
@@ -26,7 +26,7 @@ import { ExecutionTimeline } from "./ExecutionTimeline";
 import { ApprovalCard } from "./ApprovalCard";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Icon, Button, ThemeColors } from "@wso2/ui-toolkit";
-import { SessionInfoResponse, AgentInfo, PendingApprovalInfo, HumanResponse, ChatHistoryMessage } from "@wso2/ballerina-core";
+import { SessionInfoResponse, AgentInfo, PendingApprovalInfo, HumanDecision, ChatHistoryMessage } from "@wso2/ballerina-core";
 import ReactMarkdown from "react-markdown";
 import remarkMath from 'remark-math';
 import remarkGfm from 'remark-gfm';
@@ -49,7 +49,7 @@ interface ChatMessage {
     // Present when type is APPROVAL: the requests the agent paused on.
     pendingApproval?: PendingApprovalInfo;
     // Present once (some or all of) the pending approval above has been resolved.
-    decisions?: Record<string, HumanResponse>;
+    decisions?: Record<string, HumanDecision>;
     // Set when the user dismisses this batch after it keeps failing to submit. Terminal even
     // if some requests still lack a decision.
     unresolvable?: boolean;
@@ -820,7 +820,7 @@ const ChatInterface: React.FC = () => {
         );
     };
 
-    const handleApprovalDecision = async (decisions: Record<string, HumanResponse>) => {
+    const handleApprovalDecision = async (decisions: Record<string, HumanDecision>) => {
         // Lock session-changing actions (switch agent, clear chat) while a decision is in
         // flight, and capture the session token so a response that arrives after the user
         // switched/cleared sessions anyway is dropped instead of applied to the wrong chat.


### PR DESCRIPTION
## Purpose
https://github.com/ballerina-platform/module-ballerina-ai/pull/168 renamed the wire types for human-in-the-loop
approval: HumanResponse -> HumanDecision, its `decision` field ->
`outcome`, and the ApprovalDecision enum -> ApprovalOutcome. Mirror that rename across every place this codebase constructs or reads that payload, so the approval card keeps sending/reading the field name the `decision` resource actually expects:

- ballerina-core/rpc-types/agent-chat: rename the type definitions and their re-exports
- rpc-manager: rename the one type reference
- ApprovalCard: rename every `{ decision: "APPROVE" }` payload and `.decision` read to `{ outcome: "APPROVE" }` / `.outcome`, including the two styled-component prop types
- ChatInterface: rename the type reference

Fixes https://github.com/wso2/product-integrator/issues/2387

## Test Plan
- [x] Test chat agent HITL with ai module [1.15.0](https://central.ballerina.io/ballerina/ai/1.15.0) release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Renamed HITL approval types to match the `ballerina/ai` contract.
- Replaced `HumanResponse` with `HumanDecision`.
- Replaced `ApprovalDecision` with `ApprovalOutcome`.
- Renamed the `decision` field to `outcome`.
- Updated RPC manager, `ChatInterface`, `ApprovalCard`, type exports, and related payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->