### PR TITLE
Fix aliasing of cached intersection types in record config model

### DIFF
--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/find_matching_type/config/config8.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/find_matching_type/config/config8.json
@@ -1132,7 +1132,7 @@
                                         "selected": false
                                       },
                                       {
-                                        "name": "notAfter",
+                                        "name": "notBefore",
                                         "typeName": "[int, decimal]",
                                         "optional": false,
                                         "typeInfo": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/config/config8.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/config/config8.json
@@ -1,0 +1,51 @@
+{
+  "filePath": "proj",
+  "description": "sibling fields sharing an intersection type keep distinct labels (issue #2295)",
+  "codedata": {
+    "org": "org",
+    "module": "source",
+    "packageName": "source",
+    "version": "0.3.0"
+  },
+  "typeConstraint": "Meta",
+  "output": {
+    "fields": [
+      {
+        "name": "createdAt",
+        "typeName": "[int, decimal]",
+        "optional": true,
+        "typeInfo": {
+          "name": "Timestamp",
+          "orgName": "org",
+          "moduleName": "source",
+          "version": "0.3.0"
+        },
+        "defaultable": false,
+        "documentation": "",
+        "isRestType": false,
+        "selected": false
+      },
+      {
+        "name": "modifiedAt",
+        "typeName": "[int, decimal]",
+        "optional": true,
+        "typeInfo": {
+          "name": "Timestamp",
+          "orgName": "org",
+          "moduleName": "source",
+          "version": "0.3.0"
+        },
+        "defaultable": false,
+        "documentation": "",
+        "isRestType": false,
+        "selected": false
+      }
+    ],
+    "hasRestType": false,
+    "typeName": "record",
+    "optional": false,
+    "defaultable": false,
+    "isRestType": false,
+    "selected": false
+  }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/proj/types.bal
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/proj/types.bal
@@ -36,3 +36,10 @@ type ReadonlyRoot readonly & record {|
     string id;
     int count;
 |};
+
+type Timestamp readonly & [int, decimal];
+
+type Meta record {|
+    Timestamp createdAt?;
+    Timestamp modifiedAt?;
+|};

--- a/packages/ballerina-language-server/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/Type.java
+++ b/packages/ballerina-language-server/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/Type.java
@@ -449,6 +449,9 @@ public class Type {
             if (existingType instanceof RecordType recordType) {
                 return new RecordType(recordType);
             }
+            if (existingType instanceof IntersectionType intersectionType) {
+                return new IntersectionType(intersectionType);
+            }
             return existingType;
         } else {
             Type type = new Type();

--- a/packages/ballerina-language-server/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/types/IntersectionType.java
+++ b/packages/ballerina-language-server/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/types/IntersectionType.java
@@ -47,4 +47,15 @@ public class IntersectionType extends Type {
         this.displayAnnotation = intersectionType.displayAnnotation;
         this.documentation = intersectionType.documentation;
     }
+
+    @Override
+    public IntersectionType copy() {
+        IntersectionType copy = new IntersectionType(this);
+        copyBaseFields(copy);
+        copy.members = new ArrayList<>();
+        for (Type member : this.members) {
+            copy.members.add(member.copy());
+        }
+        return copy;
+    }
 }

--- a/packages/ballerina-language-server/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/types/IntersectionType.java
+++ b/packages/ballerina-language-server/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/types/IntersectionType.java
@@ -35,4 +35,16 @@ public class IntersectionType extends Type {
         this.typeName = "intersection";
         this.members = new ArrayList<>();
     }
+
+    public IntersectionType(IntersectionType intersectionType) {
+        this.typeName = intersectionType.typeName;
+        this.members = intersectionType.members;
+        this.name = intersectionType.name;
+        this.optional = intersectionType.optional;
+        this.typeInfo = intersectionType.typeInfo;
+        this.defaultable = intersectionType.defaultable;
+        this.defaultValue = intersectionType.defaultValue;
+        this.displayAnnotation = intersectionType.displayAnnotation;
+        this.documentation = intersectionType.documentation;
+    }
 }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-integrator/issues/2295

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes cached intersection type aliasing in the record configuration model.

The change preserves distinct field names for `createdAt` and `modifiedAt`, allowing users to select `createdAt` when both fields use `time:Utc` types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->