### PR TITLE
Render the Data Mapper diagram for AI-generated data mappers in review mode

### DIFF
--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -57,6 +57,7 @@ import io.ballerina.projects.Document;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LineRange;
+import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -450,7 +451,7 @@ public class SemanticDiffComputer {
                 FunctionDefinitionNode originalFunction = entry.getValue();
                 LineRange lineRange = originalFunction.lineRange();
                 Map<String, String> metadata = buildFunctionMetadata(functionName);
-                SemanticDiff diff = new SemanticDiff(ChangeType.DELETION, NodeKind.MODULE_FUNCTION,
+                SemanticDiff diff = new SemanticDiff(ChangeType.DELETION, functionNodeKind(originalFunction),
                         resolveUri(lineRange.fileName()), lineRange, metadata);
                 this.semanticDiffs.add(diff);
                 continue;
@@ -465,10 +466,26 @@ public class SemanticDiffComputer {
             FunctionDefinitionNode functionDefinitionNode = entry.getValue();
             LineRange lineRange = functionDefinitionNode.lineRange();
             Map<String, String> metadata = buildFunctionMetadata(entry.getKey());
-            SemanticDiff diff = new SemanticDiff(ChangeType.ADDITION, NodeKind.MODULE_FUNCTION,
+            SemanticDiff diff = new SemanticDiff(ChangeType.ADDITION, functionNodeKind(functionDefinitionNode),
                     resolveUri(lineRange.fileName()), lineRange, metadata);
             this.semanticDiffs.add(diff);
         }
+    }
+
+    /**
+     * Classifies a function by its body: an expression-bodied function is a data mapper, unless it is a
+     * natural-expression (NP) function. Mirrors the rule the artifact generator applies when it fills the
+     * "Data Mappers" section, so the review UI groups and renders these the same way the explorer tree does.
+     *
+     * @param functionDefinitionNode the function to classify
+     * @return the node kind to report for this function
+     */
+    private static NodeKind functionNodeKind(FunctionDefinitionNode functionDefinitionNode) {
+        if (functionDefinitionNode.functionBody() instanceof ExpressionFunctionBodyNode expressionBody
+                && !BallerinaCompilerApi.getInstance().isNaturalExpressionBody(expressionBody)) {
+            return NodeKind.DATA_MAPPING_FUNCTION;
+        }
+        return NodeKind.MODULE_FUNCTION;
     }
 
     /**

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
@@ -263,6 +263,7 @@ const MethodBadge = styled.span<{ $color: string }>`
 const NODE_KIND_FUNCTION = NodeKindEnum.MODULE_FUNCTION;
 const NODE_KIND_RESOURCE = NodeKindEnum.OBJECT_FUNCTION;
 const NODE_KIND_TYPE = NodeKindEnum.TYPE_DEFINITION;
+const NODE_KIND_DATA_MAPPER = NodeKindEnum.DATA_MAPPING_FUNCTION;
 
 interface DiffEntry {
     symbol: string;
@@ -449,6 +450,7 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
     const serviceGroups: Record<string, DiffEntry[]> = {};
     const functionEntries: DiffEntry[] = [];
     const typeEntries: DiffEntry[] = [];
+    const dataMapperEntries: DiffEntry[] = [];
     // Non-diagram construct kinds (constants, module vars, listeners, classes, enums, imports)
     const declarationEntries: DiffEntry[] = [];
     let hasTypeView = false;
@@ -484,6 +486,8 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
         } else if (diff.nodeKind === NODE_KIND_FUNCTION || diff.nodeKind === NODE_KIND_RESOURCE) {
             // Plain functions, and class methods (OBJECT_FUNCTION without a service path)
             functionEntries.push(entry);
+        } else if (diff.nodeKind === NODE_KIND_DATA_MAPPER) {
+            dataMapperEntries.push(entry);
         } else if (isType) {
             typeEntries.push(entry);
         } else {
@@ -498,6 +502,9 @@ function buildGroupsWithOffset(semanticDiffs: SemanticDiff[], startIndex: number
     }
     if (functionEntries.length > 0) {
         groups.push({ groupLabel: "functions", entries: functionEntries });
+    }
+    if (dataMapperEntries.length > 0) {
+        groups.push({ groupLabel: "data mappers", entries: dataMapperEntries });
     }
     if (typeEntries.length > 0) {
         groups.push({ groupLabel: "types", entries: typeEntries });
@@ -644,16 +651,19 @@ const CollapsibleGroupList: React.FC<{
             {groups.map((group, gi) => {
                 const isService = group.groupLabel.startsWith("service ");
                 const isFunctions = group.groupLabel === "functions";
+                const isDataMappers = group.groupLabel === "data mappers";
                 const isTypes = group.groupLabel === "types";
                 const isDesign = group.groupLabel === "design";
                 const isDeclarations = group.groupLabel === "declarations";
-                const isCollapsible = isService || isFunctions || isDeclarations;
+                const isCollapsible = isService || isFunctions || isDataMappers || isDeclarations;
                 const isCollapsed = !!collapsed[gi];
 
                 const displayLabel = isService
                     ? group.groupLabel.slice("service ".length)
                     : isDeclarations
                     ? "declarations"
+                    : isDataMappers
+                    ? "data mappers"
                     : "functions";
 
                 return (
@@ -669,6 +679,9 @@ const CollapsibleGroupList: React.FC<{
                                 )}
                                 {isFunctions && (
                                     <span className="codicon codicon-symbol-method" style={{ fontSize: "11px", color: "var(--vscode-descriptionForeground)" }} />
+                                )}
+                                {isDataMappers && (
+                                    <span className="codicon codicon-arrow-swap" style={{ fontSize: "11px", color: "var(--vscode-descriptionForeground)" }} />
                                 )}
                                 {isDeclarations && (
                                     <span className="codicon codicon-symbol-variable" style={{ fontSize: "11px", color: "var(--vscode-descriptionForeground)" }} />

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyDataMapperDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyDataMapperDiagram.tsx
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useState } from "react";
+import { ChangeTypeEnum, ModelState, NodePosition } from "@wso2/ballerina-core";
+import styled from "@emotion/styled";
+import { useRpcContext } from "@wso2/ballerina-rpc-client";
+import { ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
+import { DataMapper } from "@wso2/ballerina-data-mapper";
+import { fetchDataMapperModelVersion, ReviewModelCache } from "./reviewModelCache";
+
+const SpinnerContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+`;
+
+const Container = styled.div`
+    height: 100%;
+    pointer-events: auto;
+`;
+
+const MessageContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    color: var(--vscode-descriptionForeground);
+    padding: 0 24px;
+    text-align: center;
+`;
+
+interface ItemMetadata {
+    type: string;
+    name: string;
+    accessor?: string;
+}
+
+interface ReadonlyDataMapperDiagramProps {
+    projectPath: string;
+    filePath: string;
+    position: NodePosition;
+    name?: string;
+    onModelLoaded?: (metadata: ItemMetadata) => void;
+    /** True for the "Old" side, which the data-mapper LS service cannot serve — only the live file. */
+    useFileSchema?: boolean;
+    changeType: number;
+    /** Session-scoped model cache owned by ReviewMode — survives toggle/navigation remounts. */
+    modelCache: ReviewModelCache;
+}
+
+const noOp = () => { };
+const noOpAsync = async () => { };
+
+export function ReadonlyDataMapperDiagram(props: ReadonlyDataMapperDiagramProps): JSX.Element {
+    const { filePath, position, name, onModelLoaded, useFileSchema, changeType, modelCache } = props;
+    const { rpcClient } = useRpcContext();
+    const [modelState, setModelState] = useState<ModelState | null>(null);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+        setModelState(null);
+        setErrorMessage(null);
+        // Only the live file has a model to fetch, so the old side never renders a diagram. Report
+        // the name anyway, or the title would sit on "Loading..." for good.
+        if (useFileSchema) {
+            onModelLoaded?.({ type: "Data Mapper", name: name || "Unknown" });
+            setErrorMessage(changeType === ChangeTypeEnum.DELETION
+                ? "This data mapper was deleted."
+                : "The previous version of this data mapper is unavailable.");
+            return;
+        }
+        // A slower earlier request must not overwrite this render with the other version's model.
+        let cancelled = false;
+        fetchDataMapperModelVersion(rpcClient, modelCache, {
+            filePath,
+            position,
+            name: name ?? "",
+        })
+            .then((model) => {
+                if (cancelled) {
+                    return;
+                }
+                if (model) {
+                    setModelState({ model });
+                    onModelLoaded?.({ type: "Data Mapper", name: name || model.rootViewId || "Unknown" });
+                } else {
+                    setErrorMessage("This diagram is unavailable for the selected version.");
+                }
+            })
+            .catch((error) => {
+                console.error("[Reviewing Changes] Error fetching data mapper model:", error);
+                if (!cancelled) {
+                    setErrorMessage("This diagram could not be loaded.");
+                }
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [filePath, position, name, useFileSchema, changeType, rpcClient, modelCache]);
+
+    if (errorMessage) {
+        return <MessageContainer>{errorMessage}</MessageContainer>;
+    }
+
+    if (!modelState) {
+        return (
+            <SpinnerContainer>
+                <ProgressRing color={ThemeColors.PRIMARY} />
+            </SpinnerContainer>
+        );
+    }
+
+    return (
+        <Container>
+            <DataMapper
+                modelState={modelState}
+                name={name}
+                reusable={false}
+                onClose={noOp}
+                onRefresh={noOpAsync}
+                applyModifications={noOpAsync}
+                addArrayElement={noOpAsync}
+                convertToQuery={noOpAsync}
+                addClauses={noOpAsync}
+                deleteClause={noOpAsync}
+                getClausePosition={async () => ({ line: 0, offset: 0 })}
+                addSubMapping={noOpAsync}
+                deleteMapping={noOpAsync}
+                deleteSubMapping={noOpAsync}
+                mapWithCustomFn={noOpAsync}
+                mapWithTransformFn={noOpAsync}
+                resolveOutput={noOpAsync}
+                goToFunction={noOpAsync}
+                enrichChildFields={noOpAsync}
+                genUniqueName={async () => ""}
+                getConvertedExpression={async () => ""}
+                createConvertedVariable={noOpAsync}
+                undoRedoGroup={() => null}
+                handleView={noOp}
+                generateForm={() => <></>}
+                goToSource={noOp}
+                expressionBar={{
+                    completions: [],
+                    isUpdatingSource: false,
+                    triggerCompletions: noOp,
+                    onCompletionSelect: noOp,
+                    onSave: noOpAsync,
+                    onCancel: noOp,
+                    goToSource: noOpAsync,
+                }}
+            />
+        </Container>
+    );
+}

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -24,6 +24,7 @@ import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
 import { ExpectedFlowMetadata, ReadonlyFlowDiagram, ReviewViewMode } from "./ReadonlyFlowDiagram";
 import { diffBelongsToPackage } from "./path-utils";
 import { ReadonlyTypeDiagram } from "./ReadonlyTypeDiagram";
+import { ReadonlyDataMapperDiagram } from "./ReadonlyDataMapperDiagram";
 import { ReadonlySourceDiff } from "./ReadonlySourceDiff";
 import { getNodeKindLabel, SOURCE_VIEW_KINDS } from "./nodeKindLabels";
 import { getVersionsForChangeType, prefetchReviewView, ReviewModelCache } from "./reviewModelCache";
@@ -154,6 +155,7 @@ enum DiagramType {
     FLOW = "flow",
     TYPE = "type",
     SOURCE = "source",
+    DATA_MAPPER = "dataMapper",
 }
 
 interface ReviewView {
@@ -167,6 +169,7 @@ interface ReviewView {
     expectedMetadata?: ExpectedFlowMetadata;
     /** Construct name + before/after source, for SOURCE views (carried in diff metadata). */
     sourceMeta?: { name?: string; oldSource?: string; newSource?: string };
+    name?: string;
 }
 
 // Map numeric changeType to string
@@ -186,6 +189,9 @@ function getChangeTypeString(changeType: number): string {
 function getDiagramType(nodeKind: number): DiagramType {
     if (nodeKind === NodeKindEnum.TYPE_DEFINITION) {
         return DiagramType.TYPE;
+    }
+    if (nodeKind === NodeKindEnum.DATA_MAPPING_FUNCTION) {
+        return DiagramType.DATA_MAPPER;
     }
     if (SOURCE_VIEW_KINDS.has(nodeKind)) {
         return DiagramType.SOURCE;
@@ -237,6 +243,7 @@ function convertToReviewView(diff: SemanticDiff, projectPath: string, packageNam
             diagramType === DiagramType.SOURCE
                 ? { name: metadata?.name, oldSource: metadata?.oldSource, newSource: metadata?.newSource }
                 : undefined,
+        name: diagramType === DiagramType.DATA_MAPPER ? metadata?.name : undefined,
     };
 }
 
@@ -564,6 +571,20 @@ export function ReviewMode(): JSX.Element {
                         filePath={currentView.filePath}
                         onModelLoaded={handleModelLoaded}
                         useFileSchema={effectiveViewMode === "old"}
+                        modelCache={modelCacheRef.current}
+                    />
+                );
+            case "dataMapper":
+                return (
+                    <ReadonlyDataMapperDiagram
+                        key={diagramKey}
+                        projectPath={currentView.projectPath || projectPath}
+                        filePath={currentView.filePath}
+                        position={currentView.position}
+                        name={currentView.name}
+                        onModelLoaded={handleModelLoaded}
+                        useFileSchema={effectiveViewMode === "old"}
+                        changeType={currentView.changeType}
                         modelCache={modelCacheRef.current}
                     />
                 );

--- a/packages/ballerina-visualizer/src/views/ReviewMode/reviewModelCache.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/reviewModelCache.ts
@@ -16,9 +16,11 @@
  * under the License.
  */
 
-import { CDModel, ChangeTypeEnum, Flow, NodePosition, Type } from "@wso2/ballerina-core";
+import { CDModel, ChangeTypeEnum, ExpandedDMModel, Flow, LinePosition, NodePosition, Type } from "@wso2/ballerina-core";
 import { BallerinaRpcClient } from "@wso2/ballerina-rpc-client";
+import { STKindChecker, STNode } from "@wso2/syntax-tree";
 import { getFlowLookupPosition } from "./position-utils";
+import { toComparablePath } from "./path-utils";
 
 /**
  * Review-session-scoped cache of LS model fetches, keyed by view identity + version.
@@ -121,6 +123,89 @@ export function fetchFlowModelVersion(
     });
 }
 
+export interface DataMapperVersionParams {
+    filePath: string;
+    position: NodePosition;
+    name: string;
+}
+
+/**
+ * The LS reads input ports from the symbols visible at this position, and a function's parameters
+ * are not in scope yet at its own `function` keyword — so the body's expression is what to ask about.
+ */
+async function fetchMappingExprPosition(
+    rpcClient: BallerinaRpcClient,
+    uri: string,
+    startLine: LinePosition,
+    endLine: LinePosition
+): Promise<LinePosition> {
+    try {
+        const st = await rpcClient.getLangClientRpcClient().getSTByRange({
+            documentIdentifier: { uri: uri.replace(/^ai:\/\//i, "file://") },
+            lineRange: {
+                start: { line: startLine.line, character: startLine.offset },
+                end: { line: endLine.line, character: endLine.offset },
+            },
+        });
+        const node = (st as { syntaxTree?: STNode })?.syntaxTree;
+        if (node && STKindChecker.isFunctionDefinition(node) && STKindChecker.isExpressionFunctionBody(node.functionBody)) {
+            const exprPosition = node.functionBody.expression.position;
+            return { line: exprPosition.startLine, offset: exprPosition.startColumn };
+        }
+    } catch (error) {
+        console.error("[Reviewing Changes] Could not resolve the mapping expression position:", error);
+    }
+    return startLine;
+}
+
+/**
+ * Fetch the data-mapping function's expanded model, deduped through the session cache. Only the live
+ * version: the LS's data-mapper service holds the live workspace manager alone, so the frozen `ai://`
+ * baseline has no model to serve.
+ */
+export function fetchDataMapperModelVersion(
+    rpcClient: BallerinaRpcClient,
+    cache: ReviewModelCache,
+    params: DataMapperVersionParams
+): Promise<ExpandedDMModel | null> {
+    const { filePath, position, name } = params;
+    const key = `dataMapper:${filePath}:${positionKey(position)}`;
+    return getOrFetch(cache, key, async () => {
+        // The LS finds the node from this range and unwraps the `=> expr` body itself, so it wants
+        // the whole declaration.
+        const enclosedFn = await rpcClient.getBIDiagramRpcClient().getEnclosedFunction({
+            filePath,
+            position: { line: position.startLine, offset: position.startColumn },
+            useFileSchema: false,
+        });
+        const startLine = enclosedFn?.startLine ?? { line: position.startLine, offset: position.startColumn };
+        const endLine = enclosedFn?.endLine ?? { line: position.endLine, offset: position.endColumn };
+
+        // Unlike the flow-model endpoints, the data-mapper ones resolve this with a bare
+        // `Path.of(...)`, so they need a plain OS path and never a URI.
+        const dataMapperFilePath = toComparablePath(filePath);
+        const modelResponse = await rpcClient.getDataMapperRpcClient().getDataMapperModel({
+            filePath: dataMapperFilePath,
+            codedata: { lineRange: { fileName: dataMapperFilePath, startLine, endLine } },
+            position: await fetchMappingExprPosition(rpcClient, filePath, startLine, endLine),
+            targetField: name,
+        });
+        const { mappingsModel } = modelResponse ?? {};
+        if (!mappingsModel) {
+            console.error("[Reviewing Changes] The language server returned no data mapper model:", modelResponse);
+            return null;
+        }
+        if (!("refs" in mappingsModel)) {
+            return mappingsModel;
+        }
+        const expanded = await rpcClient.getDataMapperRpcClient().getExpandedDMFromDMModel({
+            model: mappingsModel,
+            rootViewId: name,
+        });
+        return expanded?.success ? expanded.expandedModel : null;
+    });
+}
+
 /** Fetch the type-diagram model for one version, deduped through the session cache. */
 export function fetchTypesModel(
     rpcClient: BallerinaRpcClient,
@@ -151,13 +236,14 @@ export function fetchDesignModel(
 
 /** The structural subset of ReviewMode's ReviewView that prefetching needs. */
 export interface PrefetchableReviewView {
-    /** DiagramType value: "flow" | "type" | "component" | "source". */
+    /** DiagramType value: "flow" | "type" | "component" | "source" | "dataMapper". */
     type: string;
     filePath: string;
     position: NodePosition;
     oldPosition?: NodePosition;
     projectPath: string;
     changeType: number;
+    name?: string;
 }
 
 /**
@@ -197,6 +283,13 @@ export function prefetchReviewView(
             break;
         case "component":
             fetches.push(fetchDesignModel(rpcClient, cache, view.projectPath, false));
+            break;
+        case "dataMapper":
+            fetches.push(fetchDataMapperModelVersion(rpcClient, cache, {
+                filePath: view.filePath,
+                position: view.position,
+                name: view.name ?? "",
+            }));
             break;
         default:
             break;


### PR DESCRIPTION
## Purpose

It resolves [wso2/product-integrator#2411](https://github.com/wso2/product-integrator/issues/2411)

## Changes

- Show generated data-mapping functions under a separate data mappers category.
- Open the Data Mapper diagram when a generated data mapper is selected.
- Fixed the language server to correctly identify added data-mapping functions.
- Fixed the review flow to pass the correct file path and mapping position to the Data Mapper LS API.
- Added handling for cases where the Data Mapper model is unavailable.

For Reference:

https://github.com/user-attachments/assets/c129ff6e-af8c-4b1c-ab3e-8e6185f87fc2

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixes Data Mapper diagram rendering for AI-generated mapping functions in Reviewing Changes.
- Classifies generated mapping functions as `DATA_MAPPING_FUNCTION`.
- Displays data mappers in a dedicated Review Bar category.
- Opens read-only Data Mapper diagrams with the correct file path, mapping position, and function name.
- Adds model fetching, caching, loading, and unavailable-model handling for review mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->