### PR TITLE
Add toolkit capabilities to the agent builder skill

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/skills/agent-builder/SKILL.md
+++ b/packages/ballerina-extension/src/features/ai/agent/skills/agent-builder/SKILL.md
@@ -183,6 +183,30 @@ Give `sessionId` **no default**. A default makes every call that leaves it out s
 bucket, so unrelated requests from different callers see each other's history. Required, the model
 supplies a fresh id per conversation, which is the behaviour the doc line describes.
 
+### Toolkits
+
+A toolkit bundles many tools behind one entry in the `tools` array. List it there directly, mixed
+with plain function tools — no wrapping, no spreading:
+
+```ballerina
+tools = [<toolkitVar>, <toolName>]
+```
+
+**MCP** — connect to an MCP server that is already running elsewhere by constructing the library's
+own toolkit class with its URL; do not implement a toolkit or an MCP server yourself:
+
+```ballerina
+import ballerina/ai;
+import ballerina/mcp;
+
+final ai:McpToolKit <toolkit> = check new ("<serverUrl>", info = {name: "<name>", version: "<version>"});
+```
+
+**OpenAPI has no toolkit type.** Despite sounding parallel to MCP, an OpenAPI spec does not produce
+a toolkit class in this codebase or in `ballerina/ai`. Generate an HTTP client from the spec, then
+wrap each operation you need as an ordinary connector-backed `@ai:AgentTool` function — see "Tools
+backed by a connection" above. Do not invent an `ai:OpenApiToolKit` or similar type.
+
 ## No expression-bodied functions
 
 Write agent tools and helper functions with a block body and an explicit `return`. An

--- a/packages/ballerina-extension/src/features/ai/agent/skills/agent-builder/SKILL.md
+++ b/packages/ballerina-extension/src/features/ai/agent/skills/agent-builder/SKILL.md
@@ -185,21 +185,51 @@ supplies a fresh id per conversation, which is the behaviour the doc line descri
 
 ### Toolkits
 
-A toolkit bundles many tools behind one entry in the `tools` array. List it there directly, mixed
-with plain function tools — no wrapping, no spreading:
+Reach for a toolkit instead of separate `@ai:AgentTool` functions when the tools need to share
+state across calls — the same client connection, session, or cache — not merely because they
+relate to the same task. A toolkit bundles many tools behind one entry in the `tools` array. List
+it there directly, mixed with plain function tools — no wrapping, no spreading:
 
 ```ballerina
 tools = [<toolkitVar>, <toolName>]
 ```
 
-**MCP** — connect to an MCP server that is already running elsewhere by constructing the library's
-own toolkit class with its URL; do not implement a toolkit or an MCP server yourself:
+**MCP** — connect to an MCP server that is already running elsewhere; do not implement an MCP
+server yourself. Write this small wrapper class exactly as shown (only the names and `serverUrl`
+change) — every tool the server exposes becomes available through the one `callTool` dispatcher:
 
 ```ballerina
 import ballerina/ai;
 import ballerina/mcp;
 
-final ai:McpToolKit <toolkit> = check new ("<serverUrl>", info = {name: "<name>", version: "<version>"});
+isolated class <Toolkit> {
+    *ai:McpBaseToolKit;
+    private final mcp:StreamableHttpClient mcpClient;
+    private final readonly & ai:ToolConfig[] tools;
+
+    public isolated function init(string serverUrl, mcp:Implementation info = {name: "<name>", version: "<version>"},
+            *mcp:StreamableHttpClientTransportConfig config) returns ai:Error? {
+        do {
+            self.mcpClient = check new mcp:StreamableHttpClient(serverUrl, config);
+            self.tools = check ai:getPermittedMcpToolConfigs(self.mcpClient, info, self.callTool).cloneReadOnly();
+        } on fail error e {
+            return error ai:Error("Failed to initialize MCP toolkit", e);
+        }
+    }
+
+    public isolated function getTools() returns ai:ToolConfig[] => self.tools;
+
+    @ai:AgentTool
+    public isolated function callTool(mcp:CallToolParams params) returns mcp:CallToolResult|error {
+        return self.mcpClient->callTool(params);
+    }
+}
+```
+
+Construct it with the server's URL and list it in `tools` like any other toolkit:
+
+```ballerina
+final <Toolkit> <toolkitVar> = check new ("<serverUrl>");
 ```
 
 **OpenAPI has no toolkit type.** Despite sounding parallel to MCP, an OpenAPI spec does not produce


### PR DESCRIPTION
## Purpose
> Adding information about toolkits and connecting to MCP servers to the agent building skill
> Solves issue - https://github.com/wso2/product-integrator/issues/2424


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Expanded agent-builder guidance for toolkits and MCP server integration.
- Documented MCP tool-selection limitations and construction-time authentication configuration.
- Replaced the basic authentication example with an OAuth2 client-credentials example.
- Added an example that combines toolkit and function tools.
- Clarified configuration, custom headers, and supported authoring patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->