### PR TITLE
Render the connection init form in parameter declaration order

### DIFF
--- a/packages/ballerina-side-panel/src/utils/convertConfig.ts
+++ b/packages/ballerina-side-panel/src/utils/convertConfig.ts
@@ -28,7 +28,7 @@ import { FormField } from "../components/Form/types";
  */
 export function convertConfig(properties: NodeProperties, skipKeys: string[] = []): FormField[] {
     const formFields: FormField[] = [];
-    for (const key of Object.keys(properties).sort()) {
+    for (const key of Object.keys(properties)) {
         if (skipKeys.includes(key)) {
             continue;
         }

--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/ConnectionCreator.tsx
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/ConnectionCreator.tsx
@@ -20,12 +20,12 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "r
 import { FormField, FormValues, FormImports } from "@wso2/ballerina-side-panel";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { PanelOverlayContext } from "../../views/BI/FlowDiagram/context/PanelOverlayContext";
-import { convertConfig } from "../../utils/bi";
 import { ArtifactForm } from "../../views/BI/Forms/ArtifactForm";
 import { RelativeLoader } from "../RelativeLoader";
 import { InfoBox } from "../InfoBox";
 import { ConnectionCreatorProps } from "./types";
 import { getConnectionSpecialConfig } from "./config";
+import { convertConnectionConfig } from "./connectionFormFields";
 import { updateFormFieldsWithData, updateNodeTemplateProperties, updateNodeWithConnectionVariable, updateNodeLineRange } from "./utils";
 import { cloneDeep } from "lodash";
 import { GET_DEFAULT_EMBEDDING_PROVIDER, GET_DEFAULT_MODEL_PROVIDER, LineRange, RecordTypeField, getPrimaryInputType, PropertyTypeMemberInfo } from "@wso2/ballerina-core";
@@ -74,7 +74,7 @@ export function ConnectionCreator(props: ConnectionCreatorProps): JSX.Element {
         }
 
         if (nodeFormTemplate && nodeFormTemplate.properties) {
-            const fields = convertConfig(nodeFormTemplate.properties);
+            const fields = convertConnectionConfig(nodeFormTemplate.properties);
             setConnectionFields(fields);
 
             const rtFields: RecordTypeField[] = Object.entries(nodeFormTemplate.properties)

--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/connectionFormFields.test.ts
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/connectionFormFields.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// L1: the connection `init` form reads in `init` parameter declaration order (#2402).
+// Add a captured `getNodeTemplate` payload under fixtures/connections/ to guard a connector.
+
+// @wso2/ballerina-core is mocked as in utils/convertConfig.test.ts: its barrel re-exports an
+// ESM-only WS package jest cannot load.
+jest.mock("@wso2/ballerina-core", () => ({
+    getPrimaryInputType: (types: any[]) => types?.[0],
+    isTemplateType: (value: any) => value !== null && typeof value === "object" && "template" in value,
+    isDropDownType: (value: any) =>
+        value !== null &&
+        "options" in value &&
+        (value?.fieldType === "SINGLE_SELECT" || value?.fieldType === "MULTIPLE_SELECT"),
+}));
+
+import type { NodeProperties } from "@wso2/ballerina-core";
+import { loadFixtures } from "@wso2/test-config/fixtures";
+import { convertConnectionConfig } from "./connectionFormFields";
+
+interface ConnectionFixture {
+    description?: string;
+    expectedFieldOrder: string[]; // the keys of `properties`, i.e. the order the LS sent them in
+    properties: NodeProperties;
+}
+
+const fixtures = loadFixtures<ConnectionFixture>(__dirname, "fixtures", "connections");
+const cases = fixtures.map((f) => [f.name, f.data] as [string, ConnectionFixture]);
+
+describe("connection init form field order", () => {
+    it("has fixtures to run", () => {
+        expect(fixtures.length).toBeGreaterThan(0);
+    });
+
+    it("the corpus would catch alphabetised keys", () => {
+        expect(
+            cases.some(([, fx]) => {
+                const sorted = [...fx.expectedFieldOrder].sort();
+                return fx.expectedFieldOrder.some((key, index) => key !== sorted[index]);
+            })
+        ).toBe(true);
+    });
+
+    it.each(cases)("%s -> INVARIANT: one field per property, in the order the LS sent them", (_name, fx) => {
+        const keys = convertConnectionConfig(fx.properties).map((field) => field.key);
+        expect(keys).toEqual(Object.keys(fx.properties));
+        expect(keys).toEqual(fx.expectedFieldOrder);
+    });
+
+    // `Form` renders !advanced first, then advanced; neither group may be re-ranked within itself.
+    it.each(cases)("%s -> INVARIANT: both render passes keep declaration order", (_name, fx) => {
+        const fields = convertConnectionConfig(fx.properties);
+        const order = (subset: typeof fields) => subset.map((field) => field.key);
+        const plain = order(fields.filter((field) => !field.advanced));
+        const advanced = order(fields.filter((field) => field.advanced));
+        expect(plain).toEqual(fx.expectedFieldOrder.filter((key) => plain.includes(key)));
+        expect(advanced).toEqual(fx.expectedFieldOrder.filter((key) => advanced.includes(key)));
+    });
+});

--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/connectionFormFields.ts
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/connectionFormFields.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { NodeProperties } from "@wso2/ballerina-core";
+import { FormField } from "@wso2/ballerina-side-panel";
+import { convertConfig } from "../../utils/node-property-utils";
+
+export function convertConnectionConfig(properties: NodeProperties): FormField[] {
+    return convertConfig(properties, [], false);
+}

--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/fixtures/connections/mysql-connector.json
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/fixtures/connections/mysql-connector.json
@@ -1,0 +1,305 @@
+{
+    "description": "ballerinax/mysql Client init: host, user, password, database, port, options, connectionPool",
+    "expectedFieldOrder": [
+        "host",
+        "user",
+        "password",
+        "database",
+        "port",
+        "options",
+        "connectionPool",
+        "type",
+        "variable",
+        "scope",
+        "checkError"
+    ],
+    "properties": {
+        "host": {
+            "metadata": {
+                "label": "Host",
+                "description": "MySQL server hostname"
+            },
+            "types": [
+                {
+                    "fieldType": "TEXT",
+                    "ballerinaType": "string",
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "string",
+                    "selected": false
+                }
+            ],
+            "placeholder": "\"\"",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "DEFAULTABLE",
+                "originalName": "host"
+            },
+            "defaultValue": "\"localhost\""
+        },
+        "user": {
+            "metadata": {
+                "label": "User",
+                "description": "Database username"
+            },
+            "types": [
+                {
+                    "fieldType": "TEXT",
+                    "ballerinaType": "string",
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "string?",
+                    "selected": false
+                }
+            ],
+            "placeholder": "()",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "DEFAULTABLE",
+                "originalName": "user"
+            },
+            "defaultValue": "\"root\""
+        },
+        "password": {
+            "metadata": {
+                "label": "Password",
+                "description": "Database password (optional)"
+            },
+            "types": [
+                {
+                    "fieldType": "TEXT",
+                    "ballerinaType": "string",
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "string?",
+                    "selected": false
+                }
+            ],
+            "placeholder": "()",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "DEFAULTABLE",
+                "originalName": "password"
+            },
+            "defaultValue": "()"
+        },
+        "database": {
+            "metadata": {
+                "label": "Database",
+                "description": "Database name to connect to (optional)"
+            },
+            "types": [
+                {
+                    "fieldType": "TEXT",
+                    "ballerinaType": "string",
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "string?",
+                    "selected": false
+                }
+            ],
+            "placeholder": "()",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "DEFAULTABLE",
+                "originalName": "database"
+            },
+            "defaultValue": "()"
+        },
+        "port": {
+            "metadata": {
+                "label": "Port",
+                "description": "MySQL server port"
+            },
+            "types": [
+                {
+                    "fieldType": "NUMBER",
+                    "ballerinaType": "int",
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "int",
+                    "selected": false
+                }
+            ],
+            "placeholder": "0",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "DEFAULTABLE",
+                "originalName": "port"
+            },
+            "defaultValue": "3306"
+        },
+        "options": {
+            "metadata": {
+                "label": "Options",
+                "description": "Advanced connection options (optional)"
+            },
+            "types": [
+                {
+                    "fieldType": "RECORD_MAP_EXPRESSION",
+                    "ballerinaType": "mysql:Options",
+                    "typeMembers": [
+                        {
+                            "type": "Options",
+                            "packageInfo": "ballerinax:mysql:1.19.1",
+                            "packageName": "mysql",
+                            "kind": "RECORD_TYPE",
+                            "selected": false
+                        }
+                    ],
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "mysql:Options?",
+                    "selected": false
+                }
+            ],
+            "placeholder": "()",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "DEFAULTABLE",
+                "originalName": "options"
+            },
+            "defaultValue": "()"
+        },
+        "connectionPool": {
+            "metadata": {
+                "label": "Connection Pool",
+                "description": "Connection pool for connection reuse. If not provided, the global connection pool (shared by all clients) will be used"
+            },
+            "types": [
+                {
+                    "fieldType": "RECORD_MAP_EXPRESSION",
+                    "ballerinaType": "sql:ConnectionPool",
+                    "typeMembers": [
+                        {
+                            "type": "ConnectionPool",
+                            "packageInfo": "ballerina:sql:1.19.0",
+                            "packageName": "sql",
+                            "kind": "RECORD_TYPE",
+                            "selected": false
+                        }
+                    ],
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "sql:ConnectionPool?",
+                    "selected": false
+                }
+            ],
+            "placeholder": "()",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "DEFAULTABLE",
+                "originalName": "connectionPool"
+            },
+            "defaultValue": "()"
+        },
+        "type": {
+            "metadata": {
+                "label": "Result Type",
+                "description": "Type of the variable"
+            },
+            "types": [
+                {
+                    "fieldType": "TYPE",
+                    "selected": true
+                }
+            ],
+            "value": "mysql:Client",
+            "placeholder": "var",
+            "optional": false,
+            "editable": false,
+            "advanced": false,
+            "hidden": true,
+            "codedata": {},
+            "imports": {
+                "mysql": "ballerinax/mysql"
+            }
+        },
+        "variable": {
+            "metadata": {
+                "label": "Connection Name",
+                "description": "Name of the connection"
+            },
+            "types": [
+                {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                }
+            ],
+            "value": "mysqlClient",
+            "optional": false,
+            "editable": true,
+            "advanced": false,
+            "hidden": false
+        },
+        "scope": {
+            "metadata": {
+                "label": "Connection Scope",
+                "description": "Scope of the connection, Global or Local"
+            },
+            "types": [
+                {
+                    "fieldType": "ENUM",
+                    "selected": true
+                }
+            ],
+            "value": "Global",
+            "optional": false,
+            "editable": true,
+            "advanced": true,
+            "hidden": true
+        },
+        "checkError": {
+            "metadata": {
+                "label": "Check Error",
+                "description": "Terminate on error"
+            },
+            "types": [
+                {
+                    "fieldType": "FLAG",
+                    "selected": true
+                }
+            ],
+            "value": true,
+            "optional": false,
+            "editable": false,
+            "advanced": true,
+            "hidden": true
+        }
+    }
+}

--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/fixtures/connections/pinecone-vector-store.json
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/fixtures/connections/pinecone-vector-store.json
@@ -1,0 +1,257 @@
+{
+    "description": "ballerinax/ai.pinecone VectorStore init: serviceUrl, apiKey, queryMode, config, httpConfig",
+    "expectedFieldOrder": [
+        "type",
+        "variable",
+        "serviceUrl",
+        "apiKey",
+        "queryMode",
+        "config",
+        "httpConfig",
+        "scope",
+        "checkError"
+    ],
+    "properties": {
+        "type": {
+            "metadata": {
+                "label": "Result Type",
+                "description": "Type of the variable"
+            },
+            "types": [
+                {
+                    "fieldType": "TYPE",
+                    "selected": true
+                }
+            ],
+            "value": "pinecone:VectorStore",
+            "placeholder": "var",
+            "optional": false,
+            "editable": false,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {},
+            "imports": {
+                "pinecone": "ballerinax/ai.pinecone"
+            }
+        },
+        "variable": {
+            "metadata": {
+                "label": "Vector Store Name",
+                "description": "Vector store instance name"
+            },
+            "types": [
+                {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                }
+            ],
+            "value": "pineconeVectorstore",
+            "optional": false,
+            "editable": true,
+            "advanced": false,
+            "hidden": false
+        },
+        "serviceUrl": {
+            "metadata": {
+                "label": "Service URL",
+                "description": "URL of the Pinecone API service"
+            },
+            "types": [
+                {
+                    "fieldType": "TEXT",
+                    "ballerinaType": "string",
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "string",
+                    "selected": false
+                }
+            ],
+            "placeholder": "\"\"",
+            "optional": false,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "REQUIRED",
+                "originalName": "serviceUrl"
+            }
+        },
+        "apiKey": {
+            "metadata": {
+                "label": "API Key",
+                "description": "Pinecone API key for authentication"
+            },
+            "types": [
+                {
+                    "fieldType": "TEXT",
+                    "ballerinaType": "string",
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "string",
+                    "selected": false
+                }
+            ],
+            "placeholder": "\"\"",
+            "optional": false,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "REQUIRED",
+                "originalName": "apiKey"
+            }
+        },
+        "queryMode": {
+            "metadata": {
+                "label": "Query Mode",
+                "description": "Vector query mode (defaults to ai:DENSE)"
+            },
+            "types": [
+                {
+                    "fieldType": "SINGLE_SELECT",
+                    "options": [
+                        {
+                            "label": "DENSE",
+                            "value": "\"DENSE\""
+                        },
+                        {
+                            "label": "SPARSE",
+                            "value": "\"SPARSE\""
+                        },
+                        {
+                            "label": "HYBRID",
+                            "value": "\"HYBRID\""
+                        }
+                    ],
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "ai:VectorStoreQueryMode",
+                    "selected": false
+                }
+            ],
+            "placeholder": "\"DENSE\"",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "DEFAULTABLE",
+                "originalName": "queryMode"
+            },
+            "defaultValue": "ai:DENSE"
+        },
+        "config": {
+            "metadata": {
+                "label": "Pinecone Configuration"
+            },
+            "types": [
+                {
+                    "fieldType": "RECORD_MAP_EXPRESSION",
+                    "ballerinaType": "pinecone:Configuration",
+                    "typeMembers": [
+                        {
+                            "type": "Configuration",
+                            "packageInfo": "ballerinax:ai.pinecone:1.1.5",
+                            "packageName": "ai.pinecone",
+                            "kind": "RECORD_TYPE",
+                            "selected": false
+                        }
+                    ],
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "pinecone:Configuration",
+                    "selected": false
+                }
+            ],
+            "placeholder": "{}",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "DEFAULTABLE",
+                "originalName": "config"
+            },
+            "defaultValue": "{}"
+        },
+        "httpConfig": {
+            "metadata": {
+                "label": "HTTP Configuration",
+                "description": "HTTP client configuration for the Pinecone connection\n"
+            },
+            "types": [
+                {
+                    "fieldType": "RECORD_MAP_EXPRESSION",
+                    "ballerinaType": "vector:ConnectionConfig",
+                    "typeMembers": [
+                        {
+                            "type": "ConnectionConfig",
+                            "packageInfo": "ballerinax:pinecone.vector:1.0.2",
+                            "packageName": "pinecone.vector",
+                            "kind": "RECORD_TYPE",
+                            "selected": false
+                        }
+                    ],
+                    "selected": false
+                },
+                {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "vector:ConnectionConfig",
+                    "selected": false
+                }
+            ],
+            "placeholder": "{}",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+                "kind": "DEFAULTABLE",
+                "originalName": "httpConfig"
+            },
+            "defaultValue": "{}"
+        },
+        "scope": {
+            "metadata": {
+                "label": "Connection Scope",
+                "description": "Scope of the connection, Global or Local"
+            },
+            "types": [
+                {
+                    "fieldType": "ENUM",
+                    "selected": true
+                }
+            ],
+            "value": "Global",
+            "optional": false,
+            "editable": true,
+            "advanced": true,
+            "hidden": true
+        },
+        "checkError": {
+            "metadata": {
+                "label": "Check Error",
+                "description": "Terminate on error"
+            },
+            "types": [
+                {
+                    "fieldType": "FLAG",
+                    "selected": true
+                }
+            ],
+            "value": true,
+            "optional": false,
+            "editable": false,
+            "advanced": true,
+            "hidden": true
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

Fixes wso2/product-integrator#2402 — the connector configuration panel rendered its fields alphabetically instead of in `init` declaration order. Pinecone's **Create Vector Store** showed `API Key` above `Service URL`, and `Query Mode` below `Pinecone Configuration` / `HTTP Configuration`.

## Cause

The LS sends `getNodeTemplate` properties in declaration order, and `Form` renders `formFields` as given, so the order was lost in the conversion. `ConnectionCreator` used `convertConfig`, which sorts keys by default (`node-property-utils.ts:478`). Sorted Pinecone keys are `apiKey, config, httpConfig, queryMode, serviceUrl`; `Form`'s two passes (plain, then `advanced`) split that into exactly the reported order.

The other connector path — `AddConnectionWizard` → `FlowNodeForm` → `convertNodePropertiesToFormFields` — never sorted, so the same `init` read differently depending on which panel opened it. Not Pinecone-specific: every connection kind created through this overlay was affected.

## Changes

- `ConnectionSelector/connectionFormFields.ts` (new) — `convertConnectionConfig()`, order-preserving.
- `ConnectionCreator` uses it. Covers create and edit overlays, and every connection kind (connector, vector store, model/embedding provider, chunker, memory store).
- Dropped the sort from the unreferenced `ballerina-side-panel/src/utils/convertConfig.ts`, whose doc comment claims this overlay, so wiring it up cannot reintroduce the bug.

`convertConfig`'s alphabetical default is unchanged — `FunctionForm`, `AgentToolForm` and `AIAgentSidePanel` lay themselves out around it, and flipping it would relayout five unrelated forms.

## Checks

- New L1 invariant test over captured `getNodeTemplate` payloads (Pinecone `VectorStore`, MySQL `Client`); 4 of its 6 cases fail against the pre-fix call.
- Panel now reads `Service URL, API Key`, then advanced `Query Mode, Pinecone Configuration, HTTP Configuration`.
- `ballerina-visualizer` 561 tests, `ballerina-side-panel` 222 tests, `scripts/typecheck-tests.js` clean; `tsc --noEmit` output identical to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Preserve connection form field order based on `init` parameter declarations.
- Apply the order-preserving conversion to create and edit overlays for all connection types.
- Keep alphabetical ordering for unrelated forms.
- Add connection fixtures and tests for declaration-order behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->