### PR TITLE
Fix checkpoint restore reporting failure, damaging files, and racing new generations

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/index.ts
@@ -17,6 +17,7 @@
 import { Command, ExecutionContext, GenerateAgentCodeRequest } from "@wso2/ballerina-core";
 import { StateMachine } from "../../../stateMachine";
 import { chatStateStorage } from '../../../views/ai-panel/chatStateStorage';
+import { assertNoRestoreInProgress } from '../../../views/ai-panel/checkpoint/restore-state';
 import { AICommandConfig } from "../executors/base/AICommandExecutor";
 import { createWebviewEventHandler } from "../utils/events";
 import { AgentExecutor } from './AgentExecutor';
@@ -126,6 +127,10 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
         ) {
             throw new Error('A generation is already in progress. Please wait for it to finish before starting a new one.');
         }
+
+        // A restore is mid-flight: it is about to truncate this thread, and finalizing below would
+        // implicitly accept the very generation it is reverting.
+        assertNoRestoreInProgress(projectRootPath, 'generateAgent');
 
         // Moving on to a new generation implicitly accepts a still-open previous one —
         // on EVERY thread of the project, not just this one: the upcoming ai:// baseline

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -813,7 +813,7 @@ User reverted the last made changes. The files have been restored to the state b
             if (!found) {
                 if (chatStateStorage.hasCompactedHistory(projectRootPath, threadId)) {
                     window.showWarningMessage(
-                        "This conversation was compacted to manage memory. Undo points prior to compaction are unavailable."
+                        "This conversation was compacted to manage memory. Earlier undo points are no longer available."
                     );
                     throw new Error("Checkpoint unavailable due to compaction");
                 }

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -160,6 +160,12 @@ import { approvalViewManager } from '../../features/ai/state/ApprovalViewManager
 import { chatStateStorage, isRevertible } from '../../views/ai-panel/chatStateStorage';
 import { runEventStore } from '../../features/ai/utils/run-event-store';
 import { restoreWorkspaceSnapshot } from '../../views/ai-panel/checkpoint/checkpointUtils';
+import {
+    assertNoRestoreInProgress,
+    beginRestore,
+    endRestore,
+    isRestoreInProgress
+} from '../../views/ai-panel/checkpoint/restore-state';
 import { runningServicesManager } from '../../features/ai/agent/tools/running-service-manager';
 import { executeRun } from "../../features/ai/agent/tools/ballerina-run";
 import { platformExtStore } from "../platform-ext/platform-store";
@@ -201,15 +207,20 @@ const CONNECTION_FAILURE_MESSAGE: Record<ConnectionSettleReason, string> = {
 
 /**
  * A run owns the active thread until it ends, so reparenting it mid-turn would strand the
- * run's writes. The panel already disables these actions; this backstops a webview reload
- * or a click that races the turn starting.
+ * run's writes; a restore is about to truncate that thread, and recreates it if it has gone.
+ * The panel already disables these actions; this backstops a webview reload or a click that
+ * races the turn starting.
  */
-function refuseWhileRunning(projectRootPath: string, action: string): boolean {
-    if (!runEventStore.hasActiveRun(projectRootPath)) {
-        return false;
+function refuseWhileBusy(projectRootPath: string, action: string): boolean {
+    if (runEventStore.hasActiveRun(projectRootPath)) {
+        console.warn(`[RPC] Refused ${action} — a response is still running for: ${projectRootPath}`);
+        return true;
     }
-    console.warn(`[RPC] Refused ${action} — a response is still running for: ${projectRootPath}`);
-    return true;
+    if (isRestoreInProgress(projectRootPath)) {
+        console.warn(`[RPC] Refused ${action} — a checkpoint restore is still running for: ${projectRootPath}`);
+        return true;
+    }
+    return false;
 }
 
 export class AiPanelRpcManager implements AIPanelAPI {
@@ -537,8 +548,10 @@ export class AiPanelRpcManager implements AIPanelAPI {
     }
 
     async revertGeneration(params: RevertGenerationRequest): Promise<void> {
+        const projectRootPath = resolveProjectRootPath();
+        assertNoRestoreInProgress(projectRootPath, 'revertGeneration');
+        beginRestore(projectRootPath);
         try {
-            const projectRootPath = resolveProjectRootPath();
             // Resolve the thread from the generation the bar names, not the active-thread pointer:
             // another thread can hold its own revertible generation.
             const located = chatStateStorage.findGenerationScope(projectRootPath, params.generationId);
@@ -599,6 +612,8 @@ User reverted the last made changes. The files have been restored to the state b
         } catch (error) {
             console.error("[Review Actions] Error reverting generation:", error);
             throw error;
+        } finally {
+            endRestore(projectRootPath);
         }
     }
 
@@ -778,47 +793,58 @@ User reverted the last made changes. The files have been restored to the state b
     async restoreCheckpoint(params: RestoreCheckpointRequest): Promise<void> {
         // Get project root path and thread identifiers
         const projectRootPath = resolveProjectRootPath();
-        const threadId = chatStateStorage.getActiveThreadId(resolveProjectRootPath());
+        assertNoRestoreInProgress(projectRootPath, 'restoreCheckpoint');
+        if (runEventStore.hasActiveRun(projectRootPath)) {
+            // The mirror of refuseWhileBusy: a run still writing files would land its edits on top
+            // of the restored ones, and its own generation is what the truncation is about to drop.
+            throw new Error('A response is still running. Please wait for it to finish before restoring.');
+        }
+        beginRestore(projectRootPath);
+        try {
+            const threadId = chatStateStorage.getActiveThreadId(projectRootPath);
 
-        // Find the checkpoint
-        const found = chatStateStorage.findCheckpoint(projectRootPath, threadId, params.checkpointId);
+            // Find the checkpoint
+            const found = chatStateStorage.findCheckpoint(projectRootPath, threadId, params.checkpointId);
 
-        if (!found) {
-            if (chatStateStorage.hasCompactedHistory(projectRootPath, threadId)) {
-                window.showWarningMessage(
-                    "This conversation was compacted to manage memory. Undo points prior to compaction are unavailable."
-                );
-                throw new Error("Checkpoint unavailable due to compaction");
+            if (!found) {
+                if (chatStateStorage.hasCompactedHistory(projectRootPath, threadId)) {
+                    window.showWarningMessage(
+                        "This conversation was compacted to manage memory. Undo points prior to compaction are unavailable."
+                    );
+                    throw new Error("Checkpoint unavailable due to compaction");
+                }
+                throw new Error(`Checkpoint ${params.checkpointId} not found`);
             }
-            throw new Error(`Checkpoint ${params.checkpointId} not found`);
-        }
 
-        const { checkpoint } = found;
+            const { checkpoint } = found;
 
-        // 1. Restore workspace files from checkpoint snapshot.
-        // restoreWorkspaceSnapshot reports its own failures to the user but does not throw, so a
-        // failed restore must not fall through to truncating the thread history — that loss is
-        // irreversible while the files would stay unchanged.
-        const workspaceRestored = await restoreWorkspaceSnapshot(checkpoint);
-        if (!workspaceRestored) {
-            throw new Error('Restoring the workspace from the checkpoint failed; the conversation was not rewound.');
-        }
+            // 1. Restore workspace files from checkpoint snapshot.
+            // restoreWorkspaceSnapshot reports its own failures to the user but does not throw, so a
+            // failed restore must not fall through to truncating the thread history — that loss is
+            // irreversible while the files would stay unchanged.
+            const workspaceRestored = await restoreWorkspaceSnapshot(checkpoint);
+            if (!workspaceRestored) {
+                throw new Error('Restoring the workspace from the checkpoint failed; the conversation was not rewound.');
+            }
 
-        // 2. Truncate thread history to this checkpoint
-        const restored = chatStateStorage.restoreThreadToCheckpoint(
-            projectRootPath,
-            threadId,
-            params.checkpointId
-        );
+            // 2. Truncate thread history to this checkpoint
+            const restored = chatStateStorage.restoreThreadToCheckpoint(
+                projectRootPath,
+                threadId,
+                params.checkpointId
+            );
 
-        if (!restored) {
-            throw new Error('Failed to restore thread to checkpoint');
+            if (!restored) {
+                throw new Error('Failed to restore thread to checkpoint');
+            }
+        } finally {
+            endRestore(projectRootPath);
         }
     }
 
     async clearChat(): Promise<void> {
         const projectRootPath = resolveProjectRootPath();
-        if (refuseWhileRunning(projectRootPath, 'clearChat')) { return; }
+        if (refuseWhileBusy(projectRootPath, 'clearChat')) { return; }
         // Create a new thread — preserves all existing history
         const newThreadId = chatStateStorage.createNewThread(projectRootPath);
         clearCompactionDisabledWarning(projectRootPath, newThreadId);
@@ -832,13 +858,13 @@ User reverted the last made changes. The files have been restored to the state b
 
     async switchThread(params: SwitchThreadRequest): Promise<void> {
         const projectRootPath = resolveProjectRootPath();
-        if (refuseWhileRunning(projectRootPath, 'switchThread')) { return; }
+        if (refuseWhileBusy(projectRootPath, 'switchThread')) { return; }
         chatStateStorage.switchToThread(projectRootPath, params.threadId);
     }
 
     async deleteThread(params: DeleteThreadRequest): Promise<void> {
         const projectRootPath = resolveProjectRootPath();
-        if (refuseWhileRunning(projectRootPath, 'deleteThread')) { return; }
+        if (refuseWhileBusy(projectRootPath, 'deleteThread')) { return; }
         await chatStateStorage.deleteThread(projectRootPath, params.threadId);
     }
 

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -212,7 +212,7 @@ const CONNECTION_FAILURE_MESSAGE: Record<ConnectionSettleReason, string> = {
  * races the turn starting.
  */
 function refuseWhileBusy(projectRootPath: string, action: string): boolean {
-    if (runEventStore.hasActiveRun(projectRootPath)) {
+    if (runEventStore.hasActiveRun(projectRootPath) || chatStateStorage.hasActiveExecutionFor(projectRootPath)) {
         console.warn(`[RPC] Refused ${action} — a response is still running for: ${projectRootPath}`);
         return true;
     }
@@ -797,10 +797,11 @@ User reverted the last made changes. The files have been restored to the state b
         // Get project root path and thread identifiers
         const projectRootPath = resolveProjectRootPath();
         assertNoRestoreInProgress(projectRootPath, 'restoreCheckpoint');
-        if (runEventStore.hasActiveRun(projectRootPath)) {
-            // A run still writing files would land its edits on top of the restored ones, and its
-            // own generation is what the truncation is about to drop. revertGeneration needs no
-            // such check: a running generation is never `done`, so it is never revertible.
+        if (runEventStore.hasActiveRun(projectRootPath) || chatStateStorage.hasActiveExecutionFor(projectRootPath)) {
+            // Anything still writing would land its edits on top of the restored ones, and its own
+            // generation is what the truncation is about to drop. The execution check is the one
+            // that covers executors which never begin a tracked run, the type creator among them.
+            // revertGeneration needs neither: a running generation is never `done`, so never revertible.
             throw new Error('A response is still running. Please wait for it to finish before restoring.');
         }
         beginRestore(projectRootPath);

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -456,6 +456,9 @@ export class AiPanelRpcManager implements AIPanelAPI {
 
     async generateContextTypes(params: ProcessContextTypeCreationRequest): Promise<void> {
         try {
+            // Writes a generation to the active thread without ever calling beginRun, so
+            // hasActiveRun cannot see it and the restore guard has to be asked directly.
+            assertNoRestoreInProgress(resolveProjectRootPath(), 'generateContextTypes');
             // existingTempPath: operate on the real workspace directly, no temp copy.
             const config = createExecutorConfig(params, {
                 command: Command.TypeCreator,
@@ -795,8 +798,9 @@ User reverted the last made changes. The files have been restored to the state b
         const projectRootPath = resolveProjectRootPath();
         assertNoRestoreInProgress(projectRootPath, 'restoreCheckpoint');
         if (runEventStore.hasActiveRun(projectRootPath)) {
-            // The mirror of refuseWhileBusy: a run still writing files would land its edits on top
-            // of the restored ones, and its own generation is what the truncation is about to drop.
+            // A run still writing files would land its edits on top of the restored ones, and its
+            // own generation is what the truncation is about to drop. revertGeneration needs no
+            // such check: a running generation is never `done`, so it is never revertible.
             throw new Error('A response is still running. Please wait for it to finish before restoring.');
         }
         beginRestore(projectRootPath);

--- a/packages/ballerina-extension/src/test-support/__mocks__/vscode.ts
+++ b/packages/ballerina-extension/src/test-support/__mocks__/vscode.ts
@@ -19,6 +19,8 @@
 // Minimal `vscode` stub for host-side unit/contract tests (no real editor).
 // Extend as contract tests need more surface.
 
+import * as nodeFs from "fs";
+
 /** Editor tab input, matched with `instanceof` by anything that filters tabs. */
 export class TabInputText {
     constructor(public readonly uri: { fsPath: string; toString(): string }) {}
@@ -28,6 +30,8 @@ export const window = {
     showErrorMessage: () => Promise.resolve(undefined),
     showInformationMessage: () => Promise.resolve(undefined),
     showWarningMessage: () => Promise.resolve(undefined),
+    withProgress: <T>(_options: unknown, task: (progress: { report(_v: unknown): void }) => Thenable<T>) =>
+        task({ report() {} }),
     createOutputChannel: () => ({ appendLine() {}, append() {}, show() {}, clear() {}, dispose() {} }),
     activeTextEditor: undefined,
     // Tests assign `all` and spy on `close`.
@@ -38,7 +42,24 @@ export const window = {
 };
 
 export const workspace = {
-    getConfiguration: () => ({ get: () => undefined, update: () => Promise.resolve(), inspect: () => undefined }),
+    getConfiguration: () => ({
+        // Real `get` falls back to the caller's default, and code that reads settings relies on it.
+        get: (_section: string, defaultValue?: unknown) => defaultValue,
+        update: () => Promise.resolve(),
+        inspect: () => undefined,
+    }),
+    // Backed by the real filesystem so tests can drive file-restoring code against a temp dir.
+    fs: {
+        readFile: (uri: { fsPath: string }) => Promise.resolve(nodeFs.readFileSync(uri.fsPath)),
+        writeFile: (uri: { fsPath: string }, content: Uint8Array) => {
+            nodeFs.writeFileSync(uri.fsPath, content);
+            return Promise.resolve();
+        },
+    },
+    // Tests assign these to stand in for the editor's own file scan and edit application.
+    findFiles: (_include?: unknown, _exclude?: unknown) => Promise.resolve([] as unknown[]),
+    applyEdit: (_edit: unknown) => Promise.resolve(true),
+    saveAll: (_includeUntitled?: boolean) => Promise.resolve(true),
     workspaceFolders: [] as unknown[],
     isTrusted: true,
     // Tests assign this to stand in for the documents VS Code has materialised.
@@ -57,6 +78,38 @@ export const Uri = {
     parse: (p: string) => ({ fsPath: p, path: p, scheme: "file", toString: () => p }),
 };
 
+export enum ProgressLocation {
+    SourceControl = 1,
+    Window = 10,
+    Notification = 15,
+}
+
+export class Position {
+    constructor(public readonly line: number, public readonly character: number) {}
+}
+
+export class Range {
+    constructor(public readonly start: Position, public readonly end: Position) {}
+}
+
+export class RelativePattern {
+    constructor(public readonly base: unknown, public readonly pattern: string) {}
+}
+
+/** Records what an edit would do; tests assert on `entries` and stub `workspace.applyEdit`. */
+export class WorkspaceEdit {
+    entries: { op: "create" | "delete" | "replace"; uri: { fsPath: string }; content?: string }[] = [];
+    createFile(uri: { fsPath: string }, _options?: unknown) {
+        this.entries.push({ op: "create", uri });
+    }
+    deleteFile(uri: { fsPath: string }, _options?: unknown) {
+        this.entries.push({ op: "delete", uri });
+    }
+    replace(uri: { fsPath: string }, _range: unknown, content: string) {
+        this.entries.push({ op: "replace", uri, content });
+    }
+}
+
 export enum ViewColumn {
     Active = -1,
     One = 1,
@@ -71,4 +124,17 @@ export class EventEmitter<T = unknown> {
 
 export const env = { openExternal: () => Promise.resolve(true) };
 
-export default { window, workspace, commands, Uri, ViewColumn, EventEmitter, env };
+export default {
+    window,
+    workspace,
+    commands,
+    Uri,
+    ViewColumn,
+    ProgressLocation,
+    Position,
+    Range,
+    RelativePattern,
+    WorkspaceEdit,
+    EventEmitter,
+    env,
+};

--- a/packages/ballerina-extension/src/test-support/__mocks__/vscode.ts
+++ b/packages/ballerina-extension/src/test-support/__mocks__/vscode.ts
@@ -27,9 +27,10 @@ export class TabInputText {
 }
 
 export const window = {
-    showErrorMessage: () => Promise.resolve(undefined),
-    showInformationMessage: () => Promise.resolve(undefined),
-    showWarningMessage: () => Promise.resolve(undefined),
+    // Tests reassign these to record what the user would have been shown.
+    showErrorMessage: (_message?: string, ..._items: string[]) => Promise.resolve(undefined),
+    showInformationMessage: (_message?: string, ..._items: string[]) => Promise.resolve(undefined),
+    showWarningMessage: (_message?: string, ..._items: string[]) => Promise.resolve(undefined),
     withProgress: <T>(_options: unknown, task: (progress: { report(_v: unknown): void }) => Thenable<T>) =>
         task({ report() {} }),
     createOutputChannel: () => ({ appendLine() {}, append() {}, show() {}, clear() {}, dispose() {} }),
@@ -55,6 +56,11 @@ export const workspace = {
             nodeFs.writeFileSync(uri.fsPath, content);
             return Promise.resolve();
         },
+        // Tests reassign this to assert on the options (useTrash) the caller passes.
+        delete: (uri: { fsPath: string }, _options?: { recursive?: boolean; useTrash?: boolean }) => {
+            nodeFs.rmSync(uri.fsPath, { force: true });
+            return Promise.resolve();
+        },
     },
     // Tests assign these to stand in for the editor's own file scan and edit application.
     findFiles: (_include?: unknown, _exclude?: unknown) => Promise.resolve([] as unknown[]),
@@ -63,7 +69,12 @@ export const workspace = {
     workspaceFolders: [] as unknown[],
     isTrusted: true,
     // Tests assign this to stand in for the documents VS Code has materialised.
-    textDocuments: [] as { uri: { fsPath: string; toString(): string }; isDirty: boolean; save(): Promise<boolean> }[],
+    textDocuments: [] as {
+        uri: { fsPath: string; toString(): string };
+        isDirty: boolean;
+        save(): Promise<boolean>;
+        getText?(): string;
+    }[],
     onDidChangeConfiguration: () => ({ dispose() {} }),
     onDidGrantWorkspaceTrust: () => ({ dispose() {} }),
 };

--- a/packages/ballerina-extension/src/test-support/artifactUpdateWait.test.ts
+++ b/packages/ballerina-extension/src/test-support/artifactUpdateWait.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The unsubscribe handed out by ArtifactNotificationHandler closes over the subscriber Set and
+// drops the whole notification entry once that Set is empty, so releasing a wait twice would
+// delete a Set that belongs to whoever subscribed in between.
+
+import {
+    ArtifactNotificationHandler,
+    ArtifactsUpdated,
+    startArtifactUpdateWait,
+} from "../utils/project-artifacts-handler";
+
+function publish(): void {
+    ArtifactNotificationHandler.getInstance().publish(ArtifactsUpdated.method, {
+        data: [] as never,
+        timestamp: Date.now(),
+    });
+}
+
+describe("artifact update wait", () => {
+    beforeEach(() => {
+        const handler = ArtifactNotificationHandler.getInstance() as unknown as { subscribers: Map<string, unknown> };
+        handler.subscribers.clear();
+    });
+
+    it("leaves later subscribers alone when a settled wait is cancelled", async () => {
+        const wait = startArtifactUpdateWait(() => { /* not the point of this test */ });
+        publish();
+        await expect(wait.notified).resolves.toBe(true);
+
+        // Something else starts listening in the window before the restore unwinds.
+        const laterListener = jest.fn();
+        ArtifactNotificationHandler.getInstance().subscribe(ArtifactsUpdated.method, undefined, laterListener);
+
+        // A restore that fails after the notification arrived cancels its already-settled wait.
+        wait.cancel();
+        publish();
+
+        expect(laterListener).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops listening once cancelled before any notification", async () => {
+        const onArtifacts = jest.fn();
+        const wait = startArtifactUpdateWait(onArtifacts);
+
+        wait.cancel();
+        publish();
+
+        await expect(wait.notified).resolves.toBe(false);
+        expect(onArtifacts).not.toHaveBeenCalled();
+    });
+});

--- a/packages/ballerina-extension/src/test-support/checkpointRestore.test.ts
+++ b/packages/ballerina-extension/src/test-support/checkpointRestore.test.ts
@@ -273,6 +273,44 @@ describe("what a checkpoint restore is allowed to touch", () => {
         expect(applied.filter(e => e.op === "replace").map(e => e.content)).toContain(ORIGINAL_BAL);
     });
 
+    it("restores a file whose open editor still holds pre-generation text", async () => {
+        // The agent writes non-.bal files straight to disk, so an open, unmodified editor can lag
+        // behind: its buffer matches the snapshot while disk holds the generation's content.
+        workspace.textDocuments = [{
+            uri: Uri.file(at("Config.toml")),
+            isDirty: false,
+            save: () => Promise.resolve(true),
+            getText: () => ORIGINAL_CONFIG,
+        } as never];
+
+        await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+
+        expect(fs.readFileSync(at("Config.toml"), "utf8")).toBe(ORIGINAL_CONFIG);
+    });
+
+    it("follows the user's trash setting when deleting a file the snapshot never captured", async () => {
+        fs.writeFileSync(at("added-by-hand.csv"), "id,name\n1,ada\n");
+        const deletes: Array<boolean | undefined> = [];
+        workspace.fs.delete = (_uri: { fsPath: string }, options?: { useTrash?: boolean }) => {
+            deletes.push(options?.useTrash);
+            return Promise.resolve();
+        };
+        const originalGetConfiguration = workspace.getConfiguration;
+        workspace.getConfiguration = ((section?: string) => ({
+            get: (key: string, defaultValue?: unknown) =>
+                section === "files" && key === "enableTrash" ? false : defaultValue,
+            update: () => Promise.resolve(),
+            inspect: () => undefined,
+        })) as never;
+
+        try {
+            await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+            expect(deletes).toEqual([false]);
+        } finally {
+            workspace.getConfiguration = originalGetConfiguration;
+        }
+    });
+
     it("leaves a file in place when the trash refuses it, rather than deleting it permanently", async () => {
         fs.writeFileSync(at("added-by-hand.csv"), "id,name\n1,ada\n");
         workspace.fs.delete = () => Promise.reject(new Error("trash is not available"));

--- a/packages/ballerina-extension/src/test-support/checkpointRestore.test.ts
+++ b/packages/ballerina-extension/src/test-support/checkpointRestore.test.ts
@@ -20,7 +20,7 @@
 // the artifacts of what it just wrote. That notification is advisory — it only refreshes the
 // visualizer's current location — and it can legitimately never arrive, so whether it does must
 // not decide the restore's outcome: the caller truncates the chat history on the strength of that
-// boolean, and a stale history against reverted files is what wso2/product-integrator#2406 reports.
+// boolean, and a stale history against reverted files is the state to avoid.
 
 import * as fs from "fs";
 import * as os from "os";
@@ -56,9 +56,11 @@ jest.mock("../RPCLayer", () => ({
     suppressWebviewNotifications: () => () => {},
 }));
 
-import { restoreWorkspaceSnapshot } from "../views/ai-panel/checkpoint/checkpointUtils";
+import { captureWorkspaceSnapshot, restoreWorkspaceSnapshot } from "../views/ai-panel/checkpoint/checkpointUtils";
 
 const ORIGINAL_CONFIG = 'greeting = "before the generation"\n';
+/** PNG magic bytes plus sequences no UTF-8 decoder can round-trip. */
+const RAW_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe, 0x00, 0x80]);
 const ORIGINAL_BAL = "// before the generation\n";
 
 /** Lets the restore's promise chain run to its next timer-bound step under fake timers. */
@@ -221,17 +223,64 @@ describe("what a checkpoint restore is allowed to touch", () => {
         fs.rmSync(root, { recursive: true, force: true });
     });
 
-    it("leaves a file whose bytes are not valid UTF-8 exactly as it is", async () => {
-        // A checkpoint stores decoded strings, so this file's snapshot entry is already mangled.
-        const rawBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe, 0x00, 0x80]);
-        fs.writeFileSync(at("logo.png"), rawBytes);
+    it("captures a non-text file into the file list but not into the snapshot", async () => {
+        fs.writeFileSync(at("logo.png"), RAW_BYTES);
+
+        const captured: any = await captureWorkspaceSnapshot("msg-1");
+
+        // In the file list so a restore never deletes it; out of the snapshot so a restore never
+        // writes a lossy decode over it.
+        expect(captured.fileList).toContain("logo.png");
+        expect(Object.keys(captured.workspaceSnapshot)).not.toContain("logo.png");
+        expect(captured.workspaceSnapshot["Config.toml"]).toBeDefined();
+    });
+
+    it("leaves a non-text file alone without reporting it, when the snapshot never held it", async () => {
+        fs.writeFileSync(at("logo.png"), RAW_BYTES);
         checkpoint.fileList.push("logo.png");
-        checkpoint.workspaceSnapshot["logo.png"] = rawBytes.toString("utf8");
 
         await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
 
-        expect(fs.readFileSync(at("logo.png")).equals(rawBytes)).toBe(true);
+        expect(fs.readFileSync(at("logo.png")).equals(RAW_BYTES)).toBe(true);
+        expect(warnings).toEqual([]);
+    });
+
+    it("never recreates a file from a lossy snapshot entry left by an older checkpoint", async () => {
+        // The generation deleted the image, so a restore would have to write it back — and the only
+        // content an older checkpoint has for it is the mangled decode.
+        checkpoint.fileList.push("logo.png");
+        checkpoint.workspaceSnapshot["logo.png"] = RAW_BYTES.toString("utf8");
+
+        await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+
+        expect(fs.existsSync(at("logo.png"))).toBe(false);
         expect(warnings.join(" ")).toContain("logo.png");
+    });
+
+    it("restores a file even when an SCM diff document shares its path", async () => {
+        fs.writeFileSync(at("main.bal"), "// the generation's edit\n");
+        // A `git:` document mirrors main.bal with the same fsPath and HEAD's content, which equals
+        // the snapshot — comparing against it would skip restoring the real file.
+        workspace.textDocuments = [{
+            uri: { fsPath: at("main.bal"), toString: () => `git://${at("main.bal")}`, scheme: "git" },
+            isDirty: false,
+            save: () => Promise.resolve(true),
+            getText: () => ORIGINAL_BAL,
+        } as never];
+
+        await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+
+        expect(applied.filter(e => e.op === "replace").map(e => e.content)).toContain(ORIGINAL_BAL);
+    });
+
+    it("leaves a file in place when the trash refuses it, rather than deleting it permanently", async () => {
+        fs.writeFileSync(at("added-by-hand.csv"), "id,name\n1,ada\n");
+        workspace.fs.delete = () => Promise.reject(new Error("trash is not available"));
+
+        await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+
+        expect(fs.existsSync(at("added-by-hand.csv"))).toBe(true);
+        expect(warnings.join(" ")).toContain("added-by-hand.csv");
     });
 
     it("does not rewrite a file that already matches the snapshot", async () => {

--- a/packages/ballerina-extension/src/test-support/checkpointRestore.test.ts
+++ b/packages/ballerina-extension/src/test-support/checkpointRestore.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// A checkpoint restore rewrites the workspace and then waits for the Language Server to publish
+// the artifacts of what it just wrote. That notification is advisory — it only refreshes the
+// visualizer's current location — and it can legitimately never arrive, so whether it does must
+// not decide the restore's outcome: the caller truncates the chat history on the strength of that
+// boolean, and a stale history against reverted files is what wso2/product-integrator#2406 reports.
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { Checkpoint } from "@wso2/ballerina-core/lib/state-machine-types";
+// The module jest maps `vscode` to, imported by path so the stubs tests reassign stay mutable.
+import { Uri, workspace } from "./__mocks__/vscode";
+import { ArtifactNotificationHandler, ArtifactsUpdated } from "../utils/project-artifacts-handler";
+
+const artifactLocationUpdates: unknown[] = [];
+
+jest.mock("../rpc-managers/visualizer/rpc-manager", () => ({
+    VisualizerRpcManager: class {
+        updateCurrentArtifactLocation(params: unknown) {
+            artifactLocationUpdates.push(params);
+        }
+    },
+}));
+jest.mock("../stateMachine", () => ({
+    StateMachine: { context: () => ({}) },
+    updateView: () => {},
+}));
+jest.mock("../rpc-managers/data-mapper/utils", () => ({
+    refreshDataMapper: () => Promise.resolve(),
+}));
+jest.mock("../RPCLayer", () => ({
+    notifyCurrentWebview: () => {},
+    suppressWebviewNotifications: () => () => {},
+}));
+
+import { restoreWorkspaceSnapshot } from "../views/ai-panel/checkpoint/checkpointUtils";
+
+const ORIGINAL_CONFIG = 'greeting = "before the generation"\n';
+const ORIGINAL_BAL = "// before the generation\n";
+
+/** Lets the restore's promise chain run to its next timer-bound step under fake timers. */
+async function settle(): Promise<void> {
+    for (let i = 0; i < 50; i++) {
+        await Promise.resolve();
+    }
+}
+
+/** The handler is a process-wide singleton; drop any subscription an earlier test abandoned. */
+function resetArtifactSubscribers(): void {
+    const handler = ArtifactNotificationHandler.getInstance() as unknown as { subscribers: Map<string, unknown> };
+    handler.subscribers.clear();
+}
+
+function publishArtifactsUpdated(): void {
+    ArtifactNotificationHandler.getInstance().publish(ArtifactsUpdated.method, {
+        data: [{ id: "svc" }] as never,
+        timestamp: Date.now(),
+    });
+}
+
+describe("checkpoint restore outcome vs. the artifact-update notification", () => {
+    let root: string;
+    let checkpoint: Checkpoint;
+
+    beforeEach(() => {
+        artifactLocationUpdates.length = 0;
+        resetArtifactSubscribers();
+        root = fs.mkdtempSync(path.join(os.tmpdir(), "checkpoint-restore-"));
+        fs.writeFileSync(path.join(root, "main.bal"), "// the generation's edit\n");
+        fs.writeFileSync(path.join(root, "Config.toml"), 'greeting = "the generation\'s edit"\n');
+        fs.writeFileSync(path.join(root, "extra.txt"), "added by the generation\n");
+
+        checkpoint = {
+            id: "cp-1",
+            messageId: "msg-1",
+            timestamp: 0,
+            fileList: ["main.bal", "Config.toml"],
+            workspaceSnapshot: { "main.bal": ORIGINAL_BAL, "Config.toml": ORIGINAL_CONFIG },
+            snapshotSize: ORIGINAL_BAL.length + ORIGINAL_CONFIG.length,
+        };
+
+        workspace.workspaceFolders = [{ uri: Uri.file(root) }];
+        workspace.findFiles = () =>
+            Promise.resolve(
+                ["main.bal", "Config.toml", "extra.txt"].map(name => Uri.file(path.join(root, name)))
+            );
+        workspace.applyEdit = () => Promise.resolve(true);
+        workspace.saveAll = () => Promise.resolve(true);
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it("reports the restore as successful when no artifact update ever arrives", async () => {
+        const restore = restoreWorkspaceSnapshot(checkpoint);
+        await settle();
+        await jest.advanceTimersByTimeAsync(10_000);
+
+        await expect(restore).resolves.toBe(true);
+        expect(fs.readFileSync(path.join(root, "Config.toml"), "utf8")).toBe(ORIGINAL_CONFIG);
+        expect(fs.existsSync(path.join(root, "extra.txt"))).toBe(false);
+    });
+
+    it("does not miss an artifact update published while the edits are being applied", async () => {
+        // The Language Server can answer the edit before the restore gets back to its own wait.
+        workspace.applyEdit = () => {
+            publishArtifactsUpdated();
+            return Promise.resolve(true);
+        };
+
+        let settledWithoutTimeout = false;
+        const restore = restoreWorkspaceSnapshot(checkpoint).then(result => {
+            settledWithoutTimeout = true;
+            return result;
+        });
+        await settle();
+
+        expect(settledWithoutTimeout).toBe(true);
+        await expect(restore).resolves.toBe(true);
+        expect(artifactLocationUpdates).toEqual([{ artifacts: [{ id: "svc" }] }]);
+    });
+
+    it("forwards the artifacts to the visualizer when the update arrives after the edits", async () => {
+        const restore = restoreWorkspaceSnapshot(checkpoint);
+        await settle();
+        publishArtifactsUpdated();
+        await settle();
+
+        await expect(restore).resolves.toBe(true);
+        expect(artifactLocationUpdates).toEqual([{ artifacts: [{ id: "svc" }] }]);
+    });
+
+    it("reports failure when the workspace edit itself does not apply, and stops listening", async () => {
+        workspace.applyEdit = () => Promise.resolve(false);
+
+        const restore = restoreWorkspaceSnapshot(checkpoint);
+        await settle();
+
+        await expect(restore).resolves.toBe(false);
+
+        publishArtifactsUpdated();
+        await jest.advanceTimersByTimeAsync(10_000);
+        expect(artifactLocationUpdates).toEqual([]);
+    });
+});

--- a/packages/ballerina-extension/src/test-support/checkpointRestore.test.ts
+++ b/packages/ballerina-extension/src/test-support/checkpointRestore.test.ts
@@ -27,7 +27,7 @@ import * as os from "os";
 import * as path from "path";
 import type { Checkpoint } from "@wso2/ballerina-core/lib/state-machine-types";
 // The module jest maps `vscode` to, imported by path so the stubs tests reassign stay mutable.
-import { Uri, workspace } from "./__mocks__/vscode";
+import { Uri, window, workspace } from "./__mocks__/vscode";
 import { ArtifactNotificationHandler, ArtifactsUpdated } from "../utils/project-artifacts-handler";
 
 const artifactLocationUpdates: unknown[] = [];
@@ -39,12 +39,17 @@ jest.mock("../rpc-managers/visualizer/rpc-manager", () => ({
         }
     },
 }));
+const dataMapper: { context: unknown; refresh: () => Promise<void> } = {
+    context: {},
+    refresh: () => Promise.resolve(),
+};
+
 jest.mock("../stateMachine", () => ({
-    StateMachine: { context: () => ({}) },
+    StateMachine: { context: () => dataMapper.context },
     updateView: () => {},
 }));
 jest.mock("../rpc-managers/data-mapper/utils", () => ({
-    refreshDataMapper: () => Promise.resolve(),
+    refreshDataMapper: () => dataMapper.refresh(),
 }));
 jest.mock("../RPCLayer", () => ({
     notifyCurrentWebview: () => {},
@@ -83,6 +88,9 @@ describe("checkpoint restore outcome vs. the artifact-update notification", () =
     beforeEach(() => {
         artifactLocationUpdates.length = 0;
         resetArtifactSubscribers();
+        dataMapper.context = {};
+        dataMapper.refresh = () => Promise.resolve();
+        workspace.textDocuments = [];
         root = fs.mkdtempSync(path.join(os.tmpdir(), "checkpoint-restore-"));
         fs.writeFileSync(path.join(root, "main.bal"), "// the generation's edit\n");
         fs.writeFileSync(path.join(root, "Config.toml"), 'greeting = "the generation\'s edit"\n');
@@ -162,5 +170,139 @@ describe("checkpoint restore outcome vs. the artifact-update notification", () =
         publishArtifactsUpdated();
         await jest.advanceTimersByTimeAsync(10_000);
         expect(artifactLocationUpdates).toEqual([]);
+    });
+});
+
+describe("what a checkpoint restore is allowed to touch", () => {
+    let root: string;
+    let checkpoint: Checkpoint;
+    let applied: { op: string; uri: { fsPath: string }; content?: string }[];
+    let warnings: string[];
+
+    const at = (name: string) => path.join(root, name);
+
+    beforeEach(() => {
+        artifactLocationUpdates.length = 0;
+        resetArtifactSubscribers();
+        dataMapper.context = {};
+        dataMapper.refresh = () => Promise.resolve();
+        workspace.textDocuments = [];
+        applied = [];
+        warnings = [];
+
+        root = fs.mkdtempSync(path.join(os.tmpdir(), "checkpoint-touch-"));
+        fs.writeFileSync(at("main.bal"), "// the generation's edit\n");
+        fs.writeFileSync(at("Config.toml"), 'greeting = "the generation\'s edit"\n');
+
+        checkpoint = {
+            id: "cp-1",
+            messageId: "msg-1",
+            timestamp: 0,
+            fileList: ["main.bal", "Config.toml"],
+            workspaceSnapshot: { "main.bal": ORIGINAL_BAL, "Config.toml": ORIGINAL_CONFIG },
+            snapshotSize: 0,
+        };
+
+        workspace.workspaceFolders = [{ uri: Uri.file(root) }];
+        workspace.findFiles = () =>
+            Promise.resolve(fs.readdirSync(root).map(name => Uri.file(at(name))));
+        workspace.applyEdit = (edit: unknown) => {
+            applied.push(...(edit as { entries: typeof applied }).entries);
+            return Promise.resolve(true);
+        };
+        workspace.saveAll = () => Promise.resolve(true);
+        window.showWarningMessage = (message: string) => {
+            warnings.push(message);
+            return Promise.resolve(undefined);
+        };
+    });
+
+    afterEach(() => {
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it("leaves a file whose bytes are not valid UTF-8 exactly as it is", async () => {
+        // A checkpoint stores decoded strings, so this file's snapshot entry is already mangled.
+        const rawBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe, 0x00, 0x80]);
+        fs.writeFileSync(at("logo.png"), rawBytes);
+        checkpoint.fileList.push("logo.png");
+        checkpoint.workspaceSnapshot["logo.png"] = rawBytes.toString("utf8");
+
+        await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+
+        expect(fs.readFileSync(at("logo.png")).equals(rawBytes)).toBe(true);
+        expect(warnings.join(" ")).toContain("logo.png");
+    });
+
+    it("does not rewrite a file that already matches the snapshot", async () => {
+        fs.writeFileSync(at("main.bal"), ORIGINAL_BAL);
+        fs.writeFileSync(at("Config.toml"), ORIGINAL_CONFIG);
+        const before = fs.statSync(at("Config.toml")).mtimeMs;
+
+        await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+
+        expect(applied).toEqual([]);
+        expect(fs.statSync(at("Config.toml")).mtimeMs).toBe(before);
+    });
+
+    it("still rewrites a file whose unsaved editor differs from what is on disk", async () => {
+        fs.writeFileSync(at("main.bal"), ORIGINAL_BAL);
+        workspace.textDocuments = [{
+            uri: Uri.file(at("main.bal")),
+            isDirty: true,
+            save: () => Promise.resolve(true),
+            getText: () => "// half-typed edit the user has not saved\n",
+        }];
+
+        await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+
+        expect(applied.filter(e => e.op === "replace").map(e => e.content)).toContain(ORIGINAL_BAL);
+    });
+
+    it("sends a file the snapshot never captured to the trash rather than unlinking it", async () => {
+        fs.writeFileSync(at("added-by-hand.csv"), "id,name\n1,ada\n");
+        const deletes: { fsPath: string; useTrash?: boolean }[] = [];
+        workspace.fs.delete = (uri: { fsPath: string }, options?: { useTrash?: boolean }) => {
+            deletes.push({ fsPath: uri.fsPath, useTrash: options?.useTrash });
+            return Promise.resolve();
+        };
+
+        await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+
+        expect(deletes).toEqual([{ fsPath: at("added-by-hand.csv"), useTrash: true }]);
+        // The stub deliberately does not remove it: had the code fallen back to unlink, it would be gone.
+        expect(fs.existsSync(at("added-by-hand.csv"))).toBe(true);
+    });
+
+    it("applies every other file before reporting a file it could not write", async () => {
+        // A path the generation turned into a directory: writeFileSync throws EISDIR.
+        fs.rmSync(at("Config.toml"));
+        fs.mkdirSync(at("Config.toml"));
+
+        await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(false);
+
+        expect(applied.filter(e => e.op === "replace").map(e => e.content)).toContain(ORIGINAL_BAL);
+    });
+
+    it("reports success when the post-restore data mapper refresh fails", async () => {
+        dataMapper.context = { dataMapperMetadata: { name: "transform", codeData: { lineRange: { fileName: "main.bal" } } } };
+        dataMapper.refresh = () => Promise.reject(new Error("Data mapper refresh failed."));
+
+        await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+
+        expect(fs.readFileSync(at("Config.toml"), "utf8")).toBe(ORIGINAL_CONFIG);
+    });
+    it("refuses a snapshot path that resolves outside the workspace", async () => {
+        const outside = path.join(path.dirname(root), "outside-the-workspace.txt");
+        fs.writeFileSync(outside, "not the checkpoint's business\n");
+        checkpoint.fileList.push("../outside-the-workspace.txt");
+        checkpoint.workspaceSnapshot["../outside-the-workspace.txt"] = "written by a tampered checkpoint\n";
+
+        try {
+            await expect(restoreWorkspaceSnapshot(checkpoint, true)).resolves.toBe(true);
+            expect(fs.readFileSync(outside, "utf8")).toBe("not the checkpoint's business\n");
+        } finally {
+            fs.rmSync(outside, { force: true });
+        }
     });
 });

--- a/packages/ballerina-extension/src/test-support/restoreGuard.test.ts
+++ b/packages/ballerina-extension/src/test-support/restoreGuard.test.ts
@@ -17,8 +17,8 @@
  */
 
 // A restore spans several awaits, and anything that starts a run or reparents the active thread in
-// that window corrupts the chat store — see wso2/product-integrator#2421. The refusal has to live
-// here rather than in the panel, so this pins the mechanism the RPC layer and the agent both call.
+// that window corrupts the chat store. The refusal has to live here rather than in the panel, so
+// this pins the mechanism the RPC layer and the agent both call.
 
 import {
     assertNoRestoreInProgress,
@@ -61,16 +61,11 @@ describe("restore-in-progress guard", () => {
         expect(() => assertNoRestoreInProgress(WORKSPACE, "restoreCheckpoint")).toThrow(Error);
     });
 
-    it("releases the workspace when the restore fails, not just when it succeeds", () => {
-        // Mirrors the `finally` both RPC methods wrap their body in.
-        expect(() => {
-            beginRestore(WORKSPACE);
-            try {
-                throw new Error("restoring the workspace failed");
-            } finally {
-                endRestore(WORKSPACE);
-            }
-        }).toThrow("restoring the workspace failed");
+    it("does not stack, so one release frees the workspace", () => {
+        // Both RPC entry points claim the same workspace, and each releases it in a `finally`.
+        beginRestore(WORKSPACE);
+        beginRestore(WORKSPACE);
+        endRestore(WORKSPACE);
 
         expect(isRestoreInProgress(WORKSPACE)).toBe(false);
     });

--- a/packages/ballerina-extension/src/test-support/restoreGuard.test.ts
+++ b/packages/ballerina-extension/src/test-support/restoreGuard.test.ts
@@ -20,6 +20,30 @@
 // that window corrupts the chat store. The refusal has to live here rather than in the panel, so
 // this pins the mechanism the RPC layer and the agent both call.
 
+jest.mock("@wso2/copilot-utilities/chat-persistence", () => ({
+    CopilotPersistenceStore: class {
+        saveThread() { return true; }
+        loadThread() { return undefined; }
+        listThreadIds() { return []; }
+        getWorkspaceMetadata() { return undefined; }
+        saveWorkspaceMetadata() { return true; }
+        listCheckpoints() { return []; }
+        loadCheckpoint() { return undefined; }
+        deleteThread() { return true; }
+        saveCheckpoint() { return true; }
+        loadCheckpoints() { return []; }
+        deleteCheckpoints() { return true; }
+    },
+}));
+jest.mock("../features/ai/state/ApprovalManager", () => ({
+    approvalManager: { cancelAllPending: jest.fn() },
+}));
+jest.mock("../features/ai/utils/project/temp-project", () => ({
+    cleanupTempProject: jest.fn(),
+    getReviewBaselinePath: (p: string) => `${p}-review-baseline`,
+}));
+
+import { ChatStateStorage } from "../views/ai-panel/chatStateStorage";
 import {
     assertNoRestoreInProgress,
     beginRestore,
@@ -68,5 +92,48 @@ describe("restore-in-progress guard", () => {
         endRestore(WORKSPACE);
 
         expect(isRestoreInProgress(WORKSPACE)).toBe(false);
+    });
+});
+
+// The other direction: a restore must not start while something is still writing. runEventStore
+// only sees runs buffered for panel reconnection, so an executor that never begins one — the type
+// creator among them — is invisible there and has to be seen through its registered execution.
+describe("workspace busy while an execution is registered", () => {
+    const WORKSPACE = "/ws/orders";
+    const THREAD = "thread-1";
+    let storage: ChatStateStorage;
+
+    beforeEach(() => {
+        storage = new ChatStateStorage();
+    });
+
+    it("reports the workspace busy for an execution that never begins a tracked run", () => {
+        expect(storage.hasActiveExecutionFor(WORKSPACE)).toBe(false);
+
+        storage.setActiveExecution(WORKSPACE, THREAD, {
+            generationId: "gen-1",
+            abortController: new AbortController(),
+        } as never);
+
+        expect(storage.hasActiveExecutionFor(WORKSPACE)).toBe(true);
+    });
+
+    it("frees the workspace once the execution is cleared", () => {
+        storage.setActiveExecution(WORKSPACE, THREAD, {
+            generationId: "gen-1",
+            abortController: new AbortController(),
+        } as never);
+        storage.clearActiveExecution(WORKSPACE, THREAD);
+
+        expect(storage.hasActiveExecutionFor(WORKSPACE)).toBe(false);
+    });
+
+    it("does not report another workspace busy", () => {
+        storage.setActiveExecution(WORKSPACE, THREAD, {
+            generationId: "gen-1",
+            abortController: new AbortController(),
+        } as never);
+
+        expect(storage.hasActiveExecutionFor("/ws/payments")).toBe(false);
     });
 });

--- a/packages/ballerina-extension/src/test-support/restoreGuard.test.ts
+++ b/packages/ballerina-extension/src/test-support/restoreGuard.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// A restore spans several awaits, and anything that starts a run or reparents the active thread in
+// that window corrupts the chat store — see wso2/product-integrator#2421. The refusal has to live
+// here rather than in the panel, so this pins the mechanism the RPC layer and the agent both call.
+
+import {
+    assertNoRestoreInProgress,
+    beginRestore,
+    endRestore,
+    isRestoreInProgress,
+} from "../views/ai-panel/checkpoint/restore-state";
+
+const WORKSPACE = "/ws/orders";
+const OTHER_WORKSPACE = "/ws/payments";
+
+describe("restore-in-progress guard", () => {
+    afterEach(() => {
+        endRestore(WORKSPACE);
+        endRestore(OTHER_WORKSPACE);
+    });
+
+    it("refuses while a restore holds the workspace and allows it again afterwards", () => {
+        expect(() => assertNoRestoreInProgress(WORKSPACE, "generateAgent")).not.toThrow();
+
+        beginRestore(WORKSPACE);
+        expect(isRestoreInProgress(WORKSPACE)).toBe(true);
+        expect(() => assertNoRestoreInProgress(WORKSPACE, "generateAgent")).toThrow(/restore is still in progress/);
+
+        endRestore(WORKSPACE);
+        expect(() => assertNoRestoreInProgress(WORKSPACE, "generateAgent")).not.toThrow();
+    });
+
+    it("holds only the workspace being restored", () => {
+        beginRestore(WORKSPACE);
+
+        expect(isRestoreInProgress(OTHER_WORKSPACE)).toBe(false);
+        expect(() => assertNoRestoreInProgress(OTHER_WORKSPACE, "generateAgent")).not.toThrow();
+    });
+
+    it("throws rather than reporting a flag, so an awaited RPC cannot leave the panel spinning", () => {
+        beginRestore(WORKSPACE);
+
+        // The webview's send path resets its spinner from a catch; a silent refusal never reaches it.
+        expect(() => assertNoRestoreInProgress(WORKSPACE, "restoreCheckpoint")).toThrow(Error);
+    });
+
+    it("releases the workspace when the restore fails, not just when it succeeds", () => {
+        // Mirrors the `finally` both RPC methods wrap their body in.
+        expect(() => {
+            beginRestore(WORKSPACE);
+            try {
+                throw new Error("restoring the workspace failed");
+            } finally {
+                endRestore(WORKSPACE);
+            }
+        }).toThrow("restoring the workspace failed");
+
+        expect(isRestoreInProgress(WORKSPACE)).toBe(false);
+    });
+});

--- a/packages/ballerina-extension/src/utils/project-artifacts-handler.ts
+++ b/packages/ballerina-extension/src/utils/project-artifacts-handler.ts
@@ -131,8 +131,14 @@ export function startArtifactUpdateWait(
         undefined,
         payload => {
             stopListening();
-            onArtifacts(payload.data);
+            // Settled before the callback runs: publish() swallows a throwing subscriber, so a
+            // failing callback would otherwise leave this promise pending with its timer cleared.
             settle(true);
+            try {
+                onArtifacts(payload.data);
+            } catch (error) {
+                console.error('[Artifacts] Artifact-update listener failed:', error);
+            }
         }
     );
     const timeoutId = setTimeout(() => {

--- a/packages/ballerina-extension/src/utils/project-artifacts-handler.ts
+++ b/packages/ballerina-extension/src/utils/project-artifacts-handler.ts
@@ -146,7 +146,16 @@ export function startArtifactUpdateWait(
         settle(false);
     }, timeoutMs);
 
+    let stopped = false;
+
+    // Idempotent on purpose: unsubscribe() closes over the subscriber Set and drops the whole
+    // notification entry once that Set is empty, so calling it twice would delete the Set a later
+    // subscriber created — silently unsubscribing every other listener of this notification.
     function stopListening(): void {
+        if (stopped) {
+            return;
+        }
+        stopped = true;
         clearTimeout(timeoutId);
         unsubscribe();
     }

--- a/packages/ballerina-extension/src/utils/project-artifacts-handler.ts
+++ b/packages/ballerina-extension/src/utils/project-artifacts-handler.ts
@@ -100,3 +100,56 @@ export class ArtifactNotificationHandler {
         }
     }
 }
+
+export const ARTIFACT_UPDATE_TIMEOUT_MS = 10000;
+
+export interface ArtifactUpdateWait {
+    /** Resolves `true` on the notification, `false` once the timeout passes without one. */
+    notified: Promise<boolean>;
+    cancel: () => void;
+}
+
+/**
+ * Starts a one-shot wait for the next artifact update. Arm it *before* the edit that triggers the
+ * notification: {@code publish} has no replay, so anything published in between is lost and the
+ * wait then always times out.
+ *
+ * It never rejects — an update can legitimately never arrive (the Language Server is busy, or the
+ * edit produced no artifact change), which says nothing about whether the edit itself applied.
+ */
+export function startArtifactUpdateWait(
+    onArtifacts: (artifacts: ProjectStructureArtifactResponse[]) => void,
+    timeoutMs: number = ARTIFACT_UPDATE_TIMEOUT_MS
+): ArtifactUpdateWait {
+    let settle!: (notified: boolean) => void;
+    const notified = new Promise<boolean>(resolve => {
+        settle = resolve;
+    });
+
+    const unsubscribe = ArtifactNotificationHandler.getInstance().subscribe(
+        ArtifactsUpdated.method,
+        undefined,
+        payload => {
+            stopListening();
+            onArtifacts(payload.data);
+            settle(true);
+        }
+    );
+    const timeoutId = setTimeout(() => {
+        stopListening();
+        settle(false);
+    }, timeoutMs);
+
+    function stopListening(): void {
+        clearTimeout(timeoutId);
+        unsubscribe();
+    }
+
+    return {
+        notified,
+        cancel: () => {
+            stopListening();
+            settle(false);
+        }
+    };
+}

--- a/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
@@ -1384,6 +1384,16 @@ export class ChatStateStorage {
         return this.activeExecutions.get(projectRootPath)?.get(threadId);
     }
 
+    /**
+     * True while any thread in the workspace has an execution registered. Broader than
+     * runEventStore.hasActiveRun, which only sees runs buffered for panel reconnection — the
+     * type creator and the other command executors register here without ever beginning a run.
+     */
+    hasActiveExecutionFor(projectRootPath: string): boolean {
+        const threadMap = this.activeExecutions.get(projectRootPath);
+        return threadMap !== undefined && threadMap.size > 0;
+    }
+
     hasAnyActiveExecution(): boolean {
         for (const threadMap of this.activeExecutions.values()) {
             if (threadMap.size > 0) {

--- a/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { Checkpoint } from '@wso2/ballerina-core/lib/state-machine-types';
 import { getCheckpointConfig } from './checkpointConfig';
-import { ArtifactNotificationHandler, ArtifactsUpdated } from '../../../utils/project-artifacts-handler';
+import { ArtifactUpdateWait, startArtifactUpdateWait } from '../../../utils/project-artifacts-handler';
 import { VisualizerRpcManager } from '../../../rpc-managers/visualizer/rpc-manager';
 import { StateMachine, updateView } from '../../../../src/stateMachine';
 import { refreshDataMapper } from '../../../../src/rpc-managers/data-mapper/utils';
@@ -122,6 +122,7 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
 
     const workspaceRoot = workspaceFolders[0].uri;
     let isBalFileRestored = false;
+    let artifactWait: ArtifactUpdateWait | undefined;
 
     try {
         await vscode.window.withProgress({
@@ -180,6 +181,14 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
 
             progress.report({ message: 'Applying workspace changes...' });
 
+            // Armed before the edits: the notification has no replay, so a Language Server that
+            // answers the edit before the restore reaches its own wait would be missed entirely.
+            if (!skipArtifactWait && isBalFileRestored) {
+                artifactWait = startArtifactUpdateWait(
+                    artifacts => new VisualizerRpcManager().updateCurrentArtifactLocation({ artifacts })
+                );
+            }
+
             const resumeNotifications = suppressWebviewNotifications();
             let success = true;
             try {
@@ -233,42 +242,16 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             notifyCurrentWebview();
         });
 
-        // Wait for artifact update notification if any .bal files were restored
-        if (skipArtifactWait) { return true; }
-        await new Promise<void>((resolve, reject) => {
-            if (!isBalFileRestored) {
-                resolve();
-                return;
-            }
-
-            // Get the artifact notification handler instance
-            const notificationHandler = ArtifactNotificationHandler.getInstance();
-            // Subscribe to artifact updated notifications
-            let unsubscribe = notificationHandler.subscribe(ArtifactsUpdated.method, undefined, async (payload) => {
-                new VisualizerRpcManager().updateCurrentArtifactLocation({ artifacts: payload.data });
-                clearTimeout(timeoutId);
-                resolve();
-                unsubscribe();
-            });
-
-            // Set a timeout to reject if no notification is received within 10 seconds
-            const timeoutId = setTimeout(() => {
-                console.log("[Checkpoint] No artifact update notification received within 10 seconds");
-                reject(new Error("Operation timed out. Please try again."));
-                unsubscribe();
-            }, 10000);
-
-            // Clear the timeout when notification is received
-            const originalUnsubscribe = unsubscribe;
-            unsubscribe = () => {
-                clearTimeout(timeoutId);
-                originalUnsubscribe();
-            };
-        });
+        // Advisory only — it refreshes the visualizer's location, while the files are already
+        // written and saved. A missed notification must not be reported as a failed restore.
+        if (artifactWait && !(await artifactWait.notified)) {
+            console.warn('[Checkpoint] No artifact update notification arrived; the workspace was still restored');
+        }
 
         vscode.window.showInformationMessage('Checkpoint restored successfully');
         return true;
     } catch (error) {
+        artifactWait?.cancel();
         console.error('[Checkpoint] Failed to restore workspace snapshot:', error);
         vscode.window.showErrorMessage('Failed to restore checkpoint: ' + (error as Error).message);
         return false;

--- a/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -30,9 +30,9 @@ import { notifyCurrentWebview, suppressWebviewNotifications } from '../../../../
 
 const generateId = () => `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
-async function readFileBytes(fileUri: vscode.Uri): Promise<Buffer | null> {
+function readFileBytes(fileUri: vscode.Uri): Buffer | null {
     try {
-        return Buffer.from(await vscode.workspace.fs.readFile(fileUri));
+        return fs.readFileSync(fileUri.fsPath);
     } catch {
         return null;
     }
@@ -52,7 +52,11 @@ function resolveInsideWorkspace(workspaceRoot: vscode.Uri, filePath: string): vs
 }
 
 function openDocumentText(fileUri: vscode.Uri): string | undefined {
-    return vscode.workspace.textDocuments.find(doc => doc.uri.fsPath === fileUri.fsPath)?.getText();
+    // Scheme included: an SCM diff (`git:`) document carries the same fsPath as the file it
+    // mirrors, and comparing against its HEAD content would skip restoring the real file.
+    return vscode.workspace.textDocuments
+        .find(doc => doc.uri.scheme === 'file' && doc.uri.fsPath === fileUri.fsPath)
+        ?.getText();
 }
 
 export async function captureWorkspaceSnapshot(messageId: string): Promise<Checkpoint | null> {
@@ -87,7 +91,7 @@ export async function captureWorkspaceSnapshot(messageId: string): Promise<Check
             const chunkContents = await Promise.all(chunk.map(async fileUri => {
                 try {
                     const fileContent = await vscode.workspace.fs.readFile(fileUri);
-                    return { fileUri, content: Buffer.from(fileContent).toString('utf8') };
+                    return { fileUri, bytes: Buffer.from(fileContent) };
                 } catch (error) {
                     console.error(`[Checkpoint] Failed to read file ${fileUri.fsPath}:`, error);
                     return null;
@@ -97,9 +101,19 @@ export async function captureWorkspaceSnapshot(messageId: string): Promise<Check
             for (const entry of chunkContents) {
                 if (!entry) { continue; }
                 const relativePath = path.relative(workspaceRoot.fsPath, entry.fileUri.fsPath).split(path.sep).join('/');
-                workspaceSnapshot[relativePath] = entry.content;
                 fileList.push(relativePath);
-                totalSize += entry.content.length;
+
+                // Listed but not snapshotted: a snapshot holds strings, so bytes that do not survive
+                // a UTF-8 round trip cannot be reproduced. Being in fileList keeps a restore from
+                // deleting it; being out of the snapshot keeps a restore from writing a lossy decode
+                // over it. Its size is not counted either — nothing is stored for it.
+                if (!isLosslessUtf8(entry.bytes)) {
+                    continue;
+                }
+
+                const content = entry.bytes.toString('utf8');
+                workspaceSnapshot[relativePath] = content;
+                totalSize += content.length;
             }
 
             if (totalSize > config.maxSnapshotSize) {
@@ -178,12 +192,13 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
                     continue;
                 }
 
-                const existing = await readFileBytes(fileUri);
-                if (existing && !isLosslessUtf8(existing)) {
-                    console.warn(`[Checkpoint] Leaving non-text file untouched: ${filePath}`);
+                if (content.includes('\uFFFD')) {
+                    console.warn(`[Checkpoint] Snapshot content is a lossy decode, leaving file untouched: ${filePath}`);
                     notRestored.push(filePath);
                     continue;
                 }
+
+                const existing = readFileBytes(fileUri);
 
                 // An unsaved editor, not disk, is what the user sees and what saveAll writes back,
                 // so a file only counts as already restored when the buffer matches too. Skipping
@@ -197,14 +212,18 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             }
 
             const balFilesToDelete: vscode.Uri[] = [];
-            const nonBalFilesToDelete: vscode.Uri[] = [];
+            const nonBalFilesToDelete: Array<{ fileUri: vscode.Uri; filePath: string }> = [];
             for (const filePath of filesToDelete) {
                 const fileUri = resolveInsideWorkspace(workspaceRoot, filePath);
                 if (!fileUri) {
                     console.warn(`[Checkpoint] Refusing to delete outside the workspace: ${filePath}`);
                     continue;
                 }
-                (filePath.endsWith('.bal') ? balFilesToDelete : nonBalFilesToDelete).push(fileUri);
+                if (filePath.endsWith('.bal')) {
+                    balFilesToDelete.push(fileUri);
+                } else {
+                    nonBalFilesToDelete.push({ fileUri, filePath });
+                }
             }
 
             progress.report({ message: 'Applying workspace changes...' });
@@ -225,7 +244,7 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
                 // WorkspaceEdit.replace() silently no-ops on a file with no open TextDocument,
                 // which is never true for .bal files but always true for the rest.
                 // Each file is isolated: one unwritable path must not abandon the rest half-restored.
-                for (const fileUri of nonBalFilesToDelete) {
+                for (const { fileUri, filePath } of nonBalFilesToDelete) {
                     if (!fs.existsSync(fileUri.fsPath)) {
                         continue;
                     }
@@ -233,12 +252,11 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
                         // The snapshot holds no copy of a file it never captured, so this deletion
                         // is the user's only copy — .bal deletes already get the trash via WorkspaceEdit.
                         await vscode.workspace.fs.delete(fileUri, { useTrash: true });
-                    } catch {
-                        try {
-                            fs.unlinkSync(fileUri.fsPath);
-                        } catch (error) {
-                            failed.push(`${path.basename(fileUri.fsPath)} (${(error as Error).message})`);
-                        }
+                    } catch (error) {
+                        // No unlink fallback: if the trash refused, or the user cancelled it, leaving
+                        // the file beats destroying the only copy of it.
+                        console.warn(`[Checkpoint] Could not move ${filePath} to the trash, leaving it:`, error);
+                        notRestored.push(filePath);
                     }
                 }
                 for (const { fileUri, content } of nonBalFilesToRestore) {
@@ -288,17 +306,20 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             progress.report({ message: 'Checkpoint restored successfully!' });
         });
 
-        // Advisory, and deliberately outside the block above: the files are written and saved by
-        // now, so a view that fails to refresh must not turn a completed restore into a failed one.
+        // Everything from here is advisory, and deliberately outside the block above: the files are
+        // written and saved by now, so a view that fails to refresh, or an artifact update that
+        // never arrives, must not turn a completed restore into a failed one.
         try {
             await renderDatamapper();
         } catch (error) {
             console.warn('[Checkpoint] Could not refresh the data mapper after the restore:', error);
         }
-        notifyCurrentWebview();
+        try {
+            notifyCurrentWebview();
+        } catch (error) {
+            console.warn('[Checkpoint] Could not notify the webview after the restore:', error);
+        }
 
-        // Advisory only — it refreshes the visualizer's location, while the files are already
-        // written and saved. A missed notification must not be reported as a failed restore.
         if (artifactWait && !(await artifactWait.notified)) {
             console.warn('[Checkpoint] No artifact update notification arrived; the workspace was still restored');
         }

--- a/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -20,6 +20,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { Checkpoint } from '@wso2/ballerina-core/lib/state-machine-types';
+import { isPathInside } from '@wso2/ballerina-core/lib/utils/path-utils';
 import { getCheckpointConfig } from './checkpointConfig';
 import { ArtifactUpdateWait, startArtifactUpdateWait } from '../../../utils/project-artifacts-handler';
 import { VisualizerRpcManager } from '../../../rpc-managers/visualizer/rpc-manager';
@@ -29,9 +30,30 @@ import { notifyCurrentWebview, suppressWebviewNotifications } from '../../../../
 
 const generateId = () => `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
-const SKIP_REWRITE_WHEN_UNCHANGED_FILENAMES: ReadonlySet<string> = new Set([
-    'Ballerina.toml'
-]);
+async function readFileBytes(fileUri: vscode.Uri): Promise<Buffer | null> {
+    try {
+        return Buffer.from(await vscode.workspace.fs.readFile(fileUri));
+    } catch {
+        return null;
+    }
+}
+
+// A snapshot holds decoded strings, so bytes that do not round-trip through UTF-8 were never
+// captured faithfully — writing one back replaces real bytes with U+FFFD.
+function isLosslessUtf8(bytes: Buffer): boolean {
+    return Buffer.from(bytes.toString('utf8'), 'utf8').equals(bytes);
+}
+
+// Snapshot keys are relative paths from a previous session, so they are only as trustworthy as the
+// file they were persisted in: resolve first, then refuse anything that lands outside the workspace.
+function resolveInsideWorkspace(workspaceRoot: vscode.Uri, filePath: string): vscode.Uri | null {
+    const target = path.resolve(workspaceRoot.fsPath, filePath);
+    return isPathInside(workspaceRoot.fsPath, target) ? vscode.Uri.file(target) : null;
+}
+
+function openDocumentText(fileUri: vscode.Uri): string | undefined {
+    return vscode.workspace.textDocuments.find(doc => doc.uri.fsPath === fileUri.fsPath)?.getText();
+}
 
 export async function captureWorkspaceSnapshot(messageId: string): Promise<Checkpoint | null> {
     const config = getCheckpointConfig();
@@ -121,8 +143,8 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
     }
 
     const workspaceRoot = workspaceFolders[0].uri;
-    let isBalFileRestored = false;
     let artifactWait: ArtifactUpdateWait | undefined;
+    const notRestored: string[] = [];
 
     try {
         await vscode.window.withProgress({
@@ -144,29 +166,31 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
                 filePath => !snapshotFilePaths.has(filePath)
             );
 
-            // Check if any .bal files are being modified
-            isBalFileRestored = filesToDelete.some(filePath => filePath.endsWith('.bal')) ||
-                checkpoint.fileList.some(filePath => filePath.endsWith('.bal'));
-
             progress.report({ message: `Preparing ${filesToDelete.length} deletions and ${checkpoint.fileList.length} file restorations...` });
 
             const balFilesToRestore: Array<{ fileUri: vscode.Uri; content: string }> = [];
             const nonBalFilesToRestore: Array<{ fileUri: vscode.Uri; content: string }> = [];
             for (const [filePath, content] of Object.entries(checkpoint.workspaceSnapshot)) {
-                const fileUri = vscode.Uri.file(path.join(workspaceRoot.fsPath, filePath));
+                const fileUri = resolveInsideWorkspace(workspaceRoot, filePath);
+                if (!fileUri) {
+                    console.warn(`[Checkpoint] Refusing to write outside the workspace: ${filePath}`);
+                    notRestored.push(filePath);
+                    continue;
+                }
 
-                // TODO: workaround — rewriting Ballerina.toml triggers an unwanted PackageOverview → WorkspaceOverview redirect.
-                if (SKIP_REWRITE_WHEN_UNCHANGED_FILENAMES.has(path.basename(filePath))) {
-                    let alreadyMatches = false;
-                    try {
-                        const existing = await vscode.workspace.fs.readFile(fileUri);
-                        alreadyMatches = Buffer.from(existing).toString('utf8') === content;
-                    } catch {
-                        // File does not exist on disk.
-                    }
-                    if (alreadyMatches) {
-                        continue;
-                    }
+                const existing = await readFileBytes(fileUri);
+                if (existing && !isLosslessUtf8(existing)) {
+                    console.warn(`[Checkpoint] Leaving non-text file untouched: ${filePath}`);
+                    notRestored.push(filePath);
+                    continue;
+                }
+
+                // An unsaved editor, not disk, is what the user sees and what saveAll writes back,
+                // so a file only counts as already restored when the buffer matches too. Skipping
+                // the rest spares the Language Server a recompile per untouched file.
+                const currentText = openDocumentText(fileUri) ?? existing?.toString('utf8');
+                if (currentText === content) {
+                    continue;
                 }
 
                 (filePath.endsWith('.bal') ? balFilesToRestore : nonBalFilesToRestore).push({ fileUri, content });
@@ -175,7 +199,11 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             const balFilesToDelete: vscode.Uri[] = [];
             const nonBalFilesToDelete: vscode.Uri[] = [];
             for (const filePath of filesToDelete) {
-                const fileUri = vscode.Uri.file(path.join(workspaceRoot.fsPath, filePath));
+                const fileUri = resolveInsideWorkspace(workspaceRoot, filePath);
+                if (!fileUri) {
+                    console.warn(`[Checkpoint] Refusing to delete outside the workspace: ${filePath}`);
+                    continue;
+                }
                 (filePath.endsWith('.bal') ? balFilesToDelete : nonBalFilesToDelete).push(fileUri);
             }
 
@@ -183,7 +211,7 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
 
             // Armed before the edits: the notification has no replay, so a Language Server that
             // answers the edit before the restore reaches its own wait would be missed entirely.
-            if (!skipArtifactWait && isBalFileRestored) {
+            if (!skipArtifactWait && (balFilesToRestore.length > 0 || balFilesToDelete.length > 0)) {
                 artifactWait = startArtifactUpdateWait(
                     artifacts => new VisualizerRpcManager().updateCurrentArtifactLocation({ artifacts })
                 );
@@ -191,21 +219,38 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
 
             const resumeNotifications = suppressWebviewNotifications();
             let success = true;
+            const failed: string[] = [];
             try {
                 // Non-.bal files go through fs directly (mirrors addToIntegration's split):
                 // WorkspaceEdit.replace() silently no-ops on a file with no open TextDocument,
                 // which is never true for .bal files but always true for the rest.
+                // Each file is isolated: one unwritable path must not abandon the rest half-restored.
                 for (const fileUri of nonBalFilesToDelete) {
-                    if (fs.existsSync(fileUri.fsPath)) {
-                        fs.unlinkSync(fileUri.fsPath);
+                    if (!fs.existsSync(fileUri.fsPath)) {
+                        continue;
+                    }
+                    try {
+                        // The snapshot holds no copy of a file it never captured, so this deletion
+                        // is the user's only copy — .bal deletes already get the trash via WorkspaceEdit.
+                        await vscode.workspace.fs.delete(fileUri, { useTrash: true });
+                    } catch {
+                        try {
+                            fs.unlinkSync(fileUri.fsPath);
+                        } catch (error) {
+                            failed.push(`${path.basename(fileUri.fsPath)} (${(error as Error).message})`);
+                        }
                     }
                 }
                 for (const { fileUri, content } of nonBalFilesToRestore) {
-                    const directory = path.dirname(fileUri.fsPath);
-                    if (!fs.existsSync(directory)) {
-                        fs.mkdirSync(directory, { recursive: true });
+                    try {
+                        const directory = path.dirname(fileUri.fsPath);
+                        if (!fs.existsSync(directory)) {
+                            fs.mkdirSync(directory, { recursive: true });
+                        }
+                        fs.writeFileSync(fileUri.fsPath, content, 'utf8');
+                    } catch (error) {
+                        failed.push(`${path.basename(fileUri.fsPath)} (${(error as Error).message})`);
                     }
-                    fs.writeFileSync(fileUri.fsPath, content, 'utf8');
                 }
 
                 if (balFilesToDelete.length > 0 || balFilesToRestore.length > 0) {
@@ -236,11 +281,21 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             if (!success) {
                 throw new Error('Failed to apply workspace edit');
             }
+            if (failed.length > 0) {
+                throw new Error(`could not write ${failed.length} file(s): ${failed.slice(0, 3).join(', ')}`);
+            }
 
             progress.report({ message: 'Checkpoint restored successfully!' });
-            await renderDatamapper();
-            notifyCurrentWebview();
         });
+
+        // Advisory, and deliberately outside the block above: the files are written and saved by
+        // now, so a view that fails to refresh must not turn a completed restore into a failed one.
+        try {
+            await renderDatamapper();
+        } catch (error) {
+            console.warn('[Checkpoint] Could not refresh the data mapper after the restore:', error);
+        }
+        notifyCurrentWebview();
 
         // Advisory only — it refreshes the visualizer's location, while the files are already
         // written and saved. A missed notification must not be reported as a failed restore.
@@ -248,7 +303,14 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             console.warn('[Checkpoint] No artifact update notification arrived; the workspace was still restored');
         }
 
-        vscode.window.showInformationMessage('Checkpoint restored successfully');
+        if (notRestored.length > 0) {
+            vscode.window.showWarningMessage(
+                `Checkpoint restored, except for ${notRestored.length} file(s) a checkpoint cannot ` +
+                `restore, left as they are: ${notRestored.slice(0, 3).join(', ')}`
+            );
+        } else {
+            vscode.window.showInformationMessage('Checkpoint restored successfully');
+        }
         return true;
     } catch (error) {
         artifactWait?.cancel();

--- a/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -200,11 +200,13 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
 
                 const existing = readFileBytes(fileUri);
 
-                // An unsaved editor, not disk, is what the user sees and what saveAll writes back,
-                // so a file only counts as already restored when the buffer matches too. Skipping
-                // the rest spares the Language Server a recompile per untouched file.
-                const currentText = openDocumentText(fileUri) ?? existing?.toString('utf8');
-                if (currentText === content) {
+                // Both have to agree before a file counts as already restored: an unsaved editor is
+                // what the user sees and what saveAll writes back, while an open but unmodified one
+                // can still hold pre-generation text after the agent wrote straight to disk.
+                // Skipping the rest spares the Language Server a recompile per untouched file.
+                const openText = openDocumentText(fileUri);
+                const diskText = existing?.toString('utf8');
+                if (diskText === content && (openText === undefined || openText === content)) {
                     continue;
                 }
 
@@ -244,18 +246,20 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
                 // WorkspaceEdit.replace() silently no-ops on a file with no open TextDocument,
                 // which is never true for .bal files but always true for the rest.
                 // Each file is isolated: one unwritable path must not abandon the rest half-restored.
+                // The snapshot holds no copy of a file it never captured, so this deletion is the
+                // user's only copy. Which is why it follows their own trash setting rather than a
+                // hardcoded choice — the same setting WorkspaceEdit honours for the .bal deletions.
+                const useTrash = vscode.workspace.getConfiguration('files').get<boolean>('enableTrash', true);
                 for (const { fileUri, filePath } of nonBalFilesToDelete) {
                     if (!fs.existsSync(fileUri.fsPath)) {
                         continue;
                     }
                     try {
-                        // The snapshot holds no copy of a file it never captured, so this deletion
-                        // is the user's only copy — .bal deletes already get the trash via WorkspaceEdit.
-                        await vscode.workspace.fs.delete(fileUri, { useTrash: true });
+                        await vscode.workspace.fs.delete(fileUri, { useTrash });
                     } catch (error) {
-                        // No unlink fallback: if the trash refused, or the user cancelled it, leaving
-                        // the file beats destroying the only copy of it.
-                        console.warn(`[Checkpoint] Could not move ${filePath} to the trash, leaving it:`, error);
+                        // Trash enabled but refused (a provider without trash support, or a cancelled
+                        // confirmation): leaving the file beats destroying the only copy of it.
+                        console.warn(`[Checkpoint] Could not delete ${filePath}, leaving it in place:`, error);
                         notRestored.push(filePath);
                     }
                 }
@@ -325,9 +329,11 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
         }
 
         if (notRestored.length > 0) {
+            const shown = notRestored.slice(0, 5).join(', ');
+            const rest = notRestored.length - 5;
             vscode.window.showWarningMessage(
-                `Checkpoint restored, except for ${notRestored.length} file(s) a checkpoint cannot ` +
-                `restore, left as they are: ${notRestored.slice(0, 3).join(', ')}`
+                `Checkpoint restored, except for ${notRestored.length} file(s) left as they are: ` +
+                `${shown}${rest > 0 ? ` and ${rest} more` : ''}`
             );
         } else {
             vscode.window.showInformationMessage('Checkpoint restored successfully');

--- a/packages/ballerina-extension/src/views/ai-panel/checkpoint/restore-state.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/checkpoint/restore-state.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// A restore rewrites the workspace and then truncates the thread, across enough awaits to leave the
+// user seconds in which to send a prompt or switch threads. The panel's own restoring flag cannot
+// gate that: it is webview state, so it is gone after a reload and never seen by the extension —
+// while the chat store is what a concurrent run corrupts.
+
+const restoringWorkspaces = new Set<string>();
+
+export function beginRestore(projectRootPath: string): void {
+    restoringWorkspaces.add(projectRootPath);
+}
+
+export function endRestore(projectRootPath: string): void {
+    restoringWorkspaces.delete(projectRootPath);
+}
+
+export function isRestoreInProgress(projectRootPath: string): boolean {
+    return restoringWorkspaces.has(projectRootPath);
+}
+
+/**
+ * Throws rather than returning a flag: every caller is an awaited RPC, so the webview's catch is
+ * what resets its spinner and shows the reason. A silent refusal would leave it spinning.
+ */
+export function assertNoRestoreInProgress(projectRootPath: string, action: string): void {
+    if (isRestoreInProgress(projectRootPath)) {
+        console.warn(`[RPC] Refused ${action} — a checkpoint restore is still running for: ${projectRootPath}`);
+        throw new Error('A checkpoint restore is still in progress. Please wait for it to finish.');
+    }
+}

--- a/packages/ballerina-extension/src/views/ai-panel/checkpoint/restore-state.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/checkpoint/restore-state.ts
@@ -36,8 +36,9 @@ export function isRestoreInProgress(projectRootPath: string): boolean {
 }
 
 /**
- * Throws rather than returning a flag: every caller is an awaited RPC, so the webview's catch is
- * what resets its spinner and shows the reason. A silent refusal would leave it spinning.
+ * Throws rather than returning a flag, so a caller that awaits the RPC can reset its own spinner
+ * and show the reason — the AI panel's send path does. Fire-and-forget callers (the orb's mini
+ * chat) still need their own catch to stop spinning.
  */
 export function assertNoRestoreInProgress(projectRootPath: string, action: string): void {
     if (isRestoreInProgress(projectRootPath)) {


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/2406

A checkpoint restore rewrote the workspace correctly and then reported failure, so the chat history was never rewound. Two separate things caused that, and the same pass tightens what a restore is allowed to write and delete.

- Arm the Language Server artifact-update wait *before* applying the edits, and treat its timeout as advisory instead of rejecting — the notification handler has no replay, so a notification that arrived while the restore was still finishing was lost and the 10s timeout then always fired
- Move the post-restore data mapper refresh and webview notification out of the block that decides the outcome, so a view that fails to refresh no longer turns a completed restore into a failed one
- Never overwrite a file whose bytes on disk are not valid UTF-8: a snapshot holds decoded strings, so writing one back replaced real bytes with U+FFFD (keystores, images, binary test data). The files left as they are are named in a warning
- Send non-`.bal` deletions to the OS trash instead of unlinking them — the snapshot holds no copy of a file it never captured, so that delete was the user's only copy (`.bal` deletions already got this from `WorkspaceEdit`)
- Refuse any snapshot path that resolves outside the workspace root, for writes and deletions alike
- Skip rewriting a file that already matches, comparing against an unsaved editor when one is open; this replaces the `Ballerina.toml`-only workaround and spares the Language Server a recompile per untouched file
- Isolate each non-`.bal` write and delete, so one unwritable path applies everything else and then reports what failed instead of abandoning the restore half-applied
- Arm the artifact wait only when there is actually a `.bal` edit to apply, rather than whenever the project contains a `.bal` file

It also closes the window a restore leaves open, which is what made the restore look flaky (https://github.com/wso2/product-integrator/issues/2421):

- Refuse a new generation while a restore is running — `generateAgent` throws, as it already does for a concurrent generation, so the panel's catch resets its spinner and shows why. Without this the restore implicitly accepted the generation it was reverting, captured a torn checkpoint and baseline from disk, then sliced the running turn out of the thread while it was still streaming
- Refuse a restore or a revert while a response is still running — the mirror of the guard the thread actions already had, which also covers the moment right after Stop, while the executor is still unwinding
- Refuse a second restore while one is in flight, so the review bar's discard and a separator click cannot interleave two restores over the same files
- Extend the existing guard so new chat, thread switch and thread delete are refused during a restore too; deleting the active thread mid-restore used to have the restore recreate it empty and make it the active one

The refusal is extension-side state rather than the panel's own flag, which is webview state: it is gone after a reload and the extension never sees it, while the chat store is what a concurrent run corrupts. A reopened panel still shows an untruncated thread until it reloads — that needs a completion notification and stays in #2421.

`checkpointRestore.test.ts` adds 11 unit tests covering the restore outcome (notification early / late / absent, failed edit), the non-UTF-8 file, the already-matching file, the unsaved-editor case, the trash, the containment guard, the partial-write report, and the failing data mapper refresh. `restoreGuard.test.ts` adds 4 covering the refusal, its per-workspace scoping, and its release on a failed restore.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improved checkpoint restore reliability and reporting.
- Added workspace path validation and safer file handling.
- Preserved non-UTF-8 files and moved non-`.bal` deletions to the OS trash.
- Skipped unnecessary writes and isolated per-file failures.
- Made artifact updates and post-restore refresh advisory.
- Added restore guards for generation, restore, revert, chat, and thread operations.
- Added tests for restore behavior, artifact waits, and concurrency guards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->