### PR TITLE
Add EU region support for Copilot backend URL routing

### DIFF
--- a/packages/ballerina-extension/.env.example
+++ b/packages/ballerina-extension/.env.example
@@ -1,2 +1,7 @@
 COPILOT_ROOT_URL=https://7eff1239-64bb-4663-b256-30a00d187a5c-prod.e1-us-east-azure.choreoapis.dev/copilot
 COPILOT_DEV_ROOT_URL=https://7eff1239-64bb-4663-b256-30a00d187a5c-dev.e1-us-east-azure.choreoapis.dev/copilot
+# COPILOT_STAGE_ROOT_URL=https://7eff1239-64bb-4663-b256-30a00d187a5c-staging.e1-us-east-azure.choreoapis.dev/copilot
+
+COPILOT_EU_ROOT_URL=https://366b8031-ab7f-4a98-a1bd-3369fbd00eee-prod.e1-eu-west-cdp.choreoapis.dev/copilot
+# COPILOT_EU_DEV_ROOT_URL=
+# COPILOT_EU_STAGE_ROOT_URL=

--- a/packages/ballerina-extension/.env.example
+++ b/packages/ballerina-extension/.env.example
@@ -1,6 +1,6 @@
 COPILOT_ROOT_URL=https://7eff1239-64bb-4663-b256-30a00d187a5c-prod.e1-us-east-azure.choreoapis.dev/copilot
 COPILOT_DEV_ROOT_URL=https://7eff1239-64bb-4663-b256-30a00d187a5c-dev.e1-us-east-azure.choreoapis.dev/copilot
-# COPILOT_STAGE_ROOT_URL=https://7eff1239-64bb-4663-b256-30a00d187a5c-staging.e1-us-east-azure.choreoapis.dev/copilot
+# COPILOT_STAGE_ROOT_URL=
 
 COPILOT_EU_ROOT_URL=https://366b8031-ab7f-4a98-a1bd-3369fbd00eee-prod.e1-eu-west-cdp.choreoapis.dev/copilot
 # COPILOT_EU_DEV_ROOT_URL=

--- a/packages/ballerina-extension/src/features/ai/utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils.ts
@@ -64,12 +64,20 @@ export let DEVANT_TOKEN_EXCHANGE_URL: string = _defaultBackendUrl + "/auth-api/v
 export let OLD_BACKEND_URL: string = _defaultBackendUrl + "/v2.0";
 
 export const setBackendRegion = (region: string): void => {
+    if (config.get('rootUrl')) {
+        return;
+    }
     const normalized = region?.trim().toLowerCase();
     const key = devantEnv ? `${normalized}-${devantEnv}` : normalized;
-    const regionalUrl = COPILOT_ROOT_URLS.get(key) || COPILOT_ROOT_URLS.get(normalized);
+    const regionalUrl = COPILOT_ROOT_URLS.get(key);
+    if (!regionalUrl) {
+        console.error(`No backend URL configured for region '${normalized}'`);
+        return;
+    }
     BACKEND_URL = regionalUrl;
     DEVANT_TOKEN_EXCHANGE_URL = regionalUrl + "/auth-api/v1.0/auth/token-exchange";
     OLD_BACKEND_URL = regionalUrl + "/v2.0";
+    console.log(`[Region] ${region} → BACKEND_URL: ${BACKEND_URL}`);
 };
 
 export async function closeAllBallerinaFiles(dirPath: string): Promise<void> {

--- a/packages/ballerina-extension/src/features/ai/utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils.ts
@@ -45,15 +45,35 @@ const PLATFORM_ENV_SETTING = "WSO2.WSO2-Platform.Advanced.ChoreoEnvironment";
 const devantEnv = (process.env.CHOREO_ENV || process.env.CLOUD_ENV
     || workspace.getConfiguration().get<string>(PLATFORM_ENV_SETTING) || "").trim().toLowerCase();
 const COPILOT_ROOT_URLS = new Map<string, string>([
-    ["dev", process.env.COPILOT_DEV_ROOT_URL],
-    ["stage", process.env.COPILOT_STAGE_ROOT_URL || process.env.COPILOT_DEV_ROOT_URL],
+    ["us", process.env.COPILOT_ROOT_URL],
+    ["us-dev", process.env.COPILOT_DEV_ROOT_URL],
+    ["us-stage", process.env.COPILOT_STAGE_ROOT_URL || process.env.COPILOT_DEV_ROOT_URL],
+    ["eu", process.env.COPILOT_EU_ROOT_URL],
+    ["eu-dev", process.env.COPILOT_EU_DEV_ROOT_URL || process.env.COPILOT_EU_ROOT_URL],
+    ["eu-stage", process.env.COPILOT_EU_STAGE_ROOT_URL || process.env.COPILOT_EU_DEV_ROOT_URL || process.env.COPILOT_EU_ROOT_URL],
 ]);
-export const BACKEND_URL: string = config.get('rootUrl') || COPILOT_ROOT_URLS.get(devantEnv) || process.env.COPILOT_ROOT_URL;
+const _defaultBackendUrl: string = config.get('rootUrl') || COPILOT_ROOT_URLS.get(devantEnv) || process.env.COPILOT_ROOT_URL;
 
-export const DEVANT_TOKEN_EXCHANGE_URL: string = BACKEND_URL + "/auth-api/v1.0/auth/token-exchange";
+export let BACKEND_URL: string = _defaultBackendUrl;
+
+export let DEVANT_TOKEN_EXCHANGE_URL: string = _defaultBackendUrl + "/auth-api/v1.0/auth/token-exchange";
 
 // This refers to old backend before FE Migration. We need to eventually remove this.
-export const OLD_BACKEND_URL: string = BACKEND_URL + "/v2.0";
+export let OLD_BACKEND_URL: string = _defaultBackendUrl + "/v2.0";
+
+export const setBackendRegion = (region: string): void => {
+    const normalized = region?.trim().toLowerCase();
+    const key = devantEnv ? `${normalized}-${devantEnv}` : normalized;
+    const regionalUrl = COPILOT_ROOT_URLS.get(key) || COPILOT_ROOT_URLS.get(normalized);
+    if (regionalUrl) {
+        BACKEND_URL = regionalUrl;
+        DEVANT_TOKEN_EXCHANGE_URL = regionalUrl + "/auth-api/v1.0/auth/token-exchange";
+        OLD_BACKEND_URL = regionalUrl + "/v2.0";
+        console.log(`[Region] ${region} → BACKEND_URL: ${BACKEND_URL}`);
+    } else {
+        console.log(`[Region] ${region} → no URL found, keeping current: ${BACKEND_URL}`);
+    }
+};
 
 export async function closeAllBallerinaFiles(dirPath: string): Promise<void> {
     // Check if the directory exists

--- a/packages/ballerina-extension/src/features/ai/utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils.ts
@@ -46,9 +46,11 @@ const devantEnv = (process.env.CHOREO_ENV || process.env.CLOUD_ENV
     || workspace.getConfiguration().get<string>(PLATFORM_ENV_SETTING) || "").trim().toLowerCase();
 const COPILOT_ROOT_URLS = new Map<string, string>([
     ["us", process.env.COPILOT_ROOT_URL],
+    ["us-prod", process.env.COPILOT_ROOT_URL],
     ["us-dev", process.env.COPILOT_DEV_ROOT_URL],
     ["us-stage", process.env.COPILOT_STAGE_ROOT_URL || process.env.COPILOT_DEV_ROOT_URL],
     ["eu", process.env.COPILOT_EU_ROOT_URL],
+    ["eu-prod", process.env.COPILOT_EU_ROOT_URL],
     ["eu-dev", process.env.COPILOT_EU_DEV_ROOT_URL],
     ["eu-stage", process.env.COPILOT_EU_STAGE_ROOT_URL || process.env.COPILOT_EU_DEV_ROOT_URL],
 ]);
@@ -63,21 +65,22 @@ export let DEVANT_TOKEN_EXCHANGE_URL: string = _defaultBackendUrl + "/auth-api/v
 // This refers to old backend before FE Migration. We need to eventually remove this.
 export let OLD_BACKEND_URL: string = _defaultBackendUrl + "/v2.0";
 
-export const setBackendRegion = (region: string): void => {
+export const setBackendRegion = (region: string): boolean => {
     if (config.get('rootUrl')) {
-        return;
+        return true;
     }
     const normalized = region?.trim().toLowerCase();
     const key = devantEnv ? `${normalized}-${devantEnv}` : normalized;
-    const regionalUrl = COPILOT_ROOT_URLS.get(key);
+    const regionalUrl = COPILOT_ROOT_URLS.get(key) || (devantEnv ? COPILOT_ROOT_URLS.get(normalized) : undefined);
     if (!regionalUrl) {
         console.error(`No backend URL configured for region '${normalized}'`);
-        return;
+        return false;
     }
     BACKEND_URL = regionalUrl;
     DEVANT_TOKEN_EXCHANGE_URL = regionalUrl + "/auth-api/v1.0/auth/token-exchange";
     OLD_BACKEND_URL = regionalUrl + "/v2.0";
     console.log(`[Region] ${region} → BACKEND_URL: ${BACKEND_URL}`);
+    return true;
 };
 
 export async function closeAllBallerinaFiles(dirPath: string): Promise<void> {

--- a/packages/ballerina-extension/src/features/ai/utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils.ts
@@ -49,10 +49,12 @@ const COPILOT_ROOT_URLS = new Map<string, string>([
     ["us-dev", process.env.COPILOT_DEV_ROOT_URL],
     ["us-stage", process.env.COPILOT_STAGE_ROOT_URL || process.env.COPILOT_DEV_ROOT_URL],
     ["eu", process.env.COPILOT_EU_ROOT_URL],
-    ["eu-dev", process.env.COPILOT_EU_DEV_ROOT_URL || process.env.COPILOT_EU_ROOT_URL],
-    ["eu-stage", process.env.COPILOT_EU_STAGE_ROOT_URL || process.env.COPILOT_EU_DEV_ROOT_URL || process.env.COPILOT_EU_ROOT_URL],
+    ["eu-dev", process.env.COPILOT_EU_DEV_ROOT_URL],
+    ["eu-stage", process.env.COPILOT_EU_STAGE_ROOT_URL || process.env.COPILOT_EU_DEV_ROOT_URL],
 ]);
-const _defaultBackendUrl: string = config.get('rootUrl') || COPILOT_ROOT_URLS.get(devantEnv) || process.env.COPILOT_ROOT_URL;
+
+const defaultRegionKey = devantEnv ? `us-${devantEnv}` : "us";
+const _defaultBackendUrl: string = config.get('rootUrl') || COPILOT_ROOT_URLS.get(defaultRegionKey) || process.env.COPILOT_ROOT_URL;
 
 export let BACKEND_URL: string = _defaultBackendUrl;
 
@@ -65,14 +67,9 @@ export const setBackendRegion = (region: string): void => {
     const normalized = region?.trim().toLowerCase();
     const key = devantEnv ? `${normalized}-${devantEnv}` : normalized;
     const regionalUrl = COPILOT_ROOT_URLS.get(key) || COPILOT_ROOT_URLS.get(normalized);
-    if (regionalUrl) {
-        BACKEND_URL = regionalUrl;
-        DEVANT_TOKEN_EXCHANGE_URL = regionalUrl + "/auth-api/v1.0/auth/token-exchange";
-        OLD_BACKEND_URL = regionalUrl + "/v2.0";
-        console.log(`[Region] ${region} → BACKEND_URL: ${BACKEND_URL}`);
-    } else {
-        console.log(`[Region] ${region} → no URL found, keeping current: ${BACKEND_URL}`);
-    }
+    BACKEND_URL = regionalUrl;
+    DEVANT_TOKEN_EXCHANGE_URL = regionalUrl + "/auth-api/v1.0/auth/token-exchange";
+    OLD_BACKEND_URL = regionalUrl + "/v2.0";
 };
 
 export async function closeAllBallerinaFiles(dirPath: string): Promise<void> {

--- a/packages/ballerina-extension/src/features/ai/utils/ai-client.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-client.ts
@@ -60,6 +60,7 @@ export function getBedrockRegionalPrefix(region: string): string {
 
 let cachedAnthropic: ReturnType<typeof createAnthropic> | null = null;
 let cachedAuthMethod: LoginMethod | null = null;
+let cachedBaseUrl: string | null = null;
 
 /**
  * Reusable fetch function that handles authentication with token refresh.
@@ -71,7 +72,7 @@ let cachedAuthMethod: LoginMethod | null = null;
  * @param options - Fetch options
  * @returns Promise<Response>
  */
-export async function fetchWithAuth(input: string | URL | Request, options: RequestInit = {}): Promise<Response | undefined> {
+export async function fetchWithAuth(input: string | URL | Request, options: RequestInit = {}): Promise<Response> {
     try {
         const credentials = await getAccessToken();
         const loginMethod = credentials.loginMethod;
@@ -120,17 +121,20 @@ export async function fetchWithAuth(input: string | URL | Request, options: Requ
                         if (response.status === 401) {
                             console.log("Still unauthorized after token refresh. Logging out.");
                             AIStateMachine.service().send(AIMachineEventType.SILENT_LOGOUT);
-                            return;
+                            throw new Error("Session expired. Please log in again.");
                         }
                     } else {
                         console.log("Token refresh returned null. Logging out.");
                         AIStateMachine.service().send(AIMachineEventType.SILENT_LOGOUT);
-                        return;
+                        throw new Error("Session expired. Please log in again.");
                     }
-                } catch (refreshError) {
+                } catch (refreshError: any) {
+                    if (refreshError?.message === "Session expired. Please log in again.") {
+                        throw refreshError;
+                    }
                     console.error("Token refresh failed:", refreshError);
                     AIStateMachine.service().send(AIMachineEventType.SILENT_LOGOUT);
-                    return;
+                    throw new Error("Session expired. Please log in again.");
                 }
             }
         }
@@ -148,6 +152,7 @@ export async function fetchWithAuth(input: string | URL | Request, options: Requ
     } catch (error: any) {
         if (error?.message === "TOKEN_EXPIRED") {
             AIStateMachine.service().send(AIMachineEventType.SILENT_LOGOUT);
+            throw new Error("Session expired. Please log in again.");
         } else {
             throw error;
         }
@@ -161,9 +166,10 @@ export async function fetchWithAuth(input: string | URL | Request, options: Requ
 export const getAnthropicClient = async (model: AnthropicModel): Promise<any> => {
     const loginMethod = await getLoginMethod();
 
-    // Recreate client if login method has changed or no cached instance
-    if (!cachedAnthropic || cachedAuthMethod !== loginMethod) {
-        let url = BACKEND_URL + LLM_API_BASE_PATH + "/claude";
+    // Recreate client if login method or backend URL has changed
+    const currentUrl = BACKEND_URL + LLM_API_BASE_PATH + "/claude";
+    if (!cachedAnthropic || cachedAuthMethod !== loginMethod || cachedBaseUrl !== currentUrl) {
+        let url = currentUrl;
         if (loginMethod === LoginMethod.BI_INTEL) {
             cachedAnthropic = createAnthropic({
                 baseURL: url,
@@ -249,6 +255,7 @@ export const getAnthropicClient = async (model: AnthropicModel): Promise<any> =>
         }
 
         cachedAuthMethod = loginMethod;
+        cachedBaseUrl = currentUrl;
     }
 
     // For AWS Bedrock, we return directly above, so this is for other methods

--- a/packages/ballerina-extension/src/utils/ai/auth.ts
+++ b/packages/ballerina-extension/src/utils/ai/auth.ts
@@ -18,7 +18,7 @@
 
 import * as vscode from 'vscode';
 import { extension } from "../../BalExtensionContext";
-import { DEVANT_TOKEN_EXCHANGE_URL } from '../../features/ai/utils';
+import { DEVANT_TOKEN_EXCHANGE_URL, setBackendRegion } from '../../features/ai/utils';
 import axios from 'axios';
 import { AuthCredentials, BIIntelSecrets, LoginMethod, AnthropicAwsSecrets } from '@wso2/ballerina-core';
 import { IWso2PlatformExtensionAPI } from '@wso2/wso2-platform-core';
@@ -155,6 +155,10 @@ export const getPlatformStsToken = async (): Promise<string | undefined> => {
         const api = await getPlatformExtensionAPI();
         if (!api) {
             return undefined;
+        }
+        if (api.isLoggedIn()) {
+            const { region } = api.getAuthState();
+            setBackendRegion(region.toLowerCase());
         }
         return await api.getStsToken();
     } catch (error) {

--- a/packages/ballerina-extension/src/utils/ai/auth.ts
+++ b/packages/ballerina-extension/src/utils/ai/auth.ts
@@ -157,8 +157,14 @@ export const getPlatformStsToken = async (): Promise<string | undefined> => {
             return undefined;
         }
         if (api.isLoggedIn()) {
-            const { region } = api.getAuthState();
-            setBackendRegion(region.toLowerCase());
+            try {
+                const region = api.getAuthState()?.region;
+                if (region) {
+                    setBackendRegion(region.toLowerCase());
+                }
+            } catch {
+                /* keep default region */
+            }
         }
         return await api.getStsToken();
     } catch (error) {
@@ -402,10 +408,12 @@ export const getRefreshedAccessToken = async (): Promise<string> => {
                 console.log('Refreshing token via STS exchange...');
                 const newSecrets = await refreshTokenViaStsExchange();
 
-                // Update stored credentials
+                // Update stored credentials, persisting region so warm restarts restore it
+                const api = await getPlatformExtensionAPI();
+                const region = api?.getAuthState()?.region?.trim().toLowerCase();
                 const updatedCredentials: AuthCredentials = {
                     loginMethod: LoginMethod.BI_INTEL,
-                    secrets: newSecrets
+                    secrets: { ...newSecrets, ...(region && { region }) }
                 };
                 await storeAuthCredentials(updatedCredentials);
 

--- a/packages/ballerina-extension/src/utils/ai/auth.ts
+++ b/packages/ballerina-extension/src/utils/ai/auth.ts
@@ -157,13 +157,9 @@ export const getPlatformStsToken = async (): Promise<string | undefined> => {
             return undefined;
         }
         if (api.isLoggedIn()) {
-            try {
-                const region = api.getAuthState()?.region;
-                if (region) {
-                    setBackendRegion(region.toLowerCase());
-                }
-            } catch {
-                /* keep default region */
+            const region = api.getAuthState()?.region;
+            if (region && !setBackendRegion(region.toLowerCase())) {
+                throw new Error(`No backend URL configured for region '${region}'. Rebuild the extension to pick up regional backend URLs from .env.`);
             }
         }
         return await api.getStsToken();

--- a/packages/ballerina-extension/src/utils/ai/auth.ts
+++ b/packages/ballerina-extension/src/utils/ai/auth.ts
@@ -157,9 +157,13 @@ export const getPlatformStsToken = async (): Promise<string | undefined> => {
             return undefined;
         }
         if (api.isLoggedIn()) {
-            const region = api.getAuthState()?.region;
-            if (region && !setBackendRegion(region.toLowerCase())) {
-                throw new Error(`No backend URL configured for region '${region}'. Rebuild the extension to pick up regional backend URLs from .env.`);
+            try {
+                const region = api.getAuthState()?.region;
+                if (region) {
+                    setBackendRegion(region.toLowerCase());
+                }
+            } catch {
+                /* region resolution non-fatal; keep default backend */
             }
         }
         return await api.getStsToken();
@@ -405,8 +409,13 @@ export const getRefreshedAccessToken = async (): Promise<string> => {
                 const newSecrets = await refreshTokenViaStsExchange();
 
                 // Update stored credentials, persisting region so warm restarts restore it
-                const api = await getPlatformExtensionAPI();
-                const region = api?.getAuthState()?.region?.trim().toLowerCase();
+                let region: string | undefined;
+                try {
+                    const api = await getPlatformExtensionAPI();
+                    region = api?.getAuthState()?.region?.trim().toLowerCase();
+                } catch {
+                    /* region persistence is best-effort */
+                }
                 const updatedCredentials: AuthCredentials = {
                     loginMethod: LoginMethod.BI_INTEL,
                     secrets: { ...newSecrets, ...(region && { region }) }

--- a/packages/ballerina-extension/src/views/ai-panel/aiMachine.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/aiMachine.ts
@@ -493,7 +493,12 @@ const completeSsoSignIn = async (): Promise<void> => {
         throw new Error('Failed to get STS token from platform extension');
     }
     const secrets = await exchangeStsToCopilotToken(stsToken);
-    await storeAuthCredentials({ loginMethod: LoginMethod.BI_INTEL, secrets });
+    const api = await getPlatformExtensionAPI();
+    const region = api?.getAuthState()?.region?.trim().toLowerCase();
+    await storeAuthCredentials({
+        loginMethod: LoginMethod.BI_INTEL,
+        secrets: { ...secrets, ...(region && { region }) }
+    });
     aiStateService.send(AIMachineEventType.COMPLETE_AUTH);
 };
 

--- a/packages/ballerina-extension/src/views/ai-panel/aiMachine.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/aiMachine.ts
@@ -493,8 +493,13 @@ const completeSsoSignIn = async (): Promise<void> => {
         throw new Error('Failed to get STS token from platform extension');
     }
     const secrets = await exchangeStsToCopilotToken(stsToken);
-    const api = await getPlatformExtensionAPI();
-    const region = api?.getAuthState()?.region?.trim().toLowerCase();
+    let region: string | undefined;
+    try {
+        const api = await getPlatformExtensionAPI();
+        region = api?.getAuthState()?.region?.trim().toLowerCase();
+    } catch {
+        /* region persistence is best-effort; sign-in still completes */
+    }
     await storeAuthCredentials({
         loginMethod: LoginMethod.BI_INTEL,
         secrets: { ...secrets, ...(region && { region }) }

--- a/packages/ballerina-extension/src/views/ai-panel/utils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/utils.ts
@@ -18,7 +18,7 @@
 
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import { AIUserToken, LoginMethod, AuthCredentials } from '@wso2/ballerina-core';
+import { AIUserToken, LoginMethod, AuthCredentials, BIIntelSecrets } from '@wso2/ballerina-core';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createAnthropicAws } from '@ai-sdk/anthropic-aws';
@@ -33,9 +33,11 @@ import {
     isPlatformExtensionAvailable,
     isDevantUserLoggedIn,
     getPlatformStsToken,
-    exchangeStsToCopilotToken
+    exchangeStsToCopilotToken,
+    getPlatformExtensionAPI
 } from '../../utils/ai/auth';
 import { getBedrockRegionalPrefix } from '../../features/ai/utils/ai-client';
+import { setBackendRegion } from '../../features/ai/utils';
 import { WICommandIds } from '@wso2/wso2-platform-core';
 
 const LEGACY_ACCESS_TOKEN_SECRET_KEY = 'BallerinaAIUser';
@@ -50,6 +52,13 @@ export const checkToken = async (): Promise<AuthCredentials | undefined> => {
             // First check if we have stored credentials
             const credentials = await getAccessToken();
             if (credentials) {
+                // Warm restart: restore the backend region so we don't hit US when the user is EU
+                if (credentials.loginMethod === LoginMethod.BI_INTEL) {
+                    const { region } = credentials.secrets as BIIntelSecrets;
+                    if (region) {
+                        setBackendRegion(region);
+                    }
+                }
                 resolve(credentials);
                 return;
             }
@@ -64,9 +73,11 @@ export const checkToken = async (): Promise<AuthCredentials | undefined> => {
                         const stsToken = await getPlatformStsToken();
                         if (stsToken) {
                             const secrets = await exchangeStsToCopilotToken(stsToken);
+                            const api = await getPlatformExtensionAPI();
+                            const region = api?.getAuthState()?.region?.trim().toLowerCase();
                             const newCredentials: AuthCredentials = {
                                 loginMethod: LoginMethod.BI_INTEL,
-                                secrets
+                                secrets: { ...secrets, ...(region && { region }) }
                             };
                             await storeAuthCredentials(newCredentials);
                             resolve(newCredentials);

--- a/packages/ballerina-extension/src/views/ai-panel/utils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/utils.ts
@@ -73,8 +73,13 @@ export const checkToken = async (): Promise<AuthCredentials | undefined> => {
                         const stsToken = await getPlatformStsToken();
                         if (stsToken) {
                             const secrets = await exchangeStsToCopilotToken(stsToken);
-                            const api = await getPlatformExtensionAPI();
-                            const region = api?.getAuthState()?.region?.trim().toLowerCase();
+                            let region: string | undefined;
+                            try {
+                                const api = await getPlatformExtensionAPI();
+                                region = api?.getAuthState()?.region?.trim().toLowerCase();
+                            } catch {
+                                /* region persistence is best-effort */
+                            }
                             const newCredentials: AuthCredentials = {
                                 loginMethod: LoginMethod.BI_INTEL,
                                 secrets: { ...secrets, ...(region && { region }) }


### PR DESCRIPTION
## Purpose
Introduce dynamic backend URL switching based on the user's Choreo region. BACKEND_URL, DEVANT_TOKEN_EXCHANGE_URL, and OLD_BACKEND_URL are now mutable and updated at login time via setBackendRegion(), which resolves the correct endpoint from a region-keyed map covering US and EU prod/dev/stage environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds EU backend routing for Copilot production, development, and staging environments. The extension selects regional endpoints at login through `setBackendRegion()` and updates `BACKEND_URL`, `DEVANT_TOKEN_EXCHANGE_URL`, and `OLD_BACKEND_URL`. Authentication state persists the selected region, restores it after restart, and refreshes the client when the backend URL changes. Authentication and token refresh continue when platform-extension state lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes https://github.com/wso2/product-integrator/issues/1890