### PR TITLE
Add visible `Open WSO2 Integrator Copilot` link when panel is closed

### DIFF
--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/CopilotComposer.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/CopilotComposer.tsx
@@ -19,6 +19,7 @@
 import { CSSProperties, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { AgentRunStatus, AttachmentStatus, SHARED_COMMANDS } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Button, Icon, ThemeColors } from "@wso2/ui-toolkit";
@@ -520,6 +521,11 @@ export function CopilotComposer({ onAddArtifactManually, hiding }: CopilotCompos
                     <Heading>{runHeading}</Heading>
                     {runDetail && <Subtitle $visible={!aiPanelOpen}>{runDetail}</Subtitle>}
                     {submittedPrompt && <PromptEcho>{submittedPrompt}</PromptEcho>}
+                    {showOpenCopilot && (
+                        <VSCodeLink onClick={() => openCopilotPanel(rpcClient)} style={{ marginTop: 8 }}>
+                            Open WSO2 Integrator Copilot
+                        </VSCodeLink>
+                    )}
                 </RunBlock>
             ) : shownMode === "idle" ? (
                 <IdleBlock>


### PR DESCRIPTION
## Summary
- The Copilot orb icon shown in the Package/Integration Overview empty state during an active run isn't perceived as clickable from the user's point of view — it just looks like a status indicator.
- Adds a clearly clickable "Open WSO2 Integrator Copilot" link under the status text ("Working on it…"), shown only after the Copilot panel has been closed, so users have an obvious way back in.
- Reuses the existing `showOpenCopilot` flag and `openCopilotPanel` helper already wired to the orb button — no new state, RPC, or extension-host changes needed.

It resolves: https://github.com/wso2/product-integrator/issues/2416

Reference: 

https://github.com/user-attachments/assets/45ceb106-04ee-4cb8-af54-a281c0de74e2


## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.